### PR TITLE
Expand api

### DIFF
--- a/src/lib/sentry-api.ts
+++ b/src/lib/sentry-api.ts
@@ -51,6 +51,28 @@ export class SentryApiService {
     return teamsBody.map((i) => SentryTeamSchema.parse(i));
   }
 
+  async createTeam({
+    organizationSlug,
+    name,
+  }: {
+    organizationSlug: string;
+    name: string;
+  }): Promise<z.infer<typeof SentryTeamSchema>> {
+    const response = await this.request(`/organizations/${organizationSlug}/teams/`, {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    });
+
+    return SentryTeamSchema.parse(await response.json());
+  }
+
+  async listProjects(organizationSlug: string): Promise<z.infer<typeof SentryProjectSchema>[]> {
+    const response = await this.request(`/organizations/${organizationSlug}/projects/`);
+
+    const projectsBody = await response.json<{ id: string; slug: string }[]>();
+    return projectsBody.map((i) => SentryProjectSchema.parse(i));
+  }
+
   async createProject({
     organizationSlug,
     teamSlug,


### PR DESCRIPTION
Adds create team and list projects endpoints (currently unused). 

Additionally cleans out MCP output handling. 

Fixes GH-6