### PR TITLE
refactor(logging): use Sentry.logger sink

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,9 +8,11 @@
       "type": "http",
       "url": "http://localhost:5173/mcp/sentry/mcp-server"
     },
-    "spotlight": {
-      "type": "http",
-      "url": "http://localhost:8969/mcp"
+    "sentry-spotlight": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@spotlightjs/spotlight", "--stdio-mcp"],
+      "env": {}
     }
   }
 }

--- a/docs/logging.mdc
+++ b/docs/logging.mdc
@@ -9,11 +9,13 @@ How logging works in the Sentry MCP server using LogTape and Sentry. For tracing
 
 We use [LogTape](https://logtape.org/) for structured logging with two sinks:
 - **Console sink**: JSON Lines format for log aggregation
-- **Sentry sink**: Sends logs to Sentry for monitoring
+- **Sentry sink**: Sends logs to Sentry's Logs product using `Sentry.logger.*` API
 
 Log levels are controlled by:
 1. `LOG_LEVEL` environment variable (e.g., `"debug"`, `"info"`, `"warning"`, `"error"`)
 2. Falls back to `NODE_ENV`: `"debug"` in development, `"info"` in production
+
+**Important**: We use a custom LogTape sink that calls `Sentry.logger.*` methods to send logs to Sentry's Logs product. The `@logtape/sentry` package uses `captureException/captureMessage` which creates Issues instead of Logs.
 
 Implementation: @packages/mcp-server/src/logging.ts
 

--- a/packages/mcp-server/src/logging.ts
+++ b/packages/mcp-server/src/logging.ts
@@ -14,9 +14,11 @@ import {
   parseLogLevel,
   type LogLevel,
   type Logger,
+  type LogRecord,
+  type Sink,
 } from "@logtape/logtape";
-import { getSentrySink } from "@logtape/sentry";
 import { captureException, captureMessage, withScope } from "@sentry/core";
+import * as Sentry from "@sentry/node";
 
 const ROOT_LOG_CATEGORY = ["sentry", "mcp"] as const;
 
@@ -42,6 +44,64 @@ function resolveLowestLevel(): LogLevel {
     : "info";
 }
 
+/**
+ * Creates a LogTape sink that sends logs to Sentry's Logs product using Sentry.logger.
+ *
+ * Unlike @logtape/sentry's getSentrySink which uses captureException/captureMessage
+ * (creating Issues), this sink uses Sentry.logger.* methods to send data to the
+ * Logs product.
+ *
+ * Note: This uses @sentry/node logger API. Cloudflare Workers will need a separate
+ * implementation using @sentry/cloudflare logger API.
+ */
+function createSentryLogsSink(): Sink {
+  return (record: LogRecord) => {
+    // Check if Sentry.logger is available (may not be in all environments)
+    if (!Sentry.logger) {
+      return;
+    }
+
+    // Extract message from LogRecord
+    let message = "";
+    for (let i = 0; i < record.message.length; i++) {
+      if (i % 2 === 0) {
+        message += record.message[i];
+      } else {
+        // Template values - convert to string
+        const value = record.message[i];
+        message += typeof value === "string" ? value : JSON.stringify(value);
+      }
+    }
+
+    // Extract attributes from properties
+    const attributes = record.properties as Record<string, unknown>;
+
+    // Map LogTape levels to Sentry.logger methods
+    switch (record.level) {
+      case "trace":
+        Sentry.logger.trace(message, attributes);
+        break;
+      case "debug":
+        Sentry.logger.debug(message, attributes);
+        break;
+      case "info":
+        Sentry.logger.info(message, attributes);
+        break;
+      case "warning":
+        Sentry.logger.warn(message, attributes);
+        break;
+      case "error":
+        Sentry.logger.error(message, attributes);
+        break;
+      case "fatal":
+        Sentry.logger.fatal(message, attributes);
+        break;
+      default:
+        Sentry.logger.info(message, attributes);
+    }
+  };
+}
+
 function ensureLoggingConfigured(): void {
   if (loggingConfigured) {
     return;
@@ -50,7 +110,7 @@ function ensureLoggingConfigured(): void {
   const consoleSink = getConsoleSink({
     formatter: getJsonLinesFormatter(),
   });
-  const sentrySink = getSentrySink();
+  const sentrySink = createSentryLogsSink();
 
   configureSync<SinkId, never>({
     reset: getConfig() !== null,


### PR DESCRIPTION
The upstream LogTape sink creates issues out of logs, which isnt what we want.