### PR TITLE
feat: enable OnlyRobots comments and update to v1.2.0

### DIFF
--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: getsentry/action-onlyrobots@v1.1.0
+      - uses: getsentry/action-onlyrobots@v1.2.0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          post-comment: true


### PR DESCRIPTION
## Summary

This PR enables comment functionality in the OnlyRobots GitHub Action workflow and updates the action version to v1.2.0.

## Changes

- **Feature**: Added `post-comment: true` parameter to enable humorous comments when human-written code is detected in PRs
- **Update**: Bumped OnlyRobots action version from v1.1.0 to v1.2.0 to ensure we're using the latest version and bust any caches

These changes will make the OnlyRobots integration more engaging by providing informative feedback directly in pull requests when non-AI-generated code is detected.