### PR TITLE
feat: add search support to find_organizations, find_teams, and find_projects

### DIFF
--- a/packages/mcp-server/src/api-client/client.ts
+++ b/packages/mcp-server/src/api-client/client.ts
@@ -842,7 +842,7 @@ export class SentryApiService {
       );
       const regionData = UserRegionsSchema.parse(regionsBody);
 
-      return (
+      const allOrganizations = (
         await Promise.all(
           regionData.regions.map(async (region) =>
             this.requestJSON(path, undefined, {
@@ -854,6 +854,9 @@ export class SentryApiService {
       )
         .map((data) => OrganizationListSchema.parse(data))
         .reduce((acc, curr) => acc.concat(curr), []);
+
+      // Apply the limit after combining results from all regions
+      return allOrganizations.slice(0, 25);
     } catch (error) {
       // If regions endpoint fails (e.g., older self-hosted versions identifying as sentry.io),
       // fall back to direct organizations endpoint

--- a/packages/mcp-server/src/schema.ts
+++ b/packages/mcp-server/src/schema.ts
@@ -45,6 +45,13 @@ export const ParamProjectSlugOrAll = z
     "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
   );
 
+export const ParamSearchQuery = z
+  .string()
+  .trim()
+  .describe(
+    "Search query to filter results by name or slug. Use this to narrow down results when there are many items.",
+  );
+
 export const ParamIssueShortId = z
   .string()
   .toUpperCase()

--- a/packages/mcp-server/src/tools/find-teams.ts
+++ b/packages/mcp-server/src/tools/find-teams.ts
@@ -3,7 +3,13 @@ import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
-import { ParamOrganizationSlug, ParamRegionUrl } from "../schema";
+import {
+  ParamOrganizationSlug,
+  ParamRegionUrl,
+  ParamSearchQuery,
+} from "../schema";
+
+const RESULT_LIMIT = 25;
 
 export default defineTool({
   name: "find_teams",
@@ -12,12 +18,16 @@ export default defineTool({
     "Find teams in an organization in Sentry.",
     "",
     "Use this tool when you need to:",
-    "- View all teams in a Sentry organization",
+    "- View teams in a Sentry organization",
     "- Find a team's slug to aid other tool requests",
+    "- Search for specific teams by name or slug",
+    "",
+    `Returns up to ${RESULT_LIMIT} results. If you hit this limit, use the query parameter to narrow down results.`,
   ].join("\n"),
   inputSchema: {
     organizationSlug: ParamOrganizationSlug,
     regionUrl: ParamRegionUrl.optional(),
+    query: ParamSearchQuery.optional(),
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
@@ -33,13 +43,29 @@ export default defineTool({
 
     setTag("organization.slug", organizationSlug);
 
-    const teams = await apiService.listTeams(organizationSlug);
+    const teams = await apiService.listTeams(organizationSlug, {
+      query: params.query,
+    });
+
     let output = `# Teams in **${organizationSlug}**\n\n`;
+
+    if (params.query) {
+      output += `**Search query:** "${params.query}"\n\n`;
+    }
+
     if (teams.length === 0) {
-      output += "No teams found.\n";
+      output += params.query
+        ? `No teams found matching "${params.query}".\n`
+        : "No teams found.\n";
       return output;
     }
+
     output += teams.map((team) => `- ${team.slug}\n`).join("");
+
+    if (teams.length === RESULT_LIMIT) {
+      output += `\n---\n\n**Note:** Showing ${RESULT_LIMIT} results (maximum). There may be more teams available. Use the \`query\` parameter to search for specific teams.`;
+    }
+
     return output;
   },
 });


### PR DESCRIPTION
Add optional query parameter to list endpoints to support filtering by name/slug. Return up to 25 results with clear messaging when limit is hit, directing users to use the query parameter to narrow results.

Changes:
- Added ParamSearchQuery schema for consistent search validation
- Updated API client methods (listOrganizations, listTeams, listProjects) to accept query parameter
- Hardcoded per_page=25 limit in API client (not exposed to callers)
- Updated all three find_* tools to support optional query parameter
- Added warning message when hitting 25 result limit
- Updated tool descriptions to mention search capability and result limits

Fixes #573