### PR TITLE
Fix: Update function names and parameter in tool definitions

### DIFF
--- a/packages/mcp-server/src/toolDefinitions.ts
+++ b/packages/mcp-server/src/toolDefinitions.ts
@@ -182,7 +182,7 @@ export const TOOL_DEFINITIONS = [
       "### Get details for event ID 'c49541c747cb4d8aa3efb70ca5aba243'",
       "",
       "```",
-      "get_event_details(organizationSlug='my-organization', eventId='c49541c747cb4d8aa3efb70ca5aba243')",
+      "get_issue_details(organizationSlug='my-organization', eventId='c49541c747cb4d8aa3efb70ca5aba243')",
       "```",
       "</examples>",
 
@@ -271,7 +271,7 @@ export const TOOL_DEFINITIONS = [
       "...",
       "",
       "```",
-      "find_transactions(organizationSlug='my-organization', transaction='/checkout', sortBy='latency')",
+      "find_transactions(organizationSlug='my-organization', transaction='/checkout', sortBy='duration')",
       "```",
       "",
       "</examples>",


### PR DESCRIPTION
I fixed two documentation bugs in `packages/mcp-server/src/toolDefinitions.ts`. The first bug was an incorrect tool name reference where the example showed `get_event_details()` but the actual tool name is `get_issue_details()`. The second bug was in the `find_transactions()` example which showed an invalid `sortBy='latency'` parameter - I corrected it to use the valid option `sortBy='duration'`. Both fixes were verified with linting and build checks to ensure correctness. These changes ensure the documentation examples are accurate and can be copy-pasted by users without errors.