### PR TITLE
feat: support various formats for stacktraces including threads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ OPENAI_API_KEY=your_openai_api_key
 1. **Unit Tests**: Located alongside source files, run with `pnpm test`
 2. **Evaluation Tests**: In packages/mcp-server-evals, test real Sentry operations, run with `pnpm eval`
 3. **Coverage**: Uses Vitest with V8 coverage provider
+4. **Snapshot Testing**: For testing formatted outputs (like error messages, stack traces), use `.toMatchInlineSnapshot()` instead of `.toContain()` to capture the exact output format
 
 ## Common Development Tasks
 

--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -228,20 +228,70 @@ export const ExceptionInterface = z
   })
   .partial();
 
-export const ErrorEntrySchema = z.object({
-  // XXX: Sentry can return either of these. Not sure why we never normalized it.
-  values: z.array(ExceptionInterface.optional()),
-  value: ExceptionInterface.nullable().optional(),
-});
+export const ErrorEntrySchema = z
+  .object({
+    // XXX: Sentry can return either of these. Not sure why we never normalized it.
+    values: z.array(ExceptionInterface.optional()),
+    value: ExceptionInterface.nullable().optional(),
+  })
+  .partial();
 
-export const RequestEntrySchema = z.object({
-  method: z.string().nullable(),
-  url: z.string().url().nullable(),
-  // TODO:
-  // query: z.array(z.tuple([z.string(), z.string()])).nullable(),
-  // data: z.unknown().nullable(),
-  // headers: z.array(z.tuple([z.string(), z.string()])).nullable(),
-});
+export const RequestEntrySchema = z
+  .object({
+    method: z.string().nullable(),
+    url: z.string().url().nullable(),
+    // TODO:
+    // query: z.array(z.tuple([z.string(), z.string()])).nullable(),
+    // data: z.unknown().nullable(),
+    // headers: z.array(z.tuple([z.string(), z.string()])).nullable(),
+  })
+  .partial();
+
+export const MessageEntrySchema = z
+  .object({
+    formatted: z.string().nullable(),
+    message: z.string().nullable(),
+    params: z.array(z.unknown()).optional(),
+  })
+  .partial();
+
+export const ThreadEntrySchema = z
+  .object({
+    id: z.number().nullable(),
+    name: z.string().nullable(),
+    current: z.boolean().nullable(),
+    crashed: z.boolean().nullable(),
+    state: z.string().nullable(),
+    stacktrace: z
+      .object({
+        frames: z.array(FrameInterface),
+      })
+      .nullable(),
+  })
+  .partial();
+
+export const ThreadsEntrySchema = z
+  .object({
+    values: z.array(ThreadEntrySchema),
+  })
+  .partial();
+
+export const BreadcrumbSchema = z
+  .object({
+    timestamp: z.string().nullable(),
+    type: z.string().nullable(),
+    category: z.string().nullable(),
+    level: z.string().nullable(),
+    message: z.string().nullable(),
+    data: z.record(z.unknown()).nullable(),
+  })
+  .partial();
+
+export const BreadcrumbsEntrySchema = z
+  .object({
+    values: z.array(BreadcrumbSchema),
+  })
+  .partial();
 
 const BaseEventSchema = z.object({
   id: z.string(),
@@ -251,21 +301,28 @@ const BaseEventSchema = z.object({
   type: z.unknown(),
   entries: z.array(
     z.union([
-      // TODO: there are other types
       z.object({
         type: z.literal("exception"),
         data: ErrorEntrySchema,
       }),
       z.object({
-        type: z.literal("spans"),
-        data: z.unknown(),
+        type: z.literal("message"),
+        data: MessageEntrySchema,
+      }),
+      z.object({
+        type: z.literal("threads"),
+        data: ThreadsEntrySchema,
       }),
       z.object({
         type: z.literal("request"),
-        data: z.unknown(),
+        data: RequestEntrySchema,
       }),
       z.object({
         type: z.literal("breadcrumbs"),
+        data: BreadcrumbsEntrySchema,
+      }),
+      z.object({
+        type: z.literal("spans"),
         data: z.unknown(),
       }),
       z.object({

--- a/packages/mcp-server/src/internal/formatting.test.ts
+++ b/packages/mcp-server/src/internal/formatting.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from "vitest";
+import { formatEventOutput, formatFrameHeader } from "./formatting";
+import type { Event } from "../api-client/types";
+
+describe("formatFrameHeader", () => {
+  it("uses platform as fallback when language detection fails", () => {
+    // Frame with no clear language indicators
+    const unknownFrame = {
+      filename: "/path/to/file.unknown",
+      function: "someFunction",
+      lineNo: 42,
+    };
+
+    // Without platform - should use generic format
+    expect(formatFrameHeader(unknownFrame)).toBe(
+      "    at someFunction (/path/to/file.unknown:42)",
+    );
+
+    // With platform python - should use Python format
+    expect(formatFrameHeader(unknownFrame, undefined, "python")).toBe(
+      '  File "/path/to/file.unknown", line 42, in someFunction',
+    );
+
+    // With platform java - should use Java format
+    expect(formatFrameHeader(unknownFrame, undefined, "java")).toBe(
+      "at UnknownClass.someFunction(/path/to/file.unknown:42)",
+    );
+  });
+  it("formats Java stack traces correctly", () => {
+    // With module and filename
+    const javaFrame1 = {
+      module: "com.example.ClassName",
+      function: "methodName",
+      filename: "ClassName.java",
+      lineNo: 123,
+    };
+    expect(formatFrameHeader(javaFrame1)).toBe(
+      "at com.example.ClassName.methodName(ClassName.java:123)",
+    );
+
+    // Without filename (common in Java) - needs platform hint
+    const javaFrame2 = {
+      module: "com.example.ClassName",
+      function: "methodName",
+      lineNo: 123,
+    };
+    expect(formatFrameHeader(javaFrame2, undefined, "java")).toBe(
+      "at com.example.ClassName.methodName(Unknown Source:123)",
+    );
+  });
+
+  it("formats Python stack traces correctly", () => {
+    const pythonFrame = {
+      filename: "/path/to/file.py",
+      function: "function_name",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(pythonFrame)).toBe(
+      '  File "/path/to/file.py", line 42, in function_name',
+    );
+
+    // Module only (no filename) - needs platform hint
+    const pythonModuleFrame = {
+      module: "mymodule",
+      function: "function_name",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(pythonModuleFrame, undefined, "python")).toBe(
+      '  File "mymodule", line 42, in function_name',
+    );
+  });
+
+  it("formats JavaScript stack traces correctly", () => {
+    // With column number
+    const jsFrame1 = {
+      filename: "/path/to/file.js",
+      function: "functionName",
+      lineNo: 10,
+      colNo: 15,
+    };
+    expect(formatFrameHeader(jsFrame1)).toBe(
+      "/path/to/file.js:10:15 (functionName)",
+    );
+
+    // Without column number but .js extension
+    const jsFrame2 = {
+      filename: "/path/to/file.js",
+      function: "functionName",
+      lineNo: 10,
+    };
+    expect(formatFrameHeader(jsFrame2)).toBe(
+      "/path/to/file.js:10 (functionName)",
+    );
+
+    // Anonymous function (no function name)
+    const jsFrame3 = {
+      filename: "/path/to/file.js",
+      lineNo: 10,
+      colNo: 15,
+    };
+    expect(formatFrameHeader(jsFrame3)).toBe("/path/to/file.js:10:15");
+  });
+
+  it("formats Ruby stack traces correctly", () => {
+    const rubyFrame = {
+      filename: "/path/to/file.rb",
+      function: "method_name",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(rubyFrame)).toBe(
+      "    from /path/to/file.rb:42:in `method_name`",
+    );
+
+    // Without function name
+    const rubyFrame2 = {
+      filename: "/path/to/file.rb",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(rubyFrame2)).toBe(
+      "    from /path/to/file.rb:42:in",
+    );
+  });
+
+  it("formats PHP stack traces correctly", () => {
+    // With frame index
+    const phpFrame1 = {
+      filename: "/path/to/file.php",
+      function: "functionName",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(phpFrame1, 0)).toBe(
+      "#0 /path/to/file.php(42): functionName()",
+    );
+
+    // Without frame index
+    const phpFrame2 = {
+      filename: "/path/to/file.php",
+      function: "functionName",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(phpFrame2)).toBe(
+      "/path/to/file.php(42): functionName()",
+    );
+  });
+
+  it("formats unknown languages with generic format", () => {
+    const unknownFrame = {
+      filename: "/path/to/file.unknown",
+      function: "someFunction",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(unknownFrame)).toBe(
+      "    at someFunction (/path/to/file.unknown:42)",
+    );
+  });
+
+  it("prioritizes duck typing over platform when clear indicators exist", () => {
+    // Java file but platform says python - should use Java format
+    const javaFrame = {
+      filename: "Example.java",
+      module: "com.example.Example",
+      function: "doSomething",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(javaFrame, undefined, "python")).toBe(
+      "at com.example.Example.doSomething(Example.java:42)",
+    );
+
+    // Python file but platform says java - should use Python format
+    const pythonFrame = {
+      filename: "/app/example.py",
+      function: "do_something",
+      lineNo: 42,
+    };
+    expect(formatFrameHeader(pythonFrame, undefined, "java")).toBe(
+      '  File "/app/example.py", line 42, in do_something',
+    );
+  });
+});
+
+describe("formatEventOutput", () => {
+  it("formats Java thread stack traces correctly", () => {
+    const event: Event = {
+      id: "test",
+      title: "Test Error",
+      message: null,
+      platform: "java",
+      type: "error",
+      entries: [
+        {
+          type: "message",
+          data: {
+            formatted:
+              "Cannot use this function, please use update(String sql, PreparedStatementSetter pss) instead",
+          },
+        },
+        {
+          type: "threads",
+          data: {
+            values: [
+              {
+                id: 187,
+                name: "CONTRACT_WORKER",
+                crashed: true,
+                state: "RUNNABLE",
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: "Thread.java",
+                      module: "java.lang.Thread",
+                      function: "run",
+                      lineNo: 833,
+                    },
+                    {
+                      filename: "AeronServer.java",
+                      module: "com.citics.eqd.mq.aeron.AeronServer",
+                      function: "lambda$start$3",
+                      lineNo: 110,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+      contexts: {},
+    };
+
+    const output = formatEventOutput(event);
+
+    expect(output).toMatchInlineSnapshot(`
+      "### Error
+
+      \`\`\`
+      Cannot use this function, please use update(String sql, PreparedStatementSetter pss) instead
+      \`\`\`
+
+      **Thread** (CONTRACT_WORKER)
+
+      **Stacktrace:**
+      \`\`\`
+      at java.lang.Thread.run(Thread.java:833)
+      at com.citics.eqd.mq.aeron.AeronServer.lambda$start$3(AeronServer.java:110)
+      \`\`\`
+
+      ### Additional Context
+
+      These are additional context provided by the user when they're instrumenting their application.
+
+
+
+      "
+    `);
+  });
+
+  it("formats Python exception traces correctly", () => {
+    const event: Event = {
+      id: "test",
+      title: "Test Error",
+      message: null,
+      platform: "python",
+      type: "error",
+      entries: [
+        {
+          type: "exception",
+          data: {
+            values: [
+              {
+                type: "ValueError",
+                value: "Invalid value",
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: "/app/main.py",
+                      function: "process_data",
+                      lineNo: 42,
+                    },
+                    {
+                      filename: "/app/utils.py",
+                      function: "validate",
+                      lineNo: 15,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+      contexts: {},
+    };
+
+    const output = formatEventOutput(event);
+
+    expect(output).toMatchInlineSnapshot(`
+      "### Error
+
+      \`\`\`
+      ValueError: Invalid value
+      \`\`\`
+
+      **Stacktrace:**
+      \`\`\`
+        File "/app/main.py", line 42, in process_data
+        File "/app/utils.py", line 15, in validate
+      \`\`\`
+
+      ### Additional Context
+
+      These are additional context provided by the user when they're instrumenting their application.
+
+
+
+      "
+    `);
+  });
+});

--- a/packages/mcp-server/src/internal/formatting.ts
+++ b/packages/mcp-server/src/internal/formatting.ts
@@ -13,41 +13,164 @@ import type {
   EventSchema,
   FrameInterface,
   RequestEntrySchema,
+  MessageEntrySchema,
+  ThreadsEntrySchema,
   SentryApiService,
 } from "../api-client";
 
-export function formatFrameHeader(
+/**
+ * Detects the programming language of a stack frame based on the file extension.
+ * Falls back to the platform parameter if no filename is available or extension is unrecognized.
+ *
+ * @param frame - The stack frame containing file and location information
+ * @param platform - Optional platform hint to use as fallback
+ * @returns The detected language or platform fallback or "unknown"
+ */
+function detectLanguage(
   frame: z.infer<typeof FrameInterface>,
-  platform: string | undefined | null,
-) {
-  if (platform?.startsWith("javascript")) {
-    return `${[frame.filename, frame.lineNo, frame.colNo]
-      .filter((i) => !!i)
-      .join(":")}${frame.function ? ` (${frame.function})` : ""}`;
+  platform?: string | null,
+): string {
+  // Check filename extensions
+  if (frame.filename?.endsWith(".java")) {
+    return "java";
   }
-  return `${frame.function ? `"${frame.function}"` : "unknown function"} in "${frame.filename || frame.module}"${
-    frame.lineNo
-      ? ` at line ${frame.lineNo}${frame.colNo !== null ? `:${frame.colNo}` : ""}`
-      : ""
-  }`;
+
+  if (frame.filename?.endsWith(".py")) {
+    return "python";
+  }
+
+  if (frame.filename?.match(/\.(js|ts|jsx|tsx)$/)) {
+    return "javascript";
+  }
+
+  if (frame.filename?.endsWith(".rb")) {
+    return "ruby";
+  }
+
+  if (frame.filename?.endsWith(".php")) {
+    return "php";
+  }
+
+  // Fall back to platform if provided
+  return platform || "unknown";
 }
 
-export function formatEventOutput(event: Event) {
-  let output = "";
-  for (const entry of event.entries) {
-    if (entry.type === "exception") {
-      output += formatExceptionInterfaceOutput(
-        event,
-        entry.data as z.infer<typeof ErrorEntrySchema>,
-      );
+/**
+ * Formats a stack frame into a language-specific string representation.
+ * Different languages have different conventions for displaying stack traces.
+ *
+ * @param frame - The stack frame to format
+ * @param frameIndex - Optional frame index for languages that display frame numbers
+ * @param platform - Optional platform hint for language detection fallback
+ * @returns Formatted stack frame string
+ */
+export function formatFrameHeader(
+  frame: z.infer<typeof FrameInterface>,
+  frameIndex?: number,
+  platform?: string | null,
+) {
+  const language = detectLanguage(frame, platform);
+
+  switch (language) {
+    case "java": {
+      // at com.example.ClassName.methodName(FileName.java:123)
+      const className = frame.module || "UnknownClass";
+      const method = frame.function || "<unknown>";
+      const source = frame.filename || "Unknown Source";
+      const location = frame.lineNo ? `:${frame.lineNo}` : "";
+      return `at ${className}.${method}(${source}${location})`;
     }
-    if (entry.type === "request") {
-      output += formatRequestInterfaceOutput(
-        event,
-        entry.data as z.infer<typeof RequestEntrySchema>,
-      );
+
+    case "python": {
+      // File "/path/to/file.py", line 42, in function_name
+      const file =
+        frame.filename || frame.absPath || frame.module || "<unknown>";
+      const func = frame.function || "<module>";
+      const line = frame.lineNo ? `, line ${frame.lineNo}` : "";
+      return `  File "${file}"${line}, in ${func}`;
+    }
+
+    case "javascript": {
+      // Original compact format: filename:line:col (function)
+      // This preserves backward compatibility
+      return `${[frame.filename, frame.lineNo, frame.colNo]
+        .filter((i) => !!i)
+        .join(":")}${frame.function ? ` (${frame.function})` : ""}`;
+    }
+
+    case "ruby": {
+      // from /path/to/file.rb:42:in `method_name'
+      const file = frame.filename || frame.module || "<unknown>";
+      const func = frame.function ? ` \`${frame.function}\`` : "";
+      const line = frame.lineNo ? `:${frame.lineNo}:in` : "";
+      return `    from ${file}${line}${func}`;
+    }
+
+    case "php": {
+      // #0 /path/to/file.php(42): functionName()
+      const file = frame.filename || "<unknown>";
+      const line = frame.lineNo ? `(${frame.lineNo})` : "";
+      const func = frame.function || "<unknown>";
+      const prefix = frameIndex !== undefined ? `#${frameIndex} ` : "";
+      return `${prefix}${file}${line}: ${func}()`;
+    }
+
+    default: {
+      // Generic format for unknown languages
+      const func = frame.function || "<unknown>";
+      const location = frame.filename || frame.module || "<unknown>";
+      const line = frame.lineNo ? `:${frame.lineNo}` : "";
+      const col = frame.colNo != null ? `:${frame.colNo}` : "";
+      return `    at ${func} (${location}${line}${col})`;
     }
   }
+}
+
+/**
+ * Formats a Sentry event into a structured markdown output.
+ * Includes error messages, stack traces, request info, and contextual data.
+ *
+ * @param event - The Sentry event to format
+ * @returns Formatted markdown string
+ */
+export function formatEventOutput(event: Event) {
+  let output = "";
+
+  // Look for the primary error information
+  const messageEntry = event.entries.find((e) => e.type === "message");
+  const exceptionEntry = event.entries.find((e) => e.type === "exception");
+  const threadsEntry = event.entries.find((e) => e.type === "threads");
+  const requestEntry = event.entries.find((e) => e.type === "request");
+
+  // Error message (if present)
+  if (messageEntry) {
+    output += formatMessageInterfaceOutput(
+      event,
+      messageEntry.data as z.infer<typeof MessageEntrySchema>,
+    );
+  }
+
+  // Stack trace (from exception or threads)
+  if (exceptionEntry) {
+    output += formatExceptionInterfaceOutput(
+      event,
+      exceptionEntry.data as z.infer<typeof ErrorEntrySchema>,
+    );
+  } else if (threadsEntry) {
+    output += formatThreadsInterfaceOutput(
+      event,
+      threadsEntry.data as z.infer<typeof ThreadsEntrySchema>,
+    );
+  }
+
+  // Request info (if HTTP error)
+  if (requestEntry) {
+    output += formatRequestInterfaceOutput(
+      event,
+      requestEntry.data as z.infer<typeof RequestEntrySchema>,
+    );
+  }
+
   output += formatContexts(event.contexts);
   return output;
 }
@@ -77,7 +200,7 @@ function formatExceptionInterfaceOutput(
             .join("")}`
         : "";
 
-      return `${formatFrameHeader(frame, event.platform)}${context}`;
+      return `${formatFrameHeader(frame, undefined, event.platform)}${context}`;
     })
     .join("\n")}\n${"```"}\n\n`;
   return output;
@@ -91,6 +214,55 @@ function formatRequestInterfaceOutput(
     return "";
   }
   return `### HTTP Request\n\n**Method:** ${data.method}\n**URL:** ${data.url}\n\n`;
+}
+
+function formatMessageInterfaceOutput(
+  event: Event,
+  data: z.infer<typeof MessageEntrySchema>,
+) {
+  if (!data.formatted && !data.message) {
+    return "";
+  }
+  const message = data.formatted || data.message || "";
+  return `### Error\n\n${"```"}\n${message}\n${"```"}\n\n`;
+}
+
+function formatThreadsInterfaceOutput(
+  event: Event,
+  data: z.infer<typeof ThreadsEntrySchema>,
+) {
+  if (!data.values || data.values.length === 0) {
+    return "";
+  }
+
+  // Find the crashed thread only
+  const crashedThread = data.values.find((t) => t.crashed);
+
+  if (!crashedThread?.stacktrace?.frames) {
+    return "";
+  }
+
+  let output = "";
+
+  // Include thread name if available
+  if (crashedThread.name) {
+    output += `**Thread** (${crashedThread.name})\n\n`;
+  }
+
+  output += `**Stacktrace:**\n${"```"}\n${crashedThread.stacktrace.frames
+    .map((frame) => {
+      const context = frame.context?.length
+        ? `${frame.context
+            .filter(([lineno, _]) => lineno === frame.lineNo)
+            .map(([_, code]) => `\n${code}`)
+            .join("")}`
+        : "";
+
+      return `${formatFrameHeader(frame, undefined, event.platform)}${context}`;
+    })
+    .join("\n")}\n${"```"}\n\n`;
+
+  return output;
 }
 
 function formatContexts(contexts: z.infer<typeof EventSchema>["contexts"]) {
@@ -112,6 +284,13 @@ function formatContexts(contexts: z.infer<typeof EventSchema>["contexts"]) {
     .join("\n\n")}\n\n`;
 }
 
+/**
+ * Formats a Sentry issue with its latest event into comprehensive markdown output.
+ * Includes issue metadata, event details, and usage instructions.
+ *
+ * @param params - Object containing organization slug, issue, event, and API service
+ * @returns Formatted markdown string with complete issue information
+ */
 export function formatIssueOutput({
   organizationSlug,
   issue,


### PR DESCRIPTION
- Add platform fallback to detectLanguage function for better language detection
- Filter threads to only show crashed threads, not all threads with stacktraces
- Restore formatContexts function to display additional context information
- Display thread name when formatting crashed thread stacktraces
- Simplify thread metadata output to only show thread name
- Add comprehensive tests for all formatting scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #201