### PR TITLE
fix(evals): update search-events-agent eval to use db.operation field

### DIFF
--- a/packages/mcp-server-evals/src/evals/search-events-agent.eval.ts
+++ b/packages/mcp-server-evals/src/evals/search-events-agent.eval.ts
@@ -160,10 +160,10 @@ describeEval("search-events-agent", {
         ],
         expected: {
           dataset: "spans",
-          query: /has:db\.|span\.op:db/,
+          query: "has:db.operation",
           // Agent must include avg(span.duration) since we're sorting by it
-          // Accept either span.op or db.operation as the grouping field
-          fields: /\["(span\.op|db\.operation)", .*"avg\(span\.duration\)"\]/,
+          // Use db.operation as the grouping field (span.op is deprecated)
+          fields: ["db.operation", "avg(span.duration)"],
           // Sort by average duration
           sort: "-avg(span.duration)",
           // timeRange is optional


### PR DESCRIPTION
Replace span.op with db.operation as the grouping field in database query eval, as span.op is deprecated in favor of the more specific db.operation field.