### PR TITLE
feat: Swap to project specific endpoint for listIssues

### DIFF
--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -1103,6 +1103,59 @@ export const restHandlers = [
     },
   ),
   http.get(
+    "https://sentry.io/api/0/projects/sentry-mcp-evals/foobar/issues/",
+    () => HttpResponse.json([]),
+  ),
+  http.get(
+    "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/issues/",
+    ({ request }) => {
+      const url = new URL(request.url);
+      const sort = url.searchParams.get("sort");
+
+      if (![null, "user", "freq", "date", "new", null].includes(sort)) {
+        return HttpResponse.json(
+          `Invalid sort: ${url.searchParams.get("sort")}`,
+          {
+            status: 400,
+          },
+        );
+      }
+
+      const collapse = url.searchParams.getAll("collapse");
+      if (collapse.includes("stats")) {
+        return HttpResponse.json(`Invalid collapse: ${collapse.join(",")}`, {
+          status: 400,
+        });
+      }
+
+      const query = url.searchParams.get("query");
+      const queryTokens = query?.split(" ").sort() ?? [];
+      const sortedQuery = queryTokens ? queryTokens.join(" ") : null;
+      if (
+        ![
+          null,
+          "",
+          "is:unresolved",
+          "error.handled:false is:unresolved",
+          "error.unhandled:true is:unresolved",
+          "user.email:david@sentry.io",
+        ].includes(sortedQuery)
+      ) {
+        return HttpResponse.json([]);
+      }
+
+      if (queryTokens.includes("user.email:david@sentry.io")) {
+        return HttpResponse.json([IssuePayload]);
+      }
+
+      if (sort === "date") {
+        return HttpResponse.json([IssuePayload, IssuePayload2]);
+      }
+      return HttpResponse.json([IssuePayload2, IssuePayload]);
+    },
+  ),
+
+  http.get(
     "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/",
     ({ request }) => {
       const url = new URL(request.url);

--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -294,9 +294,6 @@ export class SentryApiService {
     if (query) {
       sentryQuery.push(query);
     }
-    if (projectSlug) {
-      sentryQuery.push(`project:${projectSlug}`);
-    }
 
     const queryParams = new URLSearchParams();
     queryParams.set("per_page", "10");
@@ -307,7 +304,9 @@ export class SentryApiService {
 
     queryParams.append("collapse", "unhandled");
 
-    const apiUrl = `/organizations/${organizationSlug}/issues/?${queryParams.toString()}`;
+    const apiUrl = projectSlug
+      ? `/projects/${organizationSlug}/${projectSlug}/issues/?${queryParams.toString()}`
+      : `/organizations/${organizationSlug}/issues/?${queryParams.toString()}`;
 
     const response = await this.request(apiUrl);
 

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -63,7 +63,7 @@ describe("list_projects", () => {
 });
 
 describe("list_issues", () => {
-  it("serializes", async () => {
+  it("serializes with project", async () => {
     const tool = TOOL_HANDLERS.list_issues;
     const result = await tool(
       {
@@ -80,6 +80,48 @@ describe("list_issues", () => {
     );
     expect(result).toMatchInlineSnapshot(`
       "# Issues in **sentry-mcp-evals/cloudflare-mcp**
+
+      ## CLOUDFLARE-MCP-41
+
+      **Description**: Error: Tool list_organizations is already registered
+      **Culprit**: Object.fetch(index)
+      **First Seen**: 2025-04-03T22:51:19.403Z
+      **Last Seen**: 2025-04-12T11:34:11.000Z
+      **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
+
+      ## CLOUDFLARE-MCP-42
+
+      **Description**: Error: Tool list_issues is already registered
+      **Culprit**: Object.fetch(index)
+      **First Seen**: 2025-04-11T22:51:19.403Z
+      **Last Seen**: 2025-04-12T11:34:11.000Z
+      **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-42
+
+      # Using this information
+
+      - You can reference the Issue ID in commit messages (e.g. \`Fixes <issueID>\`) to automatically close the issue when the commit is merged.
+      - You can get more details about a specific issue by using the tool: \`get_issue_details(organizationSlug="sentry-mcp-evals", issueId=<issueID>)\`
+      "
+    `);
+  });
+
+  it("serializes without project", async () => {
+    const tool = TOOL_HANDLERS.list_issues;
+    const result = await tool(
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: undefined,
+        query: undefined,
+        sortBy: "last_seen",
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issues in **sentry-mcp-evals**
 
       ## CLOUDFLARE-MCP-41
 


### PR DESCRIPTION
This should remove any complexity around the multi-project select behaviors, which seem to not totally be implemented correctly (from a feature flag conditions pov) upstream.

Refs #155