### PR TITLE
fix: simplify stdio setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,23 @@ event:write
 Launch the transport:
 
 ```shell
-npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.example.com
+npx @sentry/mcp-server@latest --access-token=sentry-user-token
 ```
+
+Need to connect to a self-hosted deployment? Add <code>--host</code> (hostname
+only, e.g. <code>--host=sentry.example.com</code>) when you run the command.
 
 Note: You can also use environment variables:
 
 ```shell
 SENTRY_ACCESS_TOKEN=
+# Optional overrides for self-hosted deployments
 SENTRY_HOST=
 OPENAI_API_KEY=  # Required for AI-powered search tools (search_events, search_issues)
 ```
+
+If you leave the host variable unset, the CLI automatically targets the Sentry
+SaaS service. Only set the override when you operate self-hosted Sentry.
 
 ### MCP Inspector
 

--- a/docs/deployment.mdc
+++ b/docs/deployment.mdc
@@ -51,8 +51,17 @@ Required in production:
 SENTRY_CLIENT_ID=your_oauth_app_id
 SENTRY_CLIENT_SECRET=your_oauth_app_secret
 COOKIE_SECRET=32_char_random_string
-SENTRY_HOST=sentry.io  # Optional for self-hosted
 ```
+
+Optional overrides for self-hosted deployments:
+```bash
+# Leave unset to target the SaaS host
+SENTRY_HOST=sentry.example.com     # Hostname only (self-hosted only)
+```
+
+Configure these overrides only when your Cloudflare deployment connects to a
+self-hosted Sentry instance; no additional host variables are required for the
+SaaS service.
 
 Development (.dev.vars):
 ```bash

--- a/packages/mcp-cloudflare/src/client/pages/home.tsx
+++ b/packages/mcp-cloudflare/src/client/pages/home.tsx
@@ -64,7 +64,7 @@ export default function Home({ onChatClick }: HomeProps) {
             </div>
           </div>
 
-          <Section heading="What is a Model Context Protocol?">
+          <Section>
             <Prose>
               <p>
                 Simply put, it's a way to plug Sentry's API into an LLM, letting
@@ -102,21 +102,20 @@ export default function Home({ onChatClick }: HomeProps) {
             heading={
               <>
                 <div className="flex-1">Getting Started</div>
-                <div className="flex self-justify-end items-center gap-1 text-xs">
+                <div className="flex items-center gap-2 text-xs">
                   <Button
-                    variant="link"
+                    variant={!stdio ? "default" : "secondary"}
                     size="xs"
                     onClick={() => setStdio(false)}
-                    active={!stdio}
+                    className={!stdio ? "shadow-sm" : undefined}
                   >
-                    Remote
+                    Cloud
                   </Button>
-                  <span>/</span>
                   <Button
-                    variant="link"
+                    variant={stdio ? "default" : "secondary"}
                     size="xs"
                     onClick={() => setStdio(true)}
-                    active={stdio}
+                    className={stdio ? "shadow-sm" : undefined}
                   >
                     Stdio
                   </Button>
@@ -127,14 +126,14 @@ export default function Home({ onChatClick }: HomeProps) {
             <div className="relative min-h-0">
               {!stdio ? (
                 <div
-                  key="remote"
+                  key="cloud"
                   className="animate-in fade-in slide-in-from-left-4 duration-300"
                 >
                   <RemoteSetup />
                 </div>
               ) : (
                 <div
-                  key="stdio"
+                  key="stdio-self-hosted"
                   className="animate-in fade-in slide-in-from-right-4 duration-300"
                 >
                   <StdioSetup />

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -26,8 +26,8 @@ To utilize the `stdio` transport, you'll need to create an User Auth Token in Se
 ### Examples
 
 ```shell
-# Default read-only access
-npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.example.com
+# Default read-only access (SaaS)
+npx @sentry/mcp-server@latest --access-token=sentry-user-token
 
 # Override with specific scopes only (removes defaults)
 npx @sentry/mcp-server@latest --access-token=TOKEN --scopes=org:read,event:read
@@ -35,8 +35,8 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --scopes=org:read,event:read
 # Add write permissions to defaults (keeps all defaults)
 npx @sentry/mcp-server@latest --access-token=TOKEN --add-scopes=event:write,project:write
 
-# or with full URL
-npx @sentry/mcp-server@latest --access-token=sentry-user-token --url=https://sentry.example.com
+# Point at a self-hosted deployment
+npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.example.com
 ```
 
 ### Environment Variables
@@ -45,22 +45,25 @@ You can also use environment variables:
 
 ```shell
 SENTRY_ACCESS_TOKEN=your-token
-SENTRY_HOST=sentry.example.com     # Custom hostname
-SENTRY_URL=https://sentry.io       # OR base URL (precedence over SENTRY_HOST)
+# Optional overrides. Leave unset to use the default SaaS host
+SENTRY_HOST=sentry.example.com
 MCP_SCOPES=org:read,event:read     # Override default scopes (replaces defaults)
 MCP_ADD_SCOPES=event:write         # Add to default scopes (keeps defaults)
 OPENAI_API_KEY=your-openai-key     # Required for AI-powered search tools (search_events, search_issues)
 ```
+
+If `SENTRY_HOST` is not provided, the CLI automatically targets the Sentry SaaS
+endpoint.
+
+Configure this variable only when you operate a self-hosted Sentry deployment;
+it is not needed for Sentry SaaS.
 
 **Important:** The `MCP_SCOPES` environment variable or `--scopes` flag completely replaces the default scopes. Use `MCP_ADD_SCOPES` or `--add-scopes` if you want to keep the default read-only permissions and add additional ones.
 
 The host configuration accepts two distinct formats:
 
 - **`SENTRY_HOST`**: Hostname only (no protocol)
-  - Examples: `sentry.io`, `sentry.example.com`, `localhost:8000`
-- **`SENTRY_URL`**: Full URLs (hostname will be extracted)
-  - Examples: `https://sentry.io`, `https://sentry.example.com`
-  - Takes precedence over `SENTRY_HOST` if both are provided
+  - Examples: `sentry.example.com`, `sentry.internal.example.com`, `localhost:8000`
 
 **Note**: Only HTTPS connections are supported for security reasons.
 

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -57,8 +57,9 @@ OPENAI_API_KEY=your_openai_api_key
 # Required - Sentry access token with appropriate permissions
 SENTRY_ACCESS_TOKEN=your_sentry_access_token
 
-# Optional
-SENTRY_HOST=sentry.io  # For self-hosted Sentry instances (hostname or full URL)
+# Optional (self-hosted only)
+# Leave unset to target the SaaS host
+SENTRY_HOST=sentry.example.com  # Hostname only
 MCP_URL=https://mcp.sentry.dev  # MCP server host (defaults to production)
 MCP_MODEL=gpt-4o  # Override default model (GPT-4)
 
@@ -167,6 +168,8 @@ Use local stdio transport with custom Sentry host:
 ```bash
 SENTRY_HOST=sentry.example.com SENTRY_ACCESS_TOKEN=your_token pnpm mcp-test-client "Show my projects"
 ```
+
+Only configure `SENTRY_HOST` when you run self-hosted Sentry.
 
 ## Development
 


### PR DESCRIPTION
This cleans up the confusion around things like SENTRY_HOST, and undocuments SENTRY_URL as its soft-deprecated and generally is not useful.

Fixes GH-550