### PR TITLE
Query all regions for a users organizations

### DIFF
--- a/packages/mcp-server-evals/src/evals/get-issue.eval.ts
+++ b/packages/mcp-server-evals/src/evals/get-issue.eval.ts
@@ -5,7 +5,7 @@ describeEval("get-issue", {
   data: async () => {
     return [
       {
-        input: "Explain CLOUDFLARE-MCP-41 from Sentry.",
+        input: `Explain CLOUDFLARE-MCP-41 from Sentry in ${FIXTURES.organizationSlug}.`,
         expected: [
           "## CLOUDFLARE-MCP-41",
           "- **Error**: Tool list_organizations is already registered",

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -314,6 +314,15 @@ export const restHandlers = buildHandlers([
   },
   {
     method: "get",
+    path: "/api/0/users/me/regions/",
+    fetch: () => {
+      return HttpResponse.json({
+        regions: [{ name: "us", url: "https://us.sentry.io" }],
+      });
+    },
+  },
+  {
+    method: "get",
     path: "/api/0/organizations/",
     fetch: () => {
       return HttpResponse.json([OrganizationPayload]);

--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -12,6 +12,15 @@ export const UserSchema = z.object({
   email: z.string(),
 });
 
+export const UserRegionsSchema = z.object({
+  regions: z.array(
+    z.object({
+      name: z.string(),
+      url: z.string().url(),
+    }),
+  ),
+});
+
 export const OrganizationSchema = z.object({
   id: z.union([z.string(), z.number()]),
   slug: z.string(),

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -48,7 +48,7 @@ describe("find_organizations", () => {
       # Using this information
 
       - The organization's name is the identifier for the organization, and is used in many tools for \`organizationSlug\`.
-      - If a tool supports passing in the \`regionUrl\`, you should also pass in the correct value there.
+      - If a tool supports passing in the \`regionUrl\`, you MUST pass in the correct value there.
       "
     `);
   });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -57,7 +57,7 @@ export const TOOL_HANDLERS = {
 
     output += "\n\n# Using this information\n\n";
     output += `- The organization's name is the identifier for the organization, and is used in many tools for \`organizationSlug\`.\n`;
-    output += `- If a tool supports passing in the \`regionUrl\`, you should also pass in the correct value there.\n`;
+    output += `- If a tool supports passing in the \`regionUrl\`, you MUST pass in the correct value there.\n`;
 
     return output;
   },


### PR DESCRIPTION
This change is considered temporary, as we need to resolve the upstream organization querying behavior to not require multiple hops. That likely will take a bit, so for now we're going to just eat the cost here.

Fixes #227