### PR TITLE
feat(constraints): restore and fix organization/project constraints functionality

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -48,7 +48,6 @@ export default function RemoteSetup() {
           specification, including OAuth, you can connect directly.
         </p>
         <CodeSnippet snippet={endpoint} />
-        {/* Hidden for now - constraints not working correctly
         <p>
           <strong>Organization and Project Constraints:</strong> You can
           optionally constrain your MCP session to specific organizations or
@@ -64,7 +63,7 @@ export default function RemoteSetup() {
             to a specific organization and project
           </li>
         </ul>
-        */}
+
         <p>
           Sentry's MCP server supports both the SSE and HTTP Streaming
           protocols, and will negotiate based on your client's capabilities. If

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -481,6 +481,27 @@ export const restHandlers = buildHandlers([
     },
   },
   {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+    fetch: () => {
+      return HttpResponse.json({
+        ...projectFixture,
+        id: "4509106749636608",
+        slug: "cloudflare-mcp",
+      });
+    },
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/non-existent-project/",
+    fetch: () => {
+      return HttpResponse.json(
+        { detail: "The requested resource does not exist" },
+        { status: 404 },
+      );
+    },
+  },
+  {
     method: "post",
     path: "/api/0/organizations/sentry-mcp-evals/teams/",
     fetch: () => {

--- a/packages/mcp-server/src/tools/find-organizations.test.ts
+++ b/packages/mcp-server/src/tools/find-organizations.test.ts
@@ -57,4 +57,66 @@ describe("find_organizations", () => {
     );
     expect(result).toContain("Organizations");
   });
+
+  it("filters organizations when constrained to specific organization", async () => {
+    const result = await findOrganizations.handler(
+      {},
+      {
+        constraints: {
+          organizationSlug: "sentry-mcp-evals",
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    // Should contain note about constraint
+    expect(result).toContain(
+      "This MCP session is constrained to organization **sentry-mcp-evals**",
+    );
+    expect(result).toContain(
+      "Organization parameters will be automatically provided to tools",
+    );
+
+    // Should only show the constrained org
+    expect(result).toContain("sentry-mcp-evals");
+    expect(result).toMatchInlineSnapshot(`
+      "# Organizations
+
+      *Note: This MCP session is constrained to organization **sentry-mcp-evals**. Organization parameters will be automatically provided to tools.*
+      *However, you still need to use this tool to get the regionUrl for API calls.*
+
+      ## **sentry-mcp-evals**
+
+      **Web URL:** https://sentry.io/sentry-mcp-evals
+      **Region URL:** https://us.sentry.io
+
+      # Using this information
+
+      - The organization's name is the identifier for the organization, and is used in many tools for \`organizationSlug\`.
+      - If a tool supports passing in the \`regionUrl\`, you MUST pass in the correct value shown above for each organization.
+      - For Sentry's Cloud Service (sentry.io), always use the regionUrl to ensure requests go to the correct region.
+      "
+    `);
+  });
+
+  it("handles constraint to non-existent organization", async () => {
+    const result = await findOrganizations.handler(
+      {},
+      {
+        constraints: {
+          organizationSlug: "non-existent-org",
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain(
+      "This MCP session is constrained to organization **non-existent-org**",
+    );
+    expect(result).toContain(
+      "The constrained organization **non-existent-org** was not found or you don't have access to it",
+    );
+  });
 });

--- a/packages/mcp-server/src/tools/find-projects.test.ts
+++ b/packages/mcp-server/src/tools/find-projects.test.ts
@@ -18,4 +18,62 @@ describe("find_projects", () => {
       "
     `);
   });
+
+  it("filters projects when constrained to specific project", async () => {
+    const result = await findProjects.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: undefined,
+      },
+      {
+        ...getServerContext(),
+        constraints: {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+        },
+      },
+    );
+
+    // Should contain note about constraint
+    expect(result).toContain(
+      "This MCP session is constrained to project **cloudflare-mcp**",
+    );
+    expect(result).toContain(
+      "Project parameters will be automatically provided to tools",
+    );
+
+    // Should only show the constrained project
+    expect(result).toContain("cloudflare-mcp");
+    expect(result).toMatchInlineSnapshot(`
+      "# Projects in **sentry-mcp-evals**
+
+      *Note: This MCP session is constrained to project **cloudflare-mcp**. Project parameters will be automatically provided to tools.*
+
+      - **cloudflare-mcp**
+      "
+    `);
+  });
+
+  it("handles constraint to non-existent project", async () => {
+    const result = await findProjects.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: undefined,
+      },
+      {
+        ...getServerContext(),
+        constraints: {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "non-existent-project",
+        },
+      },
+    );
+
+    expect(result).toContain(
+      "This MCP session is constrained to project **non-existent-project**",
+    );
+    expect(result).toContain(
+      "The constrained project **non-existent-project** was not found in this organization or you don't have access to it",
+    );
+  });
 });

--- a/packages/mcp-server/src/tools/find-teams.ts
+++ b/packages/mcp-server/src/tools/find-teams.ts
@@ -35,6 +35,21 @@ export default defineTool({
 
     const teams = await apiService.listTeams(organizationSlug);
     let output = `# Teams in **${organizationSlug}**\n\n`;
+
+    // Add note if session is constrained
+    if (
+      context.constraints.organizationSlug ||
+      context.constraints.projectSlug
+    ) {
+      output += `*Note: This MCP session is constrained to `;
+      if (context.constraints.projectSlug) {
+        output += `project **${context.constraints.projectSlug}**`;
+      } else {
+        output += `organization **${context.constraints.organizationSlug}**`;
+      }
+      output += `. Some parameters will be automatically provided to tools.*\n\n`;
+    }
+
     if (teams.length === 0) {
       output += "No teams found.\n";
       return output;

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -58,6 +58,7 @@ export default defineTool({
     "<hints>",
     "- If the user passes a parameter in the form of name/otherName, it's likely in the format of <organizationSlug>/<projectSlug>.",
     "- Parse org/project notation directly without calling find_organizations or find_projects.",
+    "- Note: When the MCP session is constrained to a specific organization or project, those parameters may be automatically provided and won't appear in the tool signature.",
     "</hints>",
   ].join("\n"),
   inputSchema: {

--- a/packages/mcp-server/src/tools/search-issues/handler.ts
+++ b/packages/mcp-server/src/tools/search-issues/handler.ts
@@ -53,6 +53,7 @@ export default defineTool({
     "- If the user passes a parameter in the form of name/otherName, it's likely in the format of <organizationSlug>/<projectSlugOrId>.",
     "- Parse org/project notation directly without calling find_organizations or find_projects.",
     "- The projectSlugOrId parameter accepts both project slugs (e.g., 'my-project') and numeric IDs (e.g., '123456').",
+    "- Note: When the MCP session is constrained to a specific organization or project, those parameters may be automatically provided and won't appear in the tool signature.",
     "</hints>",
   ].join("\n"),
   inputSchema: {


### PR DESCRIPTION
## Summary
Restores the organization/project constraint functionality that was previously hidden and fixes critical bugs in constraint parameter mapping. This enables users to scope their MCP sessions to specific organizations or projects for improved security and focused workflows.

### Key Changes
- **Restored UI documentation**: Re-enabled constraint documentation in remote-setup.tsx that was hidden in #506
- **Fixed parameter mapping**: Corrected constraint handling in server.ts to properly map projectSlug constraints to projectSlugOrId parameters
- **Enhanced tool filtering**: Added constraint-aware filtering to find-organizations and find-projects tools
- **Improved user feedback**: Added clear notices in tool outputs when session is constrained
- **Updated tool hints**: Added documentation about automatic parameter provision when constrained

### Breaking Changes
- None

### Dependencies
- None

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>