### PR TITLE
feat: improved settings via env variables

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-transport.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-transport.ts
@@ -48,7 +48,7 @@ class SentryMCPBase extends McpAgent<Env, unknown, WorkerProps> {
         accessToken: this.props.accessToken,
         organizationSlug: this.props.organizationSlug,
         userId: this.props.id,
-        mcpHost: process.env.MCP_HOST,
+        mcpUrl: process.env.MCP_URL,
         // User agent is captured from the initial SSE/WebSocket request
         userAgent: this.cachedUserAgent,
       },

--- a/packages/mcp-cloudflare/src/server/routes/chat.ts
+++ b/packages/mcp-cloudflare/src/server/routes/chat.ts
@@ -117,7 +117,7 @@ export default new Hono<{ Bindings: Env }>().post("/", async (c) => {
               parameters || {},
               {
                 accessToken,
-                host: c.env.SENTRY_HOST || "sentry.io",
+                sentryHost: c.env.SENTRY_HOST || "sentry.io",
                 organizationSlug: null,
               },
             );

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -21,19 +21,27 @@ Launch the transport:
 
 ```shell
 npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.example.com
+# or with full URL
+npx @sentry/mcp-server@latest --access-token=sentry-user-token --url=https://sentry.example.com
 ```
 
 Note: You can also use environment variables:
 
 ```shell
 SENTRY_ACCESS_TOKEN=your-token
-SENTRY_HOST=sentry.io              # Hostname only (https:// will be added)
-SENTRY_HOST=http://localhost:8000  # Full URL (for local development)
+SENTRY_HOST=sentry.example.com     # Custom hostname
+SENTRY_URL=https://sentry.io       # OR base URL (precedence over SENTRY_HOST)
 ```
 
-The `SENTRY_HOST` parameter accepts both formats:
-- Hostname only: `sentry.io`, `sentry.example.com` (https:// will be added automatically)
-- Full URL: `https://sentry.io`, `http://localhost:8000` (protocol will be preserved)
+The host configuration accepts two distinct formats:
+
+- **`SENTRY_HOST`**: Hostname only (no protocol)
+  - Examples: `sentry.io`, `sentry.example.com`, `localhost:8000`
+- **`SENTRY_URL`**: Full URLs (hostname will be extracted)
+  - Examples: `https://sentry.io`, `https://sentry.example.com`
+  - Takes precedence over `SENTRY_HOST` if both are provided
+
+**Note**: Only HTTPS connections are supported for security reasons.
 
 By default we also enable Sentry reporting (traces, errors) upstream to our cloud service. You can disable that, or send it to a different Sentry instance by using the `--sentry-dsn` flag:
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -26,9 +26,14 @@ npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.exa
 Note: You can also use environment variables:
 
 ```shell
-SENTRY_ACCESS_TOKEN=
-SENTRY_HOST=
+SENTRY_ACCESS_TOKEN=your-token
+SENTRY_HOST=sentry.io              # Hostname only (https:// will be added)
+SENTRY_HOST=http://localhost:8000  # Full URL (for local development)
 ```
+
+The `SENTRY_HOST` parameter accepts both formats:
+- Hostname only: `sentry.io`, `sentry.example.com` (https:// will be added automatically)
+- Full URL: `https://sentry.io`, `http://localhost:8000` (protocol will be preserved)
 
 By default we also enable Sentry reporting (traces, errors) upstream to our cloud service. You can disable that, or send it to a different Sentry instance by using the `--sentry-dsn` flag:
 

--- a/packages/mcp-server/src/api-client/client.test.ts
+++ b/packages/mcp-server/src/api-client/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SentryApiService } from "./client.js";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { SentryApiService } from "./client";
 
 describe("getIssueUrl", () => {
   it("should work with sentry.io", () => {
@@ -19,21 +19,19 @@ describe("getIssueUrl", () => {
   it("should work with full URL including protocol", () => {
     const apiService = new SentryApiService({
       host: "sentry.example.com",
-      protocol: "https",
     });
     const result = apiService.getIssueUrl("sentry-mcp", "123456");
     expect(result).toMatchInlineSnapshot(
       `"https://sentry.example.com/organizations/sentry-mcp/issues/123456"`,
     );
   });
-  it("should work with http protocol", () => {
+  it("should always use HTTPS protocol", () => {
     const apiService = new SentryApiService({
       host: "localhost:8000",
-      protocol: "http",
     });
     const result = apiService.getIssueUrl("sentry-mcp", "123456");
     expect(result).toMatchInlineSnapshot(
-      `"http://localhost:8000/organizations/sentry-mcp/issues/123456"`,
+      `"https://localhost:8000/organizations/sentry-mcp/issues/123456"`,
     );
   });
 });
@@ -59,17 +57,16 @@ describe("getTraceUrl", () => {
       `"https://sentry.example.com/organizations/sentry-mcp/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d"`,
     );
   });
-  it("should work with http protocol", () => {
+  it("should always use HTTPS protocol", () => {
     const apiService = new SentryApiService({
       host: "localhost:8000",
-      protocol: "http",
     });
     const result = apiService.getTraceUrl(
       "sentry-mcp",
       "6a477f5b0f31ef7b6b9b5e1dea66c91d",
     );
     expect(result).toMatchInlineSnapshot(
-      `"http://localhost:8000/organizations/sentry-mcp/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d"`,
+      `"https://localhost:8000/organizations/sentry-mcp/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d"`,
     );
   });
 });
@@ -208,8 +205,6 @@ describe("host configuration", () => {
     // @ts-expect-error - accessing private property for testing
     expect(apiService.host).toBe("sentry.io");
     // @ts-expect-error - accessing private property for testing
-    expect(apiService.protocol).toBe("https");
-    // @ts-expect-error - accessing private property for testing
     expect(apiService.apiPrefix).toBe("https://sentry.io/api/0");
   });
 
@@ -218,54 +213,42 @@ describe("host configuration", () => {
     // @ts-expect-error - accessing private property for testing
     expect(apiService.host).toBe("localhost:8000");
     // @ts-expect-error - accessing private property for testing
-    expect(apiService.protocol).toBe("https");
-    // @ts-expect-error - accessing private property for testing
     expect(apiService.apiPrefix).toBe("https://localhost:8000/api/0");
   });
 
-  it("should handle explicit HTTPS protocol", () => {
+  it("should always use HTTPS protocol", () => {
     const apiService = new SentryApiService({
       host: "sentry.example.com",
-      protocol: "https",
     });
     // @ts-expect-error - accessing private property for testing
     expect(apiService.host).toBe("sentry.example.com");
     // @ts-expect-error - accessing private property for testing
-    expect(apiService.protocol).toBe("https");
-    // @ts-expect-error - accessing private property for testing
     expect(apiService.apiPrefix).toBe("https://sentry.example.com/api/0");
   });
 
-  it("should handle HTTP protocol", () => {
+  it("should always use HTTPS even for localhost", () => {
     const apiService = new SentryApiService({
       host: "localhost:8000",
-      protocol: "http",
     });
     // @ts-expect-error - accessing private property for testing
     expect(apiService.host).toBe("localhost:8000");
     // @ts-expect-error - accessing private property for testing
-    expect(apiService.protocol).toBe("http");
-    // @ts-expect-error - accessing private property for testing
-    expect(apiService.apiPrefix).toBe("http://localhost:8000/api/0");
+    expect(apiService.apiPrefix).toBe("https://localhost:8000/api/0");
   });
 
   it("should update host and API prefix with setHost", () => {
     const apiService = new SentryApiService({ host: "sentry.io" });
 
-    apiService.setHost("eu.sentry.io", "https");
+    apiService.setHost("eu.sentry.io");
     // @ts-expect-error - accessing private property for testing
     expect(apiService.host).toBe("eu.sentry.io");
     // @ts-expect-error - accessing private property for testing
-    expect(apiService.protocol).toBe("https");
-    // @ts-expect-error - accessing private property for testing
     expect(apiService.apiPrefix).toBe("https://eu.sentry.io/api/0");
 
-    apiService.setHost("localhost:9000", "http");
+    apiService.setHost("localhost:9000");
     // @ts-expect-error - accessing private property for testing
     expect(apiService.host).toBe("localhost:9000");
     // @ts-expect-error - accessing private property for testing
-    expect(apiService.protocol).toBe("http");
-    // @ts-expect-error - accessing private property for testing
-    expect(apiService.apiPrefix).toBe("http://localhost:9000/api/0");
+    expect(apiService.apiPrefix).toBe("https://localhost:9000/api/0");
   });
 });

--- a/packages/mcp-server/src/api-client/client.test.ts
+++ b/packages/mcp-server/src/api-client/client.test.ts
@@ -16,6 +16,26 @@ describe("getIssueUrl", () => {
       `"https://sentry.example.com/organizations/sentry-mcp/issues/123456"`,
     );
   });
+  it("should work with full URL including protocol", () => {
+    const apiService = new SentryApiService({
+      host: "sentry.example.com",
+      protocol: "https",
+    });
+    const result = apiService.getIssueUrl("sentry-mcp", "123456");
+    expect(result).toMatchInlineSnapshot(
+      `"https://sentry.example.com/organizations/sentry-mcp/issues/123456"`,
+    );
+  });
+  it("should work with http protocol", () => {
+    const apiService = new SentryApiService({
+      host: "localhost:8000",
+      protocol: "http",
+    });
+    const result = apiService.getIssueUrl("sentry-mcp", "123456");
+    expect(result).toMatchInlineSnapshot(
+      `"http://localhost:8000/organizations/sentry-mcp/issues/123456"`,
+    );
+  });
 });
 
 describe("getTraceUrl", () => {
@@ -37,6 +57,19 @@ describe("getTraceUrl", () => {
     );
     expect(result).toMatchInlineSnapshot(
       `"https://sentry.example.com/organizations/sentry-mcp/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d"`,
+    );
+  });
+  it("should work with http protocol", () => {
+    const apiService = new SentryApiService({
+      host: "localhost:8000",
+      protocol: "http",
+    });
+    const result = apiService.getTraceUrl(
+      "sentry-mcp",
+      "6a477f5b0f31ef7b6b9b5e1dea66c91d",
+    );
+    expect(result).toMatchInlineSnapshot(
+      `"http://localhost:8000/organizations/sentry-mcp/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d"`,
     );
   });
 });
@@ -166,5 +199,73 @@ describe("network error handling", () => {
       expect((error as Error).cause).toBe(fetchError);
       expect(((error as Error).cause as Error).cause).toBe(originalError);
     }
+  });
+});
+
+describe("host configuration", () => {
+  it("should handle hostname without protocol", () => {
+    const apiService = new SentryApiService({ host: "sentry.io" });
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("sentry.io");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.protocol).toBe("https");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("https://sentry.io/api/0");
+  });
+
+  it("should handle hostname with port", () => {
+    const apiService = new SentryApiService({ host: "localhost:8000" });
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("localhost:8000");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.protocol).toBe("https");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("https://localhost:8000/api/0");
+  });
+
+  it("should handle explicit HTTPS protocol", () => {
+    const apiService = new SentryApiService({
+      host: "sentry.example.com",
+      protocol: "https",
+    });
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("sentry.example.com");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.protocol).toBe("https");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("https://sentry.example.com/api/0");
+  });
+
+  it("should handle HTTP protocol", () => {
+    const apiService = new SentryApiService({
+      host: "localhost:8000",
+      protocol: "http",
+    });
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("localhost:8000");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.protocol).toBe("http");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("http://localhost:8000/api/0");
+  });
+
+  it("should update host and API prefix with setHost", () => {
+    const apiService = new SentryApiService({ host: "sentry.io" });
+
+    apiService.setHost("eu.sentry.io", "https");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("eu.sentry.io");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.protocol).toBe("https");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("https://eu.sentry.io/api/0");
+
+    apiService.setHost("localhost:9000", "http");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("localhost:9000");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.protocol).toBe("http");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("http://localhost:9000/api/0");
   });
 });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -53,6 +53,7 @@ for (const arg of process.argv.slice(2)) {
     accessToken = arg.split("=")[1];
   } else if (arg.startsWith("--host=")) {
     sentryHost = arg.split("=")[1];
+    validateSentryHost(sentryHost);
   } else if (arg.startsWith("--url=")) {
     const url = arg.split("=")[1];
     sentryHost = validateAndParseSentryUrl(url);
@@ -64,15 +65,6 @@ for (const arg of process.argv.slice(2)) {
     console.error("Error: Invalid argument:", arg);
     console.error(getUsage());
     process.exit(1);
-  }
-}
-
-// Validate command line host argument if provided
-for (const arg of process.argv.slice(2)) {
-  if (arg.startsWith("--host=")) {
-    const hostArg = arg.split("=")[1];
-    validateSentryHost(hostArg);
-    break;
   }
 }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -68,9 +68,6 @@ for (const arg of process.argv.slice(2)) {
   }
 }
 
-// Use the hostname directly (always HTTPS)
-const host = sentryHost;
-
 if (!accessToken) {
   console.error(
     "Error: No access token was provided. Pass one with `--access-token` or via `SENTRY_ACCESS_TOKEN`.",
@@ -87,7 +84,7 @@ Sentry.init({
     tags: {
       "mcp.server_version": LIB_VERSION,
       "mcp.transport": "stdio",
-      "sentry.host": host,
+      "sentry.host": sentryHost,
       "mcp.mcp-url": mcpUrl,
     },
   },
@@ -119,7 +116,7 @@ const SENTRY_TIMEOUT = 5000; // 5 seconds
 startStdio(instrumentedServer, {
   accessToken,
   organizationSlug: null,
-  sentryHost: host,
+  sentryHost,
   mcpUrl,
   userAgent: process.env.MCP_USER_AGENT || `sentry-mcp-stdio/${LIB_VERSION}`,
 }).catch((err) => {

--- a/packages/mcp-server/src/tools/get-doc.test.ts
+++ b/packages/mcp-server/src/tools/get-doc.test.ts
@@ -11,7 +11,7 @@ describe("get_doc", () => {
         accessToken: "access-token",
         userId: "1",
         organizationSlug: null,
-        host: "https://mcp.sentry.dev",
+        mcpUrl: "https://mcp.sentry.dev",
       },
     );
     expect(result).toMatchInlineSnapshot(`

--- a/packages/mcp-server/src/tools/search-docs.test.ts
+++ b/packages/mcp-server/src/tools/search-docs.test.ts
@@ -16,7 +16,7 @@ describe("search_docs", () => {
         accessToken: "access-token",
         userId: "1",
         organizationSlug: null,
-        host: "https://mcp.sentry.dev",
+        mcpUrl: "https://mcp.sentry.dev",
       },
     );
     expect(result).toMatchInlineSnapshot(`
@@ -109,7 +109,7 @@ describe("search_docs", () => {
         accessToken: "access-token",
         userId: "1",
         organizationSlug: null,
-        host: "https://mcp.sentry.dev",
+        mcpUrl: "https://mcp.sentry.dev",
       },
     );
 

--- a/packages/mcp-server/src/tools/search-docs.ts
+++ b/packages/mcp-server/src/tools/search-docs.ts
@@ -81,8 +81,8 @@ export default defineTool({
     }
     output += `\n`;
 
-    // Determine the host - use context.host if available, then check env var, otherwise default to production
-    const host = context.mcpHost || "https://mcp.sentry.dev";
+    // Determine the URL - use context.mcpUrl if available, otherwise default to production
+    const host = context.mcpUrl || "https://mcp.sentry.dev";
     const searchUrl = new URL("/api/search", host);
 
     const response = await fetchWithTimeout(

--- a/packages/mcp-server/src/tools/utils/api-utils.ts
+++ b/packages/mcp-server/src/tools/utils/api-utils.ts
@@ -13,7 +13,8 @@ export function apiServiceFromContext(
   context: ServerContext,
   opts: { regionUrl?: string } = {},
 ) {
-  let host = context.host;
+  let host = context.sentryHost;
+  let protocol = context.sentryProtocol || "https";
 
   if (opts.regionUrl?.trim()) {
     try {
@@ -34,6 +35,7 @@ export function apiServiceFromContext(
       }
 
       host = parsedUrl.host;
+      protocol = parsedUrl.protocol.replace(":", "");
     } catch (error) {
       if (error instanceof UserInputError) {
         throw error;
@@ -46,6 +48,7 @@ export function apiServiceFromContext(
 
   return new SentryApiService({
     host,
+    protocol,
     accessToken: context.accessToken,
   });
 }

--- a/packages/mcp-server/src/tools/utils/api-utils.ts
+++ b/packages/mcp-server/src/tools/utils/api-utils.ts
@@ -6,7 +6,7 @@ import type { ServerContext } from "../../types";
  * Create a Sentry API service from server context with optional region override
  * @param context - Server context containing host and access token
  * @param opts - Options object containing optional regionUrl override
- * @returns Configured SentryApiService instance
+ * @returns Configured SentryApiService instance (always uses HTTPS)
  * @throws {UserInputError} When regionUrl is provided but invalid
  */
 export function apiServiceFromContext(
@@ -14,7 +14,6 @@ export function apiServiceFromContext(
   opts: { regionUrl?: string } = {},
 ) {
   let host = context.sentryHost;
-  let protocol = context.sentryProtocol || "https";
 
   if (opts.regionUrl?.trim()) {
     try {
@@ -35,7 +34,6 @@ export function apiServiceFromContext(
       }
 
       host = parsedUrl.host;
-      protocol = parsedUrl.protocol.replace(":", "");
     } catch (error) {
       if (error instanceof UserInputError) {
         throw error;
@@ -48,7 +46,6 @@ export function apiServiceFromContext(
 
   return new SentryApiService({
     host,
-    protocol,
     accessToken: context.accessToken,
   });
 }

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -40,7 +40,6 @@ export type PromptHandlers = {
 
 export type ServerContext = {
   sentryHost?: string;
-  sentryProtocol?: string;
   mcpUrl?: string;
   accessToken: string;
   organizationSlug: string | null;

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -39,8 +39,9 @@ export type PromptHandlers = {
 };
 
 export type ServerContext = {
-  host?: string;
-  mcpHost?: string;
+  sentryHost?: string;
+  sentryProtocol?: string;
+  mcpUrl?: string;
   accessToken: string;
   organizationSlug: string | null;
   userId?: string | null;

--- a/packages/mcp-server/src/utils/url-utils.test.ts
+++ b/packages/mcp-server/src/utils/url-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { normalizeHost, extractHostname } from "./url-utils";
+
+describe("url-utils", () => {
+  describe("normalizeHost", () => {
+    it("should add https:// to hostnames by default", () => {
+      expect(normalizeHost("sentry.io")).toBe("https://sentry.io");
+      expect(normalizeHost("example.com")).toBe("https://example.com");
+    });
+
+    it("should add https:// to hostnames with ports", () => {
+      expect(normalizeHost("localhost:8000")).toBe("https://localhost:8000");
+      expect(normalizeHost("example.com:3000")).toBe(
+        "https://example.com:3000",
+      );
+    });
+
+    it("should preserve existing https:// URLs", () => {
+      expect(normalizeHost("https://sentry.io")).toBe("https://sentry.io");
+      expect(normalizeHost("https://example.com:443")).toBe(
+        "https://example.com:443",
+      );
+    });
+
+    it("should preserve existing http:// URLs", () => {
+      expect(normalizeHost("http://localhost:8000")).toBe(
+        "http://localhost:8000",
+      );
+      expect(normalizeHost("http://example.com")).toBe("http://example.com");
+    });
+
+    it("should use custom default protocol when provided", () => {
+      expect(normalizeHost("localhost:8000", "http")).toBe(
+        "http://localhost:8000",
+      );
+      expect(normalizeHost("example.com", "http")).toBe("http://example.com");
+    });
+  });
+
+  describe("extractHostname", () => {
+    it("should extract hostname from full URLs", () => {
+      expect(extractHostname("https://sentry.io")).toBe("sentry.io");
+      expect(extractHostname("http://localhost:8000")).toBe("localhost:8000");
+      expect(extractHostname("https://example.com:443")).toBe("example.com");
+    });
+
+    it("should return hostname as-is when no protocol", () => {
+      expect(extractHostname("sentry.io")).toBe("sentry.io");
+      expect(extractHostname("localhost:8000")).toBe("localhost:8000");
+      expect(extractHostname("example.com:3000")).toBe("example.com:3000");
+    });
+  });
+});

--- a/packages/mcp-server/src/utils/url-utils.test.ts
+++ b/packages/mcp-server/src/utils/url-utils.test.ts
@@ -1,53 +1,83 @@
 import { describe, expect, it } from "vitest";
-import { normalizeHost, extractHostname } from "./url-utils";
+import {
+  validateSentryHostThrows,
+  validateAndParseSentryUrlThrows,
+} from "./url-utils";
 
 describe("url-utils", () => {
-  describe("normalizeHost", () => {
-    it("should add https:// to hostnames by default", () => {
-      expect(normalizeHost("sentry.io")).toBe("https://sentry.io");
-      expect(normalizeHost("example.com")).toBe("https://example.com");
+  describe("validateSentryHostThrows", () => {
+    it("should accept valid hostnames", () => {
+      expect(() => validateSentryHostThrows("sentry.io")).not.toThrow();
+      expect(() => validateSentryHostThrows("example.com")).not.toThrow();
+      expect(() => validateSentryHostThrows("localhost:8000")).not.toThrow();
+      expect(() =>
+        validateSentryHostThrows("sentry.example.com"),
+      ).not.toThrow();
     });
 
-    it("should add https:// to hostnames with ports", () => {
-      expect(normalizeHost("localhost:8000")).toBe("https://localhost:8000");
-      expect(normalizeHost("example.com:3000")).toBe(
-        "https://example.com:3000",
+    it("should reject hostnames with http protocol", () => {
+      expect(() => validateSentryHostThrows("http://sentry.io")).toThrow(
+        "SENTRY_HOST should only contain a hostname",
+      );
+      expect(() => validateSentryHostThrows("http://example.com:8000")).toThrow(
+        "SENTRY_HOST should only contain a hostname",
       );
     });
 
-    it("should preserve existing https:// URLs", () => {
-      expect(normalizeHost("https://sentry.io")).toBe("https://sentry.io");
-      expect(normalizeHost("https://example.com:443")).toBe(
-        "https://example.com:443",
+    it("should reject hostnames with https protocol", () => {
+      expect(() => validateSentryHostThrows("https://sentry.io")).toThrow(
+        "SENTRY_HOST should only contain a hostname",
       );
-    });
-
-    it("should preserve existing http:// URLs", () => {
-      expect(normalizeHost("http://localhost:8000")).toBe(
-        "http://localhost:8000",
+      expect(() => validateSentryHostThrows("https://example.com:443")).toThrow(
+        "SENTRY_HOST should only contain a hostname",
       );
-      expect(normalizeHost("http://example.com")).toBe("http://example.com");
-    });
-
-    it("should use custom default protocol when provided", () => {
-      expect(normalizeHost("localhost:8000", "http")).toBe(
-        "http://localhost:8000",
-      );
-      expect(normalizeHost("example.com", "http")).toBe("http://example.com");
     });
   });
 
-  describe("extractHostname", () => {
-    it("should extract hostname from full URLs", () => {
-      expect(extractHostname("https://sentry.io")).toBe("sentry.io");
-      expect(extractHostname("http://localhost:8000")).toBe("localhost:8000");
-      expect(extractHostname("https://example.com:443")).toBe("example.com");
+  describe("validateAndParseSentryUrlThrows", () => {
+    it("should accept and parse valid HTTPS URLs", () => {
+      expect(validateAndParseSentryUrlThrows("https://sentry.io")).toBe(
+        "sentry.io",
+      );
+      expect(validateAndParseSentryUrlThrows("https://example.com")).toBe(
+        "example.com",
+      );
+      expect(validateAndParseSentryUrlThrows("https://localhost:8000")).toBe(
+        "localhost:8000",
+      );
+      expect(
+        validateAndParseSentryUrlThrows("https://sentry.example.com"),
+      ).toBe("sentry.example.com");
+      expect(validateAndParseSentryUrlThrows("https://example.com:443")).toBe(
+        "example.com",
+      );
     });
 
-    it("should return hostname as-is when no protocol", () => {
-      expect(extractHostname("sentry.io")).toBe("sentry.io");
-      expect(extractHostname("localhost:8000")).toBe("localhost:8000");
-      expect(extractHostname("example.com:3000")).toBe("example.com:3000");
+    it("should reject URLs without protocol", () => {
+      expect(() => validateAndParseSentryUrlThrows("sentry.io")).toThrow(
+        "SENTRY_URL must be a full HTTPS URL",
+      );
+      expect(() => validateAndParseSentryUrlThrows("example.com")).toThrow(
+        "SENTRY_URL must be a full HTTPS URL",
+      );
+    });
+
+    it("should reject HTTP URLs", () => {
+      expect(() => validateAndParseSentryUrlThrows("http://sentry.io")).toThrow(
+        "SENTRY_URL must be a full HTTPS URL",
+      );
+      expect(() =>
+        validateAndParseSentryUrlThrows("http://example.com:8000"),
+      ).toThrow("SENTRY_URL must be a full HTTPS URL");
+    });
+
+    it("should reject invalid URLs", () => {
+      expect(() => validateAndParseSentryUrlThrows("https://")).toThrow(
+        "SENTRY_URL must be a valid HTTPS URL",
+      );
+      expect(() =>
+        validateAndParseSentryUrlThrows("https://[invalid-bracket"),
+      ).toThrow("SENTRY_URL must be a valid HTTPS URL");
     });
   });
 });

--- a/packages/mcp-server/src/utils/url-utils.ts
+++ b/packages/mcp-server/src/utils/url-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Normalizes a host/URL input to ensure it has a protocol.
+ * Accepts both:
+ * - Hostnames: "sentry.io", "localhost:8000"
+ * - Full URLs: "https://sentry.io", "http://localhost:8000"
+ *
+ * @param hostOrUrl The host or URL to normalize
+ * @param defaultProtocol The protocol to use if none is provided (defaults to "https")
+ * @returns A normalized URL with protocol
+ */
+export function normalizeHost(
+  hostOrUrl: string,
+  defaultProtocol = "https",
+): string {
+  // If it already has a protocol, return as-is
+  if (hostOrUrl.startsWith("http://") || hostOrUrl.startsWith("https://")) {
+    return hostOrUrl;
+  }
+
+  // Otherwise, prepend the default protocol
+  return `${defaultProtocol}://${hostOrUrl}`;
+}
+
+/**
+ * Extracts just the hostname (without protocol) from a host/URL input.
+ *
+ * @param hostOrUrl The host or URL to extract from
+ * @returns The hostname without protocol
+ */
+export function extractHostname(hostOrUrl: string): string {
+  try {
+    // Try to parse as URL
+    const url = new URL(normalizeHost(hostOrUrl));
+    return url.host;
+  } catch {
+    // If parsing fails, assume it's already just a hostname
+    return hostOrUrl;
+  }
+}

--- a/packages/mcp-test-client/.env.example
+++ b/packages/mcp-test-client/.env.example
@@ -5,9 +5,9 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 # Get one from: https://sentry.io/settings/account/api/auth-tokens/
 SENTRY_ACCESS_TOKEN=your_sentry_access_token
 
-# Optional - Sentry host (defaults to https://sentry.io)
-# For self-hosted instances, set this to your Sentry URL
-# SENTRY_HOST=https://sentry.io
+# Optional - Sentry host (defaults to sentry.io)
+# For self-hosted instances, set this to your Sentry domain
+# SENTRY_HOST=sentry.example.com
 
 # Optional - Override the default AI model
 # Available models:

--- a/packages/mcp-test-client/.env.example
+++ b/packages/mcp-test-client/.env.example
@@ -21,7 +21,7 @@ SENTRY_ACCESS_TOKEN=your_sentry_access_token
 
 # Optional - MCP server host (defaults to https://mcp.sentry.dev)
 # For local development, use http://localhost:8787
-# MCP_HOST=https://mcp.sentry.dev
+# MCP_URL=https://mcp.sentry.dev
 
 # OAuth clients are automatically registered via Dynamic Client Registration (RFC 7591)
 # No manual client ID configuration needed

--- a/packages/mcp-test-client/.env.test
+++ b/packages/mcp-test-client/.env.test
@@ -4,4 +4,4 @@
 # Dummy values for testing - will fail but show the flow
 ANTHROPIC_API_KEY=test-key
 SENTRY_ACCESS_TOKEN=test-token
-SENTRY_HOST=https://sentry.io
+SENTRY_HOST=sentry.io

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -58,7 +58,7 @@ OPENAI_API_KEY=your_openai_api_key
 SENTRY_ACCESS_TOKEN=your_sentry_access_token
 
 # Optional
-SENTRY_HOST=https://sentry.io  # For self-hosted Sentry instances
+SENTRY_HOST=sentry.io  # For self-hosted Sentry instances (hostname or full URL)
 MCP_HOST=https://mcp.sentry.dev  # MCP server host (defaults to production)
 MCP_MODEL=gpt-4o  # Override default model (GPT-4)
 

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -59,7 +59,7 @@ SENTRY_ACCESS_TOKEN=your_sentry_access_token
 
 # Optional
 SENTRY_HOST=sentry.io  # For self-hosted Sentry instances (hostname or full URL)
-MCP_HOST=https://mcp.sentry.dev  # MCP server host (defaults to production)
+MCP_URL=https://mcp.sentry.dev  # MCP server host (defaults to production)
 MCP_MODEL=gpt-4o  # Override default model (GPT-4)
 
 # Optional - Error tracking

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -80,6 +80,7 @@ pnpm mcp-test-client --access-token=your_token "Your prompt"
 The client automatically determines the connection mode:
 
 **Local Mode (stdio transport)**: Used when an access token is provided via:
+
 1. Command-line flag (`--access-token`)
 2. Environment variable (`SENTRY_ACCESS_TOKEN`)
 3. `.env` file
@@ -89,6 +90,7 @@ The client automatically determines the connection mode:
 ### Required Sentry Permissions
 
 Your Sentry access token needs the following scopes:
+
 - `org:read`
 - `project:read`
 - `project:write`
@@ -133,6 +135,7 @@ pnpm mcp-test-client
 ```
 
 In interactive mode:
+
 - Type your prompts and press Enter
 - Type `exit` or `quit` to end the session
 - The AI maintains context across prompts
@@ -162,7 +165,7 @@ pnpm mcp-test-client --mcp-host http://localhost:8787 "List my projects"
 Use local stdio transport with custom Sentry host:
 
 ```bash
-SENTRY_HOST=my-sentry.com SENTRY_ACCESS_TOKEN=your_token pnpm mcp-test-client "Show my projects"
+SENTRY_HOST=sentry.example.com SENTRY_ACCESS_TOKEN=your_token pnpm mcp-test-client "Show my projects"
 ```
 
 ## Development
@@ -190,6 +193,7 @@ pnpm typecheck
 ### Connection Issues
 
 If you see "Failed to connect to MCP server":
+
 1. Ensure the mcp-server package is built
 2. Check that your access token is valid
 3. Verify the Sentry host URL is correct
@@ -197,6 +201,7 @@ If you see "Failed to connect to MCP server":
 ### Authentication Errors
 
 If you get authentication errors:
+
 1. Verify your OPENAI_API_KEY is set correctly
 2. Check that your SENTRY_ACCESS_TOKEN has the required permissions
 3. For self-hosted Sentry, ensure SENTRY_HOST is set
@@ -204,6 +209,7 @@ If you get authentication errors:
 ### Tool Errors
 
 If tools fail to execute:
+
 1. Check the error message for missing parameters
 2. Ensure your Sentry token has appropriate permissions
 3. Verify you have access to the requested resources
@@ -261,12 +267,12 @@ SENTRY_ACCESS_TOKEN=dummy OPENAI_API_KEY=dummy pnpm mcp-test-client --help
 ./examples/test-connection.sh
 ```
 
-
 ## Authentication Methods
 
 ### Remote Mode (OAuth)
 
 When connecting to a remote MCP server (default), the client supports OAuth 2.1 with PKCE:
+
 - No client secret required (secure for CLI applications)
 - Automatic browser-based authentication flow
 - Tokens are securely stored in memory during the session
@@ -276,6 +282,7 @@ When connecting to a remote MCP server (default), the client supports OAuth 2.1 
 ### Local Mode (Access Tokens)
 
 When using local stdio transport (automatic when access token is provided), you must provide a Sentry access token:
+
 - Set `SENTRY_ACCESS_TOKEN` environment variable
 - Or use `--access-token` command-line flag
 - Tokens need appropriate Sentry permissions (see Required Sentry Permissions section)
@@ -298,6 +305,7 @@ The CLI consists of these main components:
 ## Contributing
 
 When adding new features:
+
 1. Follow the existing code style
 2. Add new test scenarios if applicable
 3. Update this README with new usage examples

--- a/packages/mcp-test-client/src/constants.ts
+++ b/packages/mcp-test-client/src/constants.ts
@@ -1,5 +1,5 @@
-// Default MCP Server host
-export const DEFAULT_MCP_HOST = "https://mcp.sentry.dev";
+// Default MCP Server
+export const DEFAULT_MCP_URL = "https://mcp.sentry.dev";
 
 // Default AI model - using GPT-4
 export const DEFAULT_MODEL = "gpt-4o";

--- a/packages/mcp-test-client/src/index.ts
+++ b/packages/mcp-test-client/src/index.ts
@@ -32,7 +32,7 @@ program
   .option(
     "--mcp-host <host>",
     "MCP server host",
-    process.env.MCP_HOST || "https://mcp.sentry.dev",
+    process.env.MCP_URL || "https://mcp.sentry.dev",
   )
   .option("--sentry-dsn <dsn>", "Sentry DSN for error reporting")
   .action(async (prompt, options) => {

--- a/packages/mcp-test-client/src/mcp-test-client-remote.ts
+++ b/packages/mcp-test-client/src/mcp-test-client-remote.ts
@@ -1,7 +1,7 @@
 import { experimental_createMCPClient } from "ai";
 import { startNewTrace, startSpan } from "@sentry/core";
 import { OAuthClient } from "./auth/oauth.js";
-import { DEFAULT_MCP_HOST } from "./constants.js";
+import { DEFAULT_MCP_URL } from "./constants.js";
 import { logError, logSuccess } from "./logger.js";
 import type { MCPConnection, RemoteMCPConfig } from "./types.js";
 import { randomUUID } from "node:crypto";
@@ -24,7 +24,7 @@ export async function connectToRemoteMCPServer(
       },
       async (span) => {
         try {
-          const mcpHost = config.mcpHost || DEFAULT_MCP_HOST;
+          const mcpHost = config.mcpHost || DEFAULT_MCP_URL;
 
           // Remove custom attributes - let SDK handle standard attributes
           let accessToken = config.accessToken;

--- a/packages/mcp-test-client/src/mcp-test-client.ts
+++ b/packages/mcp-test-client/src/mcp-test-client.ts
@@ -46,7 +46,7 @@ export async function connectToMCPServer(
             env: {
               ...process.env,
               SENTRY_ACCESS_TOKEN: config.accessToken,
-              SENTRY_HOST: config.host || "https://sentry.io",
+              SENTRY_HOST: config.host || "sentry.io",
               ...(config.sentryDsn && { SENTRY_DSN: config.sentryDsn }),
             },
           });


### PR DESCRIPTION
Validate SENTRY_HOST to only accept hostname (e.g. "sentry.io"). Support SENTRY_URL for URLs (e.g. "https://sentry.io", "http://localhost:8000") - entirely because I'm tired of support tickets.

Remove deprecated SENTRY_AUTH_TOKEN.

Rename MCP_HOST to MCP_URL.

🤖 Generated with [Claude Code](https://claude.ai/code)