### PR TITLE
feat: improve MCP client names for better identification

### DIFF
--- a/packages/mcp-cloudflare/src/server/routes/chat.ts
+++ b/packages/mcp-cloudflare/src/server/routes/chat.ts
@@ -276,7 +276,7 @@ export default new Hono<{ Bindings: Env }>().post("/", async (c) => {
       const sseUrl = `${requestUrl.protocol}//${requestUrl.host}/sse`;
 
       mcpClient = await experimental_createMCPClient({
-        name: "sentry",
+        name: "mcp.sentry.dev (web)",
         transport: {
           type: "sse" as const,
           url: sseUrl,
@@ -305,7 +305,7 @@ export default new Hono<{ Bindings: Env }>().post("/", async (c) => {
             const sseUrl = `${requestUrl.protocol}//${requestUrl.host}/sse`;
 
             mcpClient = await experimental_createMCPClient({
-              name: "sentry",
+              name: "mcp.sentry.dev (web)",
               transport: {
                 type: "sse" as const,
                 url: sseUrl,

--- a/packages/mcp-test-client/src/mcp-test-client-remote.ts
+++ b/packages/mcp-test-client/src/mcp-test-client-remote.ts
@@ -56,7 +56,7 @@ export async function connectToRemoteMCPServer(
 
           // Create SSE client with authentication
           const client = await experimental_createMCPClient({
-            name: "sentry-mcp",
+            name: "mcp.sentry.dev (test-client)",
             transport: {
               type: "sse" as const,
               url: `${mcpHost}/sse`,

--- a/packages/mcp-test-client/src/mcp-test-client.ts
+++ b/packages/mcp-test-client/src/mcp-test-client.ts
@@ -52,6 +52,7 @@ export async function connectToMCPServer(
           });
 
           const client = await experimental_createMCPClient({
+            name: "mcp.sentry.dev (test-client)",
             transport,
           });
 


### PR DESCRIPTION
## Summary

Add descriptive names to MCP clients to distinguish between different implementations and improve monitoring/debugging capabilities.

## Changes

- **Web client**: Change from `"sentry"` to `"mcp.sentry.dev (web)"`
- **Test client (remote)**: Change from `"sentry-mcp"` to `"mcp.sentry.dev (test-client)"`
- **Test client (local)**: Add name `"mcp.sentry.dev (test-client)"` (previously unnamed)

## Benefits

- Clear identification of client type in logs and monitoring
- Consistent naming scheme across all implementations
- Better debugging experience when analyzing MCP connections
- Domain-based naming that reflects the service

---

_PR created with Claude Code_