### PR TITLE
feat: add trace details tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "start:stdio": "pnpm --stream run --filter ./packages/mcp-server start",
     "test": "dotenv -e .env -e .env.local -- turbo test",
     "test:ci": "CI=true dotenv -e .env -e .env.local -- pnpm --stream -r run test:ci",
+    "test:watch": "dotenv -e .env -e .env.local -- turbo test:watch",
     "tsc": "turbo tsc"
   },
   "dependencies": {

--- a/packages/mcp-cloudflare/package.json
+++ b/packages/mcp-cloudflare/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "type": "module",
   "license": "FSL-1.1-ALv2",
-  "files": [
-    "./dist/*"
-  ],
+  "files": ["./dist/*"],
   "exports": {
     ".": {
       "types": "./dist/index.ts",
@@ -20,9 +18,9 @@
     "cf:versions:upload": "npx wrangler versions upload",
     "preview": "vite preview",
     "cf-typegen": "wrangler types",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ci": "vitest run --coverage --reporter=junit --outputFile=tests.junit.xml",
-    "test:watch": "vitest watch",
+    "test:watch": "vitest",
     "tsc": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/mcp-server-mocks/src/fixtures/trace-event.json
+++ b/packages/mcp-server-mocks/src/fixtures/trace-event.json
@@ -1,0 +1,236 @@
+{
+  "id": "db633982397f45fca67621093b1430ef",
+  "groupID": null,
+  "eventID": "db633982397f45fca67621093b1430ef",
+  "projectID": "4509062593708032",
+  "size": 4091,
+  "entries": [
+    { "data": [], "type": "spans" },
+    {
+      "data": {
+        "values": [
+          {
+            "type": "default",
+            "timestamp": "2025-07-30T18:37:34.265000Z",
+            "level": "error",
+            "message": "[Filtered]",
+            "category": "console",
+            "data": { "arguments": ["[Filtered]"], "logger": "console" },
+            "event_id": null
+          }
+        ]
+      },
+      "type": "breadcrumbs"
+    },
+    {
+      "data": {
+        "apiTarget": null,
+        "method": "POST",
+        "url": "https://mcp.sentry.dev/mcp",
+        "query": [],
+        "fragment": null,
+        "data": null,
+        "headers": [
+          ["Accept", "application/json, text/event-stream"],
+          ["Accept-Encoding", "gzip, br"],
+          ["Accept-Language", "*"],
+          ["Authorization", "[Filtered]"],
+          ["Cf-Connecting-Ip", "203.0.113.1"],
+          ["Cf-Ipcountry", "US"],
+          ["Cf-Ray", "abcd1234ef567890"],
+          ["Cf-Visitor", "{\"scheme\":\"https\"}"],
+          ["Connection", "Keep-Alive"],
+          ["Content-Length", "54"],
+          ["Content-Type", "application/json"],
+          ["Host", "mcp.sentry.dev"],
+          ["Mcp-Protocol-Version", "2025-06-18"],
+          [
+            "Mcp-Session-Id",
+            "abc123def456789012345678901234567890abcdef1234567890abcdef123456"
+          ],
+          ["Sec-Fetch-Mode", "cors"],
+          ["User-Agent", "claude-code/1.0.63"],
+          ["X-Forwarded-Proto", "https"],
+          ["X-Real-Ip", "203.0.113.1"]
+        ],
+        "cookies": [],
+        "env": null,
+        "inferredContentType": "application/json"
+      },
+      "type": "request"
+    }
+  ],
+  "dist": null,
+  "message": "",
+  "title": "POST /mcp",
+  "location": "POST /mcp",
+  "user": {
+    "id": null,
+    "email": null,
+    "username": null,
+    "ip_address": "2001:db8::1",
+    "name": null,
+    "geo": { "country_code": "US", "region": "United States" },
+    "data": null
+  },
+  "contexts": {
+    "cloud_resource": { "cloud.provider": "cloudflare", "type": "default" },
+    "culture": { "timezone": "America/New_York", "type": "default" },
+    "runtime": { "name": "cloudflare", "type": "runtime" },
+    "trace": {
+      "trace_id": "3691b2ad31b14d65941383ba6bc3e79c",
+      "span_id": "b3d79b8311435f52",
+      "op": "http.server",
+      "status": "internal_error",
+      "exclusive_time": 3026693.000078,
+      "client_sample_rate": 1.0,
+      "origin": "auto.http.cloudflare",
+      "data": {
+        "server.address": "mcp.sentry.dev",
+        "url.scheme": "https:",
+        "url.full": "https://mcp.sentry.dev/mcp",
+        "http.request.body.size": 54,
+        "http.request.method": "POST",
+        "network.protocol.name": "HTTP/1.1",
+        "sentry.op": "http.server",
+        "sentry.origin": "auto.http.cloudflare",
+        "sentry.sample_rate": 1,
+        "sentry.source": "url",
+        "url.path": "/mcp"
+      },
+      "hash": "7b635d2b22f8087a",
+      "type": "trace"
+    }
+  },
+  "sdk": { "name": "sentry.javascript.cloudflare", "version": "9.34.0" },
+  "context": {},
+  "packages": {},
+  "type": "transaction",
+  "metadata": { "location": "POST /mcp", "title": "POST /mcp" },
+  "tags": [
+    { "key": "environment", "value": "cloudflare" },
+    { "key": "level", "value": "info" },
+    { "key": "mcp.server_version", "value": "0.17.1" },
+    { "key": "release", "value": "eece3c53-694c-4362-b599-95fc591a6cc7" },
+    { "key": "runtime.name", "value": "cloudflare" },
+    { "key": "sentry.host", "value": "sentry.io" },
+    { "key": "transaction", "value": "POST /mcp" },
+    { "key": "url", "value": "https://mcp.sentry.dev/mcp" },
+    {
+      "key": "user",
+      "value": "ip:2001:db8::1",
+      "query": "user.ip:\"2001:db8::1\""
+    }
+  ],
+  "platform": "javascript",
+  "dateReceived": "2025-07-30T18:37:34.301253Z",
+  "errors": [],
+  "occurrence": null,
+  "_meta": {
+    "entries": {
+      "1": {
+        "data": {
+          "values": {
+            "0": {
+              "data": {
+                "arguments": {
+                  "0": {
+                    "": {
+                      "rem": [["@password:filter", "s", 0, 10]],
+                      "len": 63,
+                      "chunks": [
+                        {
+                          "type": "redaction",
+                          "text": "[Filtered]",
+                          "rule_id": "@password:filter",
+                          "remark": "s"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "message": {
+                "": {
+                  "rem": [["@password:filter", "s", 0, 10]],
+                  "len": 63,
+                  "chunks": [
+                    {
+                      "type": "redaction",
+                      "text": "[Filtered]",
+                      "rule_id": "@password:filter",
+                      "remark": "s"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "2": {
+        "data": {
+          "": null,
+          "apiTarget": null,
+          "method": null,
+          "url": null,
+          "query": null,
+          "data": null,
+          "headers": {
+            "3": {
+              "1": {
+                "": {
+                  "rem": [["@password:filter", "s", 0, 10]],
+                  "len": 64,
+                  "chunks": [
+                    {
+                      "type": "redaction",
+                      "text": "[Filtered]",
+                      "rule_id": "@password:filter",
+                      "remark": "s"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "cookies": null,
+          "env": null
+        }
+      }
+    },
+    "message": null,
+    "user": null,
+    "contexts": null,
+    "sdk": null,
+    "context": null,
+    "packages": null,
+    "tags": {}
+  },
+  "startTimestamp": 1753897627.572,
+  "endTimestamp": 1753900654.265,
+  "measurements": null,
+  "breakdowns": null,
+  "release": {
+    "id": 1489295029,
+    "commitCount": 0,
+    "data": {},
+    "dateCreated": "2025-07-29T01:05:26.573000Z",
+    "dateReleased": null,
+    "deployCount": 0,
+    "ref": null,
+    "lastCommit": null,
+    "lastDeploy": null,
+    "status": "open",
+    "url": null,
+    "userAgent": null,
+    "version": "eece3c53-694c-4362-b599-95fc591a6cc7",
+    "versionInfo": {
+      "package": null,
+      "version": { "raw": "eece3c53-694c-4362-b599-95fc591a6cc7" },
+      "description": "eece3c53-694c-4362-b599-95fc591a6cc7",
+      "buildHash": null
+    }
+  },
+  "projectSlug": "mcp-server"
+}

--- a/packages/mcp-server-mocks/src/fixtures/trace-meta.json
+++ b/packages/mcp-server-mocks/src/fixtures/trace-meta.json
@@ -1,0 +1,71 @@
+{
+  "logs": 0,
+  "errors": 0,
+  "performance_issues": 0,
+  "span_count": 112.0,
+  "transaction_child_count_map": [
+    {
+      "transaction.event_id": "0daf40dc453a429c8c57e4c215c4e82c",
+      "count()": 10.0
+    },
+    {
+      "transaction.event_id": "845c0f1eb7544741a9d08cf28e144f42",
+      "count()": 1.0
+    },
+    {
+      "transaction.event_id": "b49a5b53cba046a2bab9323d8f00de96",
+      "count()": 7.0
+    },
+    {
+      "transaction.event_id": "c0db3d88529744d393f091b692c024ca",
+      "count()": 11.0
+    },
+    {
+      "transaction.event_id": "ee6e7f39107847f980e06119bf116d38",
+      "count()": 7.0
+    },
+    {
+      "transaction.event_id": "efa09ae9091e400e8865fe48aaae80d6",
+      "count()": 12.0
+    },
+    {
+      "transaction.event_id": "f398bbc635c64e2091d94679dade2957",
+      "count()": 3.0
+    },
+    {
+      "transaction.event_id": "f531c48c3eaa43be9587dd880b8ec4bb",
+      "count()": 6.0
+    },
+    {
+      "transaction.event_id": "f779775e1c6a4f09b62d68818a25d7b5",
+      "count()": 55.0
+    }
+  ],
+  "span_count_map": {
+    "cache.get": 41.0,
+    "middleware.django": 24.0,
+    "db": 11.0,
+    "function": 6.0,
+    "db.redis": 4.0,
+    "feature.flagpole.batch_has": 4.0,
+    "processor": 2.0,
+    "execute": 2.0,
+    "fetch_organization_projects": 2.0,
+    "other": 1.0,
+    "db.clickhouse": 1.0,
+    "validator": 1.0,
+    "serialize": 1.0,
+    "http.client": 1.0,
+    "base.paginate.on_results": 1.0,
+    "ratelimit.__call__": 1.0,
+    "base.dispatch.request": 1.0,
+    "discover.endpoint": 1.0,
+    "serialize.iterate": 1.0,
+    "base.dispatch.setup": 1.0,
+    "serialize.get_attrs": 1.0,
+    "build_plan.storage_query_plan_builder": 1.0,
+    "serialize.get_attrs.project.options": 1.0,
+    "check_object_permissions_on_organization": 1.0,
+    "allocation_policy.get_quota_allowance": 1.0
+  }
+}

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -50,6 +50,11 @@ import traceItemsAttributesLogsStringFixture from "./fixtures/trace-items-attrib
 import traceItemsAttributesLogsNumberFixture from "./fixtures/trace-items-attributes-logs-number.json" with {
   type: "json",
 };
+import traceMetaFixture from "./fixtures/trace-meta.json" with { type: "json" };
+import traceFixture from "./fixtures/trace.json" with { type: "json" };
+import traceEventFixture from "./fixtures/trace-event.json" with {
+  type: "json",
+};
 
 /**
  * Standard organization payload for mock responses.
@@ -759,6 +764,18 @@ export const restHandlers = buildHandlers([
     fetch: () => HttpResponse.json(issueFixture2),
   },
 
+  // Trace endpoints
+  {
+    method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+    fetch: () => HttpResponse.json(traceMetaFixture),
+  },
+  {
+    method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/trace/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+    fetch: () => HttpResponse.json(traceFixture),
+  },
+
   {
     method: "get",
     path: "/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/7ca573c0f4814912aaa9bdc77d1a7d51/",
@@ -1291,7 +1308,12 @@ export const mswServer = setupServer(
 );
 
 // Export fixtures for use in tests
-export { autofixStateFixture };
+export {
+  autofixStateFixture,
+  traceMetaFixture,
+  traceFixture,
+  traceEventFixture,
+};
 
 // Export utilities for creating mock servers
 export { setupMockServer, startMockServer } from "./utils";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -102,10 +102,10 @@
     "start": "tsx src/index.ts",
     "prepare": "pnpm run build",
     "pretest": "pnpm run generate-tool-definitions",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ci": "pnpm run generate-tool-definitions && vitest run --coverage --reporter=junit --outputFile=tests.junit.xml",
+    "test:watch": "pnpm run generate-tool-definitions && vitest",
     "tsc": "tsc --noEmit",
-    "test:watch": "vitest watch",
     "generate-tool-definitions": "tsx scripts/generate-tool-definitions.ts",
     "generate-otel-namespaces": "tsx scripts/generate-otel-namespaces.ts"
   },

--- a/packages/mcp-server/src/api-client/client.test.ts
+++ b/packages/mcp-server/src/api-client/client.test.ts
@@ -645,7 +645,7 @@ describe("API query builders", () => {
       });
 
       expect(params.toString()).toMatchInlineSnapshot(
-        `"per_page=50&query=level%3Aerror&referrer=sentry-mcp&dataset=errors&statsPeriod=24h&project=backend&sort=-count&field=title&field=project&field=count%28%29"`,
+        `"per_page=50&query=level%3Aerror&dataset=errors&statsPeriod=24h&project=backend&sort=-count&field=title&field=project&field=count%28%29"`,
       );
     });
 
@@ -709,7 +709,7 @@ describe("API query builders", () => {
       });
 
       expect(params.toString()).toMatchInlineSnapshot(
-        `"per_page=20&query=span.op%3Adb&referrer=sentry-mcp&dataset=spans&statsPeriod=1h&project=frontend&sampling=NORMAL&sort=-span.duration&field=span.op&field=span.description&field=span.duration"`,
+        `"per_page=20&query=span.op%3Adb&dataset=spans&statsPeriod=1h&project=frontend&sampling=NORMAL&sort=-span.duration&field=span.op&field=span.description&field=span.duration"`,
       );
     });
 
@@ -726,7 +726,7 @@ describe("API query builders", () => {
       });
 
       expect(params.toString()).toMatchInlineSnapshot(
-        `"per_page=30&query=severity%3Aerror&referrer=sentry-mcp&dataset=ourlogs&sort=-timestamp&field=timestamp&field=message&field=severity"`,
+        `"per_page=30&query=severity%3Aerror&dataset=ourlogs&sort=-timestamp&field=timestamp&field=message&field=severity"`,
       );
 
       // Verify sampling is not added for logs

--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -554,3 +554,65 @@ export const EventAttachmentSchema = z.object({
 });
 
 export const EventAttachmentListSchema = z.array(EventAttachmentSchema);
+
+/**
+ * Schema for Sentry trace metadata response.
+ *
+ * Contains high-level statistics about a trace including span counts,
+ * transaction breakdown, and operation type distribution.
+ */
+export const TraceMetaSchema = z.object({
+  logs: z.number(),
+  errors: z.number(),
+  performance_issues: z.number(),
+  span_count: z.number(),
+  transaction_child_count_map: z.array(
+    z.object({
+      "transaction.event_id": z.string(),
+      "count()": z.number(),
+    }),
+  ),
+  span_count_map: z.record(z.string(), z.number()),
+});
+
+/**
+ * Schema for individual spans within a trace.
+ *
+ * Represents the hierarchical structure of spans with timing information,
+ * operation details, and nested children spans.
+ */
+export const TraceSpanSchema: z.ZodType<any> = z.lazy(() =>
+  z.object({
+    children: z.array(TraceSpanSchema),
+    errors: z.array(z.any()),
+    occurrences: z.array(z.any()),
+    event_id: z.string(),
+    transaction_id: z.string(),
+    project_id: z.union([z.string(), z.number()]),
+    project_slug: z.string(),
+    profile_id: z.string(),
+    profiler_id: z.string(),
+    parent_span_id: z.string().nullable(),
+    start_timestamp: z.number(),
+    end_timestamp: z.number(),
+    measurements: z.record(z.string(), z.number()).optional(),
+    duration: z.number(),
+    transaction: z.string(),
+    is_transaction: z.boolean(),
+    description: z.string(),
+    sdk_name: z.string(),
+    op: z.string(),
+    name: z.string(),
+    event_type: z.string(),
+    additional_attributes: z.record(z.string(), z.any()),
+  }),
+);
+
+/**
+ * Schema for Sentry trace response.
+ *
+ * Contains the complete trace tree starting from root spans.
+ * The response is an array of root-level spans, each potentially
+ * containing nested children spans.
+ */
+export const TraceSchema = z.array(TraceSpanSchema);

--- a/packages/mcp-server/src/api-client/types.ts
+++ b/packages/mcp-server/src/api-client/types.ts
@@ -60,6 +60,9 @@ import type {
   TagSchema,
   TeamListSchema,
   TeamSchema,
+  TraceMetaSchema,
+  TraceSchema,
+  TraceSpanSchema,
   UserSchema,
 } from "./schema";
 
@@ -85,3 +88,8 @@ export type IssueList = z.infer<typeof IssueListSchema>;
 export type EventAttachmentList = z.infer<typeof EventAttachmentListSchema>;
 export type TagList = z.infer<typeof TagListSchema>;
 export type ClientKeyList = z.infer<typeof ClientKeyListSchema>;
+
+// Trace types
+export type TraceMeta = z.infer<typeof TraceMetaSchema>;
+export type TraceSpan = z.infer<typeof TraceSpanSchema>;
+export type Trace = z.infer<typeof TraceSchema>;

--- a/packages/mcp-server/src/schema.ts
+++ b/packages/mcp-server/src/schema.ts
@@ -54,6 +54,15 @@ export const ParamIssueUrl = z
     "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43",
   );
 
+export const ParamTraceId = z
+  .string()
+  .trim()
+  .regex(
+    /^[0-9a-fA-F]{32}$/,
+    "Trace ID must be a 32-character hexadecimal string",
+  )
+  .describe("The trace ID. e.g. `a4d1aae7216b47ff8117cf4e09ce9d0a`");
+
 export const ParamPlatform = z
   .string()
   .toLowerCase()

--- a/packages/mcp-server/src/tools/get-trace-details.test.ts
+++ b/packages/mcp-server/src/tools/get-trace-details.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  mswServer,
+  traceMetaFixture,
+  traceFixture,
+} from "@sentry/mcp-server-mocks";
+import getTraceDetails from "./get-trace-details.js";
+
+describe("get_trace_details", () => {
+  it("serializes with valid trace ID", async () => {
+    const result = await getTraceDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        traceId: "a4d1aae7216b47ff8117cf4e09ce9d0a",
+        regionUrl: undefined,
+        statsPeriod: undefined,
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\` in **sentry-mcp-evals**
+
+      ## Summary
+
+      **Total Spans**: 112
+      **Errors**: 0
+      **Performance Issues**: 0
+      **Logs**: 0
+
+      ## Operation Breakdown
+
+      - **db**: 90 spans (avg: 16ms, p95: 13ms)
+      - **feature.flagpole.batch_has**: 30 spans (avg: 18ms, p95: 32ms)
+      - **function**: 14 spans (avg: 303ms, p95: 1208ms)
+      - **http.client**: 2 spans (avg: 1223ms, p95: 1708ms)
+      - **other**: 1 spans (avg: 6ms, p95: 6ms)
+
+      ## Overview
+
+      trace [a4d1aae7]
+         └─ tools/call search_events [aa8e7f33 · 5203ms]
+            ├─ POST https://api.openai.com/v1/chat/completions [ad0f7c48 · http.client · 1708ms]
+            └─ GET https://us.sentry.io/api/0/organizations/example-org/events/ [b4abfe5e · http.client · 1482ms]
+               └─ /api/0/organizations/{organization_id_or_slug}/events/ [99a97a1d · http.server · 1408ms]
+
+      *Note: This shows a subset of spans. View the full trace for complete details.*
+
+      ## View Full Trace
+
+      **Sentry URL**: https://sentry-mcp-evals.sentry.io/explore/traces/trace/a4d1aae7216b47ff8117cf4e09ce9d0a
+
+      ## Find Related Events
+
+      Use this search query to find all events in this trace:
+      \`\`\`
+      trace:a4d1aae7216b47ff8117cf4e09ce9d0a
+      \`\`\`
+
+      You can use this query with the \`search_events\` tool to get detailed event data from this trace."
+    `);
+  });
+
+  it("serializes with custom stats period", async () => {
+    const result = await getTraceDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        traceId: "a4d1aae7216b47ff8117cf4e09ce9d0a",
+        statsPeriod: "7d",
+        regionUrl: undefined,
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+    expect(result).toContain(
+      "Trace `a4d1aae7216b47ff8117cf4e09ce9d0a` in **sentry-mcp-evals**",
+    );
+    expect(result).toContain("**Total Spans**: 112");
+    expect(result).toContain("trace:a4d1aae7216b47ff8117cf4e09ce9d0a");
+  });
+
+  it("handles trace not found error", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry/trace-meta/nonexistent/",
+        () => {
+          return new HttpResponse(null, { status: 404 });
+        },
+      ),
+    );
+
+    await expect(
+      getTraceDetails.handler(
+        {
+          organizationSlug: "sentry",
+          traceId: "nonexistent",
+          regionUrl: undefined,
+          statsPeriod: undefined,
+        },
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("validates trace ID format", async () => {
+    await expect(
+      getTraceDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          traceId: "invalid-trace-id", // Too short, not hex
+          regionUrl: undefined,
+          statsPeriod: undefined,
+        },
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+      ),
+    ).rejects.toThrow("Trace ID must be a 32-character hexadecimal string");
+  });
+
+  it("handles empty trace response", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+        () => {
+          return HttpResponse.json({
+            logs: 0,
+            errors: 0,
+            performance_issues: 0,
+            span_count: 0,
+            transaction_child_count_map: [],
+            span_count_map: {},
+          });
+        },
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+        () => {
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    const result = await getTraceDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        traceId: "a4d1aae7216b47ff8117cf4e09ce9d0a",
+        regionUrl: undefined,
+        statsPeriod: undefined,
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+
+    expect(result).toContain("**Total Spans**: 0");
+    expect(result).toContain("**Errors**: 0");
+    expect(result).toContain("## Summary");
+    expect(result).not.toContain("## Operation Breakdown");
+    expect(result).not.toContain("## Overview");
+  });
+
+  it("handles API error gracefully", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+        () => {
+          return new HttpResponse(
+            JSON.stringify({ detail: "Organization not found" }),
+            { status: 404 },
+          );
+        },
+      ),
+    );
+
+    await expect(
+      getTraceDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          traceId: "a4d1aae7216b47ff8117cf4e09ce9d0a",
+          regionUrl: undefined,
+          statsPeriod: undefined,
+        },
+        {
+          accessToken: "access-token",
+          userId: "1",
+          organizationSlug: null,
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("works with regional URL override", async () => {
+    mswServer.use(
+      http.get(
+        "https://us.sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+        () => {
+          return HttpResponse.json(traceMetaFixture);
+        },
+      ),
+      http.get(
+        "https://us.sentry.io/api/0/organizations/sentry-mcp-evals/trace/a4d1aae7216b47ff8117cf4e09ce9d0a/",
+        () => {
+          return HttpResponse.json(traceFixture);
+        },
+      ),
+    );
+
+    const result = await getTraceDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        traceId: "a4d1aae7216b47ff8117cf4e09ce9d0a",
+        regionUrl: "https://us.sentry.io",
+        statsPeriod: undefined,
+      },
+      {
+        accessToken: "access-token",
+        userId: "1",
+        organizationSlug: null,
+      },
+    );
+
+    expect(result).toContain(
+      "Trace `a4d1aae7216b47ff8117cf4e09ce9d0a` in **sentry-mcp-evals**",
+    );
+    expect(result).toContain("**Total Spans**: 112");
+  });
+});

--- a/packages/mcp-server/src/tools/get-trace-details.ts
+++ b/packages/mcp-server/src/tools/get-trace-details.ts
@@ -1,0 +1,460 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../internal/tool-helpers/define";
+import {
+  apiServiceFromContext,
+  withApiErrorHandling,
+} from "../internal/tool-helpers/api";
+import { UserInputError } from "../errors";
+import type { ServerContext } from "../types";
+import { ParamOrganizationSlug, ParamRegionUrl, ParamTraceId } from "../schema";
+
+export default defineTool({
+  name: "get_trace_details",
+  description: [
+    "Get detailed information about a specific Sentry trace by ID.",
+    "",
+    "🔍 USE THIS TOOL WHEN USERS:",
+    "- Provide a specific trace ID (e.g., 'a4d1aae7216b47ff8117cf4e09ce9d0a')",
+    "- Ask to 'show me trace [TRACE-ID]', 'explain trace [TRACE-ID]'",
+    "- Want high-level overview and link to view trace details in Sentry",
+    "- Need trace statistics and span breakdown",
+    "",
+    "❌ DO NOT USE for:",
+    "- General searching for traces (use search_events with trace queries)",
+    "- Individual span details (this shows trace overview)",
+    "",
+    "TRIGGER PATTERNS:",
+    "- 'Show me trace abc123' → use get_trace_details",
+    "- 'Explain trace a4d1aae7216b47ff8117cf4e09ce9d0a' → use get_trace_details",
+    "- 'What is trace [trace-id]' → use get_trace_details",
+    "",
+    "<examples>",
+    "### Get trace overview",
+    "```",
+    "get_trace_details(organizationSlug='my-organization', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')",
+    "```",
+    "</examples>",
+    "",
+    "<hints>",
+    "- Trace IDs are 32-character hexadecimal strings",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug,
+    regionUrl: ParamRegionUrl.optional(),
+    traceId: ParamTraceId,
+    statsPeriod: z
+      .string()
+      .optional()
+      .describe("Stats period for trace analysis (e.g., '14d', '7d')"),
+  },
+  async handler(params, context: ServerContext) {
+    // Validate trace ID format
+    if (!/^[0-9a-fA-F]{32}$/.test(params.traceId)) {
+      throw new UserInputError(
+        "Trace ID must be a 32-character hexadecimal string",
+      );
+    }
+
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl,
+    });
+
+    setTag("organization.slug", params.organizationSlug);
+    setTag("trace.id", params.traceId);
+
+    // Get trace metadata for overview
+    const traceMeta = await withApiErrorHandling(
+      () =>
+        apiService.getTraceMeta({
+          organizationSlug: params.organizationSlug,
+          traceId: params.traceId,
+          statsPeriod: params.statsPeriod,
+        }),
+      {
+        organizationSlug: params.organizationSlug,
+        traceId: params.traceId,
+      },
+    );
+
+    // Get minimal trace data to show key transactions
+    const trace = await apiService.getTrace({
+      organizationSlug: params.organizationSlug,
+      traceId: params.traceId,
+      limit: 10, // Only get top-level spans for overview
+      statsPeriod: params.statsPeriod,
+    });
+
+    return formatTraceOutput({
+      organizationSlug: params.organizationSlug,
+      traceId: params.traceId,
+      traceMeta,
+      trace,
+      apiService,
+    });
+  },
+});
+
+interface SelectedSpan {
+  event_id: string;
+  op: string;
+  name: string | null;
+  description: string;
+  duration: number;
+  is_transaction: boolean;
+  children: SelectedSpan[];
+  level: number;
+}
+
+/**
+ * Selects a subset of "interesting" spans from a trace for display in the overview.
+ *
+ * Creates a fake root span representing the entire trace, with selected interesting
+ * spans as children. This provides a unified tree view of the trace.
+ *
+ * The goal is to provide a meaningful sample of the trace that highlights the most
+ * important operations while staying within display limits. Selection prioritizes:
+ *
+ * 1. **Transactions** - Top-level operations that represent complete user requests
+ * 2. **Error spans** - Any spans that contain errors (critical for debugging)
+ * 3. **Long-running spans** - Operations >= 10ms duration (performance bottlenecks)
+ * 4. **Hierarchical context** - Maintains parent-child relationships for understanding
+ *
+ * Span inclusion rules:
+ * - All transactions are included (they're typically root-level operations)
+ * - Spans with errors are always included (debugging importance)
+ * - Spans with duration >= 10ms are included (performance relevance)
+ * - Children are recursively added up to 2 levels deep:
+ *   - Transactions can have up to 2 children each
+ *   - Regular spans can have up to 1 child each
+ * - Total output is capped at maxSpans to prevent overwhelming display
+ *
+ * @param spans - Complete array of trace spans with nested children
+ * @param traceId - Trace ID to display in the fake root span
+ * @param maxSpans - Maximum number of spans to include in output (default: 20)
+ * @returns Single-element array containing fake root span with selected spans as children
+ */
+function selectInterestingSpans(
+  spans: any[],
+  traceId: string,
+  maxSpans = 20,
+): SelectedSpan[] {
+  const selected: SelectedSpan[] = [];
+  let spanCount = 0;
+
+  function addSpan(span: any, level: number): boolean {
+    if (spanCount >= maxSpans || level > 2) return false;
+
+    const duration = span.duration || 0;
+    const isTransaction = span.is_transaction;
+    const hasErrors = span.errors?.length > 0;
+
+    // Always include transactions and spans with errors
+    // For regular spans, include if they have reasonable duration or are at root level
+    const shouldInclude =
+      isTransaction || hasErrors || level === 0 || duration >= 10; // Include spans >= 10ms
+
+    if (!shouldInclude) return false;
+
+    const selectedSpan: SelectedSpan = {
+      event_id: span.event_id,
+      op: span.op || "unknown",
+      name: span.name || null,
+      description: span.description || span.transaction || "unnamed",
+      duration,
+      is_transaction: isTransaction,
+      children: [],
+      level,
+    };
+
+    spanCount++;
+
+    // Add up to one interesting child per span, up to 2 levels deep
+    if (level < 2 && span.children?.length > 0) {
+      // Sort children by duration (descending) and take the most interesting ones
+      const sortedChildren = span.children
+        .filter((child: any) => child.duration > 5) // Only children with meaningful duration
+        .sort((a: any, b: any) => (b.duration || 0) - (a.duration || 0));
+
+      // Add up to 2 children for transactions, 1 for regular spans
+      const maxChildren = isTransaction ? 2 : 1;
+      let addedChildren = 0;
+
+      for (const child of sortedChildren) {
+        if (addedChildren >= maxChildren || spanCount >= maxSpans) break;
+
+        if (addSpan(child, level + 1)) {
+          const childSpan = selected[selected.length - 1];
+          selectedSpan.children.push(childSpan);
+          addedChildren++;
+        }
+      }
+    }
+
+    selected.push(selectedSpan);
+    return true;
+  }
+
+  // Sort root spans by duration and select the most interesting ones
+  const sortedRoots = spans
+    .sort((a, b) => (b.duration || 0) - (a.duration || 0))
+    .slice(0, 5); // Start with top 5 root spans
+
+  for (const root of sortedRoots) {
+    if (spanCount >= maxSpans) break;
+    addSpan(root, 0);
+  }
+
+  const rootSpans = selected.filter((span) => span.level === 0);
+
+  // Create fake root span representing the entire trace (no duration - traces are unbounded)
+  const fakeRoot: SelectedSpan = {
+    event_id: traceId,
+    op: "trace",
+    name: null,
+    description: `Trace ${traceId.substring(0, 8)}`,
+    duration: 0, // Traces don't have duration
+    is_transaction: false,
+    children: rootSpans,
+    level: -1, // Mark as fake root
+  };
+
+  return [fakeRoot];
+}
+
+/**
+ * Formats a span display name for the tree view.
+ *
+ * Uses span.name if available (OTEL-native), otherwise falls back to span.description.
+ *
+ * @param span - The span to format
+ * @returns A formatted display name for the span
+ */
+function formatSpanDisplayName(span: SelectedSpan): string {
+  // For the fake trace root, just return "trace"
+  if (span.op === "trace") {
+    return "trace";
+  }
+
+  // Use span.name if available (OTEL-native), otherwise use description
+  return span.name?.trim() || span.description || "unnamed";
+}
+
+/**
+ * Renders a hierarchical tree structure of spans using Unicode box-drawing characters.
+ *
+ * Creates a visual tree representation showing parent-child relationships between spans,
+ * with proper indentation and connecting lines. Each span shows its operation, short ID,
+ * description, duration, and type (transaction vs span).
+ *
+ * Tree format:
+ * - Root spans have no prefix
+ * - Child spans use ├─ for intermediate children, └─ for last child
+ * - Continuation lines use │ for vertical connections
+ * - Proper spacing maintains visual alignment
+ *
+ * @param spans - Array of selected spans with their nested children structure
+ * @returns Array of formatted markdown strings representing the tree structure
+ */
+function renderSpanTree(spans: SelectedSpan[]): string[] {
+  const lines: string[] = [];
+
+  function renderSpan(span: SelectedSpan, prefix = "", isLast = true): void {
+    const shortId = span.event_id.substring(0, 8);
+    const connector = prefix === "" ? "" : isLast ? "└─ " : "├─ ";
+    const displayName = formatSpanDisplayName(span);
+
+    // Don't show duration for the fake trace root span
+    if (span.op === "trace") {
+      lines.push(`${prefix}${connector}${displayName} [${shortId}]`);
+    } else {
+      const duration = span.duration
+        ? `${Math.round(span.duration)}ms`
+        : "unknown";
+
+      // Don't show 'default' operations as they're not meaningful
+      const opDisplay = span.op === "default" ? "" : ` · ${span.op}`;
+      lines.push(
+        `${prefix}${connector}${displayName} [${shortId}${opDisplay} · ${duration}]`,
+      );
+    }
+
+    // Render children with proper tree indentation
+    for (let i = 0; i < span.children.length; i++) {
+      const child = span.children[i];
+      const isLastChild = i === span.children.length - 1;
+      const childPrefix = prefix + (isLast ? "   " : "│  ");
+      renderSpan(child, childPrefix, isLastChild);
+    }
+  }
+
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i];
+    const isLastRoot = i === spans.length - 1;
+    renderSpan(span, "", isLastRoot);
+  }
+
+  return lines;
+}
+
+function calculateOperationStats(spans: any[]): Record<
+  string,
+  {
+    count: number;
+    avgDuration: number;
+    p95Duration: number;
+  }
+> {
+  const allSpans = getAllSpansFlattened(spans);
+  const operationSpans: Record<string, any[]> = {};
+
+  // Group leaf spans by operation type (only spans with no children)
+  for (const span of allSpans) {
+    // Only consider leaf nodes - spans that have no children
+    if (!span.children || span.children.length === 0) {
+      // Use span.op if available, otherwise extract from span.name, fallback to "unknown"
+      const op = span.op || (span.name ? span.name.split(" ")[0] : "unknown");
+      if (!operationSpans[op]) {
+        operationSpans[op] = [];
+      }
+      operationSpans[op].push(span);
+    }
+  }
+
+  const stats: Record<
+    string,
+    { count: number; avgDuration: number; p95Duration: number }
+  > = {};
+
+  // Calculate stats for each operation
+  for (const [op, opSpans] of Object.entries(operationSpans)) {
+    const durations = opSpans
+      .map((span) => span.duration || 0)
+      .filter((duration) => duration > 0)
+      .sort((a, b) => a - b);
+
+    const count = opSpans.length;
+    const avgDuration =
+      durations.length > 0
+        ? durations.reduce((sum, duration) => sum + duration, 0) /
+          durations.length
+        : 0;
+
+    // Calculate P95 (95th percentile)
+    const p95Index = Math.floor(durations.length * 0.95);
+    const p95Duration = durations.length > 0 ? durations[p95Index] || 0 : 0;
+
+    stats[op] = {
+      count,
+      avgDuration,
+      p95Duration,
+    };
+  }
+
+  return stats;
+}
+
+function getAllSpansFlattened(spans: any[]): any[] {
+  const result: any[] = [];
+
+  function collectSpans(spanList: any[]) {
+    for (const span of spanList) {
+      result.push(span);
+      if (span.children && span.children.length > 0) {
+        collectSpans(span.children);
+      }
+    }
+  }
+
+  collectSpans(spans);
+  return result;
+}
+
+function formatTraceOutput({
+  organizationSlug,
+  traceId,
+  traceMeta,
+  trace,
+  apiService,
+}: {
+  organizationSlug: string;
+  traceId: string;
+  traceMeta: any;
+  trace: any[];
+  apiService: any;
+}): string {
+  const sections: string[] = [];
+
+  // Header
+  sections.push(`# Trace \`${traceId}\` in **${organizationSlug}**`);
+  sections.push("");
+
+  // High-level statistics
+  sections.push("## Summary");
+  sections.push("");
+  sections.push(`**Total Spans**: ${traceMeta.span_count}`);
+  sections.push(`**Errors**: ${traceMeta.errors}`);
+  sections.push(`**Performance Issues**: ${traceMeta.performance_issues}`);
+  sections.push(`**Logs**: ${traceMeta.logs}`);
+
+  // Show operation breakdown with detailed stats if we have trace data
+  if (trace.length > 0) {
+    const operationStats = calculateOperationStats(trace);
+    const sortedOps = Object.entries(operationStats)
+      .filter(([, stats]) => stats.avgDuration >= 5) // Only show ops with avg duration >= 5ms
+      .sort(([, a], [, b]) => b.count - a.count)
+      .slice(0, 10); // Show top 10
+
+    if (sortedOps.length > 0) {
+      sections.push("");
+      sections.push("## Operation Breakdown");
+      sections.push("");
+
+      for (const [op, stats] of sortedOps) {
+        const avgDuration = Math.round(stats.avgDuration);
+        const p95Duration = Math.round(stats.p95Duration);
+        sections.push(
+          `- **${op}**: ${stats.count} spans (avg: ${avgDuration}ms, p95: ${p95Duration}ms)`,
+        );
+      }
+      sections.push("");
+    }
+  }
+
+  // Show span tree structure
+  if (trace.length > 0) {
+    const selectedSpans = selectInterestingSpans(trace, traceId);
+
+    if (selectedSpans.length > 0) {
+      sections.push("## Overview");
+      sections.push("");
+      const treeLines = renderSpanTree(selectedSpans);
+      sections.push(...treeLines);
+      sections.push("");
+      sections.push(
+        "*Note: This shows a subset of spans. View the full trace for complete details.*",
+      );
+      sections.push("");
+    }
+  }
+
+  // Links and usage information
+  const traceUrl = apiService.getTraceUrl(organizationSlug, traceId);
+  sections.push("## View Full Trace");
+  sections.push("");
+  sections.push(`**Sentry URL**: ${traceUrl}`);
+  sections.push("");
+  sections.push("## Find Related Events");
+  sections.push("");
+  sections.push(`Use this search query to find all events in this trace:`);
+  sections.push("```");
+  sections.push(`trace:${traceId}`);
+  sections.push("```");
+  sections.push("");
+  sections.push(
+    "You can use this query with the `search_events` tool to get detailed event data from this trace.",
+  );
+
+  return sections.join("\n");
+}

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -4,6 +4,7 @@ import findTeams from "./find-teams";
 import findProjects from "./find-projects";
 import findReleases from "./find-releases";
 import getIssueDetails from "./get-issue-details";
+import getTraceDetails from "./get-trace-details";
 import getEventAttachment from "./get-event-attachment";
 import updateIssue from "./update-issue";
 import searchEvents from "./search-events";
@@ -25,6 +26,7 @@ export default {
   find_projects: findProjects,
   find_releases: findReleases,
   get_issue_details: getIssueDetails,
+  get_trace_details: getTraceDetails,
   get_event_attachment: getEventAttachment,
   update_issue: updateIssue,
   search_events: searchEvents,

--- a/packages/mcp-test-client/package.json
+++ b/packages/mcp-test-client/package.json
@@ -11,8 +11,9 @@
     "build": "tsdown",
     "start": "node dist/index.js",
     "test-client": "node dist/index.js",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ci": "vitest run --reporter=junit --outputFile=tests.junit.xml",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
### Summary
This commit introduces a new tool, `get_trace_details`, which retrieves detailed information about a specific Sentry trace by its ID. It includes enhancements to the API client with new schemas for trace metadata and spans.

### Key Changes
- Added `get_trace_details` tool for fetching trace details and statistics.
- Introduced `TraceMetaSchema` and `TraceSchema` for structured trace data handling.
- Updated existing API client to support new trace-related functionalities.
- Enhanced test coverage for the new tool and its integration with the API.

This addition improves the ability to analyze and present trace data effectively, enhancing user experience in debugging and performance monitoring.

Fixes #421