### PR TITLE
feat: add sample prompt buttons to chat interface

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/chat/auth-form.tsx
+++ b/packages/mcp-cloudflare/src/client/components/chat/auth-form.tsx
@@ -36,7 +36,7 @@ export function AuthForm({
 
         <div className="space-y-4">
           {authError && (
-            <div className="p-3 bg-red-900/20 border border-red-500/30 rounded-lg flex items-center gap-2">
+            <div className="p-3 bg-red-900/20 border border-red-500/30 rounded flex items-center gap-2">
               <AlertCircle className="h-4 w-4 text-red-400" />
               <div className="text-red-400 text-sm">{authError}</div>
             </div>

--- a/packages/mcp-cloudflare/src/client/components/chat/chat-input.tsx
+++ b/packages/mcp-cloudflare/src/client/components/chat/chat-input.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from "react";
+import { Send, CircleStop } from "lucide-react";
+import { Button } from "../ui/button";
 
 interface ChatInputProps {
   input: string;
@@ -6,6 +8,7 @@ interface ChatInputProps {
   isOpen: boolean;
   onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onStop: () => void;
   onSlashCommand?: (command: string) => void;
 }
 
@@ -15,6 +18,7 @@ export function ChatInput({
   isOpen,
   onInputChange,
   onSubmit,
+  onStop,
   onSlashCommand,
 }: ChatInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -59,15 +63,29 @@ export function ChatInput({
 
   return (
     <form onSubmit={handleSubmit} className="relative flex-1">
-      <div className="flex space-x-2 items-center">
+      <div className="relative">
         <input
           ref={inputRef}
           value={input}
           onChange={onInputChange}
           placeholder="Ask me anything about your Sentry data..."
           disabled={isLoading}
-          className="flex-1 p-4 bg-slate-800/50 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-300 focus:border-transparent disabled:opacity-50"
+          className="w-full p-4 pr-12 rounded bg-slate-800/50 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-300 focus:border-transparent disabled:opacity-50"
         />
+        <Button
+          type={isLoading ? "button" : "submit"}
+          variant="ghost"
+          onClick={isLoading ? onStop : undefined}
+          disabled={!isLoading && !input.trim()}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-slate-400 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-slate-400 disabled:hover:bg-transparent transition-colors"
+          title={isLoading ? "Stop generation" : "Send message"}
+        >
+          {isLoading ? (
+            <CircleStop className="h-4 w-4" />
+          ) : (
+            <Send className="h-4 w-4" />
+          )}
+        </Button>
       </div>
     </form>
   );

--- a/packages/mcp-cloudflare/src/client/components/chat/chat-messages.tsx
+++ b/packages/mcp-cloudflare/src/client/components/chat/chat-messages.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from "react";
+import { useMemo } from "react";
 import { Loader2, AlertCircle } from "lucide-react";
 import { Button } from "../ui/button";
 import { MessagePart } from ".";
@@ -61,108 +61,109 @@ function processMessages(
   return allParts;
 }
 
-export const ChatMessages = forwardRef<HTMLDivElement, ChatMessagesProps>(
-  ({ messages, isChatLoading, error, onRetry }, ref) => {
-    const { handleOAuthLogin } = useAuth();
+export function ChatMessages({
+  messages,
+  isChatLoading,
+  error,
+  onRetry,
+}: ChatMessagesProps) {
+  const { handleOAuthLogin } = useAuth();
 
-    const processedParts = useMemo(
-      () => processMessages(messages, isChatLoading),
-      [messages, isChatLoading],
-    );
+  const processedParts = useMemo(
+    () => processMessages(messages, isChatLoading),
+    [messages, isChatLoading],
+  );
 
-    // Simple error handling - just check if it's auth or not
-    const errorIsAuth = error ? isAuthError(error) : false;
-    const errorMessage = error ? getErrorMessage(error) : null;
-    return (
-      <div ref={ref} className="flex-1 overflow-y-auto mx-6 mt-6 space-y-4">
-        {/* Empty State when no messages */}
-        {messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full">
-            <div className="max-w-md w-full space-y-6">
-              <div className="text-slate-400 hidden [@media(min-height:500px)]:block">
-                <img
-                  src="/flow-transparent.png"
-                  alt="Flow"
-                  width={1536}
-                  height={1024}
-                  className="w-full mb-6 bg-violet-300 rounded"
-                />
-              </div>
+  // Simple error handling - just check if it's auth or not
+  const errorIsAuth = error ? isAuthError(error) : false;
+  const errorMessage = error ? getErrorMessage(error) : null;
+  return (
+    <div className="mx-6 mt-6 space-y-4 flex-1">
+      {/* Empty State when no messages */}
+      {messages.length === 0 && (
+        <div className="flex flex-col items-center justify-center h-full">
+          <div className="max-w-md w-full space-y-6">
+            <div className="text-slate-400 hidden [@media(min-height:500px)]:block">
+              <img
+                src="/flow-transparent.png"
+                alt="Flow"
+                width={1536}
+                height={1024}
+                className="w-full mb-6 bg-violet-300 rounded"
+              />
+            </div>
 
-              <div className="text-center text-slate-400">
-                <h2 id="chat-panel-title" className="text-lg mb-2">
-                  Chat with your stack traces. Argue with confidence. Lose
-                  gracefully.
-                </h2>
-              </div>
+            <div className="text-center text-slate-400">
+              <h2 id="chat-panel-title" className="text-lg mb-2">
+                Chat with your stack traces. Argue with confidence. Lose
+                gracefully.
+              </h2>
             </div>
           </div>
-        )}
+        </div>
+      )}
 
-        {/* Show messages when we have any */}
-        {messages.length > 0 && (
-          <>
-            <h2 id="chat-panel-title" className="sr-only">
-              Chat Messages
-            </h2>
-            {processedParts.map((item) => (
-              <MessagePart
-                key={`${item.messageId}-part-${item.partIndex}`}
-                part={item.part}
-                messageId={item.messageId}
-                messageRole={item.messageRole}
-                partIndex={item.partIndex}
-                isStreaming={item.isStreaming}
-              />
-            ))}
+      {/* Show messages when we have any */}
+      {messages.length > 0 && (
+        <>
+          <h2 id="chat-panel-title" className="sr-only">
+            Chat Messages
+          </h2>
+          {processedParts.map((item) => (
+            <MessagePart
+              key={`${item.messageId}-part-${item.partIndex}`}
+              part={item.part}
+              messageId={item.messageId}
+              messageRole={item.messageRole}
+              partIndex={item.partIndex}
+              isStreaming={item.isStreaming}
+            />
+          ))}
 
-            {/* Show error or loading state */}
-            {error && errorMessage ? (
-              <div className="mr-8 p-4 bg-red-900/10 border border-red-500/30 rounded-lg">
-                <div className="flex items-start gap-3">
-                  <AlertCircle className="h-5 w-5 text-red-400 mt-0.5" />
-                  <div className="flex-1">
-                    <p className="text-red-300">{errorMessage}</p>
-                    {/* Simple action buttons */}
-                    <div className="mt-3 flex gap-2">
-                      {errorIsAuth ? (
+          {/* Show error or loading state */}
+          {error && errorMessage ? (
+            <div className="mr-8 p-4 bg-red-900/10 border border-red-500/30 rounded">
+              <div className="flex items-start gap-3">
+                <AlertCircle className="h-5 w-5 text-red-400 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-red-300">{errorMessage}</p>
+                  {/* Simple action buttons */}
+                  <div className="mt-3 flex gap-2">
+                    {errorIsAuth ? (
+                      <Button
+                        onClick={() => {
+                          handleOAuthLogin();
+                        }}
+                        size="sm"
+                        variant="secondary"
+                        className="bg-red-900/20 hover:bg-red-900/30 text-red-300 border-red-500/30 cursor-pointer"
+                      >
+                        Reauthenticate
+                      </Button>
+                    ) : (
+                      onRetry && (
                         <Button
-                          onClick={() => {
-                            handleOAuthLogin();
-                          }}
+                          onClick={onRetry}
                           size="sm"
                           variant="secondary"
                           className="bg-red-900/20 hover:bg-red-900/30 text-red-300 border-red-500/30 cursor-pointer"
                         >
-                          Reauthenticate
+                          Try again
                         </Button>
-                      ) : (
-                        onRetry && (
-                          <Button
-                            onClick={onRetry}
-                            size="sm"
-                            variant="secondary"
-                            className="bg-red-900/20 hover:bg-red-900/30 text-red-300 border-red-500/30 cursor-pointer"
-                          >
-                            Try again
-                          </Button>
-                        )
-                      )}
-                    </div>
+                      )
+                    )}
                   </div>
                 </div>
               </div>
-            ) : isChatLoading ? (
-              <div className="flex items-center space-x-2 text-slate-400 mr-8">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span>Assistant is thinking...</span>
-              </div>
-            ) : null}
-          </>
-        )}
-      </div>
-    );
-  },
-);
-
-ChatMessages.displayName = "ChatMessages";
+            </div>
+          ) : isChatLoading ? (
+            <div className="flex items-center space-x-2 text-slate-400 mr-8">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Assistant is thinking...</span>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/mcp-cloudflare/src/client/components/chat/chat-ui.tsx
+++ b/packages/mcp-cloudflare/src/client/components/chat/chat-ui.tsx
@@ -12,6 +12,22 @@ import type { Message } from "ai/react";
 // Constant empty function to avoid creating new instances on every render
 const EMPTY_FUNCTION = () => {};
 
+// Sample prompts for quick access
+const SAMPLE_PROMPTS = [
+  {
+    label: "Get Organizations",
+    prompt: "What organizations do I have access to?",
+  },
+  {
+    label: "React SDK Usage",
+    prompt: "Show me how to set up the React SDK for error monitoring",
+  },
+  {
+    label: "Recent Issues",
+    prompt: "What are my most recent issues?",
+  },
+] as const;
+
 interface ChatUIProps {
   messages: Message[];
   input: string;
@@ -26,6 +42,7 @@ interface ChatUIProps {
   onClose?: () => void;
   onLogout?: () => void;
   onSlashCommand?: (command: string) => void;
+  onSendPrompt?: (prompt: string) => void;
 }
 
 export const ChatUI = forwardRef<HTMLDivElement, ChatUIProps>(
@@ -44,6 +61,7 @@ export const ChatUI = forwardRef<HTMLDivElement, ChatUIProps>(
       onClose,
       onLogout,
       onSlashCommand,
+      onSendPrompt,
     },
     ref,
   ) => {
@@ -53,23 +71,14 @@ export const ChatUI = forwardRef<HTMLDivElement, ChatUIProps>(
         <div className="md:hidden flex items-center justify-between p-4 border-b border-slate-800 flex-shrink-0">
           {showControls && (
             <>
-              <Button
-                type="button"
-                onClick={onClose}
-                variant="ghost"
-                size="icon"
-                className="cursor-pointer"
-                title="Close"
-              >
+              <Button type="button" onClick={onClose} size="icon" title="Close">
                 <X className="h-4 w-4" />
               </Button>
 
               <Button
                 type="button"
                 onClick={onLogout}
-                variant="ghost"
                 size="icon"
-                className="cursor-pointer"
                 title="Logout"
               >
                 <LogOut className="h-4 w-4" />
@@ -78,32 +87,44 @@ export const ChatUI = forwardRef<HTMLDivElement, ChatUIProps>(
           )}
         </div>
 
-        <div className="flex-1 flex flex-col min-h-0">
-          {/* Chat Messages */}
+        {/* Chat Messages - Scrollable area */}
+        <div ref={ref} className="flex-1 overflow-y-auto mb-34 flex">
           <ChatMessages
-            ref={ref}
             messages={messages}
             isChatLoading={isChatLoading}
             error={error}
             onRetry={onRetry}
           />
+        </div>
 
-          {/* Chat Input - Always pinned at bottom */}
-          <div
-            className="flex-shrink-0 p-6"
-            style={{
-              paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
-            }}
-          >
-            <ChatInput
-              input={input}
-              isLoading={isChatLoading}
-              isOpen={isOpen}
-              onInputChange={onInputChange}
-              onSubmit={onSubmit}
-              onSlashCommand={onSlashCommand}
-            />
-          </div>
+        {/* Chat Input - Always pinned at bottom */}
+        <div className="py-4 px-6 bottom-0 left-0 right-0 absolute bg-slate-950/95 h-34 overflow-hidden">
+          {/* Sample Prompt Buttons - Always visible above input */}
+          {onSendPrompt && (
+            <div className="mb-4 flex flex-wrap gap-2 justify-center">
+              {SAMPLE_PROMPTS.map((samplePrompt) => (
+                <Button
+                  key={samplePrompt.label}
+                  type="button"
+                  onClick={() => onSendPrompt(samplePrompt.prompt)}
+                  size="sm"
+                  variant="outline"
+                >
+                  {samplePrompt.label}
+                </Button>
+              ))}
+            </div>
+          )}
+
+          <ChatInput
+            input={input}
+            isLoading={isChatLoading}
+            isOpen={isOpen}
+            onInputChange={onInputChange}
+            onSubmit={onSubmit}
+            onStop={onStop || EMPTY_FUNCTION}
+            onSlashCommand={onSlashCommand}
+          />
         </div>
       </div>
     );

--- a/packages/mcp-cloudflare/src/client/components/chat/types.ts
+++ b/packages/mcp-cloudflare/src/client/components/chat/types.ts
@@ -103,6 +103,8 @@ export interface ChatUIProps {
   onRetry?: () => void;
   onClose?: () => void;
   onLogout?: () => void;
+  onSlashCommand?: (command: string) => void;
+  onSendPrompt?: (prompt: string) => void;
 }
 
 export interface ChatMessagesProps {

--- a/packages/mcp-cloudflare/src/client/components/ui/accordion.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/accordion.tsx
@@ -40,7 +40,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center justify-between gap-4 rounded-md py-4 text-left font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180 text-lg text-white hover:text-violet-300 cursor-pointer ",
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center justify-between gap-4 py-4 text-left font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180 text-lg text-white hover:text-violet-300 cursor-pointer ",
           className,
         )}
         {...props}

--- a/packages/mcp-cloudflare/src/client/components/ui/button.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/button.tsx
@@ -4,17 +4,18 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
   {
     variants: {
       variant: {
         default: "bg-violet-300 text-black shadow-xs hover:bg-violet-300/90",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20",
-        outline: "bg-background shadow-xs hover:bg-violet-300 hover:text-black",
+        outline:
+          "bg-slate-800/50 border border-slate-600/50 shadow-xs hover:bg-slate-700/50 hover:text-white ",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:underline hover:text-violet-300",
+          "bg-background shadow-xs hover:bg-violet-300 hover:text-black",
+        ghost: "hover:text-white hover:bg-slate-700/50 ",
         link: "text-primary hover:underline hover:text-violet-300 cursor-pointer",
       },
       size: {

--- a/packages/mcp-cloudflare/src/client/components/ui/header.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/header.tsx
@@ -24,7 +24,7 @@ export const Header: React.FC<HeaderProps> = ({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" asChild>
+          <Button variant="secondary" asChild>
             <a
               href="https://github.com/getsentry/sentry-mcp"
               target="_blank"
@@ -36,7 +36,7 @@ export const Header: React.FC<HeaderProps> = ({
           </Button>
           {isAuthenticated && onLogout && (
             <Button
-              variant="outline"
+              variant="secondary"
               onClick={onLogout}
               className="hidden md:flex cursor-pointer"
             >

--- a/packages/mcp-cloudflare/src/client/hooks/use-scroll-to-bottom.ts
+++ b/packages/mcp-cloudflare/src/client/hooks/use-scroll-to-bottom.ts
@@ -1,61 +1,137 @@
 /**
- * Hook to automatically scroll to bottom of a container
+ * Hook to automatically scroll to bottom of a container with smart user scroll detection
  * Used for chat interfaces and log viewers
  */
 
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 
 interface UseScrollToBottomOptions {
-  /** Enable/disable auto-scrolling */
-  enabled?: boolean;
-  /** Smooth scroll animation */
-  smooth?: boolean;
-  /** Debounce delay in ms */
+  /** Delay before scrolling (ms) */
   delay?: number;
-  /** Dependencies that trigger scroll */
-  dependencies?: any[];
+  /** Whether to enable auto-scroll initially */
+  initialAutoScroll?: boolean;
 }
 
 export function useScrollToBottom<T extends HTMLElement>(
   options: UseScrollToBottomOptions = {},
 ) {
-  const {
-    enabled = true,
-    smooth = true,
-    delay = 0,
-    dependencies = [],
-  } = options;
+  const { delay = 0, initialAutoScroll = true } = options;
 
   const containerRef = useRef<T>(null);
   const timeoutRef = useRef<number | undefined>(undefined);
+  const lastScrollHeight = useRef(0);
+  const hasInitialScrolled = useRef(false);
 
-  const scrollToBottom = useCallback(() => {
-    if (!containerRef.current || !enabled) return;
+  // Track auto-scroll state - can be controlled externally
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(initialAutoScroll);
+
+  // Check if user is near bottom of scroll container
+  const isNearBottom = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return false;
+
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    return scrollTop + clientHeight >= scrollHeight - 100; // 100px threshold
+  }, []);
+
+  // Manual scroll to bottom function
+  const scrollToBottom = useCallback((forceInstant?: boolean) => {
+    const container = containerRef.current;
+    if (!container) return;
 
     const scrollOptions: ScrollToOptions = {
-      top: containerRef.current.scrollHeight,
-      behavior: smooth ? "smooth" : "auto",
+      top: container.scrollHeight,
+      behavior: forceInstant ? "auto" : "smooth",
     };
 
-    containerRef.current.scrollTo(scrollOptions);
-  }, [enabled, smooth]);
+    container.scrollTo(scrollOptions);
+    lastScrollHeight.current = container.scrollHeight;
+  }, []);
 
-  const scrollToBottomWithDelay = useCallback(() => {
+  // Auto-scroll with delay when needed
+  const autoScrollToBottom = useCallback(() => {
+    if (!autoScrollEnabled) return;
+
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
 
     if (delay > 0) {
-      timeoutRef.current = window.setTimeout(scrollToBottom, delay);
+      timeoutRef.current = window.setTimeout(() => scrollToBottom(), delay);
     } else {
       scrollToBottom();
     }
-  }, [scrollToBottom, delay]);
+  }, [autoScrollEnabled, scrollToBottom, delay]);
 
-  // Scroll when dependencies change
+  // Handle initial scroll when container first gets content
   useEffect(() => {
-    scrollToBottomWithDelay();
-  }, [...dependencies, scrollToBottomWithDelay]);
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Check if we have content but haven't scrolled yet
+    if (
+      container.scrollHeight > container.clientHeight &&
+      !hasInitialScrolled.current
+    ) {
+      hasInitialScrolled.current = true;
+      // Instant scroll on initial load
+      scrollToBottom(true);
+    }
+  });
+
+  // Set up scroll listener to detect user scrolling
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const nearBottom = isNearBottom();
+
+      // Update auto-scroll state based on scroll position
+      setAutoScrollEnabled(nearBottom);
+    };
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+
+    // Check initial state
+    handleScroll();
+
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }, [isNearBottom]);
+
+  // Monitor content changes with MutationObserver
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new MutationObserver(() => {
+      const newScrollHeight = container.scrollHeight;
+
+      // If content height changed and we should auto-scroll, do it
+      if (newScrollHeight !== lastScrollHeight.current && autoScrollEnabled) {
+        autoScrollToBottom();
+      }
+
+      lastScrollHeight.current = newScrollHeight;
+    });
+
+    // Observe the container and all its descendants for content changes
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: false, // Don't watch attributes to avoid style changes
+    });
+
+    // Set initial scroll height
+    lastScrollHeight.current = container.scrollHeight;
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [autoScrollToBottom, autoScrollEnabled]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -66,9 +142,5 @@ export function useScrollToBottom<T extends HTMLElement>(
     };
   }, []);
 
-  return {
-    containerRef,
-    scrollToBottom,
-    scrollToBottomWithDelay,
-  };
+  return [containerRef, scrollToBottom, setAutoScrollEnabled] as const;
 }

--- a/packages/mcp-cloudflare/src/server/routes/search.ts
+++ b/packages/mcp-cloudflare/src/server/routes/search.ts
@@ -101,6 +101,9 @@ export default new Hono<{ Bindings: Env }>().post("/", async (c) => {
       const searchParams: AutoRagSearchRequest = {
         query,
         max_num_results: maxResults,
+        ranking_options: {
+          score_threshold: 0.2,
+        },
       };
 
       // Add filename filters based on guide parameter
@@ -160,6 +163,7 @@ export default new Hono<{ Bindings: Env }>().post("/", async (c) => {
           {
             result_query: searchData.search_query,
             guide,
+            searchParams: JSON.stringify(searchParams),
           },
         );
       }

--- a/packages/mcp-server-evals/src/evals/search-docs.eval.ts
+++ b/packages/mcp-server-evals/src/evals/search-docs.eval.ts
@@ -32,7 +32,7 @@ describeEval("search-docs", {
           "- Focus on the technology the user is inquiring about.",
           "- These are just snippets. Use `get_doc(path='...')` to fetch the full content.",
           "",
-          "platforms/react",
+          "javascript/react",
         ].join("\n"),
       },
       {

--- a/packages/mcp-server/src/constants.ts
+++ b/packages/mcp-server/src/constants.ts
@@ -10,8 +10,6 @@
 export const SENTRY_PLATFORMS_BASE = [
   "javascript",
   "python",
-  "react",
-  "node",
   "java",
   "dotnet",
   "go",
@@ -19,7 +17,6 @@ export const SENTRY_PLATFORMS_BASE = [
   "ruby",
   "android",
   "apple",
-  "flutter",
   "unity",
   "unreal",
   "rust",
@@ -42,6 +39,8 @@ export const SENTRY_FRAMEWORKS: Record<string, string[]> = {
   javascript: [
     "nextjs",
     "react",
+    "gatsby",
+    "remix",
     "vue",
     "angular",
     "hono",
@@ -63,6 +62,10 @@ export const SENTRY_FRAMEWORKS: Record<string, string[]> = {
     "sveltekit",
     "tanstack-react",
     "wasm",
+    "node",
+    "koa",
+    "nestjs",
+    "hapi",
   ],
   python: [
     "django",
@@ -93,8 +96,7 @@ export const SENTRY_FRAMEWORKS: Record<string, string[]> = {
     "sqlalchemy",
     "starlette",
   ],
-  node: ["express", "fastify", "koa", "nestjs", "hapi"],
-  react: ["nextjs", "gatsby", "remix"],
+  dart: ["flutter"],
   dotnet: [
     "aspnetcore",
     "maui",

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -1540,6 +1540,27 @@ describe("search_docs", () => {
       }),
     );
   });
+
+  it("validates invalid guide parameter", async () => {
+    const tool = TOOL_HANDLERS.search_docs;
+
+    await expect(
+      tool(
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+        {
+          query: "test query",
+          maxResults: 5,
+          guide: "invalid-guide",
+        },
+      ),
+    ).rejects.toThrow(
+      "Invalid guide: \"invalid-guide\". Valid guides are: javascript, python, react, node, java, dotnet, go, php, ruby, android... Use a platform (e.g., 'javascript', 'python') or platform/guide combination (e.g., 'javascript/nextjs', 'python/django').",
+    );
+  });
 });
 
 describe("get_doc", () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -41,6 +41,7 @@ import { logError } from "./logging";
 import type { ServerContext, ToolHandlers } from "./types";
 import { setTag } from "@sentry/core";
 import { UserInputError } from "./errors";
+import { SENTRY_GUIDES } from "./constants";
 
 /**
  * Response from the search API endpoint

--- a/packages/mcp-test-client/package.json
+++ b/packages/mcp-test-client/package.json
@@ -27,7 +27,6 @@
     "open": "^10.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.15.32",
     "tsdown": "^0.12.8",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",


### PR DESCRIPTION
- Add quick action buttons above chat input for common prompts
- Support "Get Organizations" and "React SDK Usage" sample queries
- Add onSendPrompt callback to programmatically send messages
- Update chat UI to show buttons when onSendPrompt handler is provided

🤖 Generated with [Claude Code](https://claude.ai/code)