### PR TITLE
fix: add hints for org/project notation in search_events tool

### DIFF
--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -116,6 +116,11 @@ export default defineTool({
     "search_events(organizationSlug='my-org', naturalLanguageQuery='how many tokens used today')",
     "search_events(organizationSlug='my-org', naturalLanguageQuery='slowest API calls')",
     "</examples>",
+    "",
+    "<hints>",
+    "- If the user passes a parameter in the form of name/otherName, it's likely in the format of <organizationSlug>/<projectSlug>.",
+    "- Parse org/project notation directly without calling find_organizations or find_projects.",
+    "</hints>",
   ].join("\n"),
   inputSchema: {
     organizationSlug: ParamOrganizationSlug,


### PR DESCRIPTION
## Summary
- Add guidance hints to help LLMs parse org/project notation directly in search_events tool
- Prevent unnecessary find_organizations and find_projects API calls when using org/project format

## Changes
This PR adds a `<hints>` section to the search_events tool description that instructs LLMs to:
1. Recognize `name/otherName` format as `<organizationSlug>/<projectSlug>`
2. Parse this notation directly without making additional API calls

This follows the same pattern used in other tools like `find_dsns` and addresses the inefficiency reported in #393.

Fixes #393