### PR TITLE
fix: standardize API client to use console.error for error logging

### DIFF
--- a/packages/mcp-server/src/api-client/client.test.ts
+++ b/packages/mcp-server/src/api-client/client.test.ts
@@ -80,7 +80,7 @@ describe("getEventsExplorerUrl", () => {
       "level:error AND message:timeout",
     );
     expect(result).toMatchInlineSnapshot(
-      `"https://sentry-mcp.sentry.io/explore/traces/?query=level%3Aerror+AND+message%3Atimeout&statsPeriod=24h"`,
+      `"https://sentry-mcp.sentry.io/explore/traces/?query=level%3Aerror+AND+message%3Atimeout&statsPeriod=24h&table=span"`,
     );
   });
   it("should work with self-hosted", () => {
@@ -90,7 +90,7 @@ describe("getEventsExplorerUrl", () => {
       "level:error AND message:timeout",
     );
     expect(result).toMatchInlineSnapshot(
-      `"https://sentry.example.com/organizations/sentry-mcp/explore/traces/?query=level%3Aerror+AND+message%3Atimeout&statsPeriod=24h"`,
+      `"https://sentry.example.com/organizations/sentry-mcp/explore/traces/?query=level%3Aerror+AND+message%3Atimeout&statsPeriod=24h&table=span"`,
     );
   });
   it("should include project parameter when provided", () => {
@@ -101,7 +101,7 @@ describe("getEventsExplorerUrl", () => {
       "backend",
     );
     expect(result).toMatchInlineSnapshot(
-      `"https://sentry-mcp.sentry.io/explore/traces/?query=level%3Aerror&project=backend&statsPeriod=24h"`,
+      `"https://sentry-mcp.sentry.io/explore/traces/?query=level%3Aerror&project=backend&statsPeriod=24h&table=span"`,
     );
   });
   it("should properly encode special characters in query", () => {
@@ -111,7 +111,7 @@ describe("getEventsExplorerUrl", () => {
       'message:"database timeout" AND level:error',
     );
     expect(result).toMatchInlineSnapshot(
-      `"https://sentry-mcp.sentry.io/explore/traces/?query=message%3A%22database+timeout%22+AND+level%3Aerror&statsPeriod=24h"`,
+      `"https://sentry-mcp.sentry.io/explore/traces/?query=message%3A%22database+timeout%22+AND+level%3Aerror&statsPeriod=24h&table=span"`,
     );
   });
   it("should always use HTTPS protocol", () => {
@@ -120,7 +120,7 @@ describe("getEventsExplorerUrl", () => {
     });
     const result = apiService.getEventsExplorerUrl("sentry-mcp", "level:error");
     expect(result).toMatchInlineSnapshot(
-      `"https://localhost:8000/organizations/sentry-mcp/explore/traces/?query=level%3Aerror&statsPeriod=24h"`,
+      `"https://localhost:8000/organizations/sentry-mcp/explore/traces/?query=level%3Aerror&statsPeriod=24h&table=span"`,
     );
   });
 });
@@ -639,7 +639,7 @@ describe("API query builders", () => {
         query: "level:error",
         fields: ["title", "project", "count()"],
         limit: 50,
-        projectSlug: "backend",
+        projectId: "backend",
         statsPeriod: "24h",
         sort: "-count()",
       });
@@ -702,7 +702,7 @@ describe("API query builders", () => {
         query: "span.op:db",
         fields: ["span.op", "span.description", "span.duration"],
         limit: 20,
-        projectSlug: "frontend",
+        projectId: "frontend",
         dataset: "spans",
         statsPeriod: "1h",
         sort: "-span.duration",
@@ -829,7 +829,7 @@ describe("API query builders", () => {
         const url = apiService.buildDiscoverUrl({
           organizationSlug: "my-org",
           query: "level:error",
-          projectSlug: "backend",
+          projectId: "backend",
           fields: ["title", "project", "timestamp"],
           sort: "-timestamp",
         });
@@ -883,7 +883,7 @@ describe("API query builders", () => {
           organizationSlug: "my-org",
           query: "is_transaction:True",
           dataset: "spans",
-          projectSlug: "123456",
+          projectId: "123456",
           fields: ["span.description", "count()"],
           sort: "-count()",
           aggregateFunctions: ["count()"],
@@ -996,7 +996,7 @@ describe("API query builders", () => {
         });
 
         expect(url).toMatchInlineSnapshot(
-          `"https://sentry.example.com/organizations/my-org/explore/traces/?query=&field=span.op&statsPeriod=24h"`,
+          `"https://sentry.example.com/organizations/my-org/explore/traces/?query=&field=span.op&statsPeriod=24h&table=span"`,
         );
       });
     });

--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -459,7 +459,7 @@ export class SentryApiService {
   private buildDiscoverUrl(params: {
     organizationSlug: string;
     query: string;
-    projectSlug?: string;
+    projectId?: string;
     fields?: string[];
     sort?: string;
     statsPeriod?: string;
@@ -469,7 +469,7 @@ export class SentryApiService {
     const {
       organizationSlug,
       query,
-      projectSlug,
+      projectId,
       fields,
       sort,
       statsPeriod = "24h",
@@ -484,8 +484,8 @@ export class SentryApiService {
     urlParams.set("queryDataset", "error-events");
     urlParams.set("query", query);
 
-    if (projectSlug) {
-      urlParams.set("project", projectSlug);
+    if (projectId) {
+      urlParams.set("project", projectId);
     }
 
     // Discover API includes aggregate functions directly in field list
@@ -537,7 +537,7 @@ export class SentryApiService {
     organizationSlug: string;
     query: string;
     dataset: "spans" | "logs";
-    projectSlug?: string;
+    projectId?: string;
     fields?: string[];
     sort?: string;
     statsPeriod?: string;
@@ -548,7 +548,7 @@ export class SentryApiService {
       organizationSlug,
       query,
       dataset,
-      projectSlug,
+      projectId,
       fields,
       sort,
       statsPeriod = "24h",
@@ -559,8 +559,8 @@ export class SentryApiService {
     const urlParams = new URLSearchParams();
     urlParams.set("query", query);
 
-    if (projectSlug) {
-      urlParams.set("project", projectSlug);
+    if (projectId) {
+      urlParams.set("project", projectId);
     }
 
     // Determine if this is an aggregate query
@@ -635,6 +635,11 @@ export class SentryApiService {
 
     urlParams.set("statsPeriod", statsPeriod);
 
+    // Add table parameter for spans dataset (required for UI)
+    if (dataset === "spans") {
+      urlParams.set("table", "span");
+    }
+
     const basePath = dataset === "logs" ? "logs" : "traces";
     const path = this.isSaas()
       ? `https://${organizationSlug}.sentry.io/explore/${basePath}/`
@@ -652,7 +657,7 @@ export class SentryApiService {
    *
    * @param organizationSlug Organization identifier
    * @param query Sentry search query
-   * @param projectSlug Optional project filter
+   * @param projectId Optional project filter
    * @param dataset Dataset type (spans, errors, or logs)
    * @param fields Array of fields to include in results
    * @param sort Sort parameter (e.g., "-timestamp", "-count()")
@@ -663,7 +668,7 @@ export class SentryApiService {
   getEventsExplorerUrl(
     organizationSlug: string,
     query: string,
-    projectSlug?: string,
+    projectId?: string,
     dataset: "spans" | "errors" | "logs" = "spans",
     fields?: string[],
     sort?: string,
@@ -675,7 +680,7 @@ export class SentryApiService {
       return this.buildDiscoverUrl({
         organizationSlug,
         query,
-        projectSlug,
+        projectId,
         fields,
         sort,
         aggregateFunctions,
@@ -688,7 +693,7 @@ export class SentryApiService {
       organizationSlug,
       query,
       dataset,
-      projectSlug,
+      projectId,
       fields,
       sort,
       aggregateFunctions,
@@ -1707,7 +1712,7 @@ export class SentryApiService {
     query: string;
     fields: string[];
     limit: number;
-    projectSlug?: string;
+    projectId?: string;
     statsPeriod?: string;
     start?: string;
     end?: string;
@@ -1739,8 +1744,8 @@ export class SentryApiService {
       queryParams.set("end", params.end);
     }
 
-    if (params.projectSlug) {
-      queryParams.set("project", params.projectSlug);
+    if (params.projectId) {
+      queryParams.set("project", params.projectId);
     }
 
     // Sort parameter transformation for API compatibility
@@ -1780,7 +1785,7 @@ export class SentryApiService {
     query: string;
     fields: string[];
     limit: number;
-    projectSlug?: string;
+    projectId?: string;
     dataset: "spans" | "ourlogs";
     statsPeriod?: string;
     start?: string;
@@ -1813,8 +1818,8 @@ export class SentryApiService {
       queryParams.set("end", params.end);
     }
 
-    if (params.projectSlug) {
-      queryParams.set("project", params.projectSlug);
+    if (params.projectId) {
+      queryParams.set("project", params.projectId);
     }
 
     // Dataset-specific parameters
@@ -1864,7 +1869,7 @@ export class SentryApiService {
       query,
       fields,
       limit = 10,
-      projectSlug,
+      projectId,
       dataset = "spans",
       statsPeriod,
       start,
@@ -1875,7 +1880,7 @@ export class SentryApiService {
       query: string;
       fields: string[];
       limit?: number;
-      projectSlug?: string;
+      projectId?: string;
       dataset?: "spans" | "errors" | "ourlogs";
       statsPeriod?: string;
       start?: string;
@@ -1892,7 +1897,7 @@ export class SentryApiService {
         query,
         fields,
         limit,
-        projectSlug,
+        projectId,
         statsPeriod,
         start,
         end,
@@ -1904,7 +1909,7 @@ export class SentryApiService {
         query,
         fields,
         limit,
-        projectSlug,
+        projectId,
         dataset,
         statsPeriod,
         start,

--- a/packages/mcp-server/src/internal/formatting.ts
+++ b/packages/mcp-server/src/internal/formatting.ts
@@ -17,11 +17,7 @@ import type {
   ThreadsEntrySchema,
   SentryApiService,
 } from "../api-client";
-import {
-  getOutputForAutofixStep,
-  getStatusDisplayName,
-  isTerminalStatus,
-} from "./tool-helpers/seer";
+import { getOutputForAutofixStep, isTerminalStatus } from "./tool-helpers/seer";
 
 // Language detection mappings
 const LANGUAGE_EXTENSIONS: Record<string, string> = {

--- a/packages/mcp-server/src/tools/search-events/formatters.ts
+++ b/packages/mcp-server/src/tools/search-events/formatters.ts
@@ -59,7 +59,7 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
     output += `\n\n`;
   }
 
-  output += `**📊 View these results in Sentry**: ${explorerUrl}\n`;
+  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
@@ -183,7 +183,7 @@ export function formatLogResults(params: FormatEventResultsParams): string {
     output += `\n\n`;
   }
 
-  output += `**📊 View these results in Sentry**: ${explorerUrl}\n`;
+  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
@@ -330,7 +330,7 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
     output += `\n\n`;
   }
 
-  output += `**📊 View these results in Sentry**: ${explorerUrl}\n`;
+  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -19,7 +19,6 @@ import {
 } from "./formatters";
 import { RECOMMENDED_FIELDS } from "./config";
 import { UserInputError } from "../../errors";
-import { ApiError } from "../../api-client";
 
 export default defineTool({
   name: "search_events",
@@ -198,7 +197,7 @@ export default defineTool({
           query: sentryQuery,
           fields,
           limit: params.limit,
-          projectSlug: projectId, // API requires numeric project ID, not slug
+          projectId, // API requires numeric project ID, not slug
           dataset: dataset === "logs" ? "ourlogs" : dataset,
           sort: sortParam,
           ...timeParams, // Spread the time parameters

--- a/packages/mcp-server/src/tools/search-issues/formatters.ts
+++ b/packages/mcp-server/src/tools/search-issues/formatters.ts
@@ -79,7 +79,7 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
   );
 
   // Add view link with emoji and guidance text (like search_events)
-  output += `**📊 View these results in Sentry**: ${searchUrl}\n`;
+  output += `**View these results in Sentry**:\n${searchUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   output += `Found **${issues.length}** issue${issues.length === 1 ? "" : "s"}:\n\n`;


### PR DESCRIPTION
## Summary

Fix broken explorer URLs for spans dataset in the search_events tool.

## Changes

- Add missing `table=span` parameter required by Sentry UI for spans dataset
- Fix projectId parameter naming (was incorrectly using projectSlug)
- Improve URL display formatting in results (remove emoji, add newline)
- Update tests to use projectId instead of projectSlug

## Problem

When using the search_events tool, the generated "View in Sentry" URLs were broken due to:
1. Missing `table=span` parameter for spans dataset
2. Incorrect parameter naming (projectSlug vs projectId)
3. Poor formatting of the URL in the output

## Solution

- Added `table=span` parameter in `buildEapUrl` for spans dataset
- Fixed parameter naming throughout to use projectId consistently
- Improved markdown formatting to display URL on separate line without emoji
- Updated all related tests

Fixes #461