### PR TITLE
fix(api-client): update event schema to match Sentry API responses

### DIFF
--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -353,10 +353,13 @@ const BaseEventSchema = z.object({
     .array(
       z.object({
         key: z.string(),
-        value: z.string(),
+        value: z.string().nullable(),
       }),
     )
     .optional(),
+  // The _meta field contains metadata about fields in the response
+  // It's safer to type as unknown since its structure varies
+  _meta: z.unknown().optional(),
 });
 
 export const ErrorEventSchema = BaseEventSchema.omit({
@@ -371,10 +374,12 @@ export const TransactionEventSchema = BaseEventSchema.omit({
   type: true,
 }).extend({
   type: z.literal("transaction"),
-  occurrence: z.object({
-    issueTitle: z.string(),
-    culprit: z.string().nullable(),
-  }),
+  occurrence: z
+    .object({
+      issueTitle: z.string(),
+      culprit: z.string().nullable(),
+    })
+    .nullable(),
 });
 
 export const UnknownEventSchema = BaseEventSchema.omit({


### PR DESCRIPTION
## Summary
- Fixed schema validation errors when parsing Sentry API event responses
- Resolves ZodError failures that were preventing issue details from loading

## Problem
The MCP server was failing to parse event responses from the Sentry API due to overly strict schema validation. The API can return:
- Tag values that are null
- Transaction events with null occurrence fields  
- A `_meta` field containing response metadata

These mismatches caused `ZodError: Failed to validate variable` errors when calling `EventSchema.parse(body)`.

## Solution
Updated the event schema to match actual API responses:
- Allow nullable tag values: `value: z.string().nullable()`
- Allow nullable occurrence in TransactionEventSchema: `.nullable()`
- Added optional `_meta` field: `_meta: z.unknown().optional()`

Fixes MCP-SERVER-EJY and MCP-SERVER-EJY

🤖 Generated with [Claude Code](https://claude.ai/code)