### PR TITLE
fix: add User-Agent headers to API requests

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/oauth.ts
+++ b/packages/mcp-cloudflare/src/server/lib/oauth.ts
@@ -89,6 +89,7 @@ export async function exchangeCodeForAccessToken({
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": "Sentry MCP Cloudflare",
     },
     body: new URLSearchParams({
       grant_type: "authorization_code",

--- a/packages/mcp-cloudflare/src/server/routes/chat-oauth.ts
+++ b/packages/mcp-cloudflare/src/server/routes/chat-oauth.ts
@@ -114,6 +114,7 @@ async function getOrRegisterChatClient(
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
+      "User-Agent": "Sentry MCP Chat Demo",
     },
     body: JSON.stringify(registrationData),
   });
@@ -163,6 +164,7 @@ async function exchangeCodeForToken(
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       Accept: "application/json",
+      "User-Agent": "Sentry MCP Chat Demo",
     },
     body: body.toString(),
   });

--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -199,6 +199,7 @@ export class SentryApiService {
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "User-Agent": "Sentry MCP Server",
     };
     if (this.accessToken) {
       headers.Authorization = `Bearer ${this.accessToken}`;

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -100,7 +100,11 @@ async function sentryDocsHandler(
   const path = `${url.pathname.replace(/\/$/, "")}.md`;
   const mdUrl = `${url.origin}${path}`;
 
-  const response = await fetch(mdUrl);
+  const response = await fetch(mdUrl, {
+    headers: {
+      "User-Agent": "Sentry MCP Server",
+    },
+  });
   if (!response.ok) {
     if (response.status === 404) {
       throw new UserInputError(

--- a/packages/mcp-test-client/src/auth/oauth.ts
+++ b/packages/mcp-test-client/src/auth/oauth.ts
@@ -233,6 +233,7 @@ export class OAuthClient {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         Accept: "application/json",
+        "User-Agent": "Sentry MCP CLI",
       },
       body: body.toString(),
     });


### PR DESCRIPTION
Add proper User-Agent headers to all HTTP requests made by the MCP server components to improve request tracking and debugging:

- Cloudflare OAuth: "Sentry MCP Cloudflare"
- Chat Demo OAuth: "Sentry MCP Chat Demo"
- MCP Server API client: "Sentry MCP Server"
- MCP CLI OAuth: "Sentry MCP CLI"

This also should unblock ourselves, and hopefully anything legit.

🤖 Generated with [Claude Code](https://claude.ai/code)