### PR TITLE
Expand global context

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-transport.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-transport.ts
@@ -46,7 +46,7 @@ export default Sentry.instrumentDurableObjectWithSentry(
     initialScope: {
       tags: {
         durable_object: true,
-        mcp_server_version: LIB_VERSION,
+        "mcp.server_version": LIB_VERSION,
       },
     },
   }),

--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -11,8 +11,8 @@ export default function getSentryConfig(env: Env): SentryConfig {
     sendDefaultPii: true,
     initialScope: {
       tags: {
-        durable_object: true,
-        mcp_server_version: LIB_VERSION,
+        "mcp.server_version": LIB_VERSION,
+        "sentry.host": env.SENTRY_HOST,
       },
     },
     environment:
@@ -29,8 +29,20 @@ export default function getSentryConfig(env: Env): SentryConfig {
 }
 
 getSentryConfig.partial = (config: Partial<SentryConfig>) => {
-  return (env: Env) => ({
-    ...getSentryConfig(env),
-    ...config,
-  });
+  return (env: Env) => {
+    const defaultConfig = getSentryConfig(env);
+    return {
+      ...defaultConfig,
+      ...config,
+      initialScope: {
+        ...defaultConfig.initialScope,
+        ...config.initialScope,
+        tags: {
+          // idk I can't typescript
+          ...((defaultConfig.initialScope ?? {}) as any).tags,
+          ...((config.initialScope ?? {}) as any).tags,
+        },
+      },
+    };
+  };
 };

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -48,7 +48,9 @@ Sentry.init({
   tracesSampleRate: 1,
   initialScope: {
     tags: {
-      mcp_server_version: LIB_VERSION,
+      "mcp.server_version": LIB_VERSION,
+      "mcp.transport": "stdio",
+      "sentry.host": host,
     },
   },
   integrations: [


### PR DESCRIPTION
- mcp_server_version => mcp.server_version
- mcp.transport (only on stdio atm)
- sentry.host