### PR TITLE
chore: update OnlyRobots action to use v1 tag

### DIFF
--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: getsentry/action-onlyrobots@v1.3.0
+      - uses: getsentry/action-onlyrobots@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          post-comment: true

--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: getsentry/action-onlyrobots@v1.2.0
+      - uses: getsentry/action-onlyrobots@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: getsentry/action-onlyrobots@v1
+      - uses: getsentry/action-onlyrobots@v1.3.0
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/onlyrobots.yml
+++ b/.github/workflows/onlyrobots.yml
@@ -20,4 +20,3 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          post-comment: true


### PR DESCRIPTION
## Summary
- Update OnlyRobots GitHub Action from pinned version v1.2.0 to v1 tag for automatic updates
- Testing GitHub Actions cache busting for the v1 tag

## Changes
- Modified `.github/workflows/onlyrobots.yml` to use `getsentry/action-onlyrobots@v1` instead of `@v1.2.0`
- This allows the workflow to automatically receive patch and minor updates within the v1 major version
- The v1 tag exists and includes the dist/index.js file, but there may be a cache issue preventing it from being found