### PR TITLE
fix: correct explore URL generation for search_events tool

### DIFF
--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -190,7 +190,8 @@ export class SentryApiService {
    * @returns True if using Sentry SaaS, false for self-hosted instances
    */
   private isSaas(): boolean {
-    return this.host === "sentry.io";
+    // Check if it's the main sentry.io domain or a regional domain (e.g., us.sentry.io, de.sentry.io)
+    return this.host === "sentry.io" || this.host.endsWith(".sentry.io");
   }
 
   /**

--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -458,6 +458,7 @@ export class SentryApiService {
     query: string,
     projectSlug?: string,
     dataset: "spans" | "errors" | "logs" = "spans",
+    fields?: string[],
   ): string {
     const params = new URLSearchParams();
     params.set("query", query);
@@ -477,18 +478,28 @@ export class SentryApiService {
       params.set("sort", "-timestamp");
       params.set("statsPeriod", "14d");
       params.set("yAxis", "count()");
+
+      // Add mode=aggregate for aggregate queries
+      const isAggregateQuery =
+        fields?.some((field) => field.includes("(") && field.includes(")")) ||
+        false;
+      if (isAggregateQuery) {
+        params.set("mode", "aggregate");
+      }
+
+      // For SaaS, always use organizationSlug.sentry.io regardless of the API host (which might be regional)
       path = this.isSaas()
-        ? `https://${organizationSlug}.${this.host}/explore/discover/homepage/`
+        ? `https://${organizationSlug}.sentry.io/explore/discover/homepage/`
         : `https://${this.host}/organizations/${organizationSlug}/explore/discover/homepage/`;
     } else if (dataset === "logs") {
       // Logs use /explore/logs/
       path = this.isSaas()
-        ? `https://${organizationSlug}.${this.host}/explore/logs/`
+        ? `https://${organizationSlug}.sentry.io/explore/logs/`
         : `https://${this.host}/organizations/${organizationSlug}/explore/logs/`;
     } else {
       // Spans use /explore/traces/
       path = this.isSaas()
-        ? `https://${organizationSlug}.${this.host}/explore/traces/`
+        ? `https://${organizationSlug}.sentry.io/explore/traces/`
         : `https://${this.host}/organizations/${organizationSlug}/explore/traces/`;
     }
 

--- a/packages/mcp-server/src/tools/search-events.ts
+++ b/packages/mcp-server/src/tools/search-events.ts
@@ -1114,6 +1114,7 @@ export default defineTool({
       sentryQuery,
       projectId, // Pass the numeric project ID for URL generation
       dataset, // dataset is already correct for URL generation (logs, spans, errors)
+      fields, // Pass fields to detect if it's an aggregate query
     );
 
     // Type-safe access to event data


### PR DESCRIPTION
## Summary

This PR fixes two issues with the explore URLs generated by the `search_events` tool:

1. **Fixed domain generation for SaaS instances**: URLs now correctly use `organizationSlug.sentry.io` regardless of the API host (which might be regional like `us.sentry.io`)
2. **Added mode=aggregate parameter**: Aggregate queries in the errors dataset now include the `mode=aggregate` parameter

## Problem

Previously, when using regional API hosts, the tool would generate incorrect URLs like:
- `https://sentry.us.sentry.io/explore/discover/homepage/...` ❌

This PR ensures it generates:
- `https://sentry.sentry.io/explore/discover/homepage/...` ✅

Additionally, aggregate queries were missing the `mode=aggregate` parameter needed for proper display.

## Changes

- Updated `getEventsExplorerUrl()` in `client.ts` to:
  - Accept an optional `fields` parameter to detect aggregate queries
  - Always use `sentry.io` as the base domain for SaaS instances
  - Add `mode=aggregate` when aggregate functions are detected in fields
  
- Updated `search-events.ts` to pass the fields array to the URL generator

🤖 Generated with [Claude Code](https://claude.ai/code)