### PR TITLE
feat: add Sentry event scrubbing to prevent API key exposure

### DIFF
--- a/packages/mcp-cloudflare/src/client/instrument.ts
+++ b/packages/mcp-cloudflare/src/client/instrument.ts
@@ -1,9 +1,11 @@
 import * as Sentry from "@sentry/react";
+import { sentryBeforeSend } from "./utils/sentry-scrubbing";
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   sendDefaultPii: true,
   tracesSampleRate: 1,
+  beforeSend: sentryBeforeSend,
   environment:
     import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.NODE_ENV,
 });

--- a/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
@@ -9,17 +9,17 @@ interface ScrubPattern {
 // Patterns for sensitive data that should be scrubbed
 const SCRUB_PATTERNS: ScrubPattern[] = [
   {
-    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/,
     replacement: "[REDACTED_OPENAI_KEY]",
     description: "OpenAI API key",
   },
   {
-    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/,
     replacement: "Bearer [REDACTED_TOKEN]",
     description: "Bearer token",
   },
   {
-    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/,
     replacement: "[REDACTED_SENTRY_TOKEN]",
     description: "Sentry access token",
   },
@@ -32,7 +32,8 @@ function scrubValue(value: unknown): unknown {
   if (typeof value === "string") {
     let scrubbed = value;
     for (const { pattern, replacement } of SCRUB_PATTERNS) {
-      scrubbed = scrubbed.replace(pattern, replacement);
+      // Use global flag for replace to replace all occurrences
+      scrubbed = scrubbed.replace(new RegExp(pattern.source, "g"), replacement);
     }
     return scrubbed;
   }

--- a/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
@@ -1,0 +1,131 @@
+import type * as Sentry from "@sentry/react";
+
+interface ScrubPattern {
+  pattern: RegExp;
+  replacement: string;
+  description: string;
+}
+
+// Patterns for sensitive data that should be scrubbed
+const SCRUB_PATTERNS: ScrubPattern[] = [
+  {
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    replacement: "[REDACTED_OPENAI_KEY]",
+    description: "OpenAI API key",
+  },
+  {
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    replacement: "Bearer [REDACTED_TOKEN]",
+    description: "Bearer token",
+  },
+  {
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    replacement: "[REDACTED_SENTRY_TOKEN]",
+    description: "Sentry access token",
+  },
+];
+
+/**
+ * Recursively scrub sensitive data from any value
+ */
+function scrubValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    let scrubbed = value;
+    for (const { pattern, replacement } of SCRUB_PATTERNS) {
+      scrubbed = scrubbed.replace(pattern, replacement);
+    }
+    return scrubbed;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(scrubValue);
+  }
+
+  if (value && typeof value === "object") {
+    const scrubbed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      scrubbed[key] = scrubValue(val);
+    }
+    return scrubbed;
+  }
+
+  return value;
+}
+
+/**
+ * Sentry beforeSend hook that scrubs sensitive data from events
+ */
+export function sentryBeforeSend(event: any, hint: any) {
+  // Check if the event contains any sensitive patterns
+  let containsSensitive = false;
+  const eventString = JSON.stringify(event);
+
+  for (const { pattern, description } of SCRUB_PATTERNS) {
+    if (pattern.test(eventString)) {
+      containsSensitive = true;
+      console.error(
+        `[Sentry Scrubbing] Event contained sensitive data: ${description}`,
+      );
+    }
+  }
+
+  if (!containsSensitive) {
+    return event;
+  }
+
+  // Deep clone and scrub the event
+  const scrubbedEvent = JSON.parse(JSON.stringify(event));
+
+  // Scrub common event properties
+  if (scrubbedEvent.message) {
+    scrubbedEvent.message = scrubValue(scrubbedEvent.message) as string;
+  }
+
+  if (scrubbedEvent.exception?.values) {
+    scrubbedEvent.exception.values = scrubbedEvent.exception.values.map(
+      (exception: any) => ({
+        ...exception,
+        value: scrubValue(exception.value),
+      }),
+    );
+  }
+
+  if (scrubbedEvent.request) {
+    scrubbedEvent.request = scrubValue(scrubbedEvent.request);
+  }
+
+  if (scrubbedEvent.contexts) {
+    scrubbedEvent.contexts = scrubValue(scrubbedEvent.contexts);
+  }
+
+  if (scrubbedEvent.extra) {
+    scrubbedEvent.extra = scrubValue(scrubbedEvent.extra);
+  }
+
+  if (scrubbedEvent.tags) {
+    scrubbedEvent.tags = scrubValue(scrubbedEvent.tags);
+  }
+
+  // Remove breadcrumbs entirely
+  scrubbedEvent.breadcrumbs = undefined;
+
+  return scrubbedEvent;
+}
+
+/**
+ * Add a new pattern to scrub
+ */
+export function addScrubPattern(
+  pattern: RegExp,
+  replacement: string,
+  description: string,
+): void {
+  SCRUB_PATTERNS.push({ pattern, replacement, description });
+}
+
+/**
+ * Get current scrub patterns (for testing)
+ */
+export function getScrubPatterns(): ReadonlyArray<ScrubPattern> {
+  return [...SCRUB_PATTERNS];
+}

--- a/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
@@ -60,14 +60,13 @@ export function sentryBeforeSend(event: any, hint: any) {
   // Check if the event contains any sensitive patterns
   let containsSensitive = false;
 
-  let eventString;
+  let eventString: string;
   try {
     eventString = JSON.stringify(event);
   } catch (e) {
-    console.error('[Sentry Scrubbing] Failed to stringify event:', e);
-    eventString = '';
+    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
+    eventString = "";
   }
-
 
   for (const { pattern, description } of SCRUB_PATTERNS) {
     if (pattern.test(eventString)) {

--- a/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
@@ -65,7 +65,8 @@ export function sentryBeforeSend(event: any, hint: any) {
     eventString = JSON.stringify(event);
   } catch (e) {
     console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    eventString = "";
+    // Drop the event if we can't check it for sensitive data
+    return null;
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {

--- a/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/client/utils/sentry-scrubbing.ts
@@ -59,7 +59,15 @@ function scrubValue(value: unknown): unknown {
 export function sentryBeforeSend(event: any, hint: any) {
   // Check if the event contains any sensitive patterns
   let containsSensitive = false;
-  const eventString = JSON.stringify(event);
+
+  let eventString;
+  try {
+    eventString = JSON.stringify(event);
+  } catch (e) {
+    console.error('[Sentry Scrubbing] Failed to stringify event:', e);
+    eventString = '';
+  }
+
 
   for (const { pattern, description } of SCRUB_PATTERNS) {
     if (pattern.test(eventString)) {

--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -1,6 +1,7 @@
 import type { Env } from "./types";
 import { LIB_VERSION } from "@sentry/mcp-server/version";
 import * as Sentry from "@sentry/cloudflare";
+import { sentryBeforeSend } from "./utils/sentry-scrubbing";
 
 type SentryConfig = ReturnType<Parameters<typeof Sentry.withSentry>[0]>;
 
@@ -11,6 +12,7 @@ export default function getSentryConfig(env: Env): SentryConfig {
     dsn: env.SENTRY_DSN,
     tracesSampleRate: 1,
     sendDefaultPii: true,
+    beforeSend: sentryBeforeSend,
     initialScope: {
       tags: {
         "mcp.server_version": LIB_VERSION,

--- a/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
@@ -9,17 +9,17 @@ interface ScrubPattern {
 // Patterns for sensitive data that should be scrubbed
 const SCRUB_PATTERNS: ScrubPattern[] = [
   {
-    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/,
     replacement: "[REDACTED_OPENAI_KEY]",
     description: "OpenAI API key",
   },
   {
-    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/,
     replacement: "Bearer [REDACTED_TOKEN]",
     description: "Bearer token",
   },
   {
-    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/,
     replacement: "[REDACTED_SENTRY_TOKEN]",
     description: "Sentry access token",
   },
@@ -32,7 +32,8 @@ function scrubValue(value: unknown): unknown {
   if (typeof value === "string") {
     let scrubbed = value;
     for (const { pattern, replacement } of SCRUB_PATTERNS) {
-      scrubbed = scrubbed.replace(pattern, replacement);
+      // Use global flag for replace to replace all occurrences
+      scrubbed = scrubbed.replace(new RegExp(pattern.source, "g"), replacement);
     }
     return scrubbed;
   }

--- a/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
@@ -64,8 +64,8 @@ export function sentryBeforeSend(event: any, hint: any) {
     eventString = JSON.stringify(event);
   } catch (e) {
     console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    // Return the event unmodified if we can't stringify it
-    return event;
+    // Drop the event if we can't check it for sensitive data
+    return null;
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {

--- a/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
@@ -1,0 +1,131 @@
+import type * as Sentry from "@sentry/cloudflare";
+
+interface ScrubPattern {
+  pattern: RegExp;
+  replacement: string;
+  description: string;
+}
+
+// Patterns for sensitive data that should be scrubbed
+const SCRUB_PATTERNS: ScrubPattern[] = [
+  {
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    replacement: "[REDACTED_OPENAI_KEY]",
+    description: "OpenAI API key",
+  },
+  {
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    replacement: "Bearer [REDACTED_TOKEN]",
+    description: "Bearer token",
+  },
+  {
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    replacement: "[REDACTED_SENTRY_TOKEN]",
+    description: "Sentry access token",
+  },
+];
+
+/**
+ * Recursively scrub sensitive data from any value
+ */
+function scrubValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    let scrubbed = value;
+    for (const { pattern, replacement } of SCRUB_PATTERNS) {
+      scrubbed = scrubbed.replace(pattern, replacement);
+    }
+    return scrubbed;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(scrubValue);
+  }
+
+  if (value && typeof value === "object") {
+    const scrubbed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      scrubbed[key] = scrubValue(val);
+    }
+    return scrubbed;
+  }
+
+  return value;
+}
+
+/**
+ * Sentry beforeSend hook that scrubs sensitive data from events
+ */
+export function sentryBeforeSend(event: any, hint: any) {
+  // Check if the event contains any sensitive patterns
+  let containsSensitive = false;
+  const eventString = JSON.stringify(event);
+
+  for (const { pattern, description } of SCRUB_PATTERNS) {
+    if (pattern.test(eventString)) {
+      containsSensitive = true;
+      console.error(
+        `[Sentry Scrubbing] Event contained sensitive data: ${description}`,
+      );
+    }
+  }
+
+  if (!containsSensitive) {
+    return event;
+  }
+
+  // Deep clone and scrub the event
+  const scrubbedEvent = JSON.parse(JSON.stringify(event));
+
+  // Scrub common event properties
+  if (scrubbedEvent.message) {
+    scrubbedEvent.message = scrubValue(scrubbedEvent.message) as string;
+  }
+
+  if (scrubbedEvent.exception?.values) {
+    scrubbedEvent.exception.values = scrubbedEvent.exception.values.map(
+      (exception: any) => ({
+        ...exception,
+        value: scrubValue(exception.value),
+      }),
+    );
+  }
+
+  if (scrubbedEvent.request) {
+    scrubbedEvent.request = scrubValue(scrubbedEvent.request);
+  }
+
+  if (scrubbedEvent.contexts) {
+    scrubbedEvent.contexts = scrubValue(scrubbedEvent.contexts);
+  }
+
+  if (scrubbedEvent.extra) {
+    scrubbedEvent.extra = scrubValue(scrubbedEvent.extra);
+  }
+
+  if (scrubbedEvent.tags) {
+    scrubbedEvent.tags = scrubValue(scrubbedEvent.tags);
+  }
+
+  // Remove breadcrumbs entirely
+  scrubbedEvent.breadcrumbs = undefined;
+
+  return scrubbedEvent;
+}
+
+/**
+ * Add a new pattern to scrub
+ */
+export function addScrubPattern(
+  pattern: RegExp,
+  replacement: string,
+  description: string,
+): void {
+  SCRUB_PATTERNS.push({ pattern, replacement, description });
+}
+
+/**
+ * Get current scrub patterns (for testing)
+ */
+export function getScrubPatterns(): ReadonlyArray<ScrubPattern> {
+  return [...SCRUB_PATTERNS];
+}

--- a/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
@@ -59,7 +59,14 @@ function scrubValue(value: unknown): unknown {
 export function sentryBeforeSend(event: any, hint: any) {
   // Check if the event contains any sensitive patterns
   let containsSensitive = false;
-  const eventString = JSON.stringify(event);
+  let eventString: string;
+  try {
+    eventString = JSON.stringify(event);
+  } catch (e) {
+    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
+    // Return the event unmodified if we can't stringify it
+    return event;
+  }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {
     if (pattern.test(eventString)) {

--- a/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-scrubbing.ts
@@ -1,5 +1,18 @@
 import type * as Sentry from "@sentry/cloudflare";
 
+/**
+ * Error thrown when an event cannot be serialized for scrubbing
+ */
+export class EventSerializationError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError: unknown,
+  ) {
+    super(message);
+    this.name = "EventSerializationError";
+  }
+}
+
 interface ScrubPattern {
   pattern: RegExp;
   replacement: string;
@@ -63,9 +76,10 @@ export function sentryBeforeSend(event: any, hint: any) {
   try {
     eventString = JSON.stringify(event);
   } catch (e) {
-    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    // Drop the event if we can't check it for sensitive data
-    return null;
+    throw new EventSerializationError(
+      "[Sentry Scrubbing] Cannot serialize event for sensitive data check",
+      e,
+    );
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -22,6 +22,7 @@ import {
   validateSentryHost,
   validateAndParseSentryUrl,
 } from "./utils/url-utils";
+import { sentryBeforeSend } from "./internal/sentry-scrubbing";
 
 let accessToken: string | undefined = process.env.SENTRY_ACCESS_TOKEN;
 let sentryHost = "sentry.io"; // Default hostname
@@ -92,6 +93,7 @@ Sentry.init({
   dsn: sentryDsn,
   sendDefaultPii: true,
   tracesSampleRate: 1,
+  beforeSend: sentryBeforeSend,
   initialScope: {
     tags: {
       "mcp.server_version": LIB_VERSION,

--- a/packages/mcp-server/src/internal/sentry-scrubbing.test.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  sentryBeforeSend,
+  addScrubPattern,
+  getScrubPatterns,
+} from "./sentry-scrubbing";
+import type * as Sentry from "@sentry/node";
+
+describe("sentry-scrubbing", () => {
+  describe("OpenAI API key scrubbing", () => {
+    it("should scrub OpenAI API keys from message", () => {
+      const event: Sentry.Event = {
+        message:
+          "Error with key: sk-abc123def456ghi789jkl012mno345pqr678stu901vwx234",
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.message).toBe("Error with key: [REDACTED_OPENAI_KEY]");
+    });
+
+    it("should scrub multiple OpenAI keys", () => {
+      const event: Sentry.Event = {
+        message:
+          "Keys: sk-abc123def456ghi789jkl012mno345pqr678stu901vwx234 and sk-xyz123def456ghi789jkl012mno345pqr678stu901vwx234",
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.message).toBe(
+        "Keys: [REDACTED_OPENAI_KEY] and [REDACTED_OPENAI_KEY]",
+      );
+    });
+
+    it("should not scrub partial matches", () => {
+      const event: Sentry.Event = {
+        message:
+          "Not a key: sk-abc or task-abc123def456ghi789jkl012mno345pqr678stu901vwx234",
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.message).toBe(event.message);
+    });
+  });
+
+  describe("Bearer token scrubbing", () => {
+    it("should scrub Bearer tokens", () => {
+      const event: Sentry.Event = {
+        message:
+          "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.message).toBe("Authorization: Bearer [REDACTED_TOKEN]");
+    });
+  });
+
+  describe("Sentry token scrubbing", () => {
+    it("should scrub Sentry access tokens", () => {
+      const event: Sentry.Event = {
+        message:
+          "Using token: sntrys_eyJpYXQiOjE2OTQwMzMxNTMuNzk0NjI4LCJ1cmwiOiJodHRwczovL3NlbnRyeS5pbyIsInJlZ2lvbl91cmwiOiJodHRwczovL3VzLnNlbnRyeS5pbyIsIm9yZyI6InNlbnRyeSJ9_abcdef123456",
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.message).toBe("Using token: [REDACTED_SENTRY_TOKEN]");
+    });
+  });
+
+  describe("Deep object scrubbing", () => {
+    it("should scrub sensitive data from nested objects", () => {
+      const event: Sentry.Event = {
+        extra: {
+          config: {
+            apiKey: "sk-abc123def456ghi789jkl012mno345pqr678stu901vwx234",
+            headers: {
+              Authorization: "Bearer token123",
+            },
+          },
+        },
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.extra).toEqual({
+        config: {
+          apiKey: "[REDACTED_OPENAI_KEY]",
+          headers: {
+            Authorization: "Bearer [REDACTED_TOKEN]",
+          },
+        },
+      });
+    });
+
+    it("should remove breadcrumbs entirely", () => {
+      const event: Sentry.Event = {
+        message: "Test event",
+        breadcrumbs: [
+          {
+            message:
+              "API call with sk-abc123def456ghi789jkl012mno345pqr678stu901vwx234",
+            data: {
+              tokens: ["sntrys_token1", "sntrys_token2"],
+            },
+          },
+        ],
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.breadcrumbs).toBeUndefined();
+      expect(result?.message).toBe("Test event");
+    });
+  });
+
+  describe("Exception scrubbing", () => {
+    it("should scrub from exception values", () => {
+      const event: Sentry.Event = {
+        exception: {
+          values: [
+            {
+              type: "Error",
+              value:
+                "Failed to authenticate with sk-abc123def456ghi789jkl012mno345pqr678stu901vwx234",
+            },
+          ],
+        },
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.exception?.values?.[0].value).toBe(
+        "Failed to authenticate with [REDACTED_OPENAI_KEY]",
+      );
+    });
+  });
+
+  describe("No sensitive data", () => {
+    it("should return event unchanged when no sensitive data", () => {
+      const event: Sentry.Event = {
+        message: "Normal error message",
+        extra: {
+          foo: "bar",
+        },
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result).toEqual(event);
+    });
+  });
+
+  describe("Custom patterns", () => {
+    it("should support adding custom patterns", () => {
+      const initialPatterns = getScrubPatterns().length;
+
+      addScrubPattern(
+        /custom_secret_\w+/g,
+        "[REDACTED_CUSTOM]",
+        "Custom secret",
+      );
+
+      expect(getScrubPatterns().length).toBe(initialPatterns + 1);
+
+      // The new pattern is now available in sentryBeforeSend
+      const event: Sentry.Event = {
+        message: "Secret: custom_secret_12345",
+      };
+
+      const result = sentryBeforeSend(event, {});
+      expect(result?.message).toBe("Secret: [REDACTED_CUSTOM]");
+    });
+  });
+});

--- a/packages/mcp-server/src/internal/sentry-scrubbing.test.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.test.ts
@@ -179,18 +179,18 @@ describe("sentry-scrubbing", () => {
   });
 
   describe("Error handling", () => {
-    it("should handle circular references in events", () => {
+    it("should drop events with circular references", () => {
       const circular: any = { message: "Error occurred" };
       circular.self = circular; // Create circular reference
 
       const event: Sentry.Event = circular;
 
-      // Should not throw and should return the event unmodified
+      // Should return null to drop the event
       const result = sentryBeforeSend(event, {});
-      expect(result).toBe(event);
+      expect(result).toBeNull();
     });
 
-    it("should handle non-serializable values", () => {
+    it("should drop events with non-serializable values", () => {
       const event: any = {
         message: "Error with function",
         extra: {
@@ -199,9 +199,9 @@ describe("sentry-scrubbing", () => {
         },
       };
 
-      // Should not throw and should return the event unmodified
+      // Should return null to drop the event
       const result = sentryBeforeSend(event, {});
-      expect(result).toBe(event);
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/mcp-server/src/internal/sentry-scrubbing.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.ts
@@ -9,17 +9,17 @@ interface ScrubPattern {
 // Patterns for sensitive data that should be scrubbed
 const SCRUB_PATTERNS: ScrubPattern[] = [
   {
-    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/,
     replacement: "[REDACTED_OPENAI_KEY]",
     description: "OpenAI API key",
   },
   {
-    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/,
     replacement: "Bearer [REDACTED_TOKEN]",
     description: "Bearer token",
   },
   {
-    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/,
     replacement: "[REDACTED_SENTRY_TOKEN]",
     description: "Sentry access token",
   },
@@ -32,7 +32,8 @@ function scrubValue(value: unknown): unknown {
   if (typeof value === "string") {
     let scrubbed = value;
     for (const { pattern, replacement } of SCRUB_PATTERNS) {
-      scrubbed = scrubbed.replace(pattern, replacement);
+      // Use global flag for replace to replace all occurrences
+      scrubbed = scrubbed.replace(new RegExp(pattern.source, "g"), replacement);
     }
     return scrubbed;
   }

--- a/packages/mcp-server/src/internal/sentry-scrubbing.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.ts
@@ -64,8 +64,8 @@ export function sentryBeforeSend(event: any, hint: any) {
     eventString = JSON.stringify(event);
   } catch (e) {
     console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    // Return the event unmodified if we can't stringify it
-    return event;
+    // Drop the event if we can't check it for sensitive data
+    return null;
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {

--- a/packages/mcp-server/src/internal/sentry-scrubbing.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.ts
@@ -1,0 +1,131 @@
+import type * as Sentry from "@sentry/node";
+
+interface ScrubPattern {
+  pattern: RegExp;
+  replacement: string;
+  description: string;
+}
+
+// Patterns for sensitive data that should be scrubbed
+const SCRUB_PATTERNS: ScrubPattern[] = [
+  {
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    replacement: "[REDACTED_OPENAI_KEY]",
+    description: "OpenAI API key",
+  },
+  {
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    replacement: "Bearer [REDACTED_TOKEN]",
+    description: "Bearer token",
+  },
+  {
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    replacement: "[REDACTED_SENTRY_TOKEN]",
+    description: "Sentry access token",
+  },
+];
+
+/**
+ * Recursively scrub sensitive data from any value
+ */
+function scrubValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    let scrubbed = value;
+    for (const { pattern, replacement } of SCRUB_PATTERNS) {
+      scrubbed = scrubbed.replace(pattern, replacement);
+    }
+    return scrubbed;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(scrubValue);
+  }
+
+  if (value && typeof value === "object") {
+    const scrubbed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      scrubbed[key] = scrubValue(val);
+    }
+    return scrubbed;
+  }
+
+  return value;
+}
+
+/**
+ * Sentry beforeSend hook that scrubs sensitive data from events
+ */
+export function sentryBeforeSend(event: any, hint: any) {
+  // Check if the event contains any sensitive patterns
+  let containsSensitive = false;
+  const eventString = JSON.stringify(event);
+
+  for (const { pattern, description } of SCRUB_PATTERNS) {
+    if (pattern.test(eventString)) {
+      containsSensitive = true;
+      console.error(
+        `[Sentry Scrubbing] Event contained sensitive data: ${description}`,
+      );
+    }
+  }
+
+  if (!containsSensitive) {
+    return event;
+  }
+
+  // Deep clone and scrub the event
+  const scrubbedEvent = JSON.parse(JSON.stringify(event));
+
+  // Scrub common event properties
+  if (scrubbedEvent.message) {
+    scrubbedEvent.message = scrubValue(scrubbedEvent.message) as string;
+  }
+
+  if (scrubbedEvent.exception?.values) {
+    scrubbedEvent.exception.values = scrubbedEvent.exception.values.map(
+      (exception: any) => ({
+        ...exception,
+        value: scrubValue(exception.value),
+      }),
+    );
+  }
+
+  if (scrubbedEvent.request) {
+    scrubbedEvent.request = scrubValue(scrubbedEvent.request);
+  }
+
+  if (scrubbedEvent.contexts) {
+    scrubbedEvent.contexts = scrubValue(scrubbedEvent.contexts);
+  }
+
+  if (scrubbedEvent.extra) {
+    scrubbedEvent.extra = scrubValue(scrubbedEvent.extra);
+  }
+
+  if (scrubbedEvent.tags) {
+    scrubbedEvent.tags = scrubValue(scrubbedEvent.tags);
+  }
+
+  // Remove breadcrumbs entirely
+  scrubbedEvent.breadcrumbs = undefined;
+
+  return scrubbedEvent;
+}
+
+/**
+ * Add a new pattern to scrub
+ */
+export function addScrubPattern(
+  pattern: RegExp,
+  replacement: string,
+  description: string,
+): void {
+  SCRUB_PATTERNS.push({ pattern, replacement, description });
+}
+
+/**
+ * Get current scrub patterns (for testing)
+ */
+export function getScrubPatterns(): ReadonlyArray<ScrubPattern> {
+  return [...SCRUB_PATTERNS];
+}

--- a/packages/mcp-server/src/internal/sentry-scrubbing.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.ts
@@ -59,7 +59,14 @@ function scrubValue(value: unknown): unknown {
 export function sentryBeforeSend(event: any, hint: any) {
   // Check if the event contains any sensitive patterns
   let containsSensitive = false;
-  const eventString = JSON.stringify(event);
+  let eventString: string;
+  try {
+    eventString = JSON.stringify(event);
+  } catch (e) {
+    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
+    // Return the event unmodified if we can't stringify it
+    return event;
+  }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {
     if (pattern.test(eventString)) {

--- a/packages/mcp-server/src/internal/sentry-scrubbing.ts
+++ b/packages/mcp-server/src/internal/sentry-scrubbing.ts
@@ -1,5 +1,18 @@
 import type * as Sentry from "@sentry/node";
 
+/**
+ * Error thrown when an event cannot be serialized for scrubbing
+ */
+export class EventSerializationError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError: unknown,
+  ) {
+    super(message);
+    this.name = "EventSerializationError";
+  }
+}
+
 interface ScrubPattern {
   pattern: RegExp;
   replacement: string;
@@ -63,9 +76,10 @@ export function sentryBeforeSend(event: any, hint: any) {
   try {
     eventString = JSON.stringify(event);
   } catch (e) {
-    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    // Drop the event if we can't check it for sensitive data
-    return null;
+    throw new EventSerializationError(
+      "[Sentry Scrubbing] Cannot serialize event for sensitive data check",
+      e,
+    );
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {

--- a/packages/mcp-test-client/src/index.ts
+++ b/packages/mcp-test-client/src/index.ts
@@ -12,6 +12,7 @@ import { runAgent } from "./agent.js";
 import { DEFAULT_MODEL } from "./constants.js";
 import { logError, logInfo, logSuccess, logUser } from "./logger.js";
 import { LIB_VERSION } from "./version.js";
+import { sentryBeforeSend } from "./utils/sentry-scrubbing.js";
 import type { MCPConnection } from "./types.js";
 
 // Load environment variables from multiple possible locations
@@ -47,6 +48,7 @@ program
         dsn: sentryDsn,
         sendDefaultPii: true,
         tracesSampleRate: 1,
+        beforeSend: sentryBeforeSend,
         initialScope: {
           tags: {
             "gen_ai.agent.name": "sentry-mcp-agent",

--- a/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
+++ b/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
@@ -9,17 +9,17 @@ interface ScrubPattern {
 // Patterns for sensitive data that should be scrubbed
 const SCRUB_PATTERNS: ScrubPattern[] = [
   {
-    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/,
     replacement: "[REDACTED_OPENAI_KEY]",
     description: "OpenAI API key",
   },
   {
-    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/,
     replacement: "Bearer [REDACTED_TOKEN]",
     description: "Bearer token",
   },
   {
-    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/,
     replacement: "[REDACTED_SENTRY_TOKEN]",
     description: "Sentry access token",
   },
@@ -32,7 +32,8 @@ function scrubValue(value: unknown): unknown {
   if (typeof value === "string") {
     let scrubbed = value;
     for (const { pattern, replacement } of SCRUB_PATTERNS) {
-      scrubbed = scrubbed.replace(pattern, replacement);
+      // Use global flag for replace to replace all occurrences
+      scrubbed = scrubbed.replace(new RegExp(pattern.source, "g"), replacement);
     }
     return scrubbed;
   }

--- a/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
+++ b/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
@@ -64,8 +64,8 @@ export function sentryBeforeSend(event: any, hint: any) {
     eventString = JSON.stringify(event);
   } catch (e) {
     console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    // Return the event unmodified if we can't stringify it
-    return event;
+    // Drop the event if we can't check it for sensitive data
+    return null;
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {

--- a/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
+++ b/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
@@ -1,0 +1,131 @@
+import type * as Sentry from "@sentry/node";
+
+interface ScrubPattern {
+  pattern: RegExp;
+  replacement: string;
+  description: string;
+}
+
+// Patterns for sensitive data that should be scrubbed
+const SCRUB_PATTERNS: ScrubPattern[] = [
+  {
+    pattern: /\bsk-[a-zA-Z0-9]{48}\b/g,
+    replacement: "[REDACTED_OPENAI_KEY]",
+    description: "OpenAI API key",
+  },
+  {
+    pattern: /\bBearer\s+[a-zA-Z0-9\-._~+/]+=*/g,
+    replacement: "Bearer [REDACTED_TOKEN]",
+    description: "Bearer token",
+  },
+  {
+    pattern: /\bsntrys_[a-zA-Z0-9_]+\b/g,
+    replacement: "[REDACTED_SENTRY_TOKEN]",
+    description: "Sentry access token",
+  },
+];
+
+/**
+ * Recursively scrub sensitive data from any value
+ */
+function scrubValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    let scrubbed = value;
+    for (const { pattern, replacement } of SCRUB_PATTERNS) {
+      scrubbed = scrubbed.replace(pattern, replacement);
+    }
+    return scrubbed;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(scrubValue);
+  }
+
+  if (value && typeof value === "object") {
+    const scrubbed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      scrubbed[key] = scrubValue(val);
+    }
+    return scrubbed;
+  }
+
+  return value;
+}
+
+/**
+ * Sentry beforeSend hook that scrubs sensitive data from events
+ */
+export function sentryBeforeSend(event: any, hint: any) {
+  // Check if the event contains any sensitive patterns
+  let containsSensitive = false;
+  const eventString = JSON.stringify(event);
+
+  for (const { pattern, description } of SCRUB_PATTERNS) {
+    if (pattern.test(eventString)) {
+      containsSensitive = true;
+      console.error(
+        `[Sentry Scrubbing] Event contained sensitive data: ${description}`,
+      );
+    }
+  }
+
+  if (!containsSensitive) {
+    return event;
+  }
+
+  // Deep clone and scrub the event
+  const scrubbedEvent = JSON.parse(JSON.stringify(event));
+
+  // Scrub common event properties
+  if (scrubbedEvent.message) {
+    scrubbedEvent.message = scrubValue(scrubbedEvent.message) as string;
+  }
+
+  if (scrubbedEvent.exception?.values) {
+    scrubbedEvent.exception.values = scrubbedEvent.exception.values.map(
+      (exception: any) => ({
+        ...exception,
+        value: scrubValue(exception.value),
+      }),
+    );
+  }
+
+  if (scrubbedEvent.request) {
+    scrubbedEvent.request = scrubValue(scrubbedEvent.request);
+  }
+
+  if (scrubbedEvent.contexts) {
+    scrubbedEvent.contexts = scrubValue(scrubbedEvent.contexts);
+  }
+
+  if (scrubbedEvent.extra) {
+    scrubbedEvent.extra = scrubValue(scrubbedEvent.extra);
+  }
+
+  if (scrubbedEvent.tags) {
+    scrubbedEvent.tags = scrubValue(scrubbedEvent.tags);
+  }
+
+  // Remove breadcrumbs entirely
+  scrubbedEvent.breadcrumbs = undefined;
+
+  return scrubbedEvent;
+}
+
+/**
+ * Add a new pattern to scrub
+ */
+export function addScrubPattern(
+  pattern: RegExp,
+  replacement: string,
+  description: string,
+): void {
+  SCRUB_PATTERNS.push({ pattern, replacement, description });
+}
+
+/**
+ * Get current scrub patterns (for testing)
+ */
+export function getScrubPatterns(): ReadonlyArray<ScrubPattern> {
+  return [...SCRUB_PATTERNS];
+}

--- a/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
+++ b/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
@@ -59,7 +59,14 @@ function scrubValue(value: unknown): unknown {
 export function sentryBeforeSend(event: any, hint: any) {
   // Check if the event contains any sensitive patterns
   let containsSensitive = false;
-  const eventString = JSON.stringify(event);
+  let eventString: string;
+  try {
+    eventString = JSON.stringify(event);
+  } catch (e) {
+    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
+    // Return the event unmodified if we can't stringify it
+    return event;
+  }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {
     if (pattern.test(eventString)) {

--- a/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
+++ b/packages/mcp-test-client/src/utils/sentry-scrubbing.ts
@@ -1,5 +1,18 @@
 import type * as Sentry from "@sentry/node";
 
+/**
+ * Error thrown when an event cannot be serialized for scrubbing
+ */
+export class EventSerializationError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError: unknown,
+  ) {
+    super(message);
+    this.name = "EventSerializationError";
+  }
+}
+
 interface ScrubPattern {
   pattern: RegExp;
   replacement: string;
@@ -63,9 +76,10 @@ export function sentryBeforeSend(event: any, hint: any) {
   try {
     eventString = JSON.stringify(event);
   } catch (e) {
-    console.error("[Sentry Scrubbing] Failed to stringify event:", e);
-    // Drop the event if we can't check it for sensitive data
-    return null;
+    throw new EventSerializationError(
+      "[Sentry Scrubbing] Cannot serialize event for sensitive data check",
+      e,
+    );
   }
 
   for (const { pattern, description } of SCRUB_PATTERNS) {


### PR DESCRIPTION
## Summary
- Add `sentryBeforeSend` hook to scrub sensitive data from Sentry events before they are sent
- Remove breadcrumbs entirely from all events to prevent sensitive data leakage
- Detect and redact OpenAI API keys, Bearer tokens, and Sentry access tokens

## Features
- **Sensitive data detection**: Automatically detects patterns for OpenAI API keys (`sk-*`), Bearer tokens, and Sentry access tokens (`sntrys_*`)
- **Recursive scrubbing**: Deep clones events and recursively scrubs all string values in messages, exceptions, contexts, extra data, and tags
- **Console logging**: Logs to `console.error` when sensitive data is detected for monitoring
- **Extensible patterns**: Provides `addScrubPattern()` function to add custom patterns at runtime

## Implementation
Added reusable `sentry-scrubbing.ts` utility across all Sentry configurations:
- `packages/mcp-server` - stdio implementation
- `packages/mcp-cloudflare` - both server and client configurations  
- `packages/mcp-test-client` - test client configuration

Includes comprehensive test coverage for all scrubbing patterns and edge cases.