### PR TITLE
fix(cloudflare): simplify OAuth state to signed envelope

### DIFF
--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -97,13 +97,15 @@ describe("oauth authorize routes", () => {
         stateParam!,
         testEnv.COOKIE_SECRET as string,
       );
-      expect(decodedState.permissions).toEqual([
+      expect((decodedState.req as any).permissions).toEqual([
         "issue_triage",
         "project_management",
       ]);
-      expect(decodedState.clientId).toBe("test-client");
-      expect(decodedState.redirectUri).toBe("https://example.com/callback");
-      expect(decodedState.scope).toEqual(["read", "write"]);
+      expect((decodedState.req as any).clientId).toBe("test-client");
+      expect((decodedState.req as any).redirectUri).toBe(
+        "https://example.com/callback",
+      );
+      expect((decodedState.req as any).scope).toEqual(["read", "write"]);
     });
 
     it("should handle no permissions selected (read-only default)", async () => {
@@ -129,7 +131,7 @@ describe("oauth authorize routes", () => {
         stateParam!,
         testEnv.COOKIE_SECRET as string,
       );
-      expect(decodedState.permissions).toEqual([]);
+      expect((decodedState.req as any).permissions).toEqual([]);
     });
 
     it("should handle only issue triage permission", async () => {
@@ -155,7 +157,7 @@ describe("oauth authorize routes", () => {
         stateParam!,
         testEnv.COOKIE_SECRET as string,
       );
-      expect(decodedState.permissions).toEqual(["issue_triage"]);
+      expect((decodedState.req as any).permissions).toEqual(["issue_triage"]);
     });
 
     it("should include Set-Cookie header for approval", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -49,12 +49,14 @@ describe("oauth callback routes", () => {
       // Build signed state matching what /oauth/authorize issues
       const now = Date.now();
       const payload: OAuthState = {
-        clientId: "test-client",
-        redirectUri: "https://example.com/callback",
-        scope: ["read"],
+        req: {
+          clientId: "test-client",
+          redirectUri: "https://example.com/callback",
+          scope: ["read"],
+        },
         iat: now,
         exp: now + 10 * 60 * 1000,
-      };
+      } as unknown as OAuthState;
       const signedState = await signState(payload, testEnv.COOKIE_SECRET!);
 
       const request = new Request(
@@ -73,12 +75,14 @@ describe("oauth callback routes", () => {
     it("should reject callback with invalid client approval cookie", async () => {
       const now = Date.now();
       const payload: OAuthState = {
-        clientId: "test-client",
-        redirectUri: "https://example.com/callback",
-        scope: ["read"],
+        req: {
+          clientId: "test-client",
+          redirectUri: "https://example.com/callback",
+          scope: ["read"],
+        },
         iat: now,
         exp: now + 10 * 60 * 1000,
-      };
+      } as unknown as OAuthState;
       const signedState = await signState(payload, testEnv.COOKIE_SECRET!);
 
       const request = new Request(
@@ -130,12 +134,14 @@ describe("oauth callback routes", () => {
       // Build a signed state for a different client than the approved one
       const now = Date.now();
       const payload: OAuthState = {
-        clientId: "test-client",
-        redirectUri: "https://example.com/callback",
-        scope: ["read"],
+        req: {
+          clientId: "test-client",
+          redirectUri: "https://example.com/callback",
+          scope: ["read"],
+        },
         iat: now,
         exp: now + 10 * 60 * 1000,
-      };
+      } as unknown as OAuthState;
       const signedState = await signState(payload, testEnv.COOKIE_SECRET!);
 
       const request = new Request(

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -153,10 +153,7 @@ export default new Hono<{ Bindings: Env }>()
     // Build signed state for redirect to Sentry (10 minute validity)
     const now = Date.now();
     const payload: OAuthState = {
-      clientId: oauthReqWithPermissions.clientId,
-      redirectUri: oauthReqWithPermissions.redirectUri,
-      scope: oauthReqWithPermissions.scope,
-      permissions,
+      req: oauthReqWithPermissions as unknown as Record<string, unknown>,
       iat: now,
       exp: now + 10 * 60 * 1000,
     };

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -70,13 +70,8 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
     return c.text("Invalid state", 400);
   }
 
-  // Reconstruct minimal oauth request info from signed state
-  const oauthReqInfo: AuthRequestWithPermissions = {
-    clientId: parsedState.clientId,
-    redirectUri: parsedState.redirectUri,
-    scope: parsedState.scope,
-    permissions: parsedState.permissions,
-  } as AuthRequestWithPermissions;
+  // Reconstruct oauth request info exactly as provided by downstream client
+  const oauthReqInfo = parsedState.req as unknown as AuthRequestWithPermissions;
 
   if (!oauthReqInfo.clientId) {
     console.warn("Missing clientId in OAuth state");


### PR DESCRIPTION
This PR simplifies OAuth state to a small, signed envelope that preserves the full downstream AuthRequest (+permissions), solving several brittleness issues seen in real clients.

Summary
- Preserve entire request in state as `{ req, iat, exp }`
- Keep PKCE fields and any additional request params end-to-end
- Remove scope/client state mirroring and ad-hoc normalization
- Maintain replay protection with HMAC signature + iat/exp

Fixes
- Invalid state/scope parse errors (empty scope)
- PKCE mismatch: "code_verifier provided for a flow that did not use PKCE"

Testing
- pnpm run tsc && pnpm run lint && pnpm run test (all green)
- oauth authorize/callback tests updated to use `state.req`

Notes
- Minimal, surgical change in Cloudflare OAuth paths; no token secrets in logs.

Co-Authored-By: Codex CLI Agent <noreply@openai.com>