### PR TITLE
fix: add missing time parameters to events explorer URLs

### DIFF
--- a/packages/mcp-server/src/api-client/client.test.ts
+++ b/packages/mcp-server/src/api-client/client.test.ts
@@ -123,6 +123,135 @@ describe("getEventsExplorerUrl", () => {
       `"https://localhost:8000/organizations/sentry-mcp/explore/traces/?query=level%3Aerror&statsPeriod=24h&table=span"`,
     );
   });
+
+  describe("time parameters", () => {
+    it("should use statsPeriod when provided for spans dataset", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "level:error",
+        undefined, // projectId
+        "spans", // dataset
+        undefined, // fields
+        undefined, // sort
+        undefined, // aggregateFunctions
+        undefined, // groupByFields
+        "7d", // statsPeriod
+      );
+      expect(result).toContain("statsPeriod=7d");
+      expect(result).not.toContain("start=");
+      expect(result).not.toContain("end=");
+    });
+
+    it("should use start/end when provided for spans dataset", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "level:error",
+        undefined, // projectId
+        "spans", // dataset
+        undefined, // fields
+        undefined, // sort
+        undefined, // aggregateFunctions
+        undefined, // groupByFields
+        undefined, // statsPeriod
+        "2025-07-29T07:00:00", // start
+        "2025-07-31T06:59:59", // end
+      );
+      expect(result).toContain("start=2025-07-29T07%3A00%3A00");
+      expect(result).toContain("end=2025-07-31T06%3A59%3A59");
+      expect(result).not.toContain("statsPeriod=");
+    });
+
+    it("should prefer start/end over statsPeriod when both provided for spans dataset", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "level:error",
+        undefined, // projectId
+        "spans", // dataset
+        undefined, // fields
+        undefined, // sort
+        undefined, // aggregateFunctions
+        undefined, // groupByFields
+        "7d", // statsPeriod (should be ignored)
+        "2025-07-29T07:00:00", // start
+        "2025-07-31T06:59:59", // end
+      );
+      expect(result).toContain("start=2025-07-29T07%3A00%3A00");
+      expect(result).toContain("end=2025-07-31T06%3A59%3A59");
+      expect(result).not.toContain("statsPeriod=");
+    });
+
+    it("should use statsPeriod when provided for errors dataset", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "level:error",
+        undefined, // projectId
+        "errors", // dataset
+        undefined, // fields
+        undefined, // sort
+        undefined, // aggregateFunctions
+        undefined, // groupByFields
+        "14d", // statsPeriod
+      );
+      expect(result).toContain("statsPeriod=14d");
+      expect(result).not.toContain("start=");
+      expect(result).not.toContain("end=");
+    });
+
+    it("should use start/end when provided for errors dataset", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "level:error",
+        undefined, // projectId
+        "errors", // dataset
+        undefined, // fields
+        undefined, // sort
+        undefined, // aggregateFunctions
+        undefined, // groupByFields
+        undefined, // statsPeriod
+        "2025-07-29T07:00:00", // start
+        "2025-07-31T06:59:59", // end
+      );
+      expect(result).toContain("start=2025-07-29T07%3A00%3A00");
+      expect(result).toContain("end=2025-07-31T06%3A59%3A59");
+      expect(result).not.toContain("statsPeriod=");
+    });
+
+    it("should default to 24h when no time parameters provided", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "level:error",
+      );
+      expect(result).toContain("statsPeriod=24h");
+    });
+
+    it("should handle aggregate queries with time parameters for spans dataset", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "",
+        "4509062593708032", // projectId
+        "spans", // dataset
+        [
+          "equation|sum(gen_ai.usage.input_tokens) + sum(gen_ai.usage.output_tokens)",
+        ], // fields
+        "-equation|sum(gen_ai.usage.input_tokens) + sum(gen_ai.usage.output_tokens)", // sort
+        [
+          "equation|sum(gen_ai.usage.input_tokens) + sum(gen_ai.usage.output_tokens)",
+        ], // aggregateFunctions
+        [], // groupByFields
+        "7d", // statsPeriod
+      );
+      expect(result).toContain("statsPeriod=7d");
+      expect(result).toContain("project=4509062593708032");
+      expect(result).toContain("mode=aggregate");
+    });
+  });
 });
 
 describe("network error handling", () => {

--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -463,6 +463,8 @@ export class SentryApiService {
     fields?: string[];
     sort?: string;
     statsPeriod?: string;
+    start?: string;
+    end?: string;
     aggregateFunctions?: string[];
     groupByFields?: string[];
   }): string {
@@ -472,7 +474,9 @@ export class SentryApiService {
       projectId,
       fields,
       sort,
-      statsPeriod = "24h",
+      statsPeriod,
+      start,
+      end,
       aggregateFunctions,
       groupByFields,
     } = params;
@@ -502,7 +506,14 @@ export class SentryApiService {
     }
 
     urlParams.set("sort", sort || "-timestamp");
-    urlParams.set("statsPeriod", statsPeriod);
+
+    // Add time parameters - either statsPeriod or start/end
+    if (start && end) {
+      urlParams.set("start", start);
+      urlParams.set("end", end);
+    } else {
+      urlParams.set("statsPeriod", statsPeriod || "24h");
+    }
 
     // Check if this is an aggregate query
     const isAggregate = (aggregateFunctions?.length ?? 0) > 0;
@@ -541,6 +552,8 @@ export class SentryApiService {
     fields?: string[];
     sort?: string;
     statsPeriod?: string;
+    start?: string;
+    end?: string;
     aggregateFunctions?: string[];
     groupByFields?: string[];
   }): string {
@@ -551,7 +564,9 @@ export class SentryApiService {
       projectId,
       fields,
       sort,
-      statsPeriod = "24h",
+      statsPeriod,
+      start,
+      end,
       aggregateFunctions,
       groupByFields,
     } = params;
@@ -633,7 +648,13 @@ export class SentryApiService {
       urlParams.set("sort", sort);
     }
 
-    urlParams.set("statsPeriod", statsPeriod);
+    // Add time parameters - either statsPeriod or start/end
+    if (start && end) {
+      urlParams.set("start", start);
+      urlParams.set("end", end);
+    } else {
+      urlParams.set("statsPeriod", statsPeriod || "24h");
+    }
 
     // Add table parameter for spans dataset (required for UI)
     if (dataset === "spans") {
@@ -663,6 +684,9 @@ export class SentryApiService {
    * @param sort Sort parameter (e.g., "-timestamp", "-count()")
    * @param aggregateFunctions Array of aggregate functions (only used for EAP datasets)
    * @param groupByFields Array of fields to group by (only used for EAP datasets)
+   * @param statsPeriod Relative time period (e.g., "24h", "7d")
+   * @param start Absolute start time (ISO 8601)
+   * @param end Absolute end time (ISO 8601)
    * @returns Full HTTPS URL to the events explorer in Sentry UI
    */
   getEventsExplorerUrl(
@@ -674,6 +698,9 @@ export class SentryApiService {
     sort?: string,
     aggregateFunctions?: string[],
     groupByFields?: string[],
+    statsPeriod?: string,
+    start?: string,
+    end?: string,
   ): string {
     if (dataset === "errors") {
       // Route to legacy Discover API
@@ -683,6 +710,9 @@ export class SentryApiService {
         projectId,
         fields,
         sort,
+        statsPeriod,
+        start,
+        end,
         aggregateFunctions,
         groupByFields,
       });
@@ -696,6 +726,9 @@ export class SentryApiService {
       projectId,
       fields,
       sort,
+      statsPeriod,
+      start,
+      end,
       aggregateFunctions,
       groupByFields,
     });

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -226,6 +226,9 @@ export default defineTool({
       sortParam, // Pass sort parameter for URL generation
       aggregateFunctions,
       groupByFields,
+      timeParams.statsPeriod,
+      timeParams.start,
+      timeParams.end,
     );
 
     // Type-safe access to event data with proper validation


### PR DESCRIPTION
The getEventsExplorerUrl method was missing support for absolute time ranges (start/end) and custom statsPeriod values, causing search_events tool URLs to always default to 24h period. This fix ensures the generated URLs respect the time parameters from the query.

Fixes #463