### PR TITLE
fix: improve error handling in search_events agent

### DIFF
--- a/packages/mcp-server/src/tools/search-events.test.ts
+++ b/packages/mcp-server/src/tools/search-events.test.ts
@@ -24,6 +24,8 @@ describe("search_events", () => {
     query = "test query",
     fields?: string[],
     errorMessage?: string,
+    sort?: string,
+    timeRange?: { statsPeriod: string } | { start: string; end: string },
   ) => {
     const defaultFields = {
       errors: ["issue", "title", "project", "timestamp", "level", "message"],
@@ -50,7 +52,8 @@ describe("search_events", () => {
           dataset,
           query,
           fields: fields || defaultFields[dataset],
-          sort: defaultSorts[dataset],
+          sort: sort || defaultSorts[dataset],
+          ...(timeRange && { timeRange }),
         };
 
     return {
@@ -310,16 +313,16 @@ describe("search_events", () => {
 
   it("should correctly handle user agent queries", async () => {
     // Mock AI response for user agent query in spans dataset
-    mockGenerateText.mockResolvedValueOnce({
-      experimental_output: {
-        dataset: "spans",
-        query: "has:mcp.tool.name AND has:user_agent.original",
-        fields: ["user_agent.original", "count()"],
-        sort: "-count()",
-        timeRange: { statsPeriod: "24h" },
-      },
-      warnings: [],
-    });
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        "has:mcp.tool.name AND has:user_agent.original",
+        ["user_agent.original", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
 
     // Mock the Sentry API response
     mswServer.use(


### PR DESCRIPTION
## Summary

Improve error handling in the search_events agent to prevent crashes when the AI SDK fails to parse responses.

## Changes

### Bug Fixes
- Wrap `experimental_output` access in try-catch to handle `AI_NoObjectGeneratedError` gracefully
- Return safe error objects instead of throwing exceptions when AI parsing fails
- Make `query` field optional in `QueryTranslationResult` interface (not needed when there's an error)
- Simplify error responses to only include the `error` field

### Test Updates
- Enhanced `mockAIResponse` helper to accept custom sort and timeRange parameters
- Fixed test that was using an incorrect mock structure

## Impact

This change prevents the search_events tool from crashing with "No object generated" errors when the AI SDK fails to parse the model's response. Errors are now properly propagated through the system for better user feedback.

Fixes MCP-SERVER-ECD

## Related

- Issue #415: Seer AI analysis suggestions may not always be accurate (the suggestion to add `maxToolRoundtrips` was incorrect)