### PR TITLE
fix: properly format query strings in API client

### DIFF
--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -697,7 +697,7 @@ export class SentryApiService {
       : `/organizations/${organizationSlug}/releases/`;
 
     const response = await this.request(
-      `${path}${searchQuery.toString()}`,
+      searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
       undefined,
       opts,
     );
@@ -744,7 +744,9 @@ export class SentryApiService {
     }
 
     const response = await this.request(
-      `/organizations/${organizationSlug}/tags/${searchQuery.toString()}`,
+      searchQuery.toString()
+        ? `/organizations/${organizationSlug}/tags/?${searchQuery.toString()}`
+        : `/organizations/${organizationSlug}/tags/`,
       undefined,
       opts,
     );


### PR DESCRIPTION
Fixes query string formatting for releases and tags endpoints by adding proper ? separator between path and query parameters.

Fixes: MCP-SERVER-E9G

🤖 Generated with [Claude Code](https://claude.ai/code)