### PR TITLE
Validate redirectUri before OAuth completion

### DIFF
--- a/packages/mcp-cloudflare/src/server/routes/sentry-oauth.ts
+++ b/packages/mcp-cloudflare/src/server/routes/sentry-oauth.ts
@@ -120,6 +120,24 @@ export default new Hono<{
       return c.text("Invalid state", 400);
     }
 
+    // Validate redirectUri is a valid URL
+    if (!oauthReqInfo.redirectUri) {
+      logger.warn("Missing redirectUri in OAuth state");
+      return c.text("Authorization failed: No redirect URL provided", 400);
+    }
+
+    try {
+      new URL(oauthReqInfo.redirectUri);
+    } catch (err) {
+      logger.warn(
+        `Invalid redirectUri in OAuth state: ${oauthReqInfo.redirectUri}`,
+        {
+          error: String(err),
+        },
+      );
+      return c.text("Authorization failed: Invalid redirect URL", 400);
+    }
+
     // Exchange the code for an access token
     const [payload, errResponse] = await exchangeCodeForAccessToken({
       upstream_url: new URL(


### PR DESCRIPTION
Add validation for redirectUri in OAuth callback to prevent TypeError when invalid or missing redirect URLs are provided. Returns user-friendly error messages instead of throwing 500 errors.

Fix MCP-SERVER-E1S

🤖 Generated with [Claude Code](https://claude.ai/code)