### PR TITLE
Remove get_issue_summary tool

### DIFF
--- a/packages/mcp-server/src/internal/formatting.ts
+++ b/packages/mcp-server/src/internal/formatting.ts
@@ -71,6 +71,11 @@ export function formatIssueOutput({
   output += `**Culprit**: ${issue.culprit}\n`;
   output += `**First Seen**: ${new Date(issue.firstSeen).toISOString()}\n`;
   output += `**Last Seen**: ${new Date(issue.lastSeen).toISOString()}\n`;
+  output += `**Occurrences**: ${issue.count}\n`;
+  output += `**Users Impacted**: ${issue.userCount}\n`;
+  output += `**Status**: ${issue.status}\n`;
+  output += `**Platform**: ${issue.platform}\n`;
+  output += `**Project**: ${issue.project.name}\n`;
   output += `**URL**: ${apiService.getIssueUrl(organizationSlug, issue.shortId)}\n`;
   output += "\n";
   output += "## Event Details\n\n";

--- a/packages/mcp-server/src/toolDefinitions.ts
+++ b/packages/mcp-server/src/toolDefinitions.ts
@@ -140,32 +140,6 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "get_issue_summary" as const,
-    description: [
-      "Retrieve a summary of an issue in Sentry.",
-      "",
-      "Use this tool when you need to:",
-      "- View a summary of an issue in Sentry",
-      "",
-      "If the issue is an error, or you want additional information like the stacktrace, you should use `get_issue_details()` tool instead.",
-      "",
-      "<hints>",
-      "- If the user provides the issueUrl, you can ignore the organizationSlug and issueId parameters.",
-      "- If you're uncertain about which organization to query, you should call `list_organizations()` first. This especially important if an issueId is passed.",
-      "</hints>",
-    ].join("\n"),
-    paramsSchema: {
-      organizationSlug: ParamOrganizationSlug.optional(),
-      regionUrl: ParamRegionUrl.optional(),
-      issueId: ParamIssueShortId.optional(),
-      issueUrl: z
-        .string()
-        .url()
-        .describe("The URL of the issue to retrieve details for.")
-        .optional(),
-    },
-  },
-  {
     name: "get_issue_details" as const,
     description: [
       "Retrieve issue details from Sentry for a specific Issue ID, including the stacktrace and error message if available. Either issueId or issueUrl MUST be provided.",

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -363,73 +363,6 @@ describe("search_transactions", () => {
   });
 });
 
-describe("get_issue_summary", () => {
-  it("serializes with issueId", async () => {
-    const tool = TOOL_HANDLERS.get_issue_summary;
-    const result = await tool(
-      {
-        accessToken: "access-token",
-        userId: "1",
-        organizationSlug: null,
-      },
-      {
-        organizationSlug: "sentry-mcp-evals",
-        issueId: "CLOUDFLARE-MCP-41",
-        issueUrl: undefined,
-        regionUrl: undefined,
-      },
-    );
-    expect(result).toMatchInlineSnapshot(`
-      "# Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**
-
-      **Description**: Error: Tool list_organizations is already registered
-      **Culprit**: Object.fetch(index)
-      **First Seen**: 2025-04-03T22:51:19.403Z
-      **Last Seen**: 2025-04-12T11:34:11.000Z
-      **Occurrences**: 25
-      **Users Impacted**: 1
-      **Status**: unresolved
-      **Platform**: javascript
-      **Project**: CLOUDFLARE-MCP
-      **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
-      "
-    `);
-  });
-
-  it("serializes with issueUrl", async () => {
-    const tool = TOOL_HANDLERS.get_issue_summary;
-    const result = await tool(
-      {
-        accessToken: "access-token",
-        userId: "1",
-        organizationSlug: null,
-      },
-      {
-        organizationSlug: undefined,
-        issueId: undefined,
-        issueUrl: "https://sentry-mcp-evals.sentry.io/issues/6507376925",
-        regionUrl: undefined,
-      },
-    );
-
-    expect(result).toMatchInlineSnapshot(`
-      "# Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**
-
-      **Description**: Error: Tool list_organizations is already registered
-      **Culprit**: Object.fetch(index)
-      **First Seen**: 2025-04-03T22:51:19.403Z
-      **Last Seen**: 2025-04-12T11:34:11.000Z
-      **Occurrences**: 25
-      **Users Impacted**: 1
-      **Status**: unresolved
-      **Platform**: javascript
-      **Project**: CLOUDFLARE-MCP
-      **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
-      "
-    `);
-  });
-});
-
 describe("get_issue_details", () => {
   it("serializes with issueId", async () => {
     const tool = TOOL_HANDLERS.get_issue_details;
@@ -454,6 +387,11 @@ describe("get_issue_details", () => {
       **Culprit**: Object.fetch(index)
       **First Seen**: 2025-04-03T22:51:19.403Z
       **Last Seen**: 2025-04-12T11:34:11.000Z
+      **Occurrences**: 25
+      **Users Impacted**: 1
+      **Status**: unresolved
+      **Platform**: javascript
+      **Project**: CLOUDFLARE-MCP
       **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
 
       ## Event Details
@@ -504,6 +442,11 @@ describe("get_issue_details", () => {
       **Culprit**: Object.fetch(index)
       **First Seen**: 2025-04-03T22:51:19.403Z
       **Last Seen**: 2025-04-12T11:34:11.000Z
+      **Occurrences**: 25
+      **Users Impacted**: 1
+      **Status**: unresolved
+      **Platform**: javascript
+      **Project**: CLOUDFLARE-MCP
       **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
 
       ## Event Details
@@ -552,6 +495,11 @@ describe("get_issue_details", () => {
       **Culprit**: Object.fetch(index)
       **First Seen**: 2025-04-03T22:51:19.403Z
       **Last Seen**: 2025-04-12T11:34:11.000Z
+      **Occurrences**: 25
+      **Users Impacted**: 1
+      **Status**: unresolved
+      **Platform**: javascript
+      **Project**: CLOUDFLARE-MCP
       **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
 
       ## Event Details

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -261,35 +261,6 @@ export const TOOL_HANDLERS = {
     output += `- You can reference tags in the \`query\` parameter of various tools: \`tagName:tagValue\`.\n`;
     return output;
   },
-  get_issue_summary: async (context, params) => {
-    const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
-    });
-    const { organizationSlug: orgSlug, issueId: parsedIssueId } =
-      parseIssueParams({
-        organizationSlug: params.organizationSlug ?? context.organizationSlug,
-        issueId: params.issueId,
-        issueUrl: params.issueUrl,
-      });
-    setTag("organization.slug", orgSlug);
-
-    const issue = await apiService.getIssue({
-      organizationSlug: orgSlug,
-      issueId: parsedIssueId,
-    });
-    let output = `# Issue ${issue.shortId} in **${orgSlug}**\n\n`;
-    output += `**Description**: ${issue.title}\n`;
-    output += `**Culprit**: ${issue.culprit}\n`;
-    output += `**First Seen**: ${new Date(issue.firstSeen).toISOString()}\n`;
-    output += `**Last Seen**: ${new Date(issue.lastSeen).toISOString()}\n`;
-    output += `**Occurrences**: ${issue.count}\n`;
-    output += `**Users Impacted**: ${issue.userCount}\n`;
-    output += `**Status**: ${issue.status}\n`;
-    output += `**Platform**: ${issue.platform}\n`;
-    output += `**Project**: ${issue.project.name}\n`;
-    output += `**URL**: ${apiService.getIssueUrl(orgSlug, issue.shortId)}\n`;
-    return output;
-  },
   get_issue_details: async (context, params) => {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl,


### PR DESCRIPTION
This was an experiment to create efficiency with agent calls, but in practice it turns out to have very low utilization, suggesting get_issue_details is winning out.