### PR TITLE
fix: Allow requests without Origin header in CSRF middleware (#488)

### DIFF
--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -26,6 +26,12 @@ const app = new Hono<{
     "*",
     csrf({
       origin: (origin, c) => {
+        // If no Origin header is present, this cannot be a CSRF attack
+        // (CSRF requires a cross-origin request which always has an Origin header)
+        if (!origin) {
+          return true;
+        }
+        // If Origin is present, verify it matches the request URL's origin
         const requestUrl = new URL(c.req.url);
         return origin === requestUrl.origin;
       },


### PR DESCRIPTION
## Summary
- Fix 500 error when authorization requests lack Origin header
- Allow requests without Origin header since they cannot be CSRF attacks
- CSRF attacks by definition require cross-origin requests with Origin headers

## Problem
Authorization requests without an Origin header were throwing a 500 internal server error instead of being handled properly.

## Solution
Updated the CSRF middleware to explicitly allow requests without Origin headers, as these cannot be CSRF attacks. The middleware still validates the Origin when present to protect against actual CSRF attempts.

## Test plan
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] All tests pass

Fixes #488

🤖 Generated with [Claude Code](https://claude.ai/code)