### PR TITLE
feat: implement automatic token refresh with cookie-based authentication

### DIFF
--- a/packages/mcp-cloudflare/src/client/hooks/use-mcp-metadata.ts
+++ b/packages/mcp-cloudflare/src/client/hooks/use-mcp-metadata.ts
@@ -30,16 +30,13 @@ interface UseMcpMetadataResult {
   refetch: () => Promise<void>;
 }
 
-export function useMcpMetadata(
-  authToken: string | null,
-  enabled = true,
-): UseMcpMetadataResult {
+export function useMcpMetadata(enabled = true): UseMcpMetadataResult {
   const [metadata, setMetadata] = useState<McpMetadata | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchMetadata = useCallback(async () => {
-    if (!authToken || !enabled) {
+    if (!enabled) {
       return;
     }
 
@@ -48,9 +45,7 @@ export function useMcpMetadata(
 
     try {
       const response = await fetch("/api/metadata", {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
+        credentials: "include", // Include cookies
       });
 
       if (!response.ok) {
@@ -68,7 +63,7 @@ export function useMcpMetadata(
     } finally {
       setIsLoading(false);
     }
-  }, [authToken, enabled]);
+  }, [enabled]);
 
   // Fetch metadata when auth token changes or component mounts
   useEffect(() => {

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.ts
@@ -208,16 +208,15 @@ export function createHtmlPage(options: HtmlPageOptions): string {
  * Creates a success page for OAuth flows
  */
 export function createSuccessPage(
-  accessToken: string,
   options: Partial<HtmlPageOptions> = {},
 ): string {
   const bodyScript = `
-    // Pass the MCP token to the parent window
+    // Notify parent window of success
     if (window.opener) {
       window.opener.postMessage({
         type: 'SENTRY_AUTH_SUCCESS',
         data: {
-          accessToken: ${JSON.stringify(accessToken)}
+          // No token needed - auth handled via cookies
         }
       }, '*');
     }

--- a/packages/mcp-cloudflare/src/server/types/chat.ts
+++ b/packages/mcp-cloudflare/src/server/types/chat.ts
@@ -6,6 +6,7 @@
 export type ErrorName =
   // 400-level errors (client errors)
   | "MISSING_AUTH_TOKEN"
+  | "INVALID_AUTH_DATA"
   | "INVALID_MESSAGES_FORMAT"
   // 401-level errors (authentication)
   | "AUTH_EXPIRED"


### PR DESCRIPTION
## Summary

This PR implements automatic token refresh for the MCP Cloudflare demo, eliminating the need for users to re-authenticate when their tokens expire. The implementation moves from localStorage-based token storage to secure httpOnly cookies for improved security.

## Features

- **Automatic token refresh**: When a 401 error occurs, the server automatically attempts to refresh the token using the stored refresh token, then retries the request
- **Cookie-based authentication**: All tokens are now stored in secure httpOnly cookies instead of localStorage, preventing XSS attacks
- **Zero user interruption**: Token refresh happens transparently server-side without any user interaction required

## Breaking Changes

- Authentication is now entirely cookie-based; users will need to re-authenticate once after deployment
- Removed the `authToken` parameter from `useMcpMetadata` hook (now uses cookies)
- Client no longer sends Authorization headers (server reads from cookies)

## Major Changes

- Added secure cookie storage for auth data (access token, refresh token, expiration)
- Server automatically refreshes tokens on 401 errors inline within the chat endpoint
- Added `/api/auth/status` endpoint for checking authentication state
- All OAuth responses validated with Zod schemas for type safety
- Removed all localStorage usage for tokens

## Technical Details

- Tokens stored in `sentry_auth_data` httpOnly cookie with 30-day expiration
- Cookie security settings are environment-aware (HTTPS in production, HTTP in dev)
- Token refresh logic is internal to the chat endpoint (no exposed refresh endpoints)
- Uses the MCP server's OAuth refresh token endpoint

Created by Claude Code with task ID: feat/automatic-token-refresh