### PR TITLE
fix: add SENTRY_AUTH_TOKEN to deploy workflow for sourcemap uploads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Build
         run: pnpm build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Deploy to Cloudflare
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary
- Fixes sourcemap upload to Sentry during production builds by adding the missing `SENTRY_AUTH_TOKEN` environment variable to the GitHub Actions deploy workflow

## Context
The Sentry Vite plugin was configured correctly but couldn't upload sourcemaps during CI builds because the authentication token wasn't available. This prevented proper error tracking and debugging in production.

## Test plan
- Ensure `SENTRY_AUTH_TOKEN` secret is configured in GitHub repository settings
- Deploy to production will now successfully upload sourcemaps to Sentry
- Production errors will show proper stack traces with source code context