### PR TITLE
Correct canary wrangler config

### DIFF
--- a/packages/mcp-cloudflare/wrangler.canary.jsonc
+++ b/packages/mcp-cloudflare/wrangler.canary.jsonc
@@ -20,7 +20,7 @@
     }
   ],
   "assets": {
-    "directory": "./public",
+    "directory": "./dist/client",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application"
   },


### PR DESCRIPTION
The canary worker was getting 404s because the assets directory was pointing to '../client' but should point to './dist/client' where the built assets are located. The canary worker now correctly serves static assets and returns 200.