### PR TITLE
feat: add Claude Code setup instructions

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -153,6 +153,46 @@ export default function RemoteSetup() {
             </li>
           </ol>
         </SetupGuide>
+
+        <SetupGuide id="claude-code" title="Claude Code">
+          <ol>
+            <li>
+              Open Claude Code and run the following command:
+              <CodeSnippet
+                snippet={`claude mcp add --transport http sentry ${endpoint}`}
+              />
+            </li>
+            <li>
+              This will trigger an OAuth authentication flow to connect Claude
+              Code to your Sentry account.
+            </li>
+            <li>
+              Choose the appropriate scope:
+              <ul>
+                <li>
+                  <strong>local</strong> (default): Project-specific
+                  configuration
+                </li>
+                <li>
+                  <strong>project</strong>: Shared configuration via{" "}
+                  <code>.mcp.json</code>
+                </li>
+                <li>
+                  <strong>user</strong>: Available across all projects
+                </li>
+              </ul>
+            </li>
+          </ol>
+          <p>
+            <small>
+              For more details, see the{" "}
+              <a href="https://docs.anthropic.com/en/docs/claude-code/mcp">
+                Claude Code MCP documentation
+              </a>
+              .
+            </small>
+          </p>
+        </SetupGuide>
       </Accordion>
     </>
   );

--- a/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
@@ -182,6 +182,50 @@ export default function RemoteSetup() {
             </li>
           </ol>
         </SetupGuide>
+
+        <SetupGuide id="claude-code" title="Claude Code">
+          <ol>
+            <li>
+              Open Claude Code and run the following command:
+              <CodeSnippet
+                snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e SENTRY_HOST=sentry.io -- ${mcpStdioSnippet}`}
+              />
+            </li>
+            <li>
+              Replace <code>sentry-user-token</code> with your actual User Auth
+              Token.
+            </li>
+            <li>
+              If using self-hosted Sentry, replace <code>sentry.io</code> with
+              your Sentry host.
+            </li>
+            <li>
+              Choose the appropriate scope:
+              <ul>
+                <li>
+                  <strong>local</strong> (default): Project-specific
+                  configuration
+                </li>
+                <li>
+                  <strong>project</strong>: Shared configuration via{" "}
+                  <code>.mcp.json</code>
+                </li>
+                <li>
+                  <strong>user</strong>: Available across all projects
+                </li>
+              </ul>
+            </li>
+          </ol>
+          <p>
+            <small>
+              For more details, see the{" "}
+              <Link href="https://docs.anthropic.com/en/docs/claude-code/mcp">
+                Claude Code MCP documentation
+              </Link>
+              .
+            </small>
+          </p>
+        </SetupGuide>
       </Accordion>
     </>
   );


### PR DESCRIPTION
Add setup guides for integrating Sentry MCP with Claude Code, including both remote (HTTP) and local (stdio) transport configurations.

🤖 Generated with [Claude Code](https://claude.ai/code)