### PR TITLE
fix: improve 404 error handling to show all relevant parameters

### DIFF
--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -264,6 +264,7 @@ export class SentryApiService {
       throw new Error(friendlyMessage, { cause: error });
     }
 
+    // Handle error responses generically
     if (!response.ok) {
       const errorText = await response.text();
       let parsed: unknown | undefined;

--- a/packages/mcp-server/src/tools/find-organizations.ts
+++ b/packages/mcp-server/src/tools/find-organizations.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "./utils/defineTool";
-import { apiServiceFromContext } from "./utils/api-utils";
+import { apiServiceFromContext, withApiErrorHandling } from "./utils/api-utils";
 import type { ServerContext } from "../types";
 
 export default defineTool({
@@ -17,7 +17,10 @@ export default defineTool({
     // User data endpoints (like /users/me/regions/) should never use regionUrl
     // as they must always query the main API server, not region-specific servers
     const apiService = apiServiceFromContext(context);
-    const organizations = await apiService.listOrganizations();
+    const organizations = await withApiErrorHandling(
+      () => apiService.listOrganizations(),
+      {}, // No params for this endpoint
+    );
 
     let output = "# Organizations\n\n";
 

--- a/packages/mcp-server/src/tools/get-issue-details.ts
+++ b/packages/mcp-server/src/tools/get-issue-details.ts
@@ -130,7 +130,10 @@ export default defineTool({
           organizationSlug: orgSlug,
           issueId: parsedIssueId!,
         }),
-      { operation: "getIssue", resourceId: parsedIssueId },
+      {
+        organizationSlug: orgSlug,
+        issueId: parsedIssueId,
+      },
     );
 
     const event = await apiService.getLatestEventForIssue({

--- a/packages/mcp-server/src/tools/update-issue.ts
+++ b/packages/mcp-server/src/tools/update-issue.ts
@@ -109,7 +109,10 @@ export default defineTool({
           organizationSlug: orgSlug,
           issueId: parsedIssueId!,
         }),
-      { operation: "getIssue", resourceId: parsedIssueId },
+      {
+        organizationSlug: orgSlug,
+        issueId: parsedIssueId,
+      },
     );
 
     // Update the issue
@@ -121,7 +124,10 @@ export default defineTool({
           status: params.status,
           assignedTo: params.assignedTo,
         }),
-      { operation: "updateIssue", resourceId: parsedIssueId },
+      {
+        organizationSlug: orgSlug,
+        issueId: parsedIssueId,
+      },
     );
 
     let output = `# Issue ${updatedIssue.shortId} Updated in **${orgSlug}**\n\n`;


### PR DESCRIPTION
Instead of trying to guess which resource caused a 404, now we list all path parameters that were used in the API call. This provides clearer error messages that help users identify which parameter might be incorrect.

Example error message:
```
Resource not found. Please verify these parameters are correct:
  - organizationSlug: 'my-org'
  - issueId: 'PROJ-123'
```

Changes:
- Simplified error handling to remove operation tracking
- Tools now only pass path parameters that could cause 404s
- Error messages list all relevant parameters for better debugging

Fixes MCP-SERVER-EA1, MCP-SERVER-E9B

🤖 Generated with [Claude Code](https://claude.ai/code)