### PR TITLE
feat: add GitHub CLI permissions and auto-generated tool definitions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,10 @@
       "Bash(pnpm run check:*)",
       "Bash(pnpm run:*)",
       "Bash(pnpx tsx:*)",
+      "Bash(gh pr checks)",
+      "Bash(gh pr view:*)",
+      "Bash(gh run view:*)",
+      "Bash(git status)",
       "mcp__sentry__*"
     ],
     "deny": []

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,10 +14,10 @@
       "Bash(pnpm run check:*)",
       "Bash(pnpm run:*)",
       "Bash(pnpx tsx:*)",
-      "Bash(gh pr checks)",
+      "Bash(gh pr checks:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
-      "Bash(git status)",
+      "Bash(git status:*)",
       "mcp__sentry__*"
     ],
     "deny": []

--- a/packages/mcp-server/src/toolDefinitions.json
+++ b/packages/mcp-server/src/toolDefinitions.json
@@ -1,0 +1,952 @@
+[
+  {
+    "name": "whoami",
+    "description": "Identify the authenticated user in Sentry.\n\nUse this tool when you need to:\n- Get the user's name and email address.",
+    "inputSchema": {}
+  },
+  {
+    "name": "find_organizations",
+    "description": "Find organizations that the user has access to in Sentry.\n\nUse this tool when you need to:\n- View all organizations in Sentry\n- Find an organization's slug to aid other tool requests",
+    "inputSchema": {}
+  },
+  {
+    "name": "find_teams",
+    "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View all teams in a Sentry organization\n- Find a team's slug to aid other tool requests",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "find_projects",
+    "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View all projects in a Sentry organization\n- Find a project's slug to aid other tool requests",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "find_issues",
+    "description": "Find grouped issues/problems in Sentry - NOT individual events.\n\n🔍 USE THIS TOOL WHEN USERS ASK FOR:\n- 'show me issues', 'list problems', 'what issues do we have'\n- 'unresolved issues', 'recent problems affecting users'\n- 'issue summaries', 'grouped errors', 'error types'\n- General questions about problems without specific event details\n\n❌ DO NOT USE when users want:\n- Specific error events/logs from a time period (use search_events)\n- Individual occurrences with timestamps (use search_events)\n- Details about a specific issue ID like 'PROJECT-123' (use get_issue_details)\n\nCRITICAL: Issues are grouped/deduplicated problems, not individual events.\n\n<examples>\n### Find unresolved issues\n```\nfind_issues(organizationSlug='my-organization', query='is:unresolved', sortBy='last_seen')\n```\n\n### Find crashes in project\n```\nfind_issues(organizationSlug='my-organization', projectSlug='my-project', query='is:unresolved error.handled:false', sortBy='count')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n- You can use the `find_tags()` tool to see what user-defined tags are available.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool."
+          }
+        ],
+        "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "query": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The search query to apply. Use the `help(subject=\"query_syntax\")` tool to get more information about the query syntax rather than guessing."
+          }
+        ],
+        "description": "The search query to apply. Use the `help(subject=\"query_syntax\")` tool to get more information about the query syntax rather than guessing.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "sortBy": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "enum": ["last_seen", "first_seen", "count", "userCount"],
+            "description": "Sort the results either by the last time they occurred, the first time they occurred, the count of occurrences, or the number of users affected."
+          }
+        ],
+        "description": "Sort the results either by the last time they occurred, the first time they occurred, the count of occurrences, or the number of users affected.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "find_releases",
+    "description": "Find releases in Sentry.\n\nUse this tool when you need to:\n- Find recent releases in a Sentry organization\n- Find the most recent version released of a specific project\n- Determine when a release was deployed to an environment\n\n<examples>\n### Find the most recent releases in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization')\n```\n\n### Find releases matching '2ce6a27' in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization', query='2ce6a27')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+          }
+        ],
+        "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "query": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "Search for versions which contain the provided string."
+          }
+        ],
+        "description": "Search for versions which contain the provided string.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "find_tags",
+    "description": "Find tags in Sentry.\n\nUse this tool when you need to:\n- Find tags available to use in search queries (such as `find_issues()` or `find_errors()`)",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "get_issue_details",
+    "description": "Get detailed information about a specific Sentry issue by ID.\n\n🔍 USE THIS TOOL WHEN USERS:\n- Provide a specific issue ID (e.g., 'CLOUDFLARE-MCP-41', 'PROJECT-123')\n- Ask to 'explain [ISSUE-ID]', 'tell me about [ISSUE-ID]'\n- Want details/stacktrace/analysis for a known issue\n- Provide a Sentry issue URL\n\n❌ DO NOT USE for:\n- General searching or listing issues (use find_issues)\n- Root cause analysis (use analyze_issue_with_seer)\n\nTRIGGER PATTERNS:\n- 'Explain ISSUE-123' → use get_issue_details\n- 'Tell me about PROJECT-456' → use get_issue_details\n- 'What happened in [issue URL]' → use get_issue_details\n\n<examples>\n### Explain specific issue\n```\nget_issue_details(organizationSlug='my-organization', issueId='CLOUDFLARE-MCP-41')\n```\n\n### Get details for event ID\n```\nget_issue_details(organizationSlug='my-organization', eventId='c49541c747cb4d8aa3efb70ca5aba243')\n```\n</examples>\n\n<hints>\n- If the user provides the `issueUrl`, you can ignore the other parameters.\n- If the user provides `issueId` or `eventId` (only one is needed), `organizationSlug` is required.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "issueId": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+          }
+        ],
+        "description": "The Issue ID. e.g. `PROJECT-1Z43`",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "eventId": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The ID of the event."
+          }
+        ],
+        "description": "The ID of the event.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "issueUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43"
+          }
+        ],
+        "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "get_event_attachment",
+    "description": "Download attachments from a Sentry event.\n\nUse this tool when you need to:\n- Download files attached to a specific event\n- Access screenshots, log files, or other attachments uploaded with an error report\n- Retrieve attachment metadata and download URLs\n\n<examples>\n### Download a specific attachment by ID\n\n```\nget_event_attachment(organizationSlug='my-organization', projectSlug='my-project', eventId='c49541c747cb4d8aa3efb70ca5aba243', attachmentId='12345')\n```\n\n### List all attachments for an event\n\n```\nget_event_attachment(organizationSlug='my-organization', projectSlug='my-project', eventId='c49541c747cb4d8aa3efb70ca5aba243')\n```\n\n</examples>\n\n<hints>\n- If `attachmentId` is provided, the specific attachment will be downloaded as an embedded resource\n- If `attachmentId` is omitted, all attachments for the event will be listed with download information\n- The `projectSlug` is required to identify which project the event belongs to\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "type": "string",
+        "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "eventId": {
+        "type": "string",
+        "description": "The ID of the event.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "attachmentId": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The ID of the attachment to download."
+          }
+        ],
+        "description": "The ID of the attachment to download.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "update_issue",
+    "description": "Update an issue's status or assignment in Sentry. This allows you to resolve, ignore, or reassign issues.\n\nUse this tool when you need to:\n- Resolve an issue that has been fixed\n- Assign an issue to a team member or team for investigation\n- Mark an issue as ignored to reduce noise\n- Reopen a resolved issue by setting status to 'unresolved'\n\n<examples>\n### Resolve an issue\n\n```\nupdate_issue(organizationSlug='my-organization', issueId='PROJECT-123', status='resolved')\n```\n\n### Assign an issue to a user\n\n```\nupdate_issue(organizationSlug='my-organization', issueId='PROJECT-123', assignedTo='john.doe')\n```\n\n### Resolve an issue and assign it to yourself\n\n```\nupdate_issue(organizationSlug='my-organization', issueId='PROJECT-123', status='resolved', assignedTo='me')\n```\n\n### Mark an issue as ignored\n\n```\nupdate_issue(organizationSlug='my-organization', issueId='PROJECT-123', status='ignored')\n```\n\n</examples>\n\n<hints>\n- If the user provides the `issueUrl`, you can ignore the other required parameters and extract them from the URL.\n- At least one of `status` or `assignedTo` must be provided to update the issue.\n- Use 'me' as the value for `assignedTo` to assign the issue to the authenticated user.\n- Valid status values are: 'resolved', 'resolvedInNextRelease', 'unresolved', 'ignored'.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "issueId": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+          }
+        ],
+        "description": "The Issue ID. e.g. `PROJECT-1Z43`",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "issueUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43"
+          }
+        ],
+        "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "status": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "enum": [
+              "resolved",
+              "resolvedInNextRelease",
+              "unresolved",
+              "ignored"
+            ],
+            "description": "The new status for the issue. Valid values are 'resolved', 'resolvedInNextRelease', 'unresolved', and 'ignored'."
+          }
+        ],
+        "description": "The new status for the issue. Valid values are 'resolved', 'resolvedInNextRelease', 'unresolved', and 'ignored'.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "assignedTo": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The username or team slug to assign the issue to. Use 'me' to assign to yourself, or provide a username/team slug."
+          }
+        ],
+        "description": "The username or team slug to assign the issue to. Use 'me' to assign to yourself, or provide a username/team slug.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "search_events",
+    "description": "Search for error events, log entries, or trace spans. Supports both individual event queries and SQL-like aggregations.\n\nAutomatically uses natural language to search across Sentry data, returning either:\n- Individual events with full details (default)\n- Aggregated results when using functions like count(), avg(), sum(), etc.\n\nDataset Selection (AI agent determines the appropriate dataset):\n- errors: Exception/crash events\n- logs: Log entries (use for 'error logs')\n- spans: Performance/trace data, AI/LLM calls, token usage\n\nIntelligence: AI agent analyzes the query to choose the correct dataset and fields\n\n❌ DO NOT USE for 'issues' or 'problems' (use find_issues instead)\n\n📚 For detailed API patterns and examples, see: docs/search-events-api-patterns.md\n\n<examples>\nsearch_events(organizationSlug='my-org', naturalLanguageQuery='database errors in the last hour')\nsearch_events(organizationSlug='my-org', naturalLanguageQuery='how many tokens used today')\nsearch_events(organizationSlug='my-org', naturalLanguageQuery='slowest API calls')\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, it's likely in the format of <organizationSlug>/<projectSlug>.\n- Parse org/project notation directly without calling find_organizations or find_projects.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "naturalLanguageQuery": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Natural language description of what you want to search for",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool."
+          }
+        ],
+        "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "limit": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 100
+          }
+        ],
+        "default": 10,
+        "description": "Maximum number of results to return",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "includeExplanation": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "boolean"
+          }
+        ],
+        "default": false,
+        "description": "Include explanation of how the query was translated",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "create_team",
+    "description": "Create a new team in Sentry.\n\n🔍 USE THIS TOOL WHEN USERS WANT TO:\n- 'Create a new team'\n- 'Set up a team called [X]'\n- 'I need a team for my project'\n\nBe careful when using this tool!\n\n<examples>\n### Create a new team\n```\ncreate_team(organizationSlug='my-organization', name='the-goats')\n```\n</examples>\n\n<hints>\n- If any parameter is ambiguous, you should clarify with the user what they meant.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "name": {
+        "type": "string",
+        "description": "The name of the team to create.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "create_project",
+    "description": "Create a new project in Sentry (includes DSN automatically).\n\n🔍 USE THIS TOOL WHEN USERS WANT TO:\n- 'Create a new project'\n- 'Set up a project for [app/service] with team [X]'\n- 'I need a new Sentry project'\n- Create project AND need DSN in one step\n\n❌ DO NOT USE create_dsn after this - DSN is included in output.\n\nBe careful when using this tool!\n\n<examples>\n### Create new project with team\n```\ncreate_project(organizationSlug='my-organization', teamSlug='my-team', name='my-project', platform='javascript')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<teamSlug>.\n- If any parameter is ambiguous, you should clarify with the user what they meant.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "teamSlug": {
+        "type": "string",
+        "description": "The team's slug. You can find a list of existing teams in an organization using the `find_teams()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "name": {
+        "type": "string",
+        "description": "The name of the project to create. Typically this is commonly the name of the repository or service. It is only used as a visual label in Sentry.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "platform": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The platform for the project. e.g., python, javascript, react, etc."
+          }
+        ],
+        "description": "The platform for the project. e.g., python, javascript, react, etc.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "update_project",
+    "description": "Update project settings in Sentry, such as name, slug, platform, and team assignment.\n\nBe careful when using this tool!\n\nUse this tool when you need to:\n- Update a project's name or slug to fix onboarding mistakes\n- Change the platform assigned to a project\n- Update team assignment for a project\n\n<examples>\n### Update a project's name and slug\n\n```\nupdate_project(organizationSlug='my-organization', projectSlug='old-project', name='New Project Name', slug='new-project-slug')\n```\n\n### Assign a project to a different team\n\n```\nupdate_project(organizationSlug='my-organization', projectSlug='my-project', teamSlug='backend-team')\n```\n\n### Update platform\n\n```\nupdate_project(organizationSlug='my-organization', projectSlug='my-project', platform='python')\n```\n\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, it's likely in the format of <organizationSlug>/<projectSlug>.\n- Team assignment is handled separately from other project settings\n- If any parameter is ambiguous, you should clarify with the user what they meant.\n- When updating the slug, the project will be accessible at the new slug after the update\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "type": "string",
+        "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "name": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The new name for the project"
+          }
+        ],
+        "description": "The new name for the project",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "slug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The new slug for the project (must be unique)"
+          }
+        ],
+        "description": "The new slug for the project (must be unique)",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "platform": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The platform for the project. e.g., python, javascript, react, etc."
+          }
+        ],
+        "description": "The platform for the project. e.g., python, javascript, react, etc.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "teamSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The team's slug. You can find a list of existing teams in an organization using the `find_teams()` tool."
+          }
+        ],
+        "description": "The team to assign this project to. Note: this will replace the current team assignment.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "create_dsn",
+    "description": "Create an additional DSN for an EXISTING project.\n\n🔍 USE THIS TOOL WHEN:\n- Project already exists and needs additional DSN\n- 'Create another DSN for project X'\n- 'I need a production DSN for existing project'\n\n❌ DO NOT USE for new projects (use create_project instead)\n\nBe careful when using this tool!\n\n<examples>\n### Create additional DSN for existing project\n```\ncreate_dsn(organizationSlug='my-organization', projectSlug='my-project', name='Production')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n- If any parameter is ambiguous, you should clarify with the user what they meant.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "type": "string",
+        "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "name": {
+        "type": "string",
+        "description": "The name of the DSN to create, for example 'Production'.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "find_dsns",
+    "description": "List all Sentry DSNs for a specific project.\n\nUse this tool when you need to:\n- Retrieve a SENTRY_DSN for a specific project\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n- If only one parameter is provided, and it could be either `organizationSlug` or `projectSlug`, its probably `organizationSlug`, but if you're really uncertain you might want to call `find_organizations()` first.\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "type": "string",
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "projectSlug": {
+        "type": "string",
+        "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "analyze_issue_with_seer",
+    "description": "Use Seer AI to analyze production errors and get detailed root cause analysis with specific code fixes.\n\nUse this tool when you need:\n- Detailed AI-powered root cause analysis\n- Specific code fixes and implementation guidance\n- Step-by-step troubleshooting for complex issues\n- Understanding why an error is happening in production\n\nWhat this tool provides:\n- Root cause analysis with code-level explanations\n- Specific file locations and line numbers where errors occur\n- Concrete code fixes you can apply\n- Step-by-step implementation guidance\n\nThis tool automatically:\n1. Checks if analysis already exists (instant results)\n2. Starts new AI analysis if needed (~2-5 minutes)\n3. Returns complete fix recommendations\n\n<examples>\n### User: \"What's causing this error? https://my-org.sentry.io/issues/PROJECT-1Z43\"\n\n```\nanalyze_issue_with_seer(issueUrl='https://my-org.sentry.io/issues/PROJECT-1Z43')\n```\n\n### User: \"Can you help me understand why this is failing in production?\"\n\n```\nanalyze_issue_with_seer(organizationSlug='my-organization', issueId='ERROR-456')\n```\n</examples>\n\n<hints>\n- Use this tool when you need deeper analysis beyond basic issue details\n- If the user provides an issueUrl, extract it and use that parameter alone\n- The analysis includes actual code snippets and fixes, not just error descriptions\n- Results are cached - subsequent calls return instantly\n</hints>",
+    "inputSchema": {
+      "organizationSlug": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "regionUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+          }
+        ],
+        "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "issueId": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+          }
+        ],
+        "description": "The Issue ID. e.g. `PROJECT-1Z43`",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "issueUrl": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43"
+          }
+        ],
+        "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "instruction": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "description": "Optional custom instruction for the AI analysis"
+          }
+        ],
+        "description": "Optional custom instruction for the AI analysis",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "search_docs",
+    "description": "Search Sentry documentation for SDK setup, instrumentation, and configuration guidance.\n\nUse this tool when you need to:\n- Set up Sentry SDK in any language (Python, JavaScript, Go, Ruby, etc.)\n- Configure specific features like performance monitoring, error sampling, or release tracking\n- Implement custom instrumentation (spans, transactions, breadcrumbs)\n- Set up integrations with frameworks (Django, Flask, Express, Next.js, etc.)\n- Configure data scrubbing, filtering, or sampling rules\n- Troubleshoot SDK issues or find best practices\n\nThis tool searches technical documentation, NOT general information about Sentry as a company.\n\n<examples>\n### Setting up Sentry in a Python Django app\n\n```\nsearch_docs(query='Django setup configuration SENTRY_DSN', guide='python/django')\n```\n\n### Setting up source maps for Next.js\n\n```\nsearch_docs(query='source maps webpack upload', guide='javascript/nextjs')\n```\n\n### Configuring release tracking\n\n```\nsearch_docs(query='release tracking deployment integration CI/CD')\n```\n</examples>\n\n<hints>\n- Use guide parameter to filter results to specific technologies (e.g., 'javascript' or 'javascript/nextjs')\n- Include the programming language/framework in your query for SDK-specific results\n- Use technical terms like 'instrumentation', 'spans', 'transactions' for performance docs\n- Include specific feature names like 'beforeSend', 'tracesSampleRate', 'SENTRY_DSN'\n</hints>",
+    "inputSchema": {
+      "query": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 200,
+        "description": "The search query in natural language. Be specific about what you're looking for.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "maxResults": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 3,
+            "description": "Maximum number of results to return (1-10)"
+          }
+        ],
+        "description": "Maximum number of results to return (1-10)",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "guide": {
+        "anyOf": [
+          {
+            "not": {}
+          },
+          {
+            "type": "string",
+            "enum": [
+              "javascript",
+              "python",
+              "java",
+              "dotnet",
+              "go",
+              "php",
+              "ruby",
+              "android",
+              "apple",
+              "unity",
+              "unreal",
+              "rust",
+              "elixir",
+              "kotlin",
+              "native",
+              "dart",
+              "godot",
+              "nintendo-switch",
+              "playstation",
+              "powershell",
+              "react-native",
+              "xbox",
+              "javascript/nextjs",
+              "javascript/react",
+              "javascript/gatsby",
+              "javascript/remix",
+              "javascript/vue",
+              "javascript/angular",
+              "javascript/hono",
+              "javascript/svelte",
+              "javascript/express",
+              "javascript/fastify",
+              "javascript/astro",
+              "javascript/bun",
+              "javascript/capacitor",
+              "javascript/cloudflare",
+              "javascript/connect",
+              "javascript/cordova",
+              "javascript/deno",
+              "javascript/electron",
+              "javascript/ember",
+              "javascript/nuxt",
+              "javascript/solid",
+              "javascript/solidstart",
+              "javascript/sveltekit",
+              "javascript/tanstack-react",
+              "javascript/wasm",
+              "javascript/node",
+              "javascript/koa",
+              "javascript/nestjs",
+              "javascript/hapi",
+              "python/django",
+              "python/flask",
+              "python/fastapi",
+              "python/celery",
+              "python/tornado",
+              "python/pyramid",
+              "python/aiohttp",
+              "python/anthropic",
+              "python/airflow",
+              "python/aws-lambda",
+              "python/boto3",
+              "python/bottle",
+              "python/chalice",
+              "python/dramatiq",
+              "python/falcon",
+              "python/langchain",
+              "python/litestar",
+              "python/logging",
+              "python/loguru",
+              "python/openai",
+              "python/quart",
+              "python/ray",
+              "python/redis",
+              "python/rq",
+              "python/sanic",
+              "python/sqlalchemy",
+              "python/starlette",
+              "dart/flutter",
+              "dotnet/aspnetcore",
+              "dotnet/maui",
+              "dotnet/wpf",
+              "dotnet/winforms",
+              "dotnet/aspnet",
+              "dotnet/aws-lambda",
+              "dotnet/azure-functions",
+              "dotnet/blazor-webassembly",
+              "dotnet/entityframework",
+              "dotnet/google-cloud-functions",
+              "dotnet/extensions-logging",
+              "dotnet/log4net",
+              "dotnet/nlog",
+              "dotnet/serilog",
+              "dotnet/uwp",
+              "dotnet/xamarin",
+              "java/spring",
+              "java/spring-boot",
+              "java/android",
+              "java/jul",
+              "java/log4j2",
+              "java/logback",
+              "java/servlet",
+              "go/echo",
+              "go/fasthttp",
+              "go/fiber",
+              "go/gin",
+              "go/http",
+              "go/iris",
+              "go/logrus",
+              "go/negroni",
+              "go/slog",
+              "go/zerolog",
+              "php/laravel",
+              "php/symfony",
+              "ruby/delayed_job",
+              "ruby/rack",
+              "ruby/rails",
+              "ruby/resque",
+              "ruby/sidekiq",
+              "android/kotlin",
+              "apple/ios",
+              "apple/macos",
+              "apple/watchos",
+              "apple/tvos",
+              "apple/visionos",
+              "kotlin/multiplatform"
+            ],
+            "description": "Optional guide filter to limit search results to specific documentation sections. Use either a platform (e.g., 'javascript', 'python') or platform/guide combination (e.g., 'javascript/nextjs', 'python/django')."
+          }
+        ],
+        "description": "Optional guide filter to limit search results to specific documentation sections. Use either a platform (e.g., 'javascript', 'python') or platform/guide combination (e.g., 'javascript/nextjs', 'python/django').",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  },
+  {
+    "name": "get_doc",
+    "description": "Fetch the full markdown content of a Sentry documentation page.\n\nUse this tool when you need to:\n- Read the complete documentation for a specific topic\n- Get detailed implementation examples or code snippets\n- Access the full context of a documentation page\n- Extract specific sections from documentation\n\n<examples>\n### Get the Next.js integration guide\n\n```\nget_doc(path='/platforms/javascript/guides/nextjs.md')\n```\n</examples>\n\n<hints>\n- Use the path from search_docs results for accurate fetching\n- Paths should end with .md extension\n</hints>",
+    "inputSchema": {
+      "path": {
+        "type": "string",
+        "description": "The documentation path (e.g., '/platforms/javascript/guides/nextjs.md'). Get this from search_docs results.",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Added GitHub CLI commands (`gh pr checks`, `gh pr view`, `gh run view`) to Claude settings allow list for better PR and workflow run visibility
- Included auto-generated `toolDefinitions.json` file that contains JSON schemas for all MCP server tools

## Changes
The `.claude/settings.json` now includes permissions for GitHub CLI commands to enable viewing PR checks and run statuses directly from the CLI. The `toolDefinitions.json` file is auto-generated and provides structured tool definitions for the MCP server.