### PR TITLE
fix: use correct sentry.io domain for web UI URLs with regional API hosts

### DIFF
--- a/packages/mcp-server/src/api-client/client.test.ts
+++ b/packages/mcp-server/src/api-client/client.test.ts
@@ -35,6 +35,20 @@ describe("getIssueUrl", () => {
       `"https://localhost:8000/organizations/sentry-mcp/issues/123456"`,
     );
   });
+  it("should handle regional URLs correctly for SaaS", () => {
+    const apiService = new SentryApiService({ host: "us.sentry.io" });
+    const result = apiService.getIssueUrl("sentry", "PROJ-THREAD-LEAKS-12");
+    // Should use sentry.io, not us.sentry.io for web UI
+    expect(result).toEqual(
+      "https://sentry.sentry.io/issues/PROJ-THREAD-LEAKS-12",
+    );
+  });
+  it("should handle EU regional URLs correctly for SaaS", () => {
+    const apiService = new SentryApiService({ host: "eu.sentry.io" });
+    const result = apiService.getIssueUrl("myorg", "PROJECT-456");
+    // Should use sentry.io, not eu.sentry.io for web UI
+    expect(result).toEqual("https://myorg.sentry.io/issues/PROJECT-456");
+  });
 });
 
 describe("getTraceUrl", () => {
@@ -68,6 +82,17 @@ describe("getTraceUrl", () => {
     );
     expect(result).toMatchInlineSnapshot(
       `"https://localhost:8000/organizations/sentry-mcp/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d"`,
+    );
+  });
+  it("should handle regional URLs correctly for SaaS", () => {
+    const apiService = new SentryApiService({ host: "us.sentry.io" });
+    const result = apiService.getTraceUrl(
+      "sentry",
+      "6a477f5b0f31ef7b6b9b5e1dea66c91d",
+    );
+    // Should use sentry.io, not us.sentry.io for web UI
+    expect(result).toEqual(
+      "https://sentry.sentry.io/explore/traces/trace/6a477f5b0f31ef7b6b9b5e1dea66c91d",
     );
   });
 });
@@ -121,6 +146,14 @@ describe("getEventsExplorerUrl", () => {
     const result = apiService.getEventsExplorerUrl("sentry-mcp", "level:error");
     expect(result).toMatchInlineSnapshot(
       `"https://localhost:8000/organizations/sentry-mcp/explore/traces/?query=level%3Aerror&statsPeriod=24h&table=span"`,
+    );
+  });
+  it("should handle regional URLs correctly for SaaS", () => {
+    const apiService = new SentryApiService({ host: "us.sentry.io" });
+    const result = apiService.getEventsExplorerUrl("sentry", "level:error");
+    // Should use sentry.io, not us.sentry.io for web UI
+    expect(result).toEqual(
+      "https://sentry.sentry.io/explore/traces/?query=level%3Aerror&statsPeriod=24h&table=span",
     );
   });
 

--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -527,8 +527,11 @@ export class SentryApiService {
       urlParams.set("yAxis", "count()");
     }
 
+    // For SaaS instances, always use sentry.io for web UI URLs regardless of region
+    // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
+    const webHost = this.isSaas() ? "sentry.io" : this.host;
     const path = this.isSaas()
-      ? `https://${organizationSlug}.sentry.io/explore/discover/homepage/`
+      ? `https://${organizationSlug}.${webHost}/explore/discover/homepage/`
       : `https://${this.host}/organizations/${organizationSlug}/explore/discover/homepage/`;
 
     return `${path}?${urlParams.toString()}`;
@@ -662,8 +665,11 @@ export class SentryApiService {
     }
 
     const basePath = dataset === "logs" ? "logs" : "traces";
+    // For SaaS instances, always use sentry.io for web UI URLs regardless of region
+    // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
+    const webHost = this.isSaas() ? "sentry.io" : this.host;
     const path = this.isSaas()
-      ? `https://${organizationSlug}.sentry.io/explore/${basePath}/`
+      ? `https://${organizationSlug}.${webHost}/explore/${basePath}/`
       : `https://${this.host}/organizations/${organizationSlug}/explore/${basePath}/`;
 
     return `${path}?${urlParams.toString()}`;

--- a/packages/mcp-server/src/utils/url-utils.test.ts
+++ b/packages/mcp-server/src/utils/url-utils.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   validateSentryHostThrows,
   validateAndParseSentryUrlThrows,
+  getIssueUrl,
+  getIssuesSearchUrl,
+  getTraceUrl,
+  getEventsExplorerUrl,
 } from "./url-utils";
 
 describe("url-utils", () => {
@@ -78,6 +82,126 @@ describe("url-utils", () => {
       expect(() =>
         validateAndParseSentryUrlThrows("https://[invalid-bracket"),
       ).toThrow("SENTRY_URL must be a valid HTTPS URL");
+    });
+  });
+
+  describe("getIssueUrl", () => {
+    it("should handle regional URLs correctly for SaaS", () => {
+      const result = getIssueUrl("us.sentry.io", "myorg", "PROJ-123");
+      expect(result).toBe("https://myorg.sentry.io/issues/PROJ-123");
+    });
+
+    it("should handle EU regional URLs correctly", () => {
+      const result = getIssueUrl("eu.sentry.io", "myorg", "PROJ-456");
+      expect(result).toBe("https://myorg.sentry.io/issues/PROJ-456");
+    });
+
+    it("should handle standard sentry.io correctly", () => {
+      const result = getIssueUrl("sentry.io", "myorg", "PROJ-789");
+      expect(result).toBe("https://myorg.sentry.io/issues/PROJ-789");
+    });
+
+    it("should handle self-hosted correctly", () => {
+      const result = getIssueUrl("sentry.example.com", "myorg", "PROJ-123");
+      expect(result).toBe(
+        "https://sentry.example.com/organizations/myorg/issues/PROJ-123",
+      );
+    });
+  });
+
+  describe("getIssuesSearchUrl", () => {
+    it("should handle regional URLs correctly for SaaS", () => {
+      const result = getIssuesSearchUrl(
+        "us.sentry.io",
+        "myorg",
+        "is:unresolved",
+        "proj1",
+      );
+      expect(result).toBe(
+        "https://myorg.sentry.io/issues/?project=proj1&query=is%3Aunresolved",
+      );
+    });
+
+    it("should handle EU regional URLs correctly", () => {
+      const result = getIssuesSearchUrl("eu.sentry.io", "myorg", "is:resolved");
+      expect(result).toBe(
+        "https://myorg.sentry.io/issues/?query=is%3Aresolved",
+      );
+    });
+
+    it("should handle self-hosted correctly", () => {
+      const result = getIssuesSearchUrl(
+        "sentry.example.com",
+        "myorg",
+        "is:unresolved",
+        "proj1",
+      );
+      expect(result).toBe(
+        "https://sentry.example.com/organizations/myorg/issues/?project=proj1&query=is%3Aunresolved",
+      );
+    });
+  });
+
+  describe("getTraceUrl", () => {
+    it("should handle regional URLs correctly for SaaS", () => {
+      const result = getTraceUrl("us.sentry.io", "myorg", "abc123def456");
+      expect(result).toBe(
+        "https://myorg.sentry.io/explore/traces/trace/abc123def456",
+      );
+    });
+
+    it("should handle EU regional URLs correctly", () => {
+      const result = getTraceUrl("eu.sentry.io", "myorg", "xyz789");
+      expect(result).toBe(
+        "https://myorg.sentry.io/explore/traces/trace/xyz789",
+      );
+    });
+
+    it("should handle self-hosted correctly", () => {
+      const result = getTraceUrl("sentry.example.com", "myorg", "abc123");
+      expect(result).toBe(
+        "https://sentry.example.com/organizations/myorg/explore/traces/trace/abc123",
+      );
+    });
+  });
+
+  describe("getEventsExplorerUrl", () => {
+    it("should handle regional URLs correctly for SaaS", () => {
+      const result = getEventsExplorerUrl(
+        "us.sentry.io",
+        "myorg",
+        "level:error",
+        "errors",
+        "proj1",
+      );
+      expect(result).toBe(
+        "https://myorg.sentry.io/explore/?query=level%3Aerror&dataset=errors&layout=table&project=proj1",
+      );
+    });
+
+    it("should handle EU regional URLs correctly", () => {
+      const result = getEventsExplorerUrl(
+        "eu.sentry.io",
+        "myorg",
+        "level:warning",
+        "spans",
+      );
+      expect(result).toBe(
+        "https://myorg.sentry.io/explore/?query=level%3Awarning&dataset=spans&layout=table",
+      );
+    });
+
+    it("should handle self-hosted correctly", () => {
+      const result = getEventsExplorerUrl(
+        "sentry.example.com",
+        "myorg",
+        "level:error",
+        "logs",
+        "proj1",
+      );
+      expect(result).toBe(
+        "https://sentry.example.com/organizations/myorg/explore/?query=level%3Aerror&dataset=logs&layout=table&project=proj1",
+      );
     });
   });
 });

--- a/packages/mcp-server/src/utils/url-utils.ts
+++ b/packages/mcp-server/src/utils/url-utils.ts
@@ -9,7 +9,7 @@ export function isSentryHost(host: string): boolean {
 
 /**
  * Generates a Sentry issue URL.
- * @param host The Sentry host
+ * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier
  * @param issueId Issue identifier (e.g., "PROJECT-123")
  * @returns The complete issue URL
@@ -20,14 +20,17 @@ export function getIssueUrl(
   issueId: string,
 ): string {
   const isSaas = isSentryHost(host);
+  // For SaaS instances, always use sentry.io for web UI URLs regardless of region
+  // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
+  const webHost = isSaas ? "sentry.io" : host;
   return isSaas
-    ? `https://${organizationSlug}.${host}/issues/${issueId}`
+    ? `https://${organizationSlug}.${webHost}/issues/${issueId}`
     : `https://${host}/organizations/${organizationSlug}/issues/${issueId}`;
 }
 
 /**
  * Generates a Sentry issues search URL.
- * @param host The Sentry host
+ * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier
  * @param query Optional search query
  * @param projectSlugOrId Optional project slug or ID
@@ -40,8 +43,11 @@ export function getIssuesSearchUrl(
   projectSlugOrId?: string,
 ): string {
   const isSaas = isSentryHost(host);
+  // For SaaS instances, always use sentry.io for web UI URLs regardless of region
+  // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
+  const webHost = isSaas ? "sentry.io" : host;
   let url = isSaas
-    ? `https://${organizationSlug}.${host}/issues/`
+    ? `https://${organizationSlug}.${webHost}/issues/`
     : `https://${host}/organizations/${organizationSlug}/issues/`;
 
   const params = new URLSearchParams();
@@ -62,7 +68,7 @@ export function getIssuesSearchUrl(
 
 /**
  * Generates a Sentry trace URL for performance investigation.
- * @param host The Sentry host
+ * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier
  * @param traceId Trace identifier
  * @returns The complete trace URL
@@ -73,14 +79,17 @@ export function getTraceUrl(
   traceId: string,
 ): string {
   const isSaas = isSentryHost(host);
+  // For SaaS instances, always use sentry.io for web UI URLs regardless of region
+  // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
+  const webHost = isSaas ? "sentry.io" : host;
   return isSaas
-    ? `https://${organizationSlug}.${host}/explore/traces/trace/${traceId}`
+    ? `https://${organizationSlug}.${webHost}/explore/traces/trace/${traceId}`
     : `https://${host}/organizations/${organizationSlug}/explore/traces/trace/${traceId}`;
 }
 
 /**
  * Generates a Sentry events explorer URL.
- * @param host The Sentry host
+ * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier
  * @param query Search query
  * @param dataset Dataset type
@@ -97,8 +106,11 @@ export function getEventsExplorerUrl(
   fields?: string[],
 ): string {
   const isSaas = isSentryHost(host);
+  // For SaaS instances, always use sentry.io for web UI URLs regardless of region
+  // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
+  const webHost = isSaas ? "sentry.io" : host;
   let url = isSaas
-    ? `https://${organizationSlug}.${host}/explore/`
+    ? `https://${organizationSlug}.${webHost}/explore/`
     : `https://${host}/organizations/${organizationSlug}/explore/`;
 
   const params = new URLSearchParams();


### PR DESCRIPTION
Regional subdomains like us.sentry.io and eu.sentry.io are for API endpoints only. Web UI URLs should always use the base sentry.io domain for SaaS instances.