### PR TITLE
fix(permissions): isolate seer and event:write scopes

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -719,7 +719,7 @@ export function renderApprovalDialog(
                     <span class="permission-checkbox"></span>
                     <div class="optional-permission-content">
                       <span class="optional-permission-name">Issue Triage (event:write)</span>
-                      <div class="optional-permission-description">Update and manage issues - resolve, assign, and analyze problems</div>
+                      <div class="optional-permission-description">Update and manage issues - resolve, assign, and triage problems</div>
                     </div>
                   </label>
 

--- a/packages/mcp-server/src/tools/analyze-issue-with-seer.ts
+++ b/packages/mcp-server/src/tools/analyze-issue-with-seer.ts
@@ -25,7 +25,7 @@ import {
 
 export default defineTool({
   name: "analyze_issue_with_seer",
-  requiredScopes: ["event:read", "seer"],
+  requiredScopes: ["seer"],
   description: [
     "Use Seer to analyze production errors and get detailed root cause analysis with specific code fixes.",
     "",


### PR DESCRIPTION
Fixes permission isolation issues where "Issue Triage" and "Seer" permissions were incorrectly cascading:

- Updated "Issue Triage" description to remove "analyze" terminology which was confusing with Seer's analysis capabilities
- Changed analyze_issue_with_seer tool to only require "seer" scope (not event:read), ensuring proper permission isolation

This ensures users must explicitly opt-in to Seer functionality, and having event:write permissions does not automatically grant Seer access.