### PR TITLE
refactor: make agent prompts static for LLM caching and extract tool helpers

### DIFF
--- a/docs/adding-tools.mdc
+++ b/docs/adding-tools.mdc
@@ -227,6 +227,93 @@ pnpm eval your-tool
 - [ ] 1-2 eval tests (if critical)
 - [ ] Run quality checks
 
+## Agent-in-Tool Pattern
+
+Some tools (`search_events` and `search_issues`) embed AI agents to handle complex natural language translation. This pattern is used when:
+
+### When to Use This Pattern
+
+1. **Complex query translation** - Converting natural language to domain-specific query languages
+2. **Dynamic field discovery** - When available fields vary by project/context
+3. **Semantic understanding** - When the tool needs to understand intent, not just parameters
+
+### When NOT to Use This Pattern
+
+1. **Simple API calls** - Direct parameter mapping to API endpoints
+2. **Deterministic operations** - Operations with clear, unambiguous inputs
+3. **Performance-critical paths** - Embedded agents add latency and cost
+
+### Architecture
+
+```typescript
+// Tool handler delegates to embedded agent
+async handler(params, context) {
+  // 1. Embedded agent translates natural language
+  const translated = await translateQuery(params.naturalLanguageQuery, ...);
+  
+  // 2. Tool executes the translated query
+  const results = await apiService.searchEvents(translated.query, ...);
+  
+  // 3. Format and return results
+  return formatResults(results);
+}
+```
+
+### Error Handling Philosophy
+
+**DO NOT retry internally**. When the embedded agent fails:
+1. Throw a clear `UserInputError` with specific guidance
+2. Let the calling agent (Claude/Cursor) see the error
+3. The calling agent can retry with corrections if needed
+
+**IMPORTANT**: Keep system prompts static to enable LLM provider caching. Never modify prompts based on errors.
+
+```typescript
+// BAD: Dynamic prompt modification prevents caching
+let systemPrompt = basePrompt;
+if (previousError) {
+  systemPrompt += `\nPrevious error: ${previousError}`;
+}
+
+// GOOD: Static prompt with clear error boundaries
+const systemPrompt = STATIC_SYSTEM_PROMPT;
+try {
+  return await translateQuery(...);
+} catch (error) {
+  throw new UserInputError(`Could not translate query: ${error.message}`);
+}
+```
+
+### Tool Boundaries
+
+1. **Embedded Agent Responsibilities**:
+   - Translate natural language to structured queries
+   - Discover available fields/attributes
+   - Validate query syntax
+
+2. **Tool Handler Responsibilities**:
+   - Execute the translated query
+   - Handle API errors
+   - Format results for the calling agent
+
+3. **Calling Agent Responsibilities**:
+   - Decide when to use the tool
+   - Handle errors and retry if needed
+   - Interpret results
+
+### Implementation Guidelines
+
+1. **Create a CLAUDE.md file** in the tool directory documenting:
+   - The embedded agent's prompt and behavior
+   - Common translation patterns
+   - Known limitations
+
+2. **Keep agent prompts focused** - Don't duplicate general MCP knowledge
+3. **Use structured outputs** - Define clear schemas for agent responses
+4. **Provide tool discovery** - Let agents explore available fields dynamically
+
+See `packages/mcp-server/src/tools/search-events/` and `packages/mcp-server/src/tools/search-issues/` for examples.
+
 ## Worker-Specific Tools
 
 Some tools may require access to Cloudflare Worker-specific bindings (like AutoRAG, D1, R2, etc.) that aren't available in the standard ServerContext. For these cases, create a separate endpoint in the Worker that the tool can call.

--- a/docs/architecture.mdc
+++ b/docs/architecture.mdc
@@ -247,6 +247,56 @@ External documentation and data:
 - Streaming responses where applicable
 - Parallel API calls when possible
 
+## Two-Tier Agent Architecture
+
+Some tools (`search_events` and `search_issues`) implement a two-tier agent pattern:
+
+### Tier 1: Calling Agent (Claude/Cursor)
+- Decides when to use search tools
+- Provides natural language queries
+- Handles errors and retries
+- Interprets results for the user
+
+### Tier 2: Embedded Agent (GPT-4o)
+- Lives inside the MCP tool
+- Translates natural language to Sentry query syntax
+- Has its own tools for field discovery
+- Returns structured query objects
+
+### Data Flow Example
+
+```
+1. User: "Show me errors from yesterday"
+   ↓
+2. Claude: Calls search_events(naturalLanguageQuery="errors from yesterday")
+   ↓
+3. MCP Tool Handler: Receives request
+   ↓
+4. Embedded Agent (GPT-4o):
+   - Determines dataset: "errors"
+   - Calls datasetAttributes tool
+   - Translates to: {query: "", fields: [...], timeRange: {statsPeriod: "24h"}}
+   ↓
+5. MCP Tool: Executes Sentry API call
+   ↓
+6. Results formatted and returned to Claude
+   ↓
+7. Claude: Presents results to user
+```
+
+### Design Rationale
+
+This pattern is used when:
+- Query languages are complex (Sentry's search syntax)
+- Available fields vary by context (project-specific attributes)
+- Semantic understanding is required ("yesterday" → timeRange)
+
+### Error Handling
+
+- Embedded agent errors are returned as UserInputError
+- Calling agent sees the error and can retry
+- No internal retry loops - single responsibility
+
 ## Security Model
 
 - Access tokens never logged

--- a/packages/mcp-server/src/agent-tools/lookup-otel-semantics.ts
+++ b/packages/mcp-server/src/agent-tools/lookup-otel-semantics.ts
@@ -1,4 +1,7 @@
+import { tool } from "ai";
+import { z } from "zod";
 import type { SentryApiService } from "../api-client";
+import { UserInputError } from "../errors";
 
 // Import all JSON files directly
 import android from "./data/android.json";
@@ -248,4 +251,51 @@ export async function lookupOtelSemantics(
   }
 
   return response;
+}
+
+/**
+ * Create the otel-semantics-lookup tool for AI agents
+ */
+export function createOtelLookupTool(
+  apiService: SentryApiService,
+  organizationSlug: string,
+  projectId?: string,
+) {
+  return tool({
+    description:
+      "Look up OpenTelemetry semantic convention attributes for a specific namespace. OpenTelemetry attributes are universal standards that work across all datasets.",
+    parameters: z.object({
+      namespace: z
+        .string()
+        .describe(
+          "The OpenTelemetry namespace to look up (e.g., 'gen_ai', 'db', 'http', 'mcp')",
+        ),
+      searchTerm: z
+        .string()
+        .optional()
+        .describe("Optional search term to filter attributes"),
+      dataset: z
+        .enum(["spans", "errors", "logs"])
+        .describe(
+          "REQUIRED: Dataset to check attribute availability in. The agent MUST specify this based on their chosen dataset.",
+        ),
+    }),
+    execute: async ({ namespace, searchTerm, dataset }) => {
+      try {
+        return await lookupOtelSemantics(
+          namespace,
+          searchTerm,
+          dataset,
+          apiService,
+          organizationSlug,
+          projectId,
+        );
+      } catch (error) {
+        if (error instanceof UserInputError) {
+          return `Error: ${error.message}`;
+        }
+        throw error;
+      }
+    },
+  });
 }

--- a/packages/mcp-server/src/tools/search-issues/CLAUDE.md
+++ b/packages/mcp-server/src/tools/search-issues/CLAUDE.md
@@ -1,0 +1,125 @@
+# search_issues Tool - Embedded Agent Documentation
+
+This tool embeds an AI agent (GPT-4o) to translate natural language queries into Sentry's issue search syntax.
+
+## Architecture Overview
+
+The `search_issues` tool uses an "agent-in-tool" pattern similar to `search_events`:
+
+1. **MCP Tool Handler** (`handler.ts`) - Receives natural language query from calling agent
+2. **Embedded AI Agent** (`agent.ts`) - Translates to Sentry issue search syntax
+3. **API Execution** - Runs the translated query against Sentry's API
+4. **Result Formatting** - Returns formatted grouped issues to calling agent
+
+## Key Differences from search_events
+
+### Purpose
+- `search_events`: Returns individual events or aggregated statistics
+- `search_issues`: Returns grouped issues (problems) with metadata
+
+### Query Syntax
+- Uses Sentry's issue search syntax (different from event search)
+- No aggregate functions - issues are already grouped
+- Special fields like `is:`, `assigned:`, `firstSeen:`, `lastSeen:`
+
+### No Datasets
+- Issues are a single unified view across all event types
+- No dataset selection required
+
+## Embedded Agent Behavior
+
+### Available Tools
+
+The embedded agent has access to two tools:
+
+1. **discoverDatasetFields** - Discovers available issue fields
+2. **whoami** - Resolves "me" references to actual user IDs
+
+### Translation Flow
+
+1. Analyzes natural language query for issue-specific patterns
+2. Calls `discoverDatasetFields` to get available issue fields
+3. May call `whoami` to resolve "me" references
+4. Generates issue search query with proper syntax
+
+### Key Query Patterns
+
+#### Status Queries
+- "unresolved issues" → `is:unresolved`
+- "ignored bugs" → `is:ignored`
+- "resolved yesterday" → `is:resolved` + timeRange
+
+#### Assignment Queries
+- "issues assigned to me" → `assigned:me` (or resolved email)
+- "unassigned errors" → `is:unassigned`
+
+#### Impact Queries
+- "issues affecting 100+ users" → `users:>100`
+- "high volume errors" → `events:>1000`
+
+#### Time-based Queries
+- "issues from last week" → Uses timeRange parameter
+- "errors seen today" → `lastSeen:-24h`
+
+## Error Handling
+
+Follows the same MCP philosophy as search_events:
+
+1. **Agent generates query** - Using static system prompt
+2. **Validation Error** - Returns clear UserInputError to calling agent
+3. **Calling agent decides** - Whether to retry with corrections
+
+Common validation errors:
+- Invalid issue field names
+- Incorrect query syntax
+- Missing required parameters
+
+This approach enables better LLM prompt caching and cleaner error boundaries.
+
+## Issue-Specific Fields
+
+### Status Fields
+- `is:` - resolved, unresolved, ignored, archived
+- `assigned:` - user email or "me"
+- `bookmarks:` - user email
+
+### Time Fields  
+- `firstSeen:` - When issue was first seen
+- `lastSeen:` - When issue was last seen
+- `age:` - How old the issue is
+
+### Impact Fields
+- `users:` - Number of affected users
+- `events:` - Total event count
+- `level:` - error, warning, info, debug
+
+## Limitations
+
+1. **No Aggregations** - Issues are already grouped, no count()/sum()
+2. **Limited Operators** - Simpler query syntax than events
+3. **No Custom Fields** - Fixed set of issue attributes
+
+## Common Issues and Solutions
+
+### Issue: "Using event syntax for issues"
+**Cause**: Agent tries to use event search patterns
+**Solution**: Clear separation in prompt between issue and event search
+
+### Issue: "Me resolution failures"
+**Cause**: User not authenticated or API error
+**Solution**: Fallback to suggesting user provide email
+
+## Testing Queries
+
+Test various issue query patterns:
+- Status filters: "unresolved critical errors"
+- Assignment: "my issues", "unassigned bugs"
+- Impact: "issues affecting many users"
+- Time ranges: "issues from yesterday"
+- Combined: "unresolved errors assigned to me from last week"
+
+## Future Improvements
+
+1. ~~Consider removing retry mechanism - let calling agent handle retries~~ ✅ Done
+2. Better integration with issue workflow commands (resolve, assign)
+3. Extract shared agent tools to common module


### PR DESCRIPTION
## Summary

This PR refactors the AI-powered search tools (`search_events` and `search_issues`) to improve performance through static prompts and better code organization.

## Features

- **Static prompts for LLM caching**: Removed dynamic prompt modification to enable LLM provider caching, reducing latency and costs
- **Extracted reusable tool helpers**: Moved `createOtelLookupTool` and `createDatasetAttributesTool` to shared modules for better reusability

## Architectural changes

- **Removed retry mechanisms**: Both search tools now follow cleaner MCP patterns where tools return errors for upstream agents to handle
- **Consolidated tool creation**: ~130 lines of duplicate code removed by extracting tool creation helpers to appropriate modules
- **Comprehensive documentation**: Added CLAUDE.md files for both AI-powered tools documenting their embedded agent behavior

## Breaking changes

None - the external API remains unchanged.

## Test plan

- [x] TypeScript compilation passes
- [x] Linting passes  
- [x] All existing tests pass
- [x] Manual testing of search_events and search_issues tools