### PR TITLE
fix: improve error handling and add maxSteps to search_events agent

### DIFF
--- a/packages/mcp-server/src/tools/search-events.test.ts
+++ b/packages/mcp-server/src/tools/search-events.test.ts
@@ -24,6 +24,8 @@ describe("search_events", () => {
     query = "test query",
     fields?: string[],
     errorMessage?: string,
+    sort?: string,
+    timeRange?: { statsPeriod: string } | { start: string; end: string },
   ) => {
     const defaultFields = {
       errors: ["issue", "title", "project", "timestamp", "level", "message"],
@@ -50,7 +52,8 @@ describe("search_events", () => {
           dataset,
           query,
           fields: fields || defaultFields[dataset],
-          sort: defaultSorts[dataset],
+          sort: sort || defaultSorts[dataset],
+          ...(timeRange && { timeRange }),
         };
 
     return {
@@ -310,16 +313,16 @@ describe("search_events", () => {
 
   it("should correctly handle user agent queries", async () => {
     // Mock AI response for user agent query in spans dataset
-    mockGenerateText.mockResolvedValueOnce({
-      experimental_output: {
-        dataset: "spans",
-        query: "has:mcp.tool.name AND has:user_agent.original",
-        fields: ["user_agent.original", "count()"],
-        sort: "-count()",
-        timeRange: { statsPeriod: "24h" },
-      },
-      warnings: [],
-    });
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        "has:mcp.tool.name AND has:user_agent.original",
+        ["user_agent.original", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
 
     // Mock the Sentry API response
     mswServer.use(

--- a/packages/mcp-server/src/tools/search-events/agent.ts
+++ b/packages/mcp-server/src/tools/search-events/agent.ts
@@ -496,6 +496,7 @@ Fix the issue and try again with the corrected query.`;
       datasetAttributes: datasetAttributesTool,
       otelSemantics: otelLookupTool,
     },
+    maxSteps: 5, // Allow up to 5 sequential tool calls for complex queries requiring multiple lookups
     temperature: 0.1, // Low temperature for more consistent translations
     experimental_output: Output.object({
       schema: z


### PR DESCRIPTION
## Summary

Improve the search_events agent's robustness by adding better error handling and enabling multiple sequential tool calls for complex queries.

## Changes

### Bug Fixes
- Wrap `experimental_output` access in try-catch to handle `AI_NoObjectGeneratedError` gracefully
- Return safe error objects instead of throwing exceptions when AI parsing fails
- Make `query` field optional in `QueryTranslationResult` interface (not needed when there's an error)
- Simplify error responses to only include the `error` field

### Features
- Add `maxSteps: 5` to the `generateText` call to allow up to 5 sequential tool calls
- This enables the AI to gather information through multiple tools before generating the final query

### Test Updates
- Enhanced `mockAIResponse` helper to accept custom sort and timeRange parameters
- Fixed test that was using an incorrect mock structure

## Impact

These changes address two key issues:

1. **Error Handling**: Prevents the search_events tool from crashing with "No object generated" errors when the AI SDK fails to parse responses. Errors are now properly propagated through the system.

2. **Complex Queries**: Enables the AI agent to handle more complex queries that require multiple information gathering steps:
   - Determine the appropriate dataset (spans/errors/logs)
   - Query available attributes for that dataset
   - Look up OpenTelemetry semantic conventions (potentially multiple namespaces)
   - Generate the final Sentry query with all gathered information

Previously, with `maxSteps: 1` (default), the agent could only make one tool call, limiting its ability to gather sufficient context.

Fixes MCP-SERVER-ECD

## Context

While investigating the "No object generated" errors, Seer AI incorrectly suggested `maxToolRoundtrips`, but the correct parameter is `maxSteps` according to the Vercel AI SDK documentation.

## Related

- Issue #415: Seer AI accuracy concerns
- Closes PR #416 (changes incorporated here)