### PR TITLE
docs: clarify MCP service purpose and target audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![codecov](https://codecov.io/gh/getsentry/sentry-mcp/graph/badge.svg?token=khVKvJP5Ig)](https://codecov.io/gh/getsentry/sentry-mcp)
 
-This is a prototype of a remote MCP server, acting as a middleware to the upstream Sentry API provider.
+Sentry's MCP service is primarily designed for human-in-the-loop coding agents. Our tool selection and priorities are focused on developer workflows and debugging use cases, rather than providing a general-purpose MCP server for all Sentry functionality.
 
-It is based on [Cloudflare's work towards remote MCPs](https://blog.cloudflare.com/remote-model-context-protocol-servers-mcp/).
+This remote MCP server acts as middleware to the upstream Sentry API, optimized for coding assistants like Cursor, Claude Code, and similar development tools. It's based on [Cloudflare's work towards remote MCPs](https://blog.cloudflare.com/remote-model-context-protocol-servers-mcp/).
 
 ## Getting Started
 

--- a/packages/mcp-cloudflare/src/client/pages/home.tsx
+++ b/packages/mcp-cloudflare/src/client/pages/home.tsx
@@ -32,7 +32,9 @@ export default function Home({ onChatClick }: HomeProps) {
           <Prose>
             <p>
               This service implements the Model Context Protocol (MCP) for
-              interacting with <a href="https://sentry.io/welcome/">Sentry</a>.
+              interacting with <a href="https://sentry.io/welcome/">Sentry</a>,
+              focused on human-in-the-loop coding agents and developer workflows
+              rather than general-purpose API access.
             </p>
           </Prose>
 
@@ -65,9 +67,10 @@ export default function Home({ onChatClick }: HomeProps) {
               <p>
                 Simply put, it's a way to plug Sentry's API into an LLM, letting
                 you ask questions about your data in context of the LLM itself.
-                This lets you take an agent that you already use, like Cursor,
-                and pull in additional information from Sentry to help with
-                tasks like debugging, code generation, and more.
+                This lets you take a coding agent that you already use, like
+                Cursor or Claude Code, and pull in additional information from
+                Sentry to help with tasks like debugging, fixing production
+                errors, and understanding your application's behavior.
               </p>
               <p>
                 This project is still in its infancy as development of the MCP


### PR DESCRIPTION
Update README and home page to explicitly state that this MCP service is designed for human-in-the-loop coding agents (Cursor, Claude Code, etc.) rather than as a general-purpose Sentry API wrapper. This helps set proper expectations about the tool selection and priorities.