### PR TITLE
Validate ai sdk calls in cloudflare and server

### DIFF
--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -27,6 +27,10 @@ export default function getSentryConfig(env: Env): SentryConfig {
     integrations: [
       Sentry.consoleLoggingIntegration(),
       Sentry.zodErrorsIntegration(),
+      Sentry.vercelAIIntegration({
+        recordInputs: true,
+        recordOutputs: true,
+      }),
     ],
   };
 }

--- a/packages/mcp-server-evals/src/evals/utils/toolPredictionScorer.ts
+++ b/packages/mcp-server-evals/src/evals/utils/toolPredictionScorer.ts
@@ -200,6 +200,10 @@ export function ToolPredictionScorer(model: LanguageModel = defaultModel) {
         expectedDescription,
       ),
       schema: predictionSchema,
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "tool_prediction_scorer",
+      },
     });
 
     return {


### PR DESCRIPTION
Enable Sentry AI SDK telemetry for `toolPredictionScorer` and add Vercel AI integration to Cloudflare Sentry config.

This PR completes the Sentry AI SDK telemetry setup by adding missing `experimental_telemetry` to a `generateObject` call and integrating `Sentry.vercelAIIntegration` in the Cloudflare package as per Sentry documentation, ensuring comprehensive AI monitoring.

---

[Slack Thread](https://sentry.slack.com/archives/CA2V2LBDL/p1752595531527239?thread_ts=1752595531.527239&cid=CA2V2LBDL)