### PR TITLE
feat: add user agent tracking to MCP telemetry

### DIFF
--- a/docs/monitoring.mdc
+++ b/docs/monitoring.mdc
@@ -177,6 +177,16 @@ These are custom attributes - *not in draft spec* - we've added to enhance MCP o
 - `mcp.resource.name` - The name of the resource (e.g., "sentry-docs-platform", "sentry-query-syntax")
 - `mcp.transport` - The transport method used for MCP communication (values: "http", "sse", "stdio")
 
+### User Agent Tracking
+
+Following [OpenTelemetry semantic conventions for user agent](https://opentelemetry.io/docs/specs/semconv/attributes-registry/user-agent/):
+
+- `user_agent.original` - The original User-Agent header value from the client
+
+**Stdio Transport**: Set via `MCP_USER_AGENT` environment variable, defaults to `sentry-mcp-stdio/{version}`
+
+**Cloudflare Transport**: Captured from the initial SSE/WebSocket connection request headers and cached for the session
+
 ### Network Attributes
 Based on [OpenTelemetry network conventions](mdc:https:/github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/network.md):
 

--- a/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
@@ -83,7 +83,13 @@ export default function StdioSetup() {
                 snippet={JSON.stringify(
                   {
                     mcpServers: {
-                      sentry: coreConfig,
+                      sentry: {
+                        ...coreConfig,
+                        env: {
+                          ...coreConfig.env,
+                          MCP_USER_AGENT: "Cursor (stdio)",
+                        },
+                      },
                     },
                   },
                   undefined,
@@ -100,7 +106,7 @@ export default function StdioSetup() {
             <li>
               <CodeSnippet
                 noMargin
-                snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e SENTRY_HOST=sentry.io -- ${mcpStdioSnippet}`}
+                snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e SENTRY_HOST=sentry.io -e MCP_USER_AGENT="Claude Code (stdio)" -- ${mcpStdioSnippet}`}
               />
             </li>
             <li>
@@ -136,7 +142,13 @@ export default function StdioSetup() {
                 snippet={JSON.stringify(
                   {
                     mcpServers: {
-                      sentry: coreConfig,
+                      sentry: {
+                        ...coreConfig,
+                        env: {
+                          ...coreConfig.env,
+                          MCP_USER_AGENT: "Windsurf (stdio)",
+                        },
+                      },
                     },
                   },
                   undefined,
@@ -172,6 +184,10 @@ export default function StdioSetup() {
                     [mcpServerName]: {
                       type: "stdio",
                       ...coreConfig,
+                      env: {
+                        ...coreConfig.env,
+                        MCP_USER_AGENT: "VSCode (stdio)",
+                      },
                     },
                   },
                   undefined,
@@ -201,7 +217,13 @@ export default function StdioSetup() {
                 snippet={JSON.stringify(
                   {
                     context_servers: {
-                      [mcpServerName]: coreConfig,
+                      [mcpServerName]: {
+                        ...coreConfig,
+                        env: {
+                          ...coreConfig.env,
+                          MCP_USER_AGENT: "Zed (stdio)",
+                        },
+                      },
                       settings: {},
                     },
                   },

--- a/packages/mcp-cloudflare/src/server/lib/mcp-transport.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-transport.ts
@@ -6,9 +6,14 @@ import type { Env, WorkerProps } from "../types";
 import { LIB_VERSION } from "@sentry/mcp-server/version";
 import getSentryConfig from "../sentry.config";
 
-// Context from the auth process, encrypted & stored in the auth token
-// and provided to the DurableMCP as this.props
+// Props contain the authenticated user context from the OAuth flow.
+// These are encrypted and stored in the OAuth token, then provided
+// to the Durable Object as this.props on each request.
+// NOTE: Only store persistent user data in props (e.g., userId, accessToken).
+// Request-specific data like user agent should be captured per request.
 class SentryMCPBase extends McpAgent<Env, unknown, WorkerProps> {
+  private cachedUserAgent?: string;
+
   server = new McpServer({
     name: "Sentry MCP",
     version: LIB_VERSION,
@@ -26,6 +31,16 @@ class SentryMCPBase extends McpAgent<Env, unknown, WorkerProps> {
     super(state, env);
   }
 
+  // Override fetch to capture user agent from initial request
+  async fetch(request: Request): Promise<Response> {
+    // Capture user agent from the initial SSE/WebSocket connection request
+    if (!this.cachedUserAgent && request.headers.get("user-agent")) {
+      this.cachedUserAgent = request.headers.get("user-agent") || undefined;
+    }
+
+    return super.fetch(request);
+  }
+
   async init() {
     await configureServer({
       server: this.server,
@@ -34,6 +49,8 @@ class SentryMCPBase extends McpAgent<Env, unknown, WorkerProps> {
         organizationSlug: this.props.organizationSlug,
         userId: this.props.id,
         mcpHost: process.env.MCP_HOST,
+        // User agent is captured from the initial SSE/WebSocket request
+        userAgent: this.cachedUserAgent,
       },
       onToolComplete: () => {
         this.ctx.waitUntil(Sentry.flush(2000));

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -103,6 +103,7 @@ startStdio(instrumentedServer, {
   organizationSlug: null,
   host,
   mcpHost,
+  userAgent: process.env.MCP_USER_AGENT || `sentry-mcp-stdio/${LIB_VERSION}`,
 }).catch((err) => {
   console.error("Server error:", err);
   // ensure we've flushed all events

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -160,6 +160,9 @@ export async function configureServer({
             attributes: {
               "mcp.resource.name": resource.name,
               "mcp.resource.uri": url.toString(),
+              ...(context.userAgent && {
+                "user_agent.original": context.userAgent,
+              }),
             },
           },
           async () => {
@@ -209,6 +212,9 @@ export async function configureServer({
                 name: `prompts/get ${prompt.name}`,
                 attributes: {
                   "mcp.prompt.name": prompt.name,
+                  ...(context.userAgent && {
+                    "user_agent.original": context.userAgent,
+                  }),
                   ...extractMcpParameters(args[0] || {}),
                 },
               },
@@ -270,6 +276,9 @@ export async function configureServer({
                 name: `tools/call ${tool.name}`,
                 attributes: {
                   "mcp.tool.name": tool.name,
+                  ...(context.userAgent && {
+                    "user_agent.original": context.userAgent,
+                  }),
                   ...extractMcpParameters(args[0] || {}),
                 },
               },

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -77,4 +77,5 @@ export type ServerContext = {
   organizationSlug: string | null;
   userId?: string | null;
   clientId?: string;
+  userAgent?: string;
 };


### PR DESCRIPTION
- Add user_agent.original attribute to all MCP operations (tools, prompts, resources)
- Stdio: Support MCP_USER_AGENT env var with default sentry-mcp-stdio/{version}
- Cloudflare: Capture user agent from initial SSE/WebSocket request headers
- Document user agent tracking following OpenTelemetry semantic conventions

🤖 Generated with [Claude Code](https://claude.ai/code)