### PR TITLE
fix(cloudflare): ensure Sentry logs are flushed before Worker terminates

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -125,9 +125,14 @@ const mcpHandler: ExportedHandler<Env> = {
     });
 
     // Run MCP handler - context already captured in closures
-    return createMcpHandler(server, {
+    const response = await createMcpHandler(server, {
       route: url.pathname,
     })(request, env, ctx);
+
+    // Flush buffered logs before Worker terminates
+    ctx.waitUntil(Sentry.flush(2000));
+
+    return response;
   },
 };
 


### PR DESCRIPTION
After the Durable Objects to stateless migration, console logs captured were being dropped because Sentry.flush() wasn't wrapped in ctx.waitUntil(). This caused the Worker to terminate before the buffered logs could be sent to Sentry.

Traces continued to work because they're sent immediately when spans complete, but logs are buffered and require explicit flushing.

This restores the behavior from the old DO implementation where this.ctx.waitUntil(Sentry.flush()) ensured logs were sent.