### PR TITLE
fix(cloudflare): remove subpath constraint support from SSE endpoint

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -72,6 +72,11 @@ export default function RemoteSetup() {
           the SSE-only implementation with the following URL:
         </p>
         <CodeSnippet snippet={sseEndpoint} />
+        <p>
+          <strong>Note:</strong> SSE endpoints do not support organization and
+          project constraints. Use the main endpoint above if you need scoped
+          access.
+        </p>
 
         <h3>Integration Guides</h3>
       </Prose>

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -107,8 +107,9 @@ const oAuthProvider = new OAuthProvider({
   apiHandlers: {
     // NOTE: OAuthProvider only does prefix matching, not parameterized routes.
     // So "/mcp" will match "/mcp", "/mcp/org", "/mcp/org/project" etc.
-    // We use a custom wrapper to extract path params and pass them as headers
-    "/sse": createMcpHandler("/sse", true),
+    // We use a custom wrapper to extract path params for /mcp endpoints only.
+    // SSE endpoints don't support subpath constraints due to protocol limitations.
+    "/sse": SentryMCP.serveSSE("/sse"),
     "/mcp": createMcpHandler("/mcp", false),
   },
   // @ts-ignore


### PR DESCRIPTION
## Summary

Fixes the SSE endpoint that was broken after commit e84e2b319459542dc5ff8b4272f9972c8f0521e0 introduced subpath constraint support.

### Problem
The SSE endpoint stopped working because the `createMcpHandler` wrapper interfered with SSE protocol message handling by modifying request headers and creating new request objects.

### Solution  
- Reverts SSE endpoint to direct `SentryMCP.serveSSE("/sse")` handler
- Removes subpath constraint support for SSE endpoints only (due to protocol limitations)
- Keeps subpath constraints working for `/mcp` endpoints
- Updates documentation to clarify that SSE endpoints don't support constraints

### Testing
- SSE connections now work properly (tested locally)
- `/mcp` endpoints retain constraint functionality
- All quality checks pass (tsc, lint, test)

### Breaking Changes
None - this is a bug fix. SSE endpoints never properly supported constraints anyway.

🤖 Generated with Claude Code