### PR TITLE
Removing the versioning callout to the header component. 

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/ui/header.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/header.tsx
@@ -2,7 +2,6 @@ import type React from "react";
 import { SentryIcon } from "./icons/sentry";
 import { Github, LogOut } from "lucide-react";
 import { Button } from "./button";
-import { LIB_VERSION } from "@sentry/mcp-server/version";
 
 interface HeaderProps {
   isAuthenticated?: boolean;
@@ -20,7 +19,6 @@ export const Header: React.FC<HeaderProps> = ({
           <SentryIcon className="h-8 w-8 text-violet-400" />
           <div className="flex items-baseline gap-2">
             <h1 className="text-2xl font-bold whitespace-nowrap">Sentry MCP</h1>
-            <span className="text-sm text-muted-foreground">{LIB_VERSION}</span>
           </div>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
Simple fix to remove the versioning withing the header component. No need to have it and it currently shows 0.0.0 which feel like a bug.

**Now you see it**
<img width="365" height="132" alt="Screenshot 2025-07-22 at 1 08 14 PM" src="https://github.com/user-attachments/assets/3450d4ee-6f6e-4a14-ab24-333423b81b59" />

**Now you dont**
<img width="359" height="121" alt="Screenshot 2025-07-22 at 1 08 08 PM" src="https://github.com/user-attachments/assets/ad9a1347-371f-43d4-ad4d-5840488622d0" />
