### PR TITLE
fix: set explicit public directory path for Vite

### DIFF
--- a/packages/mcp-cloudflare/vite.config.ts
+++ b/packages/mcp-cloudflare/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  publicDir: "../../public",
   build: {
     sourcemap: true,
   },

--- a/packages/mcp-cloudflare/wrangler.jsonc
+++ b/packages/mcp-cloudflare/wrangler.jsonc
@@ -20,7 +20,7 @@
     }
   ],
   "assets": {
-    "directory": "public",
+    "directory": "../../public",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application"
   },


### PR DESCRIPTION
Vite expects the public directory to be found at `./public`, but that is not where the directory exists currently. This can be seen when visiting https://mcp.sentry.dev/ and the favicon fails to load

![image](https://github.com/user-attachments/assets/b8476b1c-75af-4668-ab3c-760d50b0e195)

It can also be seen when running an Open Graph meta tags check like so: https://www.opengraph.xyz/url/https%3A%2F%2Fmcp.sentry.dev

This pull request explicitly sets the `public` directory for Vite and Cloudflare to it's current location so that the images now resolve as expected.