### PR TITLE
feat: add overwatch bug prediction gh workflow

### DIFF
--- a/.github/workflows/bug-prediction.yml
+++ b/.github/workflows/bug-prediction.yml
@@ -1,0 +1,30 @@
+name: Bug Prediction (Overwatch)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  upload-overwatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Overwatch CLI
+        run: |
+          curl -o overwatch-cli https://overwatch.codecov.io/linux/cli
+          chmod +x overwatch-cli
+
+      - name: Run Overwatch CLI
+        run: |
+          ./overwatch-cli \
+            --auth-token ${{ secrets.OVERWATCH_SENTRY_AUTH_TOKEN }} \
+            --organization-slug sentry \
+            --upload-empty-on-error \
+            typescript --package-manager pnpm --eslint-pattern src

--- a/.github/workflows/bug-prediction.yml
+++ b/.github/workflows/bug-prediction.yml
@@ -21,6 +21,9 @@ jobs:
           curl -o overwatch-cli https://overwatch.codecov.io/linux/cli
           chmod +x overwatch-cli
 
+      # Using --upload-empty-on-error flag to force this step through.
+      # This workflow is a temporary workaround until this alpha feature 
+      # is merged into AI PR review
       - name: Run Overwatch CLI
         run: |
           ./overwatch-cli \


### PR DESCRIPTION
Add overwatch bug predictor github workflow to this repo to enable the alpha feature.

Note that this feature is currently being merged with the AI PR review feature (work tracked [here](https://linear.app/getsentry/project/25q2-error-prediction-becomes-a-ai-pr-review-feature-60c79fb6bcf8/issues)). 
Once that project is completed, this github action workflow can be removed (this cleanup task is tracked [here](https://linear.app/getsentry/issue/PREVENT-168)).

Also note I created a token and added a secret to this repo to enable this feature (`OVERWATCH_SENTRY_AUTH_TOKEN`). This can also get cleaned up with above when ready.