### PR TITLE
ref: remove use of SSE transport

### DIFF
--- a/docs/architecture.mdc
+++ b/docs/architecture.mdc
@@ -118,11 +118,19 @@ The MCP server supports multiple transport mechanisms:
 - Configured via command-line args
 - This is the standard MCP transport
 
-**HTTP/SSE Transport** (For web apps):
+**HTTP Transport** (For web apps):
 
-- Allows web applications to connect to MCP
+- Allows web applications to connect to MCP via HTTP streaming
 - Used by the example Cloudflare chat app
+- Main endpoint: `/mcp`
 - Not part of core MCP spec
+
+**SSE Transport** (Deprecated - will be removed):
+
+- Legacy Server-Sent Events transport
+- Endpoint: `/sse`
+- Does not support organization/project constraints
+- New integrations should use HTTP transport via `/mcp` endpoint
 
 ### 3. Authentication Strategy
 

--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -1,9 +1,4 @@
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "../ui/accordion";
+import { Accordion } from "../ui/accordion";
 import CodeSnippet from "../ui/code-snippet";
 import SetupGuide from "./setup-guide";
 import { Prose } from "../ui/prose";
@@ -15,7 +10,6 @@ const mcpServerName = import.meta.env.DEV ? "sentry-dev" : "sentry";
 
 export default function RemoteSetup() {
   const endpoint = new URL("/mcp", window.location.href).href;
-  const sseEndpoint = new URL("/sse", window.location.href).href;
 
   const mcpRemoteSnippet = `npx ${NPM_REMOTE_NAME}@latest ${endpoint}`;
   // the shared configuration for all clients
@@ -75,24 +69,6 @@ export default function RemoteSetup() {
             session to a specific organization and project
           </li>
         </ul>
-        <Accordion type="single" collapsible>
-          <AccordionItem value="sse-deprecated">
-            <AccordionTrigger>SSE support is deprecated</AccordionTrigger>
-            <AccordionContent>
-              <p className="mb-2">
-                New clients should use HTTP Streaming via the main
-                <code>/mcp</code> endpoint. If you must use the SSE-only
-                implementation, use the following URL:
-              </p>
-              <CodeSnippet noMargin snippet={sseEndpoint} />
-              <p className="mt-2">
-                <strong>Limitations:</strong> SSE endpoints do not support
-                organization or project constraints. Use the main
-                <code>/mcp</code> endpoint if you need scoped access.
-              </p>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
       </Prose>
       <Heading as="h3">Integration Guides</Heading>
       <Accordion type="single" collapsible>

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -9,7 +9,7 @@ A simple CLI tool to test the Sentry MCP server using stdio transport with an AI
 - 💬 Interactive mode by default when no prompt provided
 - 🎨 Colorized output for better readability
 - 🔄 Streaming responses for real-time feedback
-- 🌐 Remote MCP server support via SSE transport (with OAuth)
+- 🌐 Remote MCP server support via HTTP streaming (with OAuth)
 - 🏠 Local stdio transport for development
 
 ## Prerequisites
@@ -86,7 +86,7 @@ The client automatically determines the connection mode:
 2. Environment variable (`SENTRY_ACCESS_TOKEN`)
 3. `.env` file
 
-**Remote Mode (SSE transport)**: Used when no access token is provided, prompts for OAuth authentication
+**Remote Mode (HTTP streaming)**: Used when no access token is provided, prompts for OAuth authentication
 
 ### Required Sentry Permissions
 
@@ -103,17 +103,17 @@ Your Sentry access token needs the following scopes:
 
 ### Remote Mode (Default)
 
-Connect to the remote MCP server via SSE transport (uses OAuth for authentication):
+Connect to the remote MCP server via HTTP streaming (uses OAuth for authentication):
 
 ```bash
-# Connect to production MCP server (uses /sse endpoint)
+# Connect to production MCP server (uses /mcp endpoint)
 pnpm mcp-test-client
 
 # Connect to local development MCP server
 pnpm mcp-test-client --mcp-host http://localhost:8787
 ```
 
-**Note**: Remote mode uses Server-Sent Events (SSE) transport and connects to the `/sse` endpoint on the MCP server.
+**Note**: Remote mode uses HTTP streaming transport and connects to the `/mcp` endpoint on the MCP server.
 
 ### Local Mode
 

--- a/packages/mcp-test-client/package.json
+++ b/packages/mcp-test-client/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "catalog:",
+    "@modelcontextprotocol/sdk": "catalog:",
     "@sentry/core": "catalog:",
     "@sentry/mcp-server": "workspace:*",
     "@sentry/node": "catalog:",

--- a/packages/mcp-test-client/src/types.ts
+++ b/packages/mcp-test-client/src/types.ts
@@ -5,7 +5,7 @@ export interface MCPConnection {
   tools: Map<string, any>;
   disconnect: () => Promise<void>;
   sessionId: string;
-  transport: "stdio" | "sse";
+  transport: "stdio" | "http";
 }
 
 export interface MCPConfig {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 'catalog:'
         version: 1.3.22(zod@3.25.72)
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.17.2
       '@sentry/core':
         specifier: 'catalog:'
         version: 9.34.0


### PR DESCRIPTION
Update documentation to clarify transport options and deprecation status:
- Separate HTTP and SSE transports in architecture.mdc
- Mark SSE as deprecated with migration guidance
- Remove SSE accordion section from remote setup UI
- Clarify that /mcp endpoint is the recommended approach
- Swap test-client to http