### PR TITLE
feat: add configurable OpenAI API URL via CLI parameter

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -37,6 +37,9 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --add-scopes=event:write,proj
 
 # Point at a self-hosted deployment
 npx @sentry/mcp-server@latest --access-token=sentry-user-token --host=sentry.example.com
+
+# Override the OpenAI API endpoint for embedded agents (stdio only)
+npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://proxy.example.com/v1
 ```
 
 ### Environment Variables
@@ -50,6 +53,9 @@ SENTRY_HOST=sentry.example.com
 MCP_SCOPES=org:read,event:read     # Override default scopes (replaces defaults)
 MCP_ADD_SCOPES=event:write         # Add to default scopes (keeps defaults)
 OPENAI_API_KEY=your-openai-key     # Required for AI-powered search tools (search_events, search_issues)
+# No environment variable exists for the OpenAI base URL override; use --openai-base-url instead.
+# This restriction prevents unexpected environment overrides that could silently reroute requests to a
+# malicious proxy capable of harvesting the OpenAI API key provided at runtime.
 ```
 
 If `SENTRY_HOST` is not provided, the CLI automatically targets the Sentry SaaS

--- a/packages/mcp-server/src/cli/parse.test.ts
+++ b/packages/mcp-server/src/cli/parse.test.ts
@@ -9,6 +9,7 @@ describe("cli/parseArgv", () => {
       "--url=https://example.com",
       "--mcp-url=https://mcp.example.com",
       "--sentry-dsn=dsn",
+      "--openai-base-url=https://api.example.com/v1",
       "--scopes=org:read",
       "--add-scopes=event:write",
       "--all-scopes",
@@ -20,6 +21,7 @@ describe("cli/parseArgv", () => {
     expect(parsed.url).toBe("https://example.com");
     expect(parsed.mcpUrl).toBe("https://mcp.example.com");
     expect(parsed.sentryDsn).toBe("dsn");
+    expect(parsed.openaiBaseUrl).toBe("https://api.example.com/v1");
     expect(parsed.scopes).toBe("org:read");
     expect(parsed.addScopes).toBe("event:write");
     expect(parsed.allScopes).toBe(true);
@@ -49,6 +51,7 @@ describe("cli/parseEnv + merge", () => {
       "--host=clihost",
       "--mcp-url=climcp",
       "--sentry-dsn=clidsn",
+      "--openai-base-url=https://api.cli/v1",
       "--scopes=org:admin",
       "--add-scopes=project:write",
     ]);
@@ -57,6 +60,7 @@ describe("cli/parseEnv + merge", () => {
     expect(merged.host).toBe("clihost");
     expect(merged.mcpUrl).toBe("climcp");
     expect(merged.sentryDsn).toBe("clidsn");
+    expect(merged.openaiBaseUrl).toBe("https://api.cli/v1");
     expect(merged.scopes).toBe("org:admin");
     expect(merged.addScopes).toBe("project:write");
   });

--- a/packages/mcp-server/src/cli/parse.ts
+++ b/packages/mcp-server/src/cli/parse.ts
@@ -8,6 +8,7 @@ export function parseArgv(argv: string[]): CliArgs {
     url: { type: "string" as const },
     "mcp-url": { type: "string" as const },
     "sentry-dsn": { type: "string" as const },
+    "openai-base-url": { type: "string" as const },
     "organization-slug": { type: "string" as const },
     "project-slug": { type: "string" as const },
     scopes: { type: "string" as const },
@@ -50,6 +51,7 @@ export function parseArgv(argv: string[]): CliArgs {
     url: values.url as string | undefined,
     mcpUrl: values["mcp-url"] as string | undefined,
     sentryDsn: values["sentry-dsn"] as string | undefined,
+    openaiBaseUrl: values["openai-base-url"] as string | undefined,
     organizationSlug: values["organization-slug"] as string | undefined,
     projectSlug: values["project-slug"] as string | undefined,
     scopes: values.scopes as string | undefined,
@@ -84,6 +86,7 @@ export function merge(cli: CliArgs, env: EnvArgs): MergedArgs {
     host: cli.host ?? env.host,
     mcpUrl: cli.mcpUrl ?? env.mcpUrl,
     sentryDsn: cli.sentryDsn ?? env.sentryDsn,
+    openaiBaseUrl: cli.openaiBaseUrl,
     // Scopes precedence: CLI scopes/add-scopes override their env counterparts
     scopes: cli.scopes ?? env.scopes,
     addScopes: cli.addScopes ?? env.addScopes,

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -55,6 +55,27 @@ describe("cli/finalize", () => {
     expect(cfg.sentryHost).toBe("sentry.example.com");
   });
 
+  it("accepts valid OpenAI base URL", () => {
+    const cfg = finalize({
+      accessToken: "tok",
+      openaiBaseUrl: "https://api.proxy.example/v1",
+      unknownArgs: [],
+    });
+    expect(cfg.openaiBaseUrl).toBe(
+      new URL("https://api.proxy.example/v1").toString(),
+    );
+  });
+
+  it("rejects invalid OpenAI base URL", () => {
+    expect(() =>
+      finalize({
+        accessToken: "tok",
+        openaiBaseUrl: "ftp://example.com",
+        unknownArgs: [],
+      }),
+    ).toThrow(/OPENAI base URL must use http or https scheme/);
+  });
+
   it("throws on non-https URL", () => {
     expect(() =>
       finalize({ accessToken: "tok", url: "http://bad", unknownArgs: [] }),

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -7,6 +7,7 @@ import {
 import { DEFAULT_SCOPES } from "../constants";
 import {
   validateAndParseSentryUrlThrows,
+  validateOpenAiBaseUrlThrows,
   validateSentryHostThrows,
 } from "../utils/url-utils";
 import type { MergedArgs, ResolvedConfig } from "./types";
@@ -67,11 +68,16 @@ export function finalize(input: MergedArgs): ResolvedConfig {
     }
   }
 
+  const resolvedOpenAiBaseUrl = input.openaiBaseUrl
+    ? validateOpenAiBaseUrlThrows(input.openaiBaseUrl)
+    : undefined;
+
   return {
     accessToken: input.accessToken,
     sentryHost,
     mcpUrl: input.mcpUrl,
     sentryDsn: input.sentryDsn,
+    openaiBaseUrl: resolvedOpenAiBaseUrl,
     finalScopes,
     organizationSlug: input.organizationSlug,
     projectSlug: input.projectSlug,

--- a/packages/mcp-server/src/cli/types.ts
+++ b/packages/mcp-server/src/cli/types.ts
@@ -6,6 +6,7 @@ export type CliArgs = {
   url?: string;
   mcpUrl?: string;
   sentryDsn?: string;
+  openaiBaseUrl?: string;
   scopes?: string;
   addScopes?: string;
   allScopes?: boolean;
@@ -32,6 +33,7 @@ export type MergedArgs = {
   url?: string;
   mcpUrl?: string;
   sentryDsn?: string;
+  openaiBaseUrl?: string;
   scopes?: string;
   addScopes?: string;
   allScopes?: boolean;
@@ -47,6 +49,7 @@ export type ResolvedConfig = {
   sentryHost: string;
   mcpUrl?: string;
   sentryDsn?: string;
+  openaiBaseUrl?: string;
   finalScopes?: Set<Scope>;
   organizationSlug?: string;
   projectSlug?: string;

--- a/packages/mcp-server/src/cli/usage.ts
+++ b/packages/mcp-server/src/cli/usage.ts
@@ -5,35 +5,30 @@ export function buildUsage(
   defaults: ReadonlyArray<Scope>,
   all: ReadonlyArray<Scope>,
 ): string {
-  return `Usage: ${packageName} --access-token=<token> [--host=<host>|--url=<url>] [--mcp-url=<url>] [--sentry-dsn=<dsn>] [--scopes=<scope1,scope2>] [--add-scopes=<scope1,scope2>] [--all-scopes]
+  return `Usage: ${packageName} --access-token=<token> [--host=<host>]
 
-Default scopes (read-only):
-  - ${defaults.join(", ")}
+Required:
+  --access-token <token>  Sentry User Auth Token with API access
 
-Scope options:
-  --scopes      Override default scopes completely
-  --add-scopes  Add scopes to the default read-only set
-  --all-scopes  Grant all available scopes (admin-level and implied)
+Common optional flags:
+  --host <host>           Change Sentry host (self-hosted)
+  --sentry-dsn <dsn>      Override DSN used for telemetry reporting
+  --openai-base-url <url> Override OpenAI API base URL for embedded agents
 
-Constraints (stdio only):
-  --organization-slug <slug>  Constrain all tool calls to this org
-  --project-slug <slug>       Constrain to a project (optional)
+Session constraints:
+  --organization-slug <slug>  Force all calls to an organization
+  --project-slug <slug>       Optional project constraint
 
-Available scopes (higher scopes include lower):
-  - org:read, org:write, org:admin
-  - project:read, project:write, project:admin
-  - team:read, team:write, team:admin
-  - member:read, member:write, member:admin
-  - event:read, event:write, event:admin
-  - project:releases
+Scope controls:
+  --scopes <list>     Override default scopes
+  --add-scopes <list> Add scopes to defaults
+  --all-scopes        Grant every available scope
+
+Defaults: ${defaults.join(", ")}
+All scopes: ${all.join(", ")}
 
 Examples:
-  # Default read-only access
   ${packageName} --access-token=TOKEN
-  
-  # Override with specific scopes only
-  ${packageName} --access-token=TOKEN --scopes=org:read,event:read
-  
-  # Add write permissions to defaults
-  ${packageName} --access-token=TOKEN --add-scopes=event:write,project:write`;
+  ${packageName} --access-token=TOKEN --host=sentry.example.com
+  ${packageName} --access-token=TOKEN --openai-base-url=https://proxy.example.com/v1`;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,6 +24,7 @@ import { finalize } from "./cli/resolve";
 import { sentryBeforeSend } from "./internal/sentry-scrubbing";
 import { ALL_SCOPES } from "./permissions";
 import { DEFAULT_SCOPES } from "./constants";
+import { configureOpenAIProvider } from "./internal/agents/openai-provider";
 
 const packageName = "@sentry/mcp-server";
 const usageText = buildUsage(packageName, DEFAULT_SCOPES, ALL_SCOPES);
@@ -68,6 +69,8 @@ if (!process.env.OPENAI_API_KEY) {
   );
   console.warn("");
 }
+
+configureOpenAIProvider({ baseUrl: cfg.openaiBaseUrl });
 
 Sentry.init({
   dsn: cfg.sentryDsn,
@@ -117,6 +120,7 @@ startStdio(instrumentedServer, {
   },
   sentryHost: cfg.sentryHost,
   mcpUrl: cfg.mcpUrl,
+  openaiBaseUrl: cfg.openaiBaseUrl,
 }).catch((err) => {
   console.error("Server error:", err);
   // ensure we've flushed all events

--- a/packages/mcp-server/src/internal/agents/callEmbeddedAgent.ts
+++ b/packages/mcp-server/src/internal/agents/callEmbeddedAgent.ts
@@ -1,5 +1,5 @@
 import { generateText, Output } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { getOpenAIModel } from "./openai-provider";
 import type { z } from "zod";
 
 export type ToolCall = {
@@ -34,7 +34,7 @@ export async function callEmbeddedAgent<T>({
   const capturedToolCalls: ToolCall[] = [];
 
   const result = await generateText({
-    model: openai("gpt-4o"),
+    model: getOpenAIModel("gpt-4o"),
     system,
     prompt,
     tools,

--- a/packages/mcp-server/src/internal/agents/openai-provider.ts
+++ b/packages/mcp-server/src/internal/agents/openai-provider.ts
@@ -1,0 +1,33 @@
+import { createOpenAI, openai as defaultOpenAI } from "@ai-sdk/openai";
+import type { LanguageModelV1 } from "ai";
+
+let customFactory: ReturnType<typeof createOpenAI> | null = null;
+
+/**
+ * Configure the OpenAI provider factory.
+ *
+ * When a base URL is provided, the factory will use that endpoint for all
+ * subsequent model requests. Passing undefined resets to the default
+ * configuration bundled with the SDK.
+ */
+export function configureOpenAIProvider({
+  baseUrl,
+}: {
+  baseUrl?: string;
+}): void {
+  if (baseUrl) {
+    customFactory = createOpenAI({
+      baseURL: baseUrl,
+    });
+    return;
+  }
+  customFactory = null;
+}
+
+/**
+ * Retrieve a configured OpenAI language model.
+ */
+export function getOpenAIModel(model: string): LanguageModelV1 {
+  const factory = customFactory ?? defaultOpenAI;
+  return factory(model);
+}

--- a/packages/mcp-server/src/tools/search-events.test.ts
+++ b/packages/mcp-server/src/tools/search-events.test.ts
@@ -6,9 +6,13 @@ import { generateText } from "ai";
 import { UserInputError } from "../errors";
 
 // Mock the AI SDK
-vi.mock("@ai-sdk/openai", () => ({
-  openai: vi.fn(() => "mocked-model"),
-}));
+vi.mock("@ai-sdk/openai", () => {
+  const mockModel = vi.fn(() => "mocked-model");
+  return {
+    openai: mockModel,
+    createOpenAI: vi.fn(() => mockModel),
+  };
+});
 
 vi.mock("ai", () => ({
   generateText: vi.fn(),

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -52,6 +52,7 @@ export type ServerContext = {
   sentryHost?: string;
   mcpUrl?: string;
   accessToken: string;
+  openaiBaseUrl?: string;
   userId?: string | null;
   clientId?: string;
   // Granted scopes for tool access control

--- a/packages/mcp-server/src/utils/url-utils.test.ts
+++ b/packages/mcp-server/src/utils/url-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   validateSentryHostThrows,
   validateAndParseSentryUrlThrows,
+  validateOpenAiBaseUrlThrows,
   getIssueUrl,
   getIssuesSearchUrl,
   getTraceUrl,
@@ -34,6 +35,43 @@ describe("url-utils", () => {
       );
       expect(() => validateSentryHostThrows("https://example.com:443")).toThrow(
         "SENTRY_HOST should only contain a hostname",
+      );
+    });
+  });
+
+  describe("validateOpenAiBaseUrlThrows", () => {
+    it("should accept valid HTTPS URLs", () => {
+      expect(() =>
+        validateOpenAiBaseUrlThrows("https://api.openai.com/v1"),
+      ).not.toThrow();
+      expect(() =>
+        validateOpenAiBaseUrlThrows(
+          "https://custom.example.com/openai/deployments/model",
+        ),
+      ).not.toThrow();
+    });
+
+    it("should accept valid HTTP URLs for local development", () => {
+      expect(() =>
+        validateOpenAiBaseUrlThrows("http://localhost:8080/v1"),
+      ).not.toThrow();
+    });
+
+    it("should reject empty strings", () => {
+      expect(() => validateOpenAiBaseUrlThrows(" ")).toThrow(
+        "OPENAI base URL must not be empty.",
+      );
+    });
+
+    it("should reject URLs with unsupported protocols", () => {
+      expect(() => validateOpenAiBaseUrlThrows("ftp://example.com")).toThrow(
+        "OPENAI base URL must use http or https scheme",
+      );
+    });
+
+    it("should reject invalid URLs", () => {
+      expect(() => validateOpenAiBaseUrlThrows("not-a-url")).toThrow(
+        "OPENAI base URL must be a valid HTTP or HTTPS URL",
       );
     });
   });

--- a/packages/mcp-server/src/utils/url-utils.ts
+++ b/packages/mcp-server/src/utils/url-utils.ts
@@ -225,3 +225,36 @@ export function validateSentryHostThrows(host: string): void {
 export function validateAndParseSentryUrlThrows(url: string): string {
   return _validateAndParseSentryUrlInternal(url);
 }
+
+/**
+ * Validates that the provided OpenAI base URL is a valid HTTP(S) URL and returns a normalized string.
+ *
+ * @param url The URL to validate and normalize
+ * @returns The normalized URL string
+ * @throws {Error} If the URL is empty, invalid, or uses an unsupported protocol
+ */
+export function validateOpenAiBaseUrlThrows(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed.length === 0) {
+    throw new Error("OPENAI base URL must not be empty.");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch (error) {
+    throw new Error(
+      "OPENAI base URL must be a valid HTTP or HTTPS URL (e.g., https://example.com/v1).",
+      { cause: error },
+    );
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(
+      "OPENAI base URL must use http or https scheme (e.g., https://example.com/v1).",
+    );
+  }
+
+  // Preserve the exact path to support Azure or proxy endpoints that include version/path segments
+  return parsed.toString();
+}


### PR DESCRIPTION
Add --openai-base-url CLI parameter to support custom OpenAI-compatible endpoints for embedded agents in search_events and search_issues tools.

Key changes:

- Added --openai-base-url CLI parameter with validation
- Added openai-provider.ts for centralized OpenAI client configuration
- Updated embedded agents to use configurable base URL
- Added comprehensive tests for URL validation and parsing
- Updated CLI documentation with new parameter

Closes #552