### PR TITLE
Create using-api-mocks documentation

### DIFF
--- a/.cursor/rules/coding-practices.mdc
+++ b/.cursor/rules/coding-practices.mdc
@@ -13,6 +13,7 @@ For specific workflows, refer to these dedicated guides:
 
 - **adding-new-tools**: Comprehensive guide for adding new tools to the MCP server, including definitions, handlers, tests, and evaluations
 - **adding-new-prompts**: Complete workflow for adding new prompts, including implementation patterns and best practices
+- **using-api-mocks**: Complete guide for working with the MSW-based mock system, including fixtures, route handlers, and validation patterns
 
 These guides contain detailed step-by-step instructions, code examples, and specific patterns for their respective areas.
 

--- a/.cursor/rules/using-api-mocks.mdc
+++ b/.cursor/rules/using-api-mocks.mdc
@@ -1,3 +1,8 @@
+---
+description: This guide covers how to work with API mocks in the Sentry MCP server project using MSW, including fixtures, route handlers, and validation patterns.
+globs: 
+alwaysApply: false
+---
 # Using API Mocks
 
 This guide covers how to work with API mocks in the Sentry MCP server project. The mock system uses Mock Service Worker (MSW) to intercept API calls and return realistic responses for testing and development.

--- a/.cursor/rules/using-api-mocks.mdc
+++ b/.cursor/rules/using-api-mocks.mdc
@@ -1,0 +1,400 @@
+# Using API Mocks
+
+This guide covers how to work with API mocks in the Sentry MCP server project. The mock system uses Mock Service Worker (MSW) to intercept API calls and return realistic responses for testing and development.
+
+## Architecture Overview
+
+The mock system is built around these key components:
+
+- **MSW Server**: Intercepts HTTP requests and returns mock responses
+- **JSON Fixtures**: Static data files representing realistic API responses
+- **Route Handlers**: Functions that validate requests and return appropriate responses
+- **Build Process**: Compilation step required to distribute mock changes
+
+## JSON Fixtures
+
+### Structure
+
+Fixtures are stored in `packages/mcp-server-mocks/src/fixtures/` as JSON files:
+
+```
+fixtures/
+├── issue.json        # Sample issue data
+├── project.json      # Project configuration
+├── team.json         # Team information
+├── event.json        # Error event details
+├── tags.json         # Available tags
+└── autofix-state.json # Autofix feature state
+```
+
+### Using Fixtures
+
+Import fixtures at the top of the mock file:
+
+```typescript
+import autofixStateFixture from "./fixtures/autofix-state.json";
+import issueFixture from "./fixtures/issue.json";
+import eventsFixture from "./fixtures/event.json";
+import tagsFixture from "./fixtures/tags.json";
+import projectFixture from "./fixtures/project.json";
+import teamFixture from "./fixtures/team.json";
+```
+
+### Fixture Patterns
+
+**Base fixture with variations:**
+
+```typescript
+// Create variants of base fixtures for different scenarios
+const issueFixture2 = {
+  ...issueFixture,
+  id: 6507376926,
+  shortId: "CLOUDFLARE-MCP-42",
+  count: 1,
+  title: "Error: Tool list_issues is already registered",
+  firstSeen: "2025-04-11T22:51:19.403000Z",
+  lastSeen: "2025-04-12T11:34:11Z",
+};
+```
+
+**Dynamic data generation:**
+
+```typescript
+// Inline payload for dynamic data
+const OrganizationPayload = {
+  id: "4509106740723712",
+  slug: "sentry-mcp-evals",
+  name: "sentry-mcp-evals",
+  links: {
+    regionUrl: "https://us.sentry.io",
+    organizationUrl: "https://sentry.io/sentry-mcp-evals",
+  },
+};
+```
+
+## Route Definition Patterns
+
+### Basic Route Structure
+
+```typescript
+export const restHandlers = buildHandlers([
+  {
+    method: "get",
+    path: "/api/0/organizations/",
+    fetch: () => {
+      return HttpResponse.json([OrganizationPayload]);
+    },
+  },
+]);
+```
+
+### Path Parameters
+
+Handle dynamic path segments:
+
+```typescript
+{
+  method: "get",
+  path: "/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/",
+  fetch: () => HttpResponse.json(issueFixture),
+},
+```
+
+### Request Body Handling
+
+For POST/PUT requests with JSON bodies:
+
+```typescript
+{
+  method: "post",
+  path: "/api/0/teams/sentry-mcp-evals/the-goats/projects/",
+  fetch: async ({ request }) => {
+    const body = (await request.json()) as any;
+    return HttpResponse.json({
+      ...projectFixture,
+      name: body?.name || "cloudflare-mcp",
+      slug: body?.slug || "cloudflare-mcp",
+      platform: body?.platform || "node",
+    });
+  },
+},
+```
+
+## Request Validation Patterns
+
+### Query Parameter Validation
+
+Extract and validate query parameters:
+
+```typescript
+{
+  method: "get",
+  path: "/api/0/organizations/sentry-mcp-evals/events/",
+  fetch: async ({ request }) => {
+    const url = new URL(request.url);
+    const dataset = url.searchParams.get("dataset");
+    const query = url.searchParams.get("query");
+    const fields = url.searchParams.getAll("field");
+
+    // Validate dataset parameter
+    if (dataset === "spans") {
+      if (query !== "is_transaction:true") {
+        return HttpResponse.json(EmptyEventsSpansPayload);
+      }
+
+      // Validate required fields
+      if (!fields.includes("id") || !fields.includes("trace")) {
+        return HttpResponse.json("Invalid fields", { status: 400 });
+      }
+
+      return HttpResponse.json(EventsSpansPayload);
+    }
+
+    return HttpResponse.json("Invalid dataset", { status: 400 });
+  },
+},
+```
+
+### Sort Parameter Validation
+
+Handle sorting options:
+
+```typescript
+const sort = url.searchParams.get("sort");
+
+if (![null, "user", "freq", "date", "new"].includes(sort)) {
+  return HttpResponse.json(
+    `Invalid sort: ${url.searchParams.get("sort")}`,
+    { status: 400 }
+  );
+}
+
+// Return different data based on sort
+if (sort === "date") {
+  return HttpResponse.json([issueFixture, issueFixture2]);
+}
+return HttpResponse.json([issueFixture2, issueFixture]);
+```
+
+### Complex Query Validation
+
+Handle complex query strings:
+
+```typescript
+const query = url.searchParams.get("query");
+const queryTokens = query?.split(" ").sort() ?? [];
+const sortedQuery = queryTokens ? queryTokens.join(" ") : null;
+
+// Handle specific query patterns
+if (
+  ![
+    null,
+    "",
+    "is:unresolved",
+    "error.handled:false is:unresolved",
+    "project:cloudflare-mcp",
+  ].includes(sortedQuery)
+) {
+  return HttpResponse.json([]);
+}
+
+// Return filtered results
+if (queryTokens.includes("user.email:david@sentry.io")) {
+  return HttpResponse.json([issueFixture]);
+}
+```
+
+## Error Response Patterns
+
+### Validation Errors
+
+Return appropriate HTTP status codes:
+
+```typescript
+// 400 Bad Request for invalid parameters
+if (url.searchParams.get("useRpc") !== "1") {
+  return HttpResponse.json("Invalid useRpc", { status: 400 });
+}
+
+// 404 Not Found for missing resources
+if (params.org === "invalid-org") {
+  return HttpResponse.json(
+    { detail: "Organization not found" },
+    { status: 404 }
+  );
+}
+```
+
+### Detailed Error Messages
+
+Provide helpful error details:
+
+```typescript
+if (queryTokens.includes("project:remote-mcp")) {
+  return HttpResponse.json(
+    {
+      detail:
+        "Invalid query. Project(s) remote-mcp do not exist or are not actively selected.",
+    },
+    { status: 400 }
+  );
+}
+```
+
+## Multi-Region Support
+
+The `buildHandlers` function automatically creates handlers for both region URLs:
+
+```typescript
+function buildHandlers(
+  handlers: Array<{
+    method: keyof typeof http;
+    path: string;
+    fetch: Parameters<(typeof http)[keyof typeof http]>[1];
+  }>
+) {
+  return [
+    // Create handlers for both US region and generic Sentry URLs
+    ...handlers.map((handler) =>
+      http[handler.method](`https://us.sentry.io${handler.path}`, handler.fetch)
+    ),
+    ...handlers.map((handler) =>
+      http[handler.method](`https://sentry.io${handler.path}`, handler.fetch)
+    ),
+  ];
+}
+```
+
+## Building and Distribution
+
+### Build Process
+
+**Critical**: After making changes to the mocks package, you must run the build process:
+
+```bash
+cd packages/mcp-server-mocks
+pnpm build
+```
+
+This compiles the TypeScript and creates the distribution files that other packages consume.
+
+### Why Building is Required
+
+- The mocks package is consumed by other packages as a compiled dependency
+- Changes to fixtures or handlers won't be reflected until built
+- Tests in `mcp-server` and `mcp-server-evals` depend on the built output
+
+### When to Build
+
+Build the mocks package when you:
+- Add new fixtures or modify existing ones
+- Create new route handlers
+- Change request validation logic
+- Update response payloads
+- Modify error handling patterns
+
+## Testing Integration
+
+### Mock Server Setup
+
+The mock server is initialized in test files:
+
+```typescript
+import { mswServer } from "@sentry-mcp/mocks";
+
+// Start server before tests
+beforeAll(() => mswServer.listen());
+
+// Reset handlers between tests
+afterEach(() => mswServer.resetHandlers());
+
+// Clean up after tests
+afterAll(() => mswServer.close());
+```
+
+### Test Environment
+
+Mocks automatically intercept HTTP requests in the test environment, allowing tools to be tested against realistic API responses without hitting real endpoints.
+
+## Best Practices
+
+### Route Organization
+
+1. **Group related endpoints**: Keep similar functionality together
+2. **Consistent parameter validation**: Use similar patterns across routes
+3. **Realistic error scenarios**: Include common error cases
+4. **Proper status codes**: Return appropriate HTTP status codes
+
+### Fixture Management
+
+1. **Use realistic data**: Base fixtures on actual API responses
+2. **Create variations**: Build multiple scenarios from base fixtures
+3. **Keep data fresh**: Update fixtures to match current API schema
+4. **Document relationships**: Comment on how fixtures relate to each other
+
+### Validation Patterns
+
+1. **Fail fast**: Return errors early for invalid parameters
+2. **Provide helpful messages**: Include actionable error descriptions
+3. **Handle edge cases**: Consider empty results, malformed queries
+4. **Test boundaries**: Validate limits and constraints
+
+### Development Workflow
+
+1. **Build after changes**: Always run `pnpm build` after mock updates
+2. **Test integration**: Verify changes work with dependent packages
+3. **Update tests**: Ensure unit tests pass with new mock behavior
+4. **Document changes**: Comment complex validation logic
+
+## Common Patterns Summary
+
+```typescript
+// Basic route with fixture
+{
+  method: "get",
+  path: "/api/0/resource/",
+  fetch: () => HttpResponse.json(resourceFixture),
+}
+
+// Route with path parameters
+{
+  method: "get", 
+  path: "/api/0/organizations/:orgSlug/resource/",
+  fetch: ({ params }) => {
+    if (params.orgSlug === "invalid") {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    return HttpResponse.json(resourceFixture);
+  },
+}
+
+// Route with query validation
+{
+  method: "get",
+  path: "/api/0/resource/",
+  fetch: ({ request }) => {
+    const url = new URL(request.url);
+    const sort = url.searchParams.get("sort");
+    
+    if (sort && !["date", "name"].includes(sort)) {
+      return HttpResponse.json("Invalid sort", { status: 400 });
+    }
+    
+    return HttpResponse.json(sortedFixtures[sort] || resourceFixture);
+  },
+}
+
+// Route with request body
+{
+  method: "post",
+  path: "/api/0/resource/",
+  fetch: async ({ request }) => {
+    const body = await request.json();
+    return HttpResponse.json({
+      ...resourceFixture,
+      ...body,
+      id: "new-id",
+    }, { status: 201 });
+  },
+}
+```


### PR DESCRIPTION
A new rule file, `using-api-mocks.mdc`, was created to document the API mocking system. This guide focuses on the Mock Service Worker (MSW) implementation for the Sentry API.

The `using-api-mocks.mdc` guide covers:
*   **JSON Fixtures**: Details on organizing and using data from `packages/mcp-server-mocks/src/fixtures/` for mock responses, including patterns for variations and dynamic data.
*   **Route Definition Patterns**: Examples for defining GET, POST/PUT routes, handling path parameters, and processing request bodies.
*   **Request Validation Patterns**: Guidance on extracting and validating query parameters (e.g., `dataset`, `sort`, complex `query` strings) and returning appropriate HTTP status codes.
*   **Error Response Patterns**: Demonstrates returning validation errors (e.g., 400 Bad Request) and not found errors (404 Not Found) with detailed messages.
*   **Multi-Region Support**: Explains how `buildHandlers` automatically creates handlers for both US region and generic Sentry URLs.
*   **Building and Distribution**: Emphasizes the critical need to run `pnpm build` in `packages/mcp-server-mocks` after any changes to fixtures or handlers, explaining that this compiles TypeScript for consumption by other packages.

Additionally, `coding-practices.mdc` was updated to include a reference to the new `using-api-mocks.mdc` guide in its "Related Guidelines" section.