### PR TITLE
fix: use UserInputError for unsupported time series queries in search_events

### DIFF
--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -127,7 +127,7 @@ export default defineTool({
 
     // Handle Search Events Agent errors first
     if (parsed.error) {
-      throw new Error(
+      throw new UserInputError(
         `Search Events Agent could not translate query "${params.naturalLanguageQuery}". Error: ${parsed.error}`,
       );
     }


### PR DESCRIPTION
## Summary
- Fixed error handling in `search_events` tool to properly handle unsupported time series queries
- Changed from throwing generic `Error` to `UserInputError` for better MCP protocol compliance
- Added test coverage for time series query rejection

## Details
The `search_events` tool was failing at the infrastructure level when users requested time series aggregations (e.g., "requests to tools over time"). The AI agent correctly identified these as unsupported but the handler threw a generic JavaScript Error, causing complete tool execution failure.

This change ensures proper error propagation through the MCP protocol, allowing calling agents to handle the limitation gracefully and potentially suggest alternative queries.

Fixes MCP-SERVER-ECH

## Test plan
- [x] Added new test case for time series query rejection
- [x] Updated existing test to verify UserInputError is thrown
- [x] All tests pass
- [x] TypeScript compilation successful
- [x] Linting passes

_Created using Claude Code_