### PR TITLE
fix(cloudflare): rewrite MCP handler URL to strip tenant segments

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -119,11 +119,17 @@ const mcpHandler: ExportedHandler<Env> = {
       },
     });
 
+    // Rewrite request URL to strip org/project segments since we've already
+    // extracted them into serverContext.constraints
+    const rewrittenUrl = new URL(request.url);
+    rewrittenUrl.pathname = "/mcp";
+    const rewrittenRequest = new Request(rewrittenUrl, request);
+
     // Run MCP handler within ServerContext (AsyncLocalStorage)
     return serverContextStorage.run(serverContext, () => {
       return createMcpHandler(server, {
         route: "/mcp",
-      })(request, env, ctx);
+      })(rewrittenRequest, env, ctx);
     });
   },
 };


### PR DESCRIPTION
Fixes an issue where the MCP handler was receiving URLs with org/project segments (e.g., /mcp/org/project) which caused routing issues. The handler now extracts constraints from the URL path, then rewrites the URL to /mcp before passing it to the MCP handler.

Changes:
- Extract org/project constraints from URL path
- Rewrite request URL to /mcp before passing to MCP handler
- Simplify tests to verify behavior rather than implementation details
- Add URL rewriting verification in tests