### PR TITLE
fix: handle 'me' references in search_events

### DIFF
--- a/packages/mcp-server-evals/src/evals/search-events.eval.ts
+++ b/packages/mcp-server-evals/src/evals/search-events.eval.ts
@@ -214,6 +214,27 @@ describeEval("search-events", {
           },
         ],
       },
+      {
+        input: `Show me errors affecting me in ${FIXTURES.organizationSlug}`,
+        expectedTools: [
+          {
+            name: "find_organizations",
+            arguments: {},
+          },
+          {
+            name: "whoami",
+            arguments: {},
+          },
+          {
+            name: "search_events",
+            arguments: {
+              organizationSlug: FIXTURES.organizationSlug,
+              naturalLanguageQuery: "errors affecting user.id:12345",
+              dataset: "errors",
+            },
+          },
+        ],
+      },
     ];
   },
   task: NoOpTaskRunner(),

--- a/packages/mcp-server/src/tools/search-events/agent.ts
+++ b/packages/mcp-server/src/tools/search-events/agent.ts
@@ -61,6 +61,12 @@ IMPORTANT SEMANTIC CONVENTIONS:
 - "token usage", "tokens used", "input tokens", "output tokens" → use gen_ai.usage.* attributes
 - "user agents", "user agent strings", "browser", "client" → use user_agent.original attribute
 
+CRITICAL - HANDLING "ME" REFERENCES:
+- If the query contains "me", "my", "myself", or "affecting me", you CANNOT resolve this directly
+- Instead, return an error explaining that the user should first call the 'whoami' tool to get their user ID
+- Suggest the exact query format they should use after getting their user ID (e.g., "user.id:12345")
+- Example error: "Cannot resolve 'me' reference. Please first use the 'whoami' tool to get your user ID, then search for 'user.id:<your-id>'"
+
 CRITICAL TOOL USAGE: You have access to the otelSemantics tool to look up OpenTelemetry semantic convention attributes. Use this tool when:
 - The query asks about concepts that should have OpenTelemetry attributes but you don't see them in the available fields
 - You need to find the correct attribute names for token usage, AI calls, database queries, HTTP requests, etc.
@@ -457,6 +463,11 @@ CRITICAL TOOL USAGE:
 1. Use datasetAttributes tool to discover what fields are available for your chosen dataset
 2. Use otelSemantics tool when you need specific OpenTelemetry attributes (gen_ai.*, db.*, http.*, etc.)
 3. IMPORTANT: For ambiguous terms like "user agents", "browser", "client" - ALWAYS use the datasetAttributes tool to find the correct field name (typically user_agent.original) instead of assuming it's related to user.id
+
+CRITICAL - HANDLING "ME" REFERENCES:
+- If the query contains "me", "my", "myself", or "affecting me", you CANNOT resolve this directly
+- Return an error message instructing the user to first call the 'whoami' tool
+- Example: "Cannot resolve 'me' in the query. Please first use the 'whoami' tool to get your user ID, then search for 'user.id:<your-id>' or 'user.email:<your-email>'"
 
 QUERY MODES:
 1. INDIVIDUAL EVENTS (default): Returns raw event data


### PR DESCRIPTION
## Summary

The search_events tool's AI agent now properly handles queries containing "me" references by instructing users to first call the whoami tool.

## Changes

### Bug Fix
- Updated the search_events AI agent prompts to detect "me", "my", "myself", or "affecting me" references
- Agent now returns an instructive error message explaining that the user should first use the 'whoami' tool to get their user ID
- Provides clear guidance on the correct query format after obtaining the user ID (e.g., "user.id:12345")

### Testing
- Added eval test case for "me" query handling that expects the whoami tool to be called first

## Context

Previously, when users queried "errors affecting me", the search_events tool would incorrectly use `user.id:me` which doesn't resolve to anything in Sentry. Now it properly instructs the LLM to orchestrate the tools by first calling whoami to get the actual user ID.

_Pull request created with Claude Code_