### PR TITLE
feat: add optional tags support to event schema and format output accordingly

### DIFF
--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -349,6 +349,14 @@ const BaseEventSchema = z.object({
         .passthrough(),
     )
     .optional(),
+  tags: z
+    .array(
+      z.object({
+        key: z.string(),
+        value: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 export const ErrorEventSchema = BaseEventSchema.omit({

--- a/packages/mcp-server/src/internal/formatting.ts
+++ b/packages/mcp-server/src/internal/formatting.ts
@@ -188,6 +188,7 @@ export function formatEventOutput(event: Event) {
     );
   }
 
+  output += formatTags(event.tags);
   output += formatContexts(event.contexts);
   return output;
 }
@@ -592,6 +593,15 @@ function findFirstInAppFrame(
     }
   }
   return undefined;
+}
+
+function formatTags(tags: z.infer<typeof EventSchema>["tags"]) {
+  if (!tags || tags.length === 0) {
+    return "";
+  }
+  return `### Tags\n\n${tags
+    .map((tag) => `**${tag.key}**: ${tag.value}`)
+    .join("\n")}\n\n`;
 }
 
 function formatContexts(contexts: z.infer<typeof EventSchema>["contexts"]) {

--- a/packages/mcp-server/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-server/src/tools/get-issue-details.test.ts
@@ -56,6 +56,15 @@ describe("get_issue_details", () => {
       **Method:** GET
       **URL:** https://mcp.sentry.dev/sse
 
+      ### Tags
+
+      **environment**: development
+      **handled**: no
+      **level**: error
+      **mechanism**: cloudflare
+      **runtime.name**: cloudflare
+      **url**: https://mcp.sentry.dev/sse
+
       ### Additional Context
 
       These are additional context provided by the user when they're instrumenting their application.
@@ -137,6 +146,15 @@ describe("get_issue_details", () => {
       **Method:** GET
       **URL:** https://mcp.sentry.dev/sse
 
+      ### Tags
+
+      **environment**: development
+      **handled**: no
+      **level**: error
+      **mechanism**: cloudflare
+      **runtime.name**: cloudflare
+      **url**: https://mcp.sentry.dev/sse
+
       ### Additional Context
 
       These are additional context provided by the user when they're instrumenting their application.
@@ -216,6 +234,15 @@ describe("get_issue_details", () => {
 
       **Method:** GET
       **URL:** https://mcp.sentry.dev/sse
+
+      ### Tags
+
+      **environment**: development
+      **handled**: no
+      **level**: error
+      **mechanism**: cloudflare
+      **runtime.name**: cloudflare
+      **url**: https://mcp.sentry.dev/sse
 
       ### Additional Context
 


### PR DESCRIPTION
### Summary
This commit introduces an optional `tags` field to the event schema, allowing for structured tagging of events. Additionally, it implements a new `formatTags` function to format these tags in the event output.

### Key Changes
- Added `tags` field to `BaseEventSchema` as an optional array of objects containing `key` and `value` strings.
- Updated `formatEventOutput` to include formatted tags in the output if present.

This enhancement improves the event structure and output readability, facilitating better event categorization and analysis.

Fixes #453