### PR TITLE
feat(cloudflare): add deprecation endpoint for removed SSE transport

### DIFF
--- a/packages/mcp-cloudflare/src/server/app.test.ts
+++ b/packages/mcp-cloudflare/src/server/app.test.ts
@@ -26,4 +26,20 @@ describe("app", () => {
       expect(text).toContain("Model Context Protocol");
     });
   });
+
+  describe("GET /sse", () => {
+    it("should return deprecation message with 410 status", async () => {
+      const res = await app.request("/sse");
+
+      expect(res.status).toBe(410);
+
+      const json = await res.json();
+      expect(json).toEqual({
+        error: "SSE transport has been removed",
+        message:
+          "The SSE transport endpoint is no longer supported. Please use the HTTP transport at /mcp instead.",
+        migrationGuide: "https://mcp.sentry.dev",
+      });
+    });
+  });
 });

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -71,7 +71,18 @@ const app = new Hono<{
   .route("/api/chat", chat)
   .route("/api/search", search)
   .route("/api/metadata", metadata)
-  .route("/.mcp", mcpRoutes);
+  .route("/.mcp", mcpRoutes)
+  .get("/sse", (c) => {
+    return c.json(
+      {
+        error: "SSE transport has been removed",
+        message:
+          "The SSE transport endpoint is no longer supported. Please use the HTTP transport at /mcp instead.",
+        migrationGuide: "https://mcp.sentry.dev",
+      },
+      410,
+    );
+  });
 
 // TODO: propagate the error as sentry isnt injecting into hono
 app.onError((err, c) => {


### PR DESCRIPTION
Add /sse endpoint that returns HTTP 410 (Gone) with clear deprecation message directing users to the /mcp HTTP transport endpoint. Includes migration guide link to mcp.sentry.dev.