### PR TITLE
Add checks: write permission for JUnit test reports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to Cloudflare
 permissions:
   contents: read
   deployments: write
+  checks: write
 
 on:
   workflow_run:


### PR DESCRIPTION
The mikepenz/action-junit-report action needs checks: write permission to create check runs for smoke test results. This fixes the 'Resource not accessible by integration' error when publishing test reports.