### PR TITLE
fix: prevent LLM from duplicating sort parameters in query field

### DIFF
--- a/packages/mcp-server/src/tools/search-events/agent.ts
+++ b/packages/mcp-server/src/tools/search-events/agent.ts
@@ -147,17 +147,21 @@ When user asks for calculated metrics, ratios, or conversions:
 - IMPORTANT: Equations are ONLY supported in the spans dataset, NOT in errors or logs
 
 SORTING RULES (CRITICAL - YOU MUST ALWAYS SPECIFY A SORT):
-1. DEFAULT SORTING:
+1. CRITICAL: Sort MUST go in the separate "sort" field, NEVER in the "query" field
+   - WRONG: query: "level:error sort:-timestamp" ← Sort syntax in query field is FORBIDDEN
+   - CORRECT: query: "level:error", sort: "-timestamp" ← Sort in separate field
+
+2. DEFAULT SORTING:
    - errors dataset: Use "-timestamp" (newest first)
    - spans dataset: Use "-span.duration" (slowest first)  
    - logs dataset: Use "-timestamp" (newest first)
 
-2. SORTING SYNTAX:
+3. SORTING SYNTAX:
    - Use "-" prefix for descending order (e.g., "-timestamp" for newest first)
    - Use field name without prefix for ascending order
    - For aggregate queries: sort by aggregate function results (e.g., "-count()" for highest count first)
 
-3. IMPORTANT SORTING REQUIREMENTS:
+4. IMPORTANT SORTING REQUIREMENTS:
    - YOU MUST ALWAYS INCLUDE A SORT PARAMETER
    - CRITICAL: The field you sort by MUST be included in your fields array
    - If sorting by "-timestamp", include "timestamp" in fields

--- a/packages/mcp-server/src/tools/search-issues/config.ts
+++ b/packages/mcp-server/src/tools/search-issues/config.ts
@@ -19,11 +19,18 @@ QUERY PATTERNS:
 - Impact: userCount:>100, eventCount:>1000
 - Assignment: assignedOrSuggested:email@example.com
 
-SORT OPTIONS:
-- date: Last seen (default)
-- freq: Event frequency
-- new: First seen
-- user: User count
+SORTING RULES:
+1. CRITICAL: Sort MUST go in the separate "sort" field, NEVER in the "query" field
+   - WRONG: query: "is:unresolved sort:user" ← Sort syntax in query field is FORBIDDEN
+   - CORRECT: query: "is:unresolved", sort: "user" ← Sort in separate field
+
+2. AVAILABLE SORT OPTIONS:
+   - date: Last seen (default)
+   - freq: Event frequency  
+   - new: First seen
+   - user: User count
+
+3. IMPORTANT: Query field is for filtering only (is:, level:, environment:, etc.)
 
 'ME' REFERENCES:
 - When the user says "assigned to me" or similar, you MUST use the whoami tool to get the current user's email
@@ -31,11 +38,11 @@ SORT OPTIONS:
 - Example: "assigned to me" → use whoami tool → assignedOrSuggested:user@example.com
 
 EXAMPLES:
-"critical bugs" → level:error is:unresolved
-"errors from last week" → is:unresolved lastSeen:-7d
-"affecting 100+ users" → userCount:>100
-"assigned to john@example.com" → assignedOrSuggested:john@example.com
-"production errors" → environment:production level:error
+"critical bugs" → query: "level:error is:unresolved", sort: "date"
+"worst issues affecting the most users" → query: "is:unresolved", sort: "user"
+"assigned to john@example.com" → query: "assignedOrSuggested:john@example.com", sort: "date"
+
+NEVER: query: "is:unresolved sort:user" ← Sort goes in separate field!
 
 Always use the issueFields tool to discover available fields when needed.
 Use the whoami tool when you need to resolve 'me' references.`;


### PR DESCRIPTION
## Summary
- Fixed AI agents incorrectly including sort syntax in the query field
- Made system prompts explicit about sort parameter separation
- Unified sorting rules structure between search_issues and search_events agents

## Changes

### Bug Fix
The AI agents for `search_issues` and `search_events` were sometimes incorrectly including sort syntax (e.g., `sort:user`) in the query field instead of using the separate sort parameter. This caused malformed queries like:
```json
{"query": "is:unresolved sort:user", "sort": "user"}
```

### Implementation
- Updated system prompts to explicitly state that sort MUST go in the separate "sort" field
- Added clear WRONG vs CORRECT examples to prevent confusion
- Unified the sorting rules structure between both agents for consistency
- Reduced redundant examples while keeping key patterns clear

This ensures queries like "worst issues affecting the most users" correctly generate:
```json
{"query": "is:unresolved", "sort": "user"}
```

_Created with [Claude Code](https://docs.anthropic.com/en/docs/claude-code)_