### PR TITLE
fix: add validation to ensure sort field is included in search_events fields array

### DIFF
--- a/packages/mcp-server/src/tools/search-events/agent.ts
+++ b/packages/mcp-server/src/tools/search-events/agent.ts
@@ -183,6 +183,12 @@ SORTING RULES (CRITICAL - YOU MUST ALWAYS SPECIFY A SORT):
    - If user asks for "slowest", use "-span.duration" or "-avg(span.duration)"
    - If user asks for "latest" or "recent", use "-timestamp"
    - If unsure, use the default sort for the dataset
+   
+   VALIDATION: Before returning your response, verify:
+   - If sort is "-timestamp", fields MUST contain "timestamp"
+   - If sort is "-count()", fields MUST contain "count()"
+   - If sort is any "-field", fields MUST contain "field"
+   - This is MANDATORY - Sentry will reject queries where sort field is not in the selected fields
 
 YOUR RESPONSE FORMAT:
 Return a JSON object with these fields:
@@ -206,6 +212,12 @@ CORRECT EXAMPLES (FOLLOW THESE PATTERNS):
     "fields": ["gen_ai.request.model", "sum(gen_ai.usage.input_tokens)", "sum(gen_ai.usage.output_tokens)"],
     "sort": "-sum(gen_ai.usage.input_tokens)",
     "timeRange": {"statsPeriod": "24h"}
+  }
+- "gen_ai.operation.name values" (showing unique values):
+  {
+    "query": "has:gen_ai.operation.name",
+    "fields": ["gen_ai.operation.name", "count()"],
+    "sort": "-count()"
   }
 - "errors with null user IDs":
   {
@@ -233,6 +245,7 @@ IMPORTANT NOTES:
 - Add any fields mentioned in the user's query to the fields array
 - If the user asks about a specific field (e.g., "show me user emails"), include that field
 - CRITICAL: The field you're sorting by MUST be included in your fields array (e.g., if sort is "-timestamp", fields must include "timestamp")
+- VALIDATION REQUIREMENT: Sentry will REJECT queries where the sort field is not in the selected fields array. ALWAYS ensure your sort field is included in fields.
 - Do NOT include project: filters in your query (project filtering is handled separately)
 - For spans/errors: When user mentions time periods, include timestamp filters in query
 - For logs: When user mentions time periods, do NOT include timestamp filters - handled automatically

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -218,6 +218,20 @@ export default defineTool({
     // Use the AI-provided sort parameter
     const sortParam = parsed.sort;
 
+    // Validate that the sort field is included in the fields array
+    // Extract the field name from the sort parameter (e.g., "-timestamp" -> "timestamp", "-count()" -> "count()")
+    const sortField = sortParam.startsWith("-")
+      ? sortParam.substring(1)
+      : sortParam;
+
+    // Check if the sort field is included in the fields array
+    if (!fields.includes(sortField)) {
+      // Always throw an error to help the agent learn the correct pattern
+      throw new UserInputError(
+        `Sort field "${sortField}" (from sort parameter "${sortParam}") must be included in the fields array. Sentry requires that any field used for sorting must also be explicitly selected. Current fields: [${fields.join(", ")}]. Please add "${sortField}" to the fields array or choose a different sort field that's already in the fields array.`,
+      );
+    }
+
     // Extract time range parameters from parsed response
     const timeParams: { statsPeriod?: string; start?: string; end?: string } =
       {};


### PR DESCRIPTION
## Summary
- Adds runtime validation to ensure the sort field is always included in the fields array for search_events queries
- Returns clear error messages for self-correction when validation fails
- Fixes MCP-SERVER-ECJ error caused by missing sort field in Sentry API queries

Fixes MCP-SERVER-ECJ

## Changes

### Bug Fix
The search_events tool was generating queries where the sort field wasn't included in the selected fields, causing Sentry API errors. This fix adds validation to catch this issue and provide clear feedback to the AI agent.

### Implementation Details
- Added validation in `handler.ts` that checks if the sort field exists in the fields array
- Enhanced agent instructions in `agent.ts` with stronger requirements and validation steps
- Added a concrete example for "X values" queries to demonstrate proper field selection
- Replaced internal "Snuba" references with "Sentry" to avoid exposing implementation details

## Test Plan
- [x] All existing tests pass
- [x] TypeScript compilation succeeds
- [x] Linting passes
- [x] Manual testing confirms validation works correctly