### PR TITLE
fix: add missing checks:write permission to OnlyRobots workflow

### DIFF
--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -8,7 +8,6 @@ permissions:
   contents: read
   pull-requests: write
   checks: write
-  issues: write
 
 jobs:
   review:

--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds the missing `checks:write` permission to the OnlyRobots GitHub Action workflow
- Removes the unnecessary `issues:write` permission

## Problem
The OnlyRobots action requires `checks:write` permission to create GitHub check runs, but our workflow was missing this permission. According to the [OnlyRobots README](https://github.com/getsentry/action-onlyrobots/blob/main/README.md), the required permissions are:
- `contents: read`
- `pull-requests: write`
- `checks: write` ← This was missing

We also had `issues:write` which is not required by the action.

## Solution
- Added `checks: write` to the permissions section
- Removed `issues: write` as it's not needed

## Test plan
The OnlyRobots action should now be able to create check runs on pull requests without permission errors.