### PR TITLE
fix(api-client): handle mixed span/issue arrays in trace responses

### DIFF
--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -614,10 +614,33 @@ export const TraceSpanSchema: z.ZodType<any> = z.lazy(() =>
 );
 
 /**
+ * Schema for issue objects that can appear in trace responses.
+ *
+ * When Sentry's trace API returns standalone errors, they are returned as
+ * SerializedIssue objects that lack the span-specific fields.
+ */
+export const TraceIssueSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]).optional(),
+    issue_id: z.union([z.string(), z.number()]).optional(),
+    project_id: z.union([z.string(), z.number()]).optional(),
+    project_slug: z.string().optional(),
+    title: z.string().optional(),
+    culprit: z.string().optional(),
+    type: z.string().optional(),
+    timestamp: z.union([z.string(), z.number()]).optional(),
+  })
+  .passthrough();
+
+/**
  * Schema for Sentry trace response.
  *
  * Contains the complete trace tree starting from root spans.
- * The response is an array of root-level spans, each potentially
- * containing nested children spans.
+ * The response is an array that can contain both root-level spans
+ * and standalone issue objects. The Sentry API's query_trace_data
+ * function returns a mixed list of SerializedSpan and SerializedIssue
+ * objects when there are errors not directly associated with spans.
  */
-export const TraceSchema = z.array(TraceSpanSchema);
+export const TraceSchema = z.array(
+  z.union([TraceSpanSchema, TraceIssueSchema]),
+);

--- a/packages/mcp-server/src/api-client/types.ts
+++ b/packages/mcp-server/src/api-client/types.ts
@@ -63,6 +63,7 @@ import type {
   TraceMetaSchema,
   TraceSchema,
   TraceSpanSchema,
+  TraceIssueSchema,
   UserSchema,
 } from "./schema";
 
@@ -92,4 +93,5 @@ export type ClientKeyList = z.infer<typeof ClientKeyListSchema>;
 // Trace types
 export type TraceMeta = z.infer<typeof TraceMetaSchema>;
 export type TraceSpan = z.infer<typeof TraceSpanSchema>;
+export type TraceIssue = z.infer<typeof TraceIssueSchema>;
 export type Trace = z.infer<typeof TraceSchema>;

--- a/packages/mcp-server/src/tools/get-trace-details.ts
+++ b/packages/mcp-server/src/tools/get-trace-details.ts
@@ -152,6 +152,17 @@ function selectInterestingSpans(
   const selected: SelectedSpan[] = [];
   let spanCount = 0;
 
+  // Filter out non-span items (issues) from the trace data
+  // Spans must have children array, duration, and other span-specific fields
+  const actualSpans = spans.filter(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      "children" in item &&
+      Array.isArray(item.children) &&
+      "duration" in item,
+  );
+
   function addSpan(span: any, level: number): boolean {
     if (spanCount >= maxSpans || level > MAX_DEPTH) return false;
 
@@ -209,7 +220,7 @@ function selectInterestingSpans(
   }
 
   // Sort root spans by duration and select the most interesting ones
-  const sortedRoots = spans
+  const sortedRoots = actualSpans
     .sort((a, b) => (b.duration || 0) - (a.duration || 0))
     .slice(0, 5); // Start with top 5 root spans
 
@@ -370,6 +381,17 @@ function calculateOperationStats(spans: any[]): Record<
 function getAllSpansFlattened(spans: any[]): any[] {
   const result: any[] = [];
 
+  // Filter out non-span items (issues) from the trace data
+  // Spans must have children array and duration
+  const actualSpans = spans.filter(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      "children" in item &&
+      Array.isArray(item.children) &&
+      "duration" in item,
+  );
+
   function collectSpans(spanList: any[]) {
     for (const span of spanList) {
       result.push(span);
@@ -379,7 +401,7 @@ function getAllSpansFlattened(spans: any[]): any[] {
     }
   }
 
-  collectSpans(spans);
+  collectSpans(actualSpans);
   return result;
 }
 


### PR DESCRIPTION
Fixes MCP-SERVER-EJS

The Sentry API's trace endpoint can return a heterogeneous array containing both SerializedSpan and SerializedIssue objects when there are standalone errors not associated with specific spans. This caused ZodError validation failures with missing required fields.

Changes:
- Add TraceIssueSchema to handle issue objects in trace responses
- Update TraceSchema to accept union of TraceSpanSchema and TraceIssueSchema
- Filter out non-span items in selectInterestingSpans and getAllSpansFlattened to prevent processing issues as spans

This fix allows the MCP server to properly handle trace responses that contain both spans and standalone issue objects without validation errors.