### PR TITLE
fix: Move logging into Sentry

### DIFF
--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -1,4 +1,3 @@
-import { logError } from "../logging";
 import {
   OrganizationListSchema,
   ClientKeySchema,
@@ -34,6 +33,9 @@ import type {
   Team,
   TeamList,
 } from "./types";
+// TODO: this is shared - so ideally, for safety, it uses @sentry/core, but currently
+// logger isnt exposed (or rather, it is, but its not the right logger)
+import { logger } from "@sentry/node";
 
 export class ApiError extends Error {
   constructor(
@@ -97,7 +99,7 @@ export class SentryApiService {
       headers.Authorization = `Bearer ${this.accessToken}`;
     }
 
-    console.log(`[sentryApi] ${options.method || "GET"} ${url}`);
+    logger.info(logger.fmt`[sentryApi] ${options.method || "GET"} ${url}`);
     const response = await fetch(url, {
       ...options,
       headers,


### PR DESCRIPTION
Avoid using console.log in stdio as stdout is used for the transport communication.,

Fixes GH-190