### PR TITLE
feat(smoke-tests): add identifiable user-agent for smoke test requests

### DIFF
--- a/packages/smoke-tests/src/smoke.test.ts
+++ b/packages/smoke-tests/src/smoke.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import pkg from "../package.json";
 
 const PREVIEW_URL = process.env.PREVIEW_URL;
 // All endpoints should respond quickly - 1 second is plenty for 401/200 responses
@@ -7,7 +8,7 @@ const IS_LOCAL_DEV =
   PREVIEW_URL?.includes("localhost") || PREVIEW_URL?.includes("127.0.0.1");
 
 // User-Agent for smoke tests - identifies these as automated smoke tests
-const SMOKE_TEST_USER_AGENT = "sentry-mcp-smoke-tests/0.20.0";
+const SMOKE_TEST_USER_AGENT = `sentry-mcp-smoke-tests/${pkg.version}`;
 
 // Skip all smoke tests if PREVIEW_URL is not set
 const describeIfPreviewUrl = PREVIEW_URL ? describe : describe.skip;


### PR DESCRIPTION
Add a well-defined User-Agent header to all smoke test HTTP requests to make them easily identifiable in server logs and analytics. The user-agent uses the format "sentry-mcp-smoke-tests".