### PR TITLE
fix(security): add SSRF protection for regionUrl parameter

### DIFF
--- a/docs/security.mdc
+++ b/docs/security.mdc
@@ -66,6 +66,43 @@ Context propagated through:
 
 ## Security Measures
 
+### SSRF Protection
+
+The MCP server validates `regionUrl` parameters to prevent Server-Side Request Forgery (SSRF) attacks:
+
+```typescript
+// Region URL validation rules:
+// 1. Must be a subdomain of the base host
+// 2. For sentry.io, only 'us' and 'de' regions allowed
+// 3. Prevents requests to arbitrary external domains
+
+validateRegionUrl("https://evil.com", "sentry.io"); // ❌ Throws error
+validateRegionUrl("https://us.sentry.io", "sentry.io"); // ✅ Allowed
+validateRegionUrl("https://subdomain.self-hosted.com", "self-hosted.com"); // ✅ Allowed
+```
+
+Implementation: `packages/mcp-server/src/internal/tool-helpers/validate-region-url.ts`
+
+### Prompt Injection Protection
+
+Tools that accept user input are vulnerable to prompt injection attacks. Key mitigations:
+
+1. **Parameter Validation**: All tool inputs validated with Zod schemas
+2. **URL Validation**: URLs parsed and validated before use
+3. **Region Constraints**: Region URLs restricted to known Sentry domains
+4. **No Direct Command Execution**: Tools don't execute user-provided commands
+
+Example protection in tools:
+```typescript
+// URLs must be valid and from expected domains
+if (!issueUrl.includes('sentry.io')) {
+  throw new UserInputError("Invalid Sentry URL");
+}
+
+// Region URLs validated against base host
+const validatedHost = validateRegionUrl(regionUrl, baseHost);
+```
+
 ### State Parameter Protection
 
 ```typescript

--- a/packages/mcp-server/src/internal/tool-helpers/validate-region-url.test.ts
+++ b/packages/mcp-server/src/internal/tool-helpers/validate-region-url.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { validateRegionUrl } from "./validate-region-url";
+import { UserInputError } from "../../errors";
+
+describe("validateRegionUrl", () => {
+  describe("sentry.io validation", () => {
+    it("allows exact match for sentry.io", () => {
+      const result = validateRegionUrl("https://sentry.io", "sentry.io");
+      expect(result).toBe("sentry.io");
+    });
+
+    it("allows us.sentry.io for sentry.io base", () => {
+      const result = validateRegionUrl("https://us.sentry.io", "sentry.io");
+      expect(result).toBe("us.sentry.io");
+    });
+
+    it("allows de.sentry.io for sentry.io base", () => {
+      const result = validateRegionUrl("https://de.sentry.io", "sentry.io");
+      expect(result).toBe("de.sentry.io");
+    });
+
+    it("rejects unknown region subdomains for sentry.io", () => {
+      expect(() =>
+        validateRegionUrl("https://evil.sentry.io", "sentry.io"),
+      ).toThrow(UserInputError);
+      expect(() =>
+        validateRegionUrl("https://evil.sentry.io", "sentry.io"),
+      ).toThrow("Allowed regions for sentry.io are: us, de");
+    });
+
+    it("rejects completely different domains for sentry.io", () => {
+      expect(() => validateRegionUrl("https://evil.com", "sentry.io")).toThrow(
+        UserInputError,
+      );
+      expect(() => validateRegionUrl("https://evil.com", "sentry.io")).toThrow(
+        "For sentry.io, regionUrl must be sentry.io or [region].sentry.io",
+      );
+    });
+
+    it("handles http protocol for sentry.io", () => {
+      const result = validateRegionUrl("http://us.sentry.io", "sentry.io");
+      expect(result).toBe("us.sentry.io");
+    });
+  });
+
+  describe("self-hosted validation", () => {
+    it("allows exact match for self-hosted", () => {
+      const result = validateRegionUrl(
+        "https://sentry.company.com",
+        "sentry.company.com",
+      );
+      expect(result).toBe("sentry.company.com");
+    });
+
+    it("allows subdomain for self-hosted", () => {
+      const result = validateRegionUrl(
+        "https://eu.sentry.company.com",
+        "sentry.company.com",
+      );
+      expect(result).toBe("eu.sentry.company.com");
+    });
+
+    it("allows nested subdomains for self-hosted", () => {
+      const result = validateRegionUrl(
+        "https://region.eu.sentry.company.com",
+        "sentry.company.com",
+      );
+      expect(result).toBe("region.eu.sentry.company.com");
+    });
+
+    it("rejects different domains for self-hosted", () => {
+      expect(() =>
+        validateRegionUrl("https://evil.com", "sentry.company.com"),
+      ).toThrow(UserInputError);
+      expect(() =>
+        validateRegionUrl("https://evil.com", "sentry.company.com"),
+      ).toThrow(
+        "The regionUrl host must be sentry.company.com or a subdomain of sentry.company.com",
+      );
+    });
+
+    it("rejects parent domains for self-hosted", () => {
+      expect(() =>
+        validateRegionUrl("https://company.com", "sentry.company.com"),
+      ).toThrow(UserInputError);
+    });
+  });
+
+  describe("protocol validation", () => {
+    it("rejects URLs without protocol", () => {
+      expect(() => validateRegionUrl("sentry.io", "sentry.io")).toThrow(
+        UserInputError,
+      );
+      expect(() => validateRegionUrl("sentry.io", "sentry.io")).toThrow(
+        "Must be a valid URL",
+      );
+    });
+
+    it("rejects non-http/https protocols", () => {
+      expect(() => validateRegionUrl("ftp://sentry.io", "sentry.io")).toThrow(
+        UserInputError,
+      );
+      expect(() => validateRegionUrl("ftp://sentry.io", "sentry.io")).toThrow(
+        "Must include protocol (http:// or https://)",
+      );
+    });
+
+    it("rejects malformed URLs", () => {
+      expect(() => validateRegionUrl("https://", "sentry.io")).toThrow(
+        UserInputError,
+      );
+      expect(() => validateRegionUrl("https://", "sentry.io")).toThrow(
+        "Must be a valid URL",
+      );
+    });
+
+    it("rejects protocol-only hosts", () => {
+      expect(() => validateRegionUrl("https://https", "sentry.io")).toThrow(
+        UserInputError,
+      );
+      expect(() => validateRegionUrl("https://https", "sentry.io")).toThrow(
+        "The host cannot be just a protocol name",
+      );
+    });
+  });
+
+  describe("case sensitivity", () => {
+    it("handles case-insensitive matching for sentry.io", () => {
+      const result = validateRegionUrl("https://US.SENTRY.IO", "sentry.io");
+      expect(result).toBe("us.sentry.io");
+    });
+
+    it("handles case-insensitive matching for self-hosted", () => {
+      const result = validateRegionUrl(
+        "https://SENTRY.COMPANY.COM",
+        "sentry.company.com",
+      );
+      expect(result).toBe("sentry.company.com");
+    });
+
+    it("handles mixed case base host", () => {
+      const result = validateRegionUrl("https://us.sentry.io", "SENTRY.IO");
+      expect(result).toBe("us.sentry.io");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles trailing slashes in URL", () => {
+      const result = validateRegionUrl("https://us.sentry.io/", "sentry.io");
+      expect(result).toBe("us.sentry.io");
+    });
+
+    it("handles URL with path", () => {
+      const result = validateRegionUrl(
+        "https://us.sentry.io/api/0/organizations/",
+        "sentry.io",
+      );
+      expect(result).toBe("us.sentry.io");
+    });
+
+    it("handles URL with query params", () => {
+      const result = validateRegionUrl(
+        "https://us.sentry.io?test=1",
+        "sentry.io",
+      );
+      expect(result).toBe("us.sentry.io");
+    });
+
+    it("handles URL with port", () => {
+      const result = validateRegionUrl(
+        "https://sentry.company.com:8080",
+        "sentry.company.com:8080",
+      );
+      expect(result).toBe("sentry.company.com:8080");
+    });
+
+    it("rejects when port doesn't match", () => {
+      expect(() =>
+        validateRegionUrl(
+          "https://sentry.company.com:8080",
+          "sentry.company.com",
+        ),
+      ).toThrow(UserInputError);
+    });
+  });
+});

--- a/packages/mcp-server/src/internal/tool-helpers/validate-region-url.ts
+++ b/packages/mcp-server/src/internal/tool-helpers/validate-region-url.ts
@@ -1,0 +1,89 @@
+import { UserInputError } from "../../errors";
+
+/**
+ * Allowed region subdomains for sentry.io
+ * Only these specific regions are permitted when using Sentry's cloud service
+ */
+const SENTRY_IO_ALLOWED_REGIONS = new Set(["us", "de"]);
+
+/**
+ * Validates that a regionUrl is a valid subset of the base host.
+ * Prevents SSRF attacks by ensuring the regionUrl cannot point to arbitrary external domains.
+ *
+ * Rules:
+ * 1. regionUrl host must be the base host or a subdomain of it
+ * 2. For sentry.io, only specific region subdomains are allowed (us, de)
+ * 3. Protocol must be http:// or https://
+ *
+ * @param regionUrl - The region URL to validate
+ * @param baseHost - The base host to validate against
+ * @returns The validated host if valid
+ * @throws {UserInputError} If the regionUrl is invalid
+ */
+export function validateRegionUrl(regionUrl: string, baseHost: string): string {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(regionUrl);
+  } catch {
+    throw new UserInputError(
+      `Invalid regionUrl provided: ${regionUrl}. Must be a valid URL.`,
+    );
+  }
+
+  // Validate protocol
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    throw new UserInputError(
+      `Invalid regionUrl provided: ${regionUrl}. Must include protocol (http:// or https://).`,
+    );
+  }
+
+  // Validate that the host is not just the protocol name
+  if (parsedUrl.host === "https" || parsedUrl.host === "http") {
+    throw new UserInputError(
+      `Invalid regionUrl provided: ${regionUrl}. The host cannot be just a protocol name.`,
+    );
+  }
+
+  const regionHost = parsedUrl.host.toLowerCase();
+  const baseLower = baseHost.toLowerCase();
+
+  // For sentry.io, enforce allowlist
+  if (baseLower === "sentry.io") {
+    // Allow exact match
+    if (regionHost === "sentry.io") {
+      return regionHost;
+    }
+
+    // Check if it's a subdomain
+    const match = regionHost.match(/^([^.]+)\.sentry\.io$/);
+    if (!match) {
+      throw new UserInputError(
+        `Invalid regionUrl: ${regionUrl}. For sentry.io, regionUrl must be sentry.io or [region].sentry.io`,
+      );
+    }
+
+    // Validate against allowlist
+    const region = match[1];
+    if (!SENTRY_IO_ALLOWED_REGIONS.has(region)) {
+      throw new UserInputError(
+        `Invalid regionUrl: ${regionUrl}. Allowed regions for sentry.io are: ${Array.from(SENTRY_IO_ALLOWED_REGIONS).join(", ")}`,
+      );
+    }
+
+    return regionHost;
+  }
+
+  // For other hosts (self-hosted), must be same domain or subdomain
+  if (regionHost === baseLower) {
+    return regionHost;
+  }
+
+  // Check if it's a subdomain of the base host
+  if (regionHost.endsWith(`.${baseLower}`)) {
+    return regionHost;
+  }
+
+  throw new UserInputError(
+    `Invalid regionUrl: ${regionUrl}. The regionUrl host must be ${baseHost} or a subdomain of ${baseHost}`,
+  );
+}


### PR DESCRIPTION
## Summary
- Added validation to prevent Server-Side Request Forgery (SSRF) attacks via regionUrl parameter
- Ensures regionUrl can only point to subdomains of the base host
- Implements allowlist for sentry.io regions (us, de)

## Problem
The MCP server accepted any URL as `regionUrl` parameter without validation, potentially allowing attackers to:
- Redirect API requests to arbitrary external domains
- Leak Bearer tokens to attacker-controlled servers
- Perform SSRF attacks against internal infrastructure

## Solution
Created a validation utility that:
1. **Domain validation**: regionUrl must be same domain or subdomain of base host
2. **Sentry.io allowlist**: Only `us.sentry.io` and `de.sentry.io` allowed for cloud
3. **Protocol validation**: Must use http:// or https://
4. **Comprehensive tests**: Full test coverage for all validation scenarios

## Changes
- Added `validate-region-url.ts` utility with strict validation rules
- Updated `apiServiceFromContext()` to validate all regionUrl inputs
- Added comprehensive test suite with 23 test cases
- Updated security documentation with SSRF and prompt injection guidance

## Test plan
- [x] Unit tests pass (23 tests covering all scenarios)
- [x] TypeScript compilation successful
- [x] Linting checks pass
- [x] Full test suite passes

## Security Impact
This is a security fix that prevents potential SSRF vulnerabilities. No breaking changes for legitimate usage.

🤖 Generated with [Claude Code](https://claude.ai/code)