### PR TITLE
feat: add Claude commands for PR management

### DIFF
--- a/.claude/commands/gh-pr.md
+++ b/.claude/commands/gh-pr.md
@@ -1,0 +1,14 @@
+Create (or update) a Pull Request.
+
+We use the GitHub CLI (`gh`) to manage pull requests.
+
+If this branch does not already have a pull request, create one:
+
+- If we're on the main branch, switch to a working branch.
+- Commit our changes if we haven't already.
+
+If we already have one:
+
+- Verify our changes against the base branch and update the PR title and description to maintain accuracy.
+
+We should never focus on a test plan in the PR, but rather a concise description of the changes (features, breaking changes, major bug fixes, and architectural changes). Only include changes if they're present. We're always contrasting against our base branch when we describe these changes.

--- a/.claude/commands/gh-review.md
+++ b/.claude/commands/gh-review.md
@@ -1,0 +1,9 @@
+Address feedback and checks in a Pull Request.
+
+We use the GitHub CLI (`gh`) to manage pull requests.
+
+Review the status checks for this PR, and identify any failures from them.
+
+If there are no failures, review the PR feedback.
+
+Do NOT assume feedback is valid. You should always verify that the feedback is truthful (the bug is real, for example), and then attempt to address it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:mcp.sentry.dev)",
+      "WebFetch(domain:docs.sentry.io)",
+      "WebFetch(domain:develop.sentry.dev)",
+      "WebFetch(domain:modelcontextprotocol.io)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "Bash(grep:*)",
+      "Bash(jq:*)",
+      "Bash(pnpx vitest:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm run typecheck:*)",
+      "Bash(pnpm run check:*)",
+      "Bash(pnpm run:*)",
+      "Bash(pnpx tsx:*)",
+      "mcp__sentry__*"
+    ],
+    "deny": []
+  },
+  "enableAllProjectMcpServers": true,
+  "includeCoAuthoredBy": false,
+  "enabledMcpjsonServers": ["sentry"]
+}


### PR DESCRIPTION
## Summary
- Add custom Claude commands for managing pull requests with proper conventions
- Include Claude settings file with appropriate MCP permissions
- Enable streamlined PR workflows through `/gh-pr` and `/gh-review` commands

## Changes
- **New feature**: Added `/gh-pr` command for creating/updating pull requests
- **New feature**: Added `/gh-review` command for addressing PR feedback and status checks
- **Configuration**: Added Claude settings with MCP permissions for Sentry integration

These commands help maintain consistent PR practices and integrate with the GitHub CLI workflow.