### PR TITLE
feat(tools): add support for context (extra) data in get_issue_details

### DIFF
--- a/packages/mcp-server/src/api-client/schema.ts
+++ b/packages/mcp-server/src/api-client/schema.ts
@@ -358,6 +358,9 @@ const BaseEventSchema = z.object({
         .passthrough(),
     )
     .optional(),
+  // "context" (singular) is the legacy "extra" field for arbitrary user-defined data
+  // This is different from "contexts" (plural) which are structured contexts
+  context: z.record(z.string(), z.unknown()).optional(),
   tags: z
     .array(
       z.object({

--- a/packages/mcp-server/src/internal/formatting.ts
+++ b/packages/mcp-server/src/internal/formatting.ts
@@ -209,6 +209,7 @@ export function formatEventOutput(
   }
 
   output += formatTags(event.tags);
+  output += formatContext(event.context);
   output += formatContexts(event.contexts);
   return output;
 }
@@ -1376,6 +1377,19 @@ function formatTags(tags: z.infer<typeof EventSchema>["tags"]) {
   }
   return `### Tags\n\n${tags
     .map((tag) => `**${tag.key}**: ${tag.value}`)
+    .join("\n")}\n\n`;
+}
+
+function formatContext(context: z.infer<typeof EventSchema>["context"]) {
+  if (!context || Object.keys(context).length === 0) {
+    return "";
+  }
+  return `### Extra Data\n\nAdditional data attached to this event.\n\n${Object.entries(
+    context,
+  )
+    .map(([key, value]) => {
+      return `**${key}**: ${JSON.stringify(value, undefined, 2)}`;
+    })
     .join("\n")}\n\n`;
 }
 


### PR DESCRIPTION
The get_issue_details tool now displays the 'context' field (also known as 'extra' data) from Sentry events. This field contains arbitrary user-defined data that users attach to events for additional context.

Changes:
- Added 'context' field to BaseEventSchema in api-client/schema.ts
- Created formatContext() function to format extra data as markdown
- Updated formatEventOutput() to include context data in output
- Added comprehensive test case for context data display

Fixes #578