### PR TITLE
Use shortVersion instead of version in release error search query

### DIFF
--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -254,7 +254,7 @@ export const TOOL_HANDLERS = {
     output += "\n\n";
     output += "# Using this information\n\n";
     output += `- You can reference the Release version in commit messages or documentation.\n`;
-    output += `- You can search for issues in a specific release using the \`find_errors()\` tool with the query \`release:${releases.length ? releases[0]!.version : "VERSION"}\`.\n`;
+    output += `- You can search for issues in a specific release using the \`find_errors()\` tool with the query \`release:${releases.length ? releases[0]!.shortVersion : "VERSION"}\`.\n`;
     return output;
   },
   find_tags: async (context, params) => {


### PR DESCRIPTION
I fixed a property inconsistency bug in the `find_releases` function within `packages/mcp-server/src/tools.ts`. The function was using `release.shortVersion` to display release information but incorrectly referenced `releases[0]!.version` in the usage example. I modified the example to use `releases[0]!.shortVersion` instead, ensuring consistent version format display throughout the function output. This change prevents potential user confusion by maintaining uniform version string references in both the main output and usage examples.