### PR TITLE
fix: propagate specific error messages to users instead of generic API errors

### DIFF
--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -138,17 +138,18 @@ export default defineTool({
     // Convert project slug to ID if needed - we need this for attribute fetching
     let projectId: string | undefined;
     if (params.projectSlug) {
-      try {
-        const project = await apiService.getProject({
+      const project = await withApiErrorHandling(
+        () =>
+          apiService.getProject({
+            organizationSlug,
+            projectSlugOrId: params.projectSlug!,
+          }),
+        {
           organizationSlug,
           projectSlugOrId: params.projectSlug,
-        });
-        projectId = String(project.id);
-      } catch (error) {
-        throw new UserInputError(
-          `Project '${params.projectSlug}' not found in organization '${organizationSlug}'`,
-        );
-      }
+        },
+      );
+      projectId = String(project.id);
     }
 
     // Translate the natural language query using Search Events Agent with error feedback
@@ -165,7 +166,7 @@ export default defineTool({
 
     // Handle Search Events Agent errors first
     if (parsed.error) {
-      throw new UserInputError(
+      throw new Error(
         `Search Events Agent could not translate query "${params.naturalLanguageQuery}". Error: ${parsed.error}`,
       );
     }

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -145,7 +145,7 @@ export default defineTool({
         });
         projectId = String(project.id);
       } catch (error) {
-        throw new Error(
+        throw new UserInputError(
           `Project '${params.projectSlug}' not found in organization '${organizationSlug}'`,
         );
       }
@@ -165,7 +165,7 @@ export default defineTool({
 
     // Handle Search Events Agent errors first
     if (parsed.error) {
-      throw new Error(
+      throw new UserInputError(
         `Search Events Agent could not translate query "${params.naturalLanguageQuery}". Error: ${parsed.error}`,
       );
     }

--- a/packages/mcp-server/src/tools/search-issues/handler.ts
+++ b/packages/mcp-server/src/tools/search-issues/handler.ts
@@ -139,17 +139,18 @@ export default defineTool({
         projectId = params.projectSlugOrId;
       } else {
         // It's a slug, convert to ID
-        try {
-          const project = await apiService.getProject({
+        const project = await withApiErrorHandling(
+          () =>
+            apiService.getProject({
+              organizationSlug: params.organizationSlug,
+              projectSlugOrId: params.projectSlugOrId!,
+            }),
+          {
             organizationSlug: params.organizationSlug,
             projectSlugOrId: params.projectSlugOrId,
-          });
-          projectId = String(project.id);
-        } catch (error) {
-          throw new UserInputError(
-            `Project '${params.projectSlugOrId}' not found in organization '${params.organizationSlug}'`,
-          );
-        }
+          },
+        );
+        projectId = String(project.id);
       }
     }
 

--- a/packages/mcp-server/src/tools/search-issues/handler.ts
+++ b/packages/mcp-server/src/tools/search-issues/handler.ts
@@ -146,7 +146,7 @@ export default defineTool({
           });
           projectId = String(project.id);
         } catch (error) {
-          throw new Error(
+          throw new UserInputError(
             `Project '${params.projectSlugOrId}' not found in organization '${params.organizationSlug}'`,
           );
         }


### PR DESCRIPTION
## Summary
Fixes error handling to show specific error messages to users instead of generic "problem communicating with the Sentry API" messages.

## Changes
- Use `UserInputError` instead of generic `Error` for project not found errors in both `search-issues` and `search-events` tools
- Use `UserInputError` for query translation failures in `search-events` tool
- Server error handler now properly recognizes these as user input errors and displays the actual error message

## Example
**Before**: "It looks like there was a problem communicating with the Sentry API."
**After**: "Project 'sentry-mcp' not found in organization 'sentry'"

Fixes MCP-SERVER-ED7