### PR TITLE
fix(mcp-cloudflare): resolve OAuth unsupported_grant_type error

### DIFF
--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -74,7 +74,8 @@ export async function exchangeCodeForAccessToken({
       client_id,
       client_secret,
       code,
-      ...(redirect_uri ? { redirect_uri } : {}),
+      // binding the redirect_uri creates an unsupported_grant_type error
+      // ...(redirect_uri ? { redirect_uri } : {}),
     }).toString(),
   });
   if (!resp.ok) {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
-import { logger } from "@sentry/cloudflare";
 import {
   renderApprovalDialog,
   parseRedirectApproval,
@@ -58,7 +57,7 @@ export default new Hono<{ Bindings: Env }>()
       // Log invalid redirect URI errors without sending them to Sentry
       const errorMessage = err instanceof Error ? err.message : String(err);
       if (errorMessage.includes("Invalid redirect URI")) {
-        logger.warn(`OAuth authorization failed: ${errorMessage}`, {
+        console.warn(`OAuth authorization failed: ${errorMessage}`, {
           error: errorMessage,
           // Don't include the full error object to prevent Sentry capture
         });
@@ -110,7 +109,7 @@ export default new Hono<{ Bindings: Env }>()
     try {
       result = await parseRedirectApproval(c.req.raw, c.env.COOKIE_SECRET);
     } catch (err) {
-      logger.warn(`Failed to parse approval form: ${err}`, {
+      console.warn(`Failed to parse approval form: ${err}`, {
         error: String(err),
       });
       return c.text("Invalid request", 400);
@@ -138,14 +137,14 @@ export default new Hono<{ Bindings: Env }>()
         Array.isArray(client?.redirectUris) &&
         client.redirectUris.includes(oauthReqWithPermissions.redirectUri);
       if (!uriIsAllowed) {
-        logger.warn("Redirect URI not registered for client", {
+        console.warn("Redirect URI not registered for client", {
           clientId: oauthReqWithPermissions.clientId,
           redirectUri: oauthReqWithPermissions.redirectUri,
         });
         return c.text("Invalid redirect URI", 400);
       }
     } catch (lookupErr) {
-      logger.warn("Failed to validate client redirect URI", {
+      console.warn("Failed to validate client redirect URI", {
         error: String(lookupErr),
       });
       return c.text("Invalid request", 400);


### PR DESCRIPTION
## Summary
Fixes OAuth token exchange failing with `unsupported_grant_type` error by removing the `redirect_uri` parameter from the token exchange request. This addresses an issue where the OAuth flow would fail during the callback phase.

### Key Changes
- Fixed token exchange: Removed `redirect_uri` parameter that was causing grant type errors
- Improved logging: Replaced Sentry logger with console.warn for expected OAuth validation failures to enable local debugging

### Breaking Changes
- None

### Dependencies
- None

Co-Authored-By: Claude <noreply@anthropic.com>