### PR TITLE
fix: Pass along regionUrl to embedded tools

### DIFF
--- a/packages/mcp-server/src/internal/agents/tools/dataset-fields.ts
+++ b/packages/mcp-server/src/internal/agents/tools/dataset-fields.ts
@@ -60,13 +60,15 @@ export async function discoverDatasetFields(
 
 /**
  * Create a tool for discovering available fields in a dataset
+ * The tool is pre-bound with the API service and organization configured for the appropriate region
  */
-export function createDatasetFieldsTool(
-  apiService: SentryApiService,
-  organizationSlug: string,
-  dataset: DatasetType,
-  projectId?: string,
-) {
+export function createDatasetFieldsTool(options: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  dataset: DatasetType;
+  projectId?: string;
+}) {
+  const { apiService, organizationSlug, dataset, projectId } = options;
   return agentTool({
     description: `Discover available fields for ${dataset} searches in Sentry`,
     parameters: z.object({

--- a/packages/mcp-server/src/internal/agents/tools/otel-semantics.ts
+++ b/packages/mcp-server/src/internal/agents/tools/otel-semantics.ts
@@ -247,11 +247,16 @@ export async function lookupOtelSemantics(
 /**
  * Create the otel-semantics-lookup tool for AI agents
  */
-export function createOtelLookupTool(
-  apiService: SentryApiService,
-  organizationSlug: string,
-  projectId?: string,
-) {
+/**
+ * Create a tool for looking up OpenTelemetry semantic convention attributes
+ * The tool is pre-bound with the API service and organization configured for the appropriate region
+ */
+export function createOtelLookupTool(options: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  projectId?: string;
+}) {
+  const { apiService, organizationSlug, projectId } = options;
   return agentTool({
     description:
       "Look up OpenTelemetry semantic convention attributes for a specific namespace. OpenTelemetry attributes are universal standards that work across all datasets.",

--- a/packages/mcp-server/src/internal/agents/tools/whoami.ts
+++ b/packages/mcp-server/src/internal/agents/tools/whoami.ts
@@ -25,8 +25,10 @@ export async function getCurrentUser(
 
 /**
  * Create a tool for getting current user information
+ * The tool is pre-bound with the API service configured for the appropriate region
  */
-export function createWhoamiTool(apiService: SentryApiService) {
+export function createWhoamiTool(options: { apiService: SentryApiService }) {
+  const { apiService } = options;
   return agentTool({
     description: "Get the current authenticated user's information",
     parameters: z.object({}),

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -102,12 +102,12 @@ export default defineTool({
 
     // Translate the natural language query using Search Events Agent
     // The agent will determine the dataset and fetch the appropriate attributes
-    const agentResult = await searchEventsAgent(
-      params.naturalLanguageQuery,
+    const agentResult = await searchEventsAgent({
+      query: params.naturalLanguageQuery,
       organizationSlug,
       apiService,
       projectId,
-    );
+    });
 
     const parsed = agentResult.result;
 

--- a/packages/mcp-server/src/tools/search-events/utils.ts
+++ b/packages/mcp-server/src/tools/search-events/utils.ts
@@ -87,12 +87,14 @@ export async function fetchCustomAttributes(
 
 /**
  * Create a tool for the agent to query available attributes by dataset
+ * The tool is pre-bound with the API service and organization configured for the appropriate region
  */
-export function createDatasetAttributesTool(
-  apiService: SentryApiService,
-  organizationSlug: string,
-  projectId?: string,
-) {
+export function createDatasetAttributesTool(options: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  projectId?: string;
+}) {
+  const { apiService, organizationSlug, projectId } = options;
   return agentTool({
     description:
       "Query available attributes and fields for a specific Sentry dataset to understand what data is available",

--- a/packages/mcp-server/src/tools/search-issues/handler.ts
+++ b/packages/mcp-server/src/tools/search-issues/handler.ts
@@ -112,12 +112,12 @@ export default defineTool({
     }
 
     // Translate natural language to Sentry query
-    const agentResult = await searchIssuesAgent(
-      params.naturalLanguageQuery,
-      params.organizationSlug,
+    const agentResult = await searchIssuesAgent({
+      query: params.naturalLanguageQuery,
+      organizationSlug: params.organizationSlug,
       apiService,
       projectId,
-    );
+    });
 
     const translatedQuery = agentResult.result;
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/getsentry/sentry-mcp/issues/526 by refactoring embedded agent tools to support `regionUrl` as a passable argument alongside `organizationSlug`.

## Problem

Issue #526 requested making embedded agent tools support `regionUrl` for multi-region Sentry deployments. The previous architecture required agents to create their own API service, making it difficult to pass region configuration cleanly.

## Solution

### Agent Interface Simplification
- **searchEventsAgent** and **searchIssuesAgent** now take `apiService` directly in options object
- Pre-bind tools with region-aware API service instead of passing region parameters to tools
- Handlers create region-configured API service and pass to agents

### Tool Creation Consistency  
- Updated all `createXTool` functions to use object parameters:
  - `createWhoamiTool({apiService})`
  - `createDatasetFieldsTool({apiService, organizationSlug, dataset, projectId})`
  - `createOtelLookupTool({apiService, organizationSlug, projectId})`
  - `createDatasetAttributesTool({apiService, organizationSlug, projectId})`

## Architecture

```
Handler → Creates apiService with regionUrl → Agent → Uses pre-bound tools → Multi-region API calls
```

Tools are now "bound/curried" with the correct region configuration rather than taking region parameters as callable arguments.

## Test Plan

- ✅ All functionality tests pass
- ✅ Tool definitions generate correctly
- ✅ Multi-region support works through pre-configured API service

Fixes #526