### PR TITLE
fix(oauth): correct redirect_uri in token exchange

### DIFF
--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -75,16 +75,21 @@ export async function exchangeCodeForAccessToken({
       client_id,
       client_secret,
       code,
-      // binding the redirect_uri creates an unsupported_grant_type error
-      // ...(redirect_uri ? { redirect_uri } : {}),
+      ...(redirect_uri ? { redirect_uri } : {}),
     }).toString(),
   });
   if (!resp.ok) {
+    const responseText = await resp.text();
     const eventId = logIssue(
-      `[oauth] Failed to exchange code for access token: ${await resp.text()}`,
+      `[oauth] Failed to exchange code for access token: ${responseText}`,
       {
         oauth: {
           client_id,
+          status: resp.status,
+          statusText: resp.statusText,
+          hasRedirectUri: !!redirect_uri,
+          redirectUri: redirect_uri,
+          hasCode: !!code,
         },
       },
     );

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -144,6 +144,9 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   }
 
   // Exchange the code for an access token
+  // Note: redirect_uri must match the one used in the authorization request
+  // This is the Sentry callback URL, not the downstream MCP client's redirect URI
+  const sentryCallbackUrl = new URL("/oauth/callback", c.req.url).href;
   const [payload, errResponse] = await exchangeCodeForAccessToken({
     upstream_url: new URL(
       SENTRY_TOKEN_URL,
@@ -152,7 +155,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
     client_id: c.env.SENTRY_CLIENT_ID,
     client_secret: c.env.SENTRY_CLIENT_SECRET,
     code: c.req.query("code"),
-    redirect_uri: oauthReqInfo.redirectUri,
+    redirect_uri: sentryCallbackUrl,
   });
   if (errResponse) return errResponse;
 


### PR DESCRIPTION
Fixes MCP-SERVER-DR8 - OAuth invalid_grant error

The OAuth token exchange was failing with invalid_grant because the redirect_uri parameter didn't match between the authorization request and token exchange request.

Changes:
- Include redirect_uri in token exchange (was commented out)
- Use Sentry callback URL instead of downstream client's redirect URI
- Add detailed error logging for debugging (status, redirect_uri, etc.)

The redirect_uri in token exchange must exactly match the one used in the authorization request per OAuth 2.0 spec (RFC 6749).