### PR TITLE
fix benchmark

### DIFF
--- a/benchmark-agent.sh
+++ b/benchmark-agent.sh
@@ -101,7 +101,15 @@ echo "  Max:     ${agent_max}s"
 echo "  Average: ${agent_avg}s"
 echo ""
 echo "Difference:"
-echo "  +${diff}s (${percent}% slower)"
+if (( $(echo "$diff > 0" | bc -l) )); then
+  echo "  +${diff}s (${percent}% slower)"
+elif (( $(echo "$diff < 0" | bc -l) )); then
+  abs_diff=$(echo "scale=2; -1 * $diff" | bc)
+  abs_percent=$(echo "scale=1; -1 * $percent" | bc)
+  echo "  -${abs_diff}s (${abs_percent}% faster)"
+else
+  echo "  No difference (0%)"
+fi
 echo ""
 
 # Show all individual results


### PR DESCRIPTION
always said `slower`

From Claude Code

```
⏺ Looking at the benchmark script, the calculation is mathematically correct:

  diff=$(echo "scale=2; $agent_avg - $direct_avg" | bc)
  percent=$(echo "scale=1; ($agent_avg - $direct_avg) / $direct_avg * 100" | bc)

  However, there's a presentation issue - the output assumes agent mode is always slower:

  echo "  +${diff}s (${percent}% slower)"

  Problem: If direct mode is actually slower than agent mode, you'd get confusing output like:
  - +-1.5s (-10% slower)

  The fix should handle both cases:

  # Calculate difference
  diff=$(echo "scale=2; $agent_avg - $direct_avg" | bc)
  percent=$(echo "scale=1; ($agent_avg - $direct_avg) / $direct_avg * 100" | bc)

  # Determine if slower or faster
  if (( $(echo "$diff > 0" | bc -l) )); then
    echo "Difference:"
    echo "  +${diff}s (${percent}% slower)"
  else
    abs_diff=$(echo "scale=2; -1 * $diff" | bc)
    abs_percent=$(echo "scale=1; -1 * $percent" | bc)
    echo "Difference:"
    echo "  -${abs_diff}s (${abs_percent}% faster)"
  fi

  Would you like me to fix this in the script?
```