### PR TITLE
feat: add OPENAI_API_KEY documentation and remove MCP_USER_AGENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ If you're looking to contribute, learn how it works, or to run this for self-hos
 
 While this repository is focused on acting as an MCP service, we also support a `stdio` transport. This is still a work in progress, but is the easiest way to adapt run the MCP against a self-hosted Sentry install.
 
+**Note:** The AI-powered search tools (`search_events` and `search_issues`) require an OpenAI API key. These tools use natural language processing to translate queries into Sentry's query syntax. Without the API key, these specific tools will be unavailable, but all other tools will function normally.
+
 To utilize the `stdio` transport, you'll need to create an User Auth Token in Sentry with the necessary scopes. As of writing this is:
 
 ```
@@ -40,6 +42,7 @@ Note: You can also use environment variables:
 ```shell
 SENTRY_ACCESS_TOKEN=
 SENTRY_HOST=
+OPENAI_API_KEY=  # Required for AI-powered search tools (search_events, search_issues)
 ```
 
 ### MCP Inspector
@@ -93,7 +96,7 @@ pnpm test
 Evals will require a `.env` file with some config:
 
 ```shell
-OPENAI_API_KEY=
+OPENAI_API_KEY=  # Also required for AI-powered search tools in production
 ```
 
 Once that's done you can run them using:

--- a/docs/monitoring.mdc
+++ b/docs/monitoring.mdc
@@ -183,8 +183,6 @@ Following [OpenTelemetry semantic conventions for user agent](https://openteleme
 
 - `user_agent.original` - The original User-Agent header value from the client
 
-**Stdio Transport**: Set via `MCP_USER_AGENT` environment variable, defaults to `sentry-mcp-stdio/{version}`
-
 **Cloudflare Transport**: Captured from the initial SSE/WebSocket connection request headers and cached for the session
 
 ### Network Attributes

--- a/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
@@ -16,6 +16,7 @@ export default function StdioSetup() {
     env: {
       SENTRY_ACCESS_TOKEN: "sentry-user-token",
       SENTRY_HOST: "sentry.io",
+      OPENAI_API_KEY: "your-openai-key", // Required for AI-powered search tools
     },
   };
 
@@ -88,7 +89,6 @@ export default function StdioSetup() {
                         ...coreConfig,
                         env: {
                           ...coreConfig.env,
-                          MCP_USER_AGENT: "Cursor (stdio)",
                         },
                       },
                     },
@@ -107,7 +107,7 @@ export default function StdioSetup() {
             <li>
               <CodeSnippet
                 noMargin
-                snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e SENTRY_HOST=sentry.io -e MCP_USER_AGENT="Claude Code (stdio)" -- ${mcpStdioSnippet}`}
+                snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e SENTRY_HOST=sentry.io -e OPENAI_API_KEY=your-openai-key -- ${mcpStdioSnippet}`}
               />
             </li>
             <li>
@@ -147,7 +147,6 @@ export default function StdioSetup() {
                         ...coreConfig,
                         env: {
                           ...coreConfig.env,
-                          MCP_USER_AGENT: "Windsurf (stdio)",
                         },
                       },
                     },
@@ -187,7 +186,6 @@ export default function StdioSetup() {
                       ...coreConfig,
                       env: {
                         ...coreConfig.env,
-                        MCP_USER_AGENT: "VSCode (stdio)",
                       },
                     },
                   },
@@ -222,7 +220,6 @@ export default function StdioSetup() {
                         ...coreConfig,
                         env: {
                           ...coreConfig.env,
-                          MCP_USER_AGENT: "Zed (stdio)",
                         },
                       },
                       settings: {},

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,6 +6,9 @@ This package is primarily for running the `stdio` MCP server. If you do not know
 
 <https://mcp.sentry.dev>
 
+**Note:** Some tools require additional configuration:
+- **AI-powered search tools** (`search_events` and `search_issues`): These tools use OpenAI to translate natural language queries into Sentry's query syntax. They require an `OPENAI_API_KEY` environment variable. Without this key, these specific tools will be unavailable, but all other tools will function normally.
+
 To utilize the `stdio` transport, you'll need to create an User Auth Token in Sentry with the necessary scopes. As of writing this is:
 
 ```
@@ -31,6 +34,7 @@ Note: You can also use environment variables:
 SENTRY_ACCESS_TOKEN=your-token
 SENTRY_HOST=sentry.example.com     # Custom hostname
 SENTRY_URL=https://sentry.io       # OR base URL (precedence over SENTRY_HOST)
+OPENAI_API_KEY=your-openai-key     # Required for AI-powered search tools (search_events, search_issues)
 ```
 
 The host configuration accepts two distinct formats:

--- a/packages/mcp-server/src/constants.ts
+++ b/packages/mcp-server/src/constants.ts
@@ -5,6 +5,11 @@
  */
 
 /**
+ * MCP Server identification
+ */
+export const MCP_SERVER_NAME = "Sentry MCP" as const;
+
+/**
  * Common Sentry platforms that have documentation available
  */
 export const SENTRY_PLATFORMS_BASE = [

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -76,6 +76,18 @@ if (!accessToken) {
   process.exit(1);
 }
 
+// Check for OpenAI API key and warn if missing
+if (!process.env.OPENAI_API_KEY) {
+  console.warn("Warning: OPENAI_API_KEY environment variable is not set.");
+  console.warn("The following AI-powered search tools will be unavailable:");
+  console.warn("  - search_events (natural language event search)");
+  console.warn("  - search_issues (natural language issue search)");
+  console.warn(
+    "All other tools will function normally. To enable AI-powered search, set OPENAI_API_KEY.",
+  );
+  console.warn("");
+}
+
 Sentry.init({
   dsn: sentryDsn,
   sendDefaultPii: true,
@@ -118,7 +130,6 @@ startStdio(instrumentedServer, {
   organizationSlug: null,
   sentryHost,
   mcpUrl,
-  userAgent: process.env.MCP_USER_AGENT || `sentry-mcp-stdio/${LIB_VERSION}`,
 }).catch((err) => {
   console.error("Server error:", err);
   // ensure we've flushed all events

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -38,6 +38,7 @@ import { PROMPT_HANDLERS } from "./prompts";
 import { ApiError } from "./api-client";
 import { UserInputError, ConfigurationError } from "./errors";
 import { LIB_VERSION } from "./version";
+import { MCP_SERVER_NAME } from "./constants";
 
 /**
  * Type guard to identify Sentry API errors.
@@ -367,12 +368,8 @@ export async function configureServer({
                   ...(context.mcpProtocolVersion && {
                     "mcp.protocol.version": context.mcpProtocolVersion,
                   }),
-                  ...(context.mcpServerName && {
-                    "mcp.server.name": context.mcpServerName,
-                  }),
-                  ...(context.mcpServerVersion && {
-                    "mcp.server.version": context.mcpServerVersion,
-                  }),
+                  "mcp.server.name": MCP_SERVER_NAME,
+                  "mcp.server.version": LIB_VERSION,
                   ...extractMcpParameters(args[0] || {}),
                 },
               },
@@ -444,12 +441,8 @@ export async function configureServer({
                   ...(context.mcpProtocolVersion && {
                     "mcp.protocol.version": context.mcpProtocolVersion,
                   }),
-                  ...(context.mcpServerName && {
-                    "mcp.server.name": context.mcpServerName,
-                  }),
-                  ...(context.mcpServerVersion && {
-                    "mcp.server.version": context.mcpServerVersion,
-                  }),
+                  "mcp.server.name": MCP_SERVER_NAME,
+                  "mcp.server.version": LIB_VERSION,
                   ...extractMcpParameters(params || {}),
                 },
               },


### PR DESCRIPTION
## Summary

Improve documentation and configuration handling for AI-powered search tools in the stdio distribution.

## Changes

### Features
- **OPENAI_API_KEY documentation**: Added clear documentation across all setup guides explaining that AI-powered search tools (`search_events` and `search_issues`) require an OpenAI API key
- **Startup warnings**: Added non-blocking startup warning when OPENAI_API_KEY is missing, listing which tools will be unavailable
- **Simplified configuration**: Removed MCP_USER_AGENT environment variable - no longer needed as stdio transport handles this internally

### Breaking Changes
- Removed `MCP_USER_AGENT` environment variable support (was only used for telemetry identification)

### Architectural Changes  
- Server identification now uses static constants (`MCP_SERVER_NAME`, `LIB_VERSION`) instead of passing values through context
- Removed `mcpServerName` and `mcpServerVersion` from `ServerContext` type

---

_PR created with Claude Code_