### PR TITLE
fix(cloudflare): hide project/org constraints documentation

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -48,6 +48,7 @@ export default function RemoteSetup() {
           specification, including OAuth, you can connect directly.
         </p>
         <CodeSnippet snippet={endpoint} />
+        {/* Hidden for now - constraints not working correctly
         <p>
           <strong>Organization and Project Constraints:</strong> You can
           optionally constrain your MCP session to specific organizations or
@@ -63,6 +64,7 @@ export default function RemoteSetup() {
             to a specific organization and project
           </li>
         </ul>
+        */}
         <p>
           Sentry's MCP server supports both the SSE and HTTP Streaming
           protocols, and will negotiate based on your client's capabilities. If


### PR DESCRIPTION
## Summary
- Temporarily hides the organization/project constraints documentation from the remote setup page
- The subpath-based MCP constraints feature is currently not working correctly

## Changes
- Commented out the constraints documentation section rather than deleting it
- This makes it easy to restore once the feature is working properly

## Test plan
- [x] Visual inspection - constraints documentation no longer visible on setup page
- [x] Code remains commented for easy restoration