### PR TITLE
feat: add logging for empty search results

### DIFF
--- a/packages/mcp-server/src/tools/search-events/formatters.ts
+++ b/packages/mcp-server/src/tools/search-events/formatters.ts
@@ -5,6 +5,7 @@ import {
   getNumberValue,
   isAggregateQuery,
 } from "./utils";
+import * as Sentry from "@sentry/node";
 
 /**
  * Format error event results for display
@@ -37,6 +38,16 @@ export function formatErrorResults(
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
+    Sentry.logger.info(
+      Sentry.logger
+        .fmt`No error events found for query: ${params.naturalLanguageQuery}`,
+      {
+        query: sentryQuery,
+        fields: fields,
+        organizationSlug: organizationSlug,
+        dataset: "errors",
+      },
+    );
     output += `No results found.\n\n`;
     output += `Try being more specific or using different terms in your search.\n`;
     return output;
@@ -148,6 +159,16 @@ export function formatLogResults(
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
+    Sentry.logger.info(
+      Sentry.logger
+        .fmt`No log events found for query: ${params.naturalLanguageQuery}`,
+      {
+        query: sentryQuery,
+        fields: fields,
+        organizationSlug: organizationSlug,
+        dataset: "logs",
+      },
+    );
     output += `No results found.\n\n`;
     output += `Try being more specific or using different terms in your search.\n`;
     return output;
@@ -283,6 +304,16 @@ export function formatSpanResults(
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
+    Sentry.logger.info(
+      Sentry.logger
+        .fmt`No span events found for query: ${params.naturalLanguageQuery}`,
+      {
+        query: sentryQuery,
+        fields: fields,
+        organizationSlug: organizationSlug,
+        dataset: "spans",
+      },
+    );
     output += `No results found.\n\n`;
     output += `Try being more specific or using different terms in your search.\n`;
     return output;

--- a/packages/mcp-server/src/tools/search-issues/formatters.ts
+++ b/packages/mcp-server/src/tools/search-issues/formatters.ts
@@ -1,5 +1,6 @@
 import type { Issue } from "../../api-client";
 import { getIssueUrl, getIssuesSearchUrl } from "../../utils/url-utils";
+import * as Sentry from "@sentry/node";
 
 /**
  * Format issue search results for display
@@ -35,6 +36,16 @@ export function formatIssueResults(
   }
 
   if (issues.length === 0) {
+    Sentry.logger.info(
+      Sentry.logger
+        .fmt`No issues found for query: ${naturalLanguageQuery || query}`,
+      {
+        query: query,
+        organizationSlug: organizationSlug,
+        projectSlug: projectSlugOrId,
+        naturalLanguageQuery: naturalLanguageQuery,
+      },
+    );
     output += "No issues found matching your search criteria.\n\n";
     output += "Try adjusting your search criteria or time range.";
     return output;


### PR DESCRIPTION
## Summary

Add structured logging when search-events or search-issues return no results. This helps monitor search patterns and understand user queries that yield empty results.

## Changes

- Add Sentry.logger.info() calls with structured context when no results are found
- Log natural language query, translated query, fields, organization, and dataset information
- Apply to all three search-events formatters (errors, logs, spans) and search-issues formatter

## Implementation Details

Uses Sentry's modern logging API with the `logger.fmt` template tag for structured logging. The logs are at info level since empty results are expected scenarios, not errors.

---

_PR created with Claude Code_