### PR TITLE
feat: add responseType parameter for JSON output in tools

### DIFF
--- a/packages/mcp-server/src/tools/create-team.test.ts
+++ b/packages/mcp-server/src/tools/create-team.test.ts
@@ -27,4 +27,26 @@ describe("create_team", () => {
       "
     `);
   });
+  it("returns json", async () => {
+    const result = await createTeam.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        name: "the-goats",
+        responseType: "json",
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+    expect(result).toMatchObject({
+      organizationSlug: "sentry-mcp-evals",
+      team: {
+        id: "4509109078196224",
+        slug: "the-goats",
+        name: "the-goats",
+      },
+    });
+  });
 });

--- a/packages/mcp-server/src/tools/create-team.ts
+++ b/packages/mcp-server/src/tools/create-team.ts
@@ -45,12 +45,20 @@ export default defineTool({
       organizationSlug,
       name: params.name,
     });
-    let output = `# New Team in **${organizationSlug}**\n\n`;
-    output += `**ID**: ${team.id}\n`;
-    output += `**Slug**: ${team.slug}\n`;
-    output += `**Name**: ${team.name}\n`;
-    output += "# Using this information\n\n";
-    output += `- You should always inform the user of the Team Slug value.\n`;
-    return output;
+    let mdOutput = `# New Team in **${organizationSlug}**\n\n`;
+    mdOutput += `**ID**: ${team.id}\n`;
+    mdOutput += `**Slug**: ${team.slug}\n`;
+    mdOutput += `**Name**: ${team.name}\n`;
+    mdOutput += "# Using this information\n\n";
+    mdOutput += `- You should always inform the user of the Team Slug value.\n`;
+
+    if (params.responseType === "json") {
+      return {
+        organizationSlug,
+        team,
+      };
+    }
+
+    return mdOutput;
   },
 });

--- a/packages/mcp-server/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-server/src/tools/get-issue-details.test.ts
@@ -294,4 +294,37 @@ describe("get_issue_details", () => {
     expect(result).toContain("## Seer AI Analysis");
     expect(result).toContain("Consolidate bottle and price data fetching");
   });
+
+  it("returns json", async () => {
+    const result = await getIssueDetails.handler(
+      {
+        responseType: "json",
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: undefined,
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+    expect(result).toMatchObject({
+      autofixState: expect.any(String),
+      event: {
+        id: "7ca573c0f4814912aaa9bdc77d1a7d51",
+        occurredAt: "2025-04-08T21:15:04.000Z",
+      },
+      issue: {
+        count: "25",
+        culprit: "Object.fetch(index)",
+        firstSeen: "2025-04-03T22:51:19.403Z",
+        id: "6507376925",
+        lastSeen: "2025-04-12T11:34:11.000Z",
+        url: expect.any(String),
+      },
+    });
+  });
 });

--- a/packages/mcp-server/src/tools/get-issue-details.ts
+++ b/packages/mcp-server/src/tools/get-issue-details.ts
@@ -103,6 +103,7 @@ export default defineTool({
         event,
         apiService,
         autofixState,
+        responseType: params.responseType,
       });
     }
 
@@ -165,6 +166,7 @@ export default defineTool({
       event,
       apiService,
       autofixState,
+      responseType: params.responseType,
     });
   },
 });

--- a/packages/mcp-server/src/tools/types.ts
+++ b/packages/mcp-server/src/tools/types.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import { z } from "zod";
 import type { ServerContext } from "../types";
 import type {
   TextContent,
@@ -6,16 +6,26 @@ import type {
   EmbeddedResource,
 } from "@modelcontextprotocol/sdk/types.js";
 
+export const ResponseTypeSchema = z.enum(["md", "json"]).default("md");
+
 export interface ToolConfig<
   TSchema extends Record<string, z.ZodType> = Record<string, z.ZodType>,
 > {
   name: string;
   description: string;
-  inputSchema: TSchema;
+  inputSchema: TSchema & {
+    responseType?: typeof ResponseTypeSchema;
+  };
   handler: (
-    params: z.infer<z.ZodObject<TSchema>>,
+    params: z.infer<z.ZodObject<TSchema>> & {
+      responseType?: "md" | "json";
+    },
     context: ServerContext,
-  ) => Promise<string | (TextContent | ImageContent | EmbeddedResource)[]>;
+  ) => Promise<
+    | string
+    | Record<string, unknown>
+    | (TextContent | ImageContent | EmbeddedResource)[]
+  >;
 }
 
 /**

--- a/packages/mcp-server/src/tools/update-project.test.ts
+++ b/packages/mcp-server/src/tools/update-project.test.ts
@@ -73,4 +73,31 @@ describe("update_project", () => {
       "
     `);
   });
+  it("returns json", async () => {
+    const result = await updateProject.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        name: undefined,
+        slug: undefined,
+        platform: undefined,
+        teamSlug: "backend-team",
+        regionUrl: undefined,
+        responseType: "json",
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+    expect(result).toMatchObject({
+      organizationSlug: "sentry-mcp-evals",
+      project: {
+        id: "4509106749636608",
+        slug: "cloudflare-mcp",
+        name: "cloudflare-mcp",
+      },
+    });
+  });
 });

--- a/packages/mcp-server/src/tools/update-project.ts
+++ b/packages/mcp-server/src/tools/update-project.ts
@@ -124,12 +124,12 @@ export default defineTool({
       }
     }
 
-    let output = `# Updated Project in **${organizationSlug}**\n\n`;
-    output += `**ID**: ${project.id}\n`;
-    output += `**Slug**: ${project.slug}\n`;
-    output += `**Name**: ${project.name}\n`;
+    let mdOutput = `# Updated Project in **${organizationSlug}**\n\n`;
+    mdOutput += `**ID**: ${project.id}\n`;
+    mdOutput += `**Slug**: ${project.slug}\n`;
+    mdOutput += `**Name**: ${project.name}\n`;
     if (project.platform) {
-      output += `**Platform**: ${project.platform}\n`;
+      mdOutput += `**Platform**: ${project.platform}\n`;
     }
 
     // Display what was updated
@@ -141,16 +141,24 @@ export default defineTool({
       updates.push(`team assignment to "${params.teamSlug}"`);
 
     if (updates.length > 0) {
-      output += `\n## Updates Applied\n`;
-      output += updates.map((update) => `- Updated ${update}`).join("\n");
-      output += `\n`;
+      mdOutput += `\n## Updates Applied\n`;
+      mdOutput += updates.map((update) => `- Updated ${update}`).join("\n");
+      mdOutput += `\n`;
     }
 
-    output += "\n# Using this information\n\n";
-    output += `- The project is now accessible at slug: \`${project.slug}\`\n`;
+    mdOutput += "\n# Using this information\n\n";
+    mdOutput += `- The project is now accessible at slug: \`${project.slug}\`\n`;
     if (params.teamSlug) {
-      output += `- The project is now assigned to the \`${params.teamSlug}\` team\n`;
+      mdOutput += `- The project is now assigned to the \`${params.teamSlug}\` team\n`;
     }
-    return output;
+
+    if (params.responseType === "json") {
+      return {
+        organizationSlug,
+        project,
+      };
+    }
+
+    return mdOutput;
   },
 });

--- a/packages/mcp-server/src/tools/whoami.test.ts
+++ b/packages/mcp-server/src/tools/whoami.test.ts
@@ -19,4 +19,23 @@ describe("whoami", () => {
     `,
     );
   });
+  it("returns json", async () => {
+    const result = await whoami.handler(
+      { responseType: "json" },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "user": {
+          "email": "john.doe@example.com",
+          "id": "1",
+          "name": "John Doe",
+        },
+      }
+    `);
+  });
 });

--- a/packages/mcp-server/src/tools/whoami.ts
+++ b/packages/mcp-server/src/tools/whoami.ts
@@ -17,6 +17,12 @@ export default defineTool({
     // as they must always query the main API server, not region-specific servers
     const apiService = apiServiceFromContext(context);
     const user = await apiService.getAuthenticatedUser();
-    return `You are authenticated as ${user.name} (${user.email}).\n\nYour Sentry User ID is ${user.id}.`;
+    const mdOutput = `You are authenticated as ${user.name} (${user.email}).\n\nYour Sentry User ID is ${user.id}.`;
+    if (params.responseType === "json") {
+      return {
+        user,
+      };
+    }
+    return mdOutput;
   },
 });


### PR DESCRIPTION
## Summary
- Introduced a `responseType` parameter to various tools, allowing users to specify output format as either Markdown or JSON.
- Updated `formatIssueOutput`, `createTeam`, `getIssueDetails`, `updateProject`, and `whoami` functions to handle JSON responses.

## Changes
- Enhanced output formatting in tools to support JSON responses, improving integration with other systems and APIs.
- Added corresponding test cases to validate JSON output for each tool.

## Note:
- I have only done this for a few tools where I needed json response, once any core team member approves of this method, will move forward with other tools 