### PR TITLE
Remove trailing punctuation from issue IDs

### DIFF
--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -143,7 +143,7 @@ const BaseEventSchema = z.object({
   title: z.string(),
   message: z.string().nullable(),
   platform: z.string().nullable(),
-  type: z.union([z.literal("error"), z.literal("transaction"), z.unknown()]),
+  type: z.unknown(),
   entries: z.array(
     z.union([
       // TODO: there are other types


### PR DESCRIPTION
LLMs arent always going to nail what we need from a parameter inputs, so this massages one known failure situation where the LLM passed the issueId including a trailing period.