### PR TITLE
feat: add support for chained exceptions in error formatting

### DIFF
--- a/packages/mcp-server/src/internal/test-fixtures.ts
+++ b/packages/mcp-server/src/internal/test-fixtures.ts
@@ -131,6 +131,16 @@ export class EventBuilder {
     return this;
   }
 
+  withChainedExceptions(exceptions: ExceptionValue[]): this {
+    this.event.entries.push({
+      type: "exception",
+      data: {
+        values: exceptions,
+      },
+    });
+    return this;
+  }
+
   withThread(thread: Thread): this {
     const existingThread = this.event.entries.find((e) => e.type === "threads");
     if (


### PR DESCRIPTION
- Handle both single exception (value) and chained exceptions (values)
- Display exceptions in reverse order (outermost first) with chain indicators
- Show enhanced frame details only for the outermost exception
- Add comprehensive tests for chained exception scenarios
- Add withChainedExceptions helper to test EventBuilder

Fixes #251

🤖 Generated with [Claude Code](https://claude.ai/code)