### PR TITLE
feat: add issue alert rule management tools

### DIFF
--- a/packages/mcp-server-mocks/src/fixtures/issue-alert-rules.json
+++ b/packages/mcp-server-mocks/src/fixtures/issue-alert-rules.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "3",
+    "conditions": [
+      {
+        "interval": "1h",
+        "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+        "value": 10,
+        "name": "The issue is seen more than 10 times in 1h",
+        "comparisonType": "count"
+      }
+    ],
+    "filters": [
+      {
+        "value": "1",
+        "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
+        "name": "The event's issue category is Error"
+      }
+    ],
+    "actions": [
+      {
+        "targetType": "Team",
+        "fallthroughType": "ActiveMembers",
+        "id": "sentry.mail.actions.NotifyEmailAction",
+        "targetIdentifier": "4367234414355",
+        "name": "Send a notification to Team and if none can be found then send a notification to ActiveMembers"
+      }
+    ],
+    "actionMatch": "any",
+    "filterMatch": "any",
+    "frequency": 60,
+    "name": "High Frequency Error Alert",
+    "dateCreated": "2023-01-15T06:45:34.353346Z",
+    "owner": "team:63562",
+    "createdBy": {
+      "id": 2435786,
+      "name": "John Doe",
+      "email": "john.doe@example.com"
+    },
+    "environment": "production",
+    "projects": ["cloudflare-mcp"],
+    "status": "active",
+    "snooze": false
+  },
+  {
+    "id": "4",
+    "conditions": [
+      {
+        "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+        "name": "A new issue is created"
+      }
+    ],
+    "filters": [
+      {
+        "value": "error",
+        "id": "sentry.rules.filters.level.LevelFilter",
+        "name": "The event's level is equal to error"
+      }
+    ],
+    "actions": [
+      {
+        "targetType": "Member",
+        "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+        "targetIdentifier": "123456",
+        "channel": "#alerts",
+        "name": "Send a notification to the Test Slack workspace to #alerts"
+      }
+    ],
+    "actionMatch": "all",
+    "filterMatch": "all",
+    "frequency": 30,
+    "name": "New Error Alert",
+    "dateCreated": "2023-02-20T14:30:22.123456Z",
+    "owner": "user:123456",
+    "createdBy": {
+      "id": 123456,
+      "name": "Jane Smith",
+      "email": "jane.smith@example.com"
+    },
+    "environment": null,
+    "projects": ["cloudflare-mcp"],
+    "status": "active",
+    "snooze": false
+  }
+]

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -31,6 +31,8 @@ import tagsFixture from "./fixtures/tags.json";
 import projectFixture from "./fixtures/project.json";
 import teamFixture from "./fixtures/team.json";
 
+import issueAlertRulesFixture from "./fixtures/issue-alert-rules.json";
+
 /**
  * Standard organization payload for mock responses.
  * Used across multiple endpoints for consistency.
@@ -833,6 +835,111 @@ export const restHandlers = buildHandlers([
         assignedTo: body?.assignedTo || issueFixture2.assignedTo,
       };
       return HttpResponse.json(updatedIssue);
+    },
+  },
+  // Issue Alert endpoints
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/",
+    fetch: async ({ request }) => {
+      return HttpResponse.json(issueAlertRulesFixture);
+    },
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/3/",
+    fetch: async ({ request }) => {
+      return HttpResponse.json(issueAlertRulesFixture[0]);
+    },
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/4/",
+    fetch: async ({ request }) => {
+      return HttpResponse.json(issueAlertRulesFixture[1]);
+    },
+  },
+  {
+    method: "delete",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/3/",
+    fetch: async ({ request }) => {
+      return HttpResponse.json({}, { status: 204 });
+    },
+  },
+  {
+    method: "delete",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/4/",
+    fetch: async ({ request }) => {
+      return HttpResponse.json({}, { status: 204 });
+    },
+  },
+  {
+    method: "put",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/3/",
+    fetch: async ({ request }) => {
+      const body = (await request.json()) as any;
+      const updatedRule = {
+        ...issueAlertRulesFixture[0],
+        name: body?.name || issueAlertRulesFixture[0].name,
+        frequency: body?.frequency || issueAlertRulesFixture[0].frequency,
+        actionMatch: body?.actionMatch || issueAlertRulesFixture[0].actionMatch,
+        filterMatch: body?.filterMatch || issueAlertRulesFixture[0].filterMatch,
+        conditions: body?.conditions || issueAlertRulesFixture[0].conditions,
+        filters: body?.filters || issueAlertRulesFixture[0].filters,
+        actions: body?.actions || issueAlertRulesFixture[0].actions,
+        owner: body?.owner || issueAlertRulesFixture[0].owner,
+        environment: body?.environment || issueAlertRulesFixture[0].environment,
+      };
+      return HttpResponse.json(updatedRule);
+    },
+  },
+  {
+    method: "put",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/4/",
+    fetch: async ({ request }) => {
+      const body = (await request.json()) as any;
+      const updatedRule = {
+        ...issueAlertRulesFixture[1],
+        name: body?.name || issueAlertRulesFixture[1].name,
+        frequency: body?.frequency || issueAlertRulesFixture[1].frequency,
+        actionMatch: body?.actionMatch || issueAlertRulesFixture[1].actionMatch,
+        filterMatch: body?.filterMatch || issueAlertRulesFixture[1].filterMatch,
+        conditions: body?.conditions || issueAlertRulesFixture[1].conditions,
+        filters: body?.filters || issueAlertRulesFixture[1].filters,
+        actions: body?.actions || issueAlertRulesFixture[1].actions,
+        owner: body?.owner || issueAlertRulesFixture[1].owner,
+        environment: body?.environment || issueAlertRulesFixture[1].environment,
+      };
+      return HttpResponse.json(updatedRule);
+    },
+  },
+  {
+    method: "post",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/",
+    fetch: async ({ request }) => {
+      const body = (await request.json()) as any;
+      const newRule = {
+        id: "5",
+        conditions: body?.conditions || [],
+        filters: body?.filters || [],
+        actions: body?.actions || [],
+        actionMatch: body?.actionMatch || "any",
+        filterMatch: body?.filterMatch || "all",
+        frequency: body?.frequency || 1440,
+        name: body?.name || "New Alert Rule",
+        dateCreated: new Date().toISOString(),
+        owner: body?.owner || null,
+        createdBy: {
+          id: 24601,
+          name: "Jean Valjean",
+          email: "jean@example.com",
+        },
+        environment: body?.environment || null,
+        projects: ["cloudflare-mcp"],
+        status: "active",
+        snooze: false,
+      };
+      return HttpResponse.json(newRule);
     },
   },
 ]);

--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -456,3 +456,70 @@ export const AutofixRunStateSchema = z.object({
     .passthrough()
     .nullable(),
 });
+
+/**
+ * Alert-related schemas for Sentry's alert rules API
+ */
+
+// Issue Alert Rule schemas
+export const IssueAlertRuleConditionSchema = z
+  .object({
+    interval: z.string().optional(),
+    id: z.string(),
+    value: z.union([z.string(), z.number()]).optional(),
+    name: z.string().optional(),
+    comparisonType: z.string().optional(),
+  })
+  .passthrough();
+
+export const IssueAlertRuleFilterSchema = z
+  .object({
+    value: z.union([z.string(), z.number()]),
+    id: z.string(),
+    name: z.string().optional(),
+    match: z.string().optional(),
+    key: z.string().optional(),
+    attribute: z.string().optional(),
+  })
+  .passthrough();
+
+export const IssueAlertRuleActionSchema = z
+  .object({
+    targetType: z.string().optional(),
+    fallthroughType: z.string().optional(),
+    id: z.string(),
+    targetIdentifier: z.union([z.string(), z.number()]).nullable().optional(),
+    name: z.string().optional(),
+    workspace: z.string().optional(),
+    channel: z.string().optional(),
+    uuid: z.string().optional(),
+    channel_id: z.string().optional(),
+    tags: z.string().optional(),
+  })
+  .passthrough();
+
+export const IssueAlertRuleSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  conditions: z.array(IssueAlertRuleConditionSchema),
+  filters: z.array(IssueAlertRuleFilterSchema),
+  actions: z.array(IssueAlertRuleActionSchema),
+  actionMatch: z.string(),
+  filterMatch: z.string(),
+  frequency: z.number(),
+  name: z.string(),
+  dateCreated: z.string().datetime(),
+  owner: z.string().nullable(),
+  createdBy: z
+    .object({
+      id: z.union([z.string(), z.number()]),
+      name: z.string(),
+      email: z.string(),
+    })
+    .nullable(),
+  environment: z.string().nullable(),
+  projects: z.array(z.string()),
+  status: z.string(),
+  snooze: z.boolean(),
+});
+
+export const IssueAlertRuleListSchema = z.array(IssueAlertRuleSchema);

--- a/packages/mcp-server/src/api-client/types.ts
+++ b/packages/mcp-server/src/api-client/types.ts
@@ -59,6 +59,8 @@ import type {
   TeamListSchema,
   TeamSchema,
   UserSchema,
+  IssueAlertRuleSchema,
+  IssueAlertRuleListSchema,
 } from "./schema";
 
 export type User = z.infer<typeof UserSchema>;
@@ -81,3 +83,6 @@ export type ReleaseList = z.infer<typeof ReleaseListSchema>;
 export type IssueList = z.infer<typeof IssueListSchema>;
 export type TagList = z.infer<typeof TagListSchema>;
 export type ClientKeyList = z.infer<typeof ClientKeyListSchema>;
+
+export type IssueAlertRule = z.infer<typeof IssueAlertRuleSchema>;
+export type IssueAlertRuleList = z.infer<typeof IssueAlertRuleListSchema>;

--- a/packages/mcp-server/src/schema.ts
+++ b/packages/mcp-server/src/schema.ts
@@ -90,3 +90,10 @@ export const ParamAssignedTo = z
   .describe(
     "The username or team slug to assign the issue to. Use 'me' to assign to yourself, or provide a username/team slug.",
   );
+
+export const ParamRuleId = z
+  .string()
+  .trim()
+  .describe(
+    "The ID of the issue alert rule. You can find rule IDs using the `find_issue_alert_rules()` tool.",
+  );

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -268,7 +268,6 @@ describe("find_tags", () => {
       },
       {
         organizationSlug: "sentry-mcp-evals",
-        projectSlug: undefined,
         regionUrl: undefined,
       },
     );
@@ -753,6 +752,9 @@ describe("update_project", () => {
         projectSlug: "cloudflare-mcp",
         teamSlug: "the-goats",
         regionUrl: undefined,
+        name: undefined,
+        slug: undefined,
+        platform: undefined,
       },
     );
     expect(result).toMatchInlineSnapshot(`
@@ -1396,5 +1398,635 @@ describe("update_issue", () => {
     ).rejects.toThrow(
       "At least one of `status` or `assignedTo` must be provided to update the issue",
     );
+  });
+});
+
+describe("find_issue_alert_rules", () => {
+  it("serializes", async () => {
+    const tool = TOOL_HANDLERS.find_issue_alert_rules;
+    const result = await tool(
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        regionUrl: undefined,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issue Alert Rules in **sentry-mcp-evals/cloudflare-mcp**
+
+      ## High Frequency Error Alert
+
+      **ID**: 3
+      **Status**: active
+      **Frequency**: 60 minutes
+      **Environment**: production
+      **Owner**: team:63562
+      **Conditions**: The issue is seen more than 10 times in 1h
+      **Filters**: The event's issue category is Error
+      **Actions**: Send a notification to Team and if none can be found then send a notification to ActiveMembers
+      **Action Match**: any
+      **Filter Match**: any
+      **Created**: 2023-01-15T06:45:34.353Z
+      **Snooze**: No
+
+      ## New Error Alert
+
+      **ID**: 4
+      **Status**: active
+      **Frequency**: 30 minutes
+      **Environment**: All environments
+      **Owner**: user:123456
+      **Conditions**: A new issue is created
+      **Filters**: The event's level is equal to error
+      **Actions**: Send a notification to the Test Slack workspace to #alerts
+      **Action Match**: all
+      **Filter Match**: all
+      **Created**: 2023-02-20T14:30:22.123Z
+      **Snooze**: No
+
+      # Using this information
+
+      - You can get more details about a specific rule using: \`get_issue_alert_rule_details(organizationSlug="sentry-mcp-evals", projectSlug="cloudflare-mcp", ruleId=<ruleId>)\`
+      - You can delete a rule using: \`delete_issue_alert_rule(organizationSlug="sentry-mcp-evals", projectSlug="cloudflare-mcp", ruleId=<ruleId>)\`
+      "
+    `);
+  });
+
+  it("validates required parameters", async () => {
+    const tool = TOOL_HANDLERS.find_issue_alert_rules;
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: undefined,
+          projectSlug: "cloudflare-mcp",
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Organization slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: undefined,
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Project slug is required");
+  });
+});
+
+describe("get_issue_alert_rule_details", () => {
+  it("serializes", async () => {
+    const tool = TOOL_HANDLERS.get_issue_alert_rule_details;
+    const result = await tool(
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        ruleId: "123456",
+        regionUrl: undefined,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issue Alert Rule: **High Priority Issues**
+
+      **ID**: 123456
+      **Project**: sentry-mcp-evals/cloudflare-mcp
+      **Status**: active
+      **Frequency**: 5 minutes
+      **Environment**: production
+      **Owner**: team:backend
+      **Action Match**: all
+      **Filter Match**: any
+      **Snooze**: No
+
+      ## Conditions
+
+      - **An event is seen**
+        - Interval: 1m
+        - Value: 1
+        - Comparison: count
+      - **The issue is first seen**
+
+      ## Filters
+
+      - **The issue is older or newer than**
+        - Value: 60
+        - Match: older
+        - Key: age
+      - **The event's level is equal to**
+        - Value: error
+        - Match: equal
+        - Attribute: level
+
+      ## Actions
+
+      - **Send a notification to Slack**
+        - Target Type: specific
+        - Target: #alerts
+        - Workspace: team-workspace
+        - Channel: alerts
+        - Channel ID: C1234567890
+      - **Send an email to Team**
+        - Target Type: team
+        - Target: backend-team
+        - Fallthrough: members
+
+      ## Metadata
+
+      **Created**: 2025-01-01T10:00:00.000Z
+      **Created By**: John Doe (john.doe@example.com)
+      "
+    `);
+  });
+
+  it("validates required parameters", async () => {
+    const tool = TOOL_HANDLERS.get_issue_alert_rule_details;
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: undefined,
+          projectSlug: "cloudflare-mcp",
+          ruleId: "123456",
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Organization slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: undefined,
+          ruleId: "123456",
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Project slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          ruleId: undefined,
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Rule ID is required");
+  });
+});
+
+describe("delete_issue_alert_rule", () => {
+  it("serializes", async () => {
+    const tool = TOOL_HANDLERS.delete_issue_alert_rule;
+    const result = await tool(
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        ruleId: "123456",
+        regionUrl: undefined,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issue Alert Rule Deleted
+
+      Successfully deleted issue alert rule **123456** from project **sentry-mcp-evals/cloudflare-mcp**.
+
+      The alert rule has been permanently removed and will no longer trigger alerts.
+      "
+    `);
+  });
+
+  it("validates required parameters", async () => {
+    const tool = TOOL_HANDLERS.delete_issue_alert_rule;
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: undefined,
+          projectSlug: "cloudflare-mcp",
+          ruleId: "123456",
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Organization slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: undefined,
+          ruleId: "123456",
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Project slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          ruleId: undefined,
+          regionUrl: undefined,
+        },
+      ),
+    ).rejects.toThrow("Rule ID is required");
+  });
+});
+
+describe("update_issue_alert_rule", () => {
+  it("serializes", async () => {
+    const tool = TOOL_HANDLERS.update_issue_alert_rule;
+    const result = await tool(
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        ruleId: "123456",
+        name: "Updated High Priority Issues",
+        frequency: 10,
+        actionMatch: "any",
+        filterMatch: "all",
+        regionUrl: undefined,
+        conditions: undefined,
+        filters: undefined,
+        actions: undefined,
+        owner: undefined,
+        environment: undefined,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issue Alert Rule Updated
+
+      Successfully updated issue alert rule **Updated High Priority Issues** (ID: 123456) in project **sentry-mcp-evals/cloudflare-mcp**.
+
+      **Status**: active
+      **Frequency**: 10 minutes
+      **Environment**: production
+      **Owner**: team:backend
+
+      ## Updated Configuration
+
+      **Conditions**: 2 configured
+      **Filters**: 2 configured
+      **Actions**: 2 configured
+      **Action Match**: any
+      **Filter Match**: all
+
+      The alert rule configuration has been successfully updated and is now active.
+      "
+    `);
+  });
+
+  it("validates required parameters", async () => {
+    const tool = TOOL_HANDLERS.update_issue_alert_rule;
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: undefined,
+          projectSlug: "cloudflare-mcp",
+          ruleId: "123456",
+          regionUrl: undefined,
+          name: undefined,
+          frequency: undefined,
+          actionMatch: undefined,
+          filterMatch: undefined,
+          conditions: undefined,
+          filters: undefined,
+          actions: undefined,
+          owner: undefined,
+          environment: undefined,
+        },
+      ),
+    ).rejects.toThrow("Organization slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: undefined,
+          ruleId: "123456",
+          regionUrl: undefined,
+          name: undefined,
+          frequency: undefined,
+          actionMatch: undefined,
+          filterMatch: undefined,
+          conditions: undefined,
+          filters: undefined,
+          actions: undefined,
+          owner: undefined,
+          environment: undefined,
+        },
+      ),
+    ).rejects.toThrow("Project slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          ruleId: undefined,
+          regionUrl: undefined,
+          name: undefined,
+          frequency: undefined,
+          actionMatch: undefined,
+          filterMatch: undefined,
+          conditions: undefined,
+          filters: undefined,
+          actions: undefined,
+          owner: undefined,
+          environment: undefined,
+        },
+      ),
+    ).rejects.toThrow("Rule ID is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          ruleId: "123456",
+          regionUrl: undefined,
+          name: undefined,
+          frequency: undefined,
+          actionMatch: undefined,
+          filterMatch: undefined,
+          conditions: undefined,
+          filters: undefined,
+          actions: undefined,
+          owner: undefined,
+          environment: undefined,
+        },
+      ),
+    ).rejects.toThrow(
+      "At least one field must be provided to update the alert rule",
+    );
+  });
+});
+
+describe("create_issue_alert_rule", () => {
+  it("serializes", async () => {
+    const tool = TOOL_HANDLERS.create_issue_alert_rule;
+    const result = await tool(
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        name: "New Critical Alert Rule",
+        frequency: 5,
+        actionMatch: "all",
+        filterMatch: "any",
+        conditions: [
+          {
+            id: "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            interval: "1m",
+            value: 100,
+            comparisonType: "count",
+          },
+        ],
+        filters: [
+          {
+            id: "sentry.rules.filters.level.LevelFilter",
+            match: "gte",
+            level: "40",
+            value: "40",
+          },
+        ],
+        actions: [
+          {
+            id: "sentry.mail.actions.NotifyEmailAction",
+            targetType: "Team",
+            targetIdentifier: "backend-team",
+          },
+        ],
+        owner: "team:backend",
+        environment: "production",
+        regionUrl: undefined,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issue Alert Rule Created
+
+      Successfully created issue alert rule **New Critical Alert Rule** (ID: 5) in project **sentry-mcp-evals/cloudflare-mcp**.
+
+      **Status**: active
+      **Frequency**: 5 minutes
+      **Environment**: production
+      **Owner**: team:backend
+
+      ## Configuration
+
+      **Conditions**: 1 configured
+      **Filters**: 1 configured
+      **Actions**: 1 configured
+      **Action Match**: all
+      **Filter Match**: any
+
+      The alert rule has been created and is now active. It will trigger alerts based on the configured conditions.
+
+      # Using this information
+
+      - You can view details using: \`get_issue_alert_rule_details(organizationSlug="sentry-mcp-evals", projectSlug="cloudflare-mcp", ruleId="5")\`
+      - You can update the rule using: \`update_issue_alert_rule(organizationSlug="sentry-mcp-evals", projectSlug="cloudflare-mcp", ruleId="5")\`
+      - You can delete the rule using: \`delete_issue_alert_rule(organizationSlug="sentry-mcp-evals", projectSlug="cloudflare-mcp", ruleId="5")\`"
+    `);
+  });
+
+  it("validates required parameters", async () => {
+    const tool = TOOL_HANDLERS.create_issue_alert_rule;
+    const validParams = {
+      name: "Test Rule",
+      conditions: [
+        {
+          id: "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+          interval: "1m",
+          value: 1,
+        },
+      ],
+      actions: [
+        {
+          id: "sentry.mail.actions.NotifyEmailAction",
+          targetType: "Team",
+          targetIdentifier: "backend-team",
+        },
+      ],
+      frequency: undefined,
+      actionMatch: undefined,
+      filterMatch: undefined,
+      filters: undefined,
+      owner: undefined,
+      environment: undefined,
+    };
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: undefined,
+          projectSlug: "cloudflare-mcp",
+          regionUrl: undefined,
+          ...validParams,
+        },
+      ),
+    ).rejects.toThrow("Organization slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: undefined,
+          regionUrl: undefined,
+          ...validParams,
+        },
+      ),
+    ).rejects.toThrow("Project slug is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          regionUrl: undefined,
+          ...validParams,
+          name: undefined,
+        },
+      ),
+    ).rejects.toThrow("Rule name is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          regionUrl: undefined,
+          ...validParams,
+          conditions: undefined,
+        },
+      ),
+    ).rejects.toThrow("At least one condition is required");
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          regionUrl: undefined,
+          ...validParams,
+          actions: undefined,
+        },
+      ),
+    ).rejects.toThrow("At least one action is required");
   });
 });


### PR DESCRIPTION
# Add Issue Alert Rule Management Tools

## Summary

Adds 5 new MCP tools for complete CRUD operations on Sentry issue alert rules:

- **`find_issue_alert_rules`** - List rules in a project
- **`get_issue_alert_rule_details`** - Get rule configuration details  
- **`create_issue_alert_rule`** - Create new alert rules
- **`update_issue_alert_rule`** - Modify existing rules
- **`delete_issue_alert_rule`** - Delete rules

## What's Included

- Full API client methods in `SentryApiService`
- Comprehensive Zod schemas for validation
- MSW mock handlers for testing
- Minor typing improvements in tools.ts for better type safety