### PR TITLE
fix: allow issue IDs to start with numbers

### DIFF
--- a/packages/mcp-server/src/internal/issue-helpers.test.ts
+++ b/packages/mcp-server/src/internal/issue-helpers.test.ts
@@ -101,19 +101,47 @@ describe("extractIssueId", () => {
 });
 
 describe("parseIssueId", () => {
-  it("should remove trailing punctuation from issue ID", () => {
-    expect(
-      // trailing period and exclamation
-      parseIssueId("CLOUDFLARE-MCP-41.!"),
-    ).toBe("CLOUDFLARE-MCP-41");
+  describe("cleaning", () => {
+    it("should remove trailing punctuation", () => {
+      expect(parseIssueId("CLOUDFLARE-MCP-41.!")).toBe("CLOUDFLARE-MCP-41");
+    });
+
+    it("should remove special characters except dash and underscore", () => {
+      expect(parseIssueId("ID_123-456!@#")).toBe("ID_123-456");
+    });
   });
 
-  it("should not modify a clean issue ID", () => {
-    expect(parseIssueId("CLOUDFLARE-MCP-41")).toBe("CLOUDFLARE-MCP-41");
-  });
+  describe("format validation", () => {
+    it("should accept pure numeric issue IDs", () => {
+      expect(parseIssueId("12345")).toBe("12345");
+    });
 
-  it("should remove special characters except dash and underscore", () => {
-    expect(parseIssueId("ID_123-456!@#")).toBe("ID_123-456");
+    it("should accept project-based IDs starting with letters", () => {
+      expect(parseIssueId("PROJECT-123")).toBe("PROJECT-123");
+      expect(parseIssueId("MCP-SERVER-E9E")).toBe("MCP-SERVER-E9E");
+    });
+
+    it("should accept project-based IDs starting with numbers", () => {
+      expect(parseIssueId("3R-3")).toBe("3R-3");
+      expect(parseIssueId("3R-AUTOMATION-SYSTEM-3")).toBe(
+        "3R-AUTOMATION-SYSTEM-3",
+      );
+    });
+
+    it("should throw error for invalid formats", () => {
+      // Starting with hyphen
+      expect(() => parseIssueId("-123")).toThrowError(
+        /Invalid issue ID format/,
+      );
+
+      // Ending with hyphen
+      expect(() => parseIssueId("PROJECT-")).toThrowError(
+        /Invalid issue ID format/,
+      );
+
+      // Empty string after cleaning
+      expect(() => parseIssueId("!!!")).toThrowError(/Invalid issue ID format/);
+    });
   });
 });
 

--- a/packages/mcp-server/src/internal/issue-helpers.ts
+++ b/packages/mcp-server/src/internal/issue-helpers.ts
@@ -88,7 +88,8 @@ export function parseIssueId(issueId: string) {
 
   // Validate against common Sentry issue ID patterns
   // Either numeric IDs or PROJECT-ABC123 format
-  const validFormatRegex = /^(\d+|[A-Za-z][\w-]*-[A-Za-z0-9]+)$/;
+  // Allow project codes to start with alphanumeric characters (including numbers)
+  const validFormatRegex = /^(\d+|[A-Za-z0-9][\w-]*-[A-Za-z0-9]+)$/;
 
   if (!validFormatRegex.test(finalIssueId)) {
     throw new Error(


### PR DESCRIPTION
The parseIssueId regex was too restrictive and rejected valid issue IDs that start with numbers (e.g., "3R-AUTOMATION-SYSTEM-3"). Updated the regex to accept alphanumeric characters at the start of project codes.

Also cleaned up duplicate tests while ensuring comprehensive coverage of all valid and invalid formats.

Fixes MCP-SERVER-E9E

🤖 Generated with [Claude Code](https://claude.ai/code)