### PR TITLE
feat: enhance Vercel AI SDK integration with telemetry

### DIFF
--- a/packages/mcp-server/src/tools/search-events.ts
+++ b/packages/mcp-server/src/tools/search-events.ts
@@ -975,6 +975,10 @@ export default defineTool({
           .optional()
           .describe("Error message if the query cannot be translated"),
       }),
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: `search_events_${dataset}`,
+      },
     });
 
     // Handle AI errors first


### PR DESCRIPTION
## Summary

This PR enhances the existing Vercel AI SDK integration by adding telemetry configuration to the `generateObject` call in the search_events tool.

## Changes

- Added `experimental_telemetry` configuration to the `generateObject` call
- Set `isEnabled: true` to enable telemetry tracking
- Set `functionId` to `search_events_{dataset}` to differentiate between errors, logs, and spans queries

## Why This Matters

The Vercel AI integration was already configured in our Sentry.init with `recordInputs` and `recordOutputs` enabled, but our AI function calls weren't taking advantage of the telemetry features. By adding the `experimental_telemetry` configuration:

1. AI function calls are now properly tracked in Sentry with clear identification
2. Different dataset queries (errors, logs, spans) can be analyzed separately
3. We get better observability into AI performance and behavior

## Implementation

The change is minimal and focused - we simply add the telemetry configuration to our existing `generateObject` call:

```typescript
experimental_telemetry: {
  isEnabled: true,
  functionId: `search_events_${dataset}`,
},
```

This works with the existing `vercelAIIntegration` that's already configured in our Sentry initialization.

🤖 Generated with [Claude Code](https://claude.ai/code)