### PR TITLE
feat: add User-Agent headers to all outgoing HTTP requests

### DIFF
--- a/packages/mcp-server/scripts/generate-otel-namespaces.ts
+++ b/packages/mcp-server/scripts/generate-otel-namespaces.ts
@@ -196,6 +196,11 @@ async function fetchYamlContent(namespace: string): Promise<string | null> {
   try {
     const response = await fetch(
       `${GITHUB_BASE_URL}/${namespace}/registry.yaml`,
+      {
+        headers: {
+          "User-Agent": "Sentry MCP Server",
+        },
+      },
     );
     if (!response.ok) {
       console.log(`⚠️  No registry.yaml found for namespace: ${namespace}`);

--- a/packages/mcp-server/src/internal/agents/openai-provider.ts
+++ b/packages/mcp-server/src/internal/agents/openai-provider.ts
@@ -1,5 +1,12 @@
-import { createOpenAI, openai as defaultOpenAI } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModelV1 } from "ai";
+
+// Create a default factory with User-Agent header
+const defaultFactory = createOpenAI({
+  headers: {
+    "User-Agent": "Sentry MCP Server",
+  },
+});
 
 let customFactory: ReturnType<typeof createOpenAI> | null = null;
 let defaultModel = "gpt-5";
@@ -24,6 +31,9 @@ export function configureOpenAIProvider({
   if (baseUrl) {
     customFactory = createOpenAI({
       baseURL: baseUrl,
+      headers: {
+        "User-Agent": "Sentry MCP Server",
+      },
     });
   } else {
     customFactory = null;
@@ -39,6 +49,6 @@ export function configureOpenAIProvider({
  * If no model is specified, uses the configured default model (gpt-5).
  */
 export function getOpenAIModel(model?: string): LanguageModelV1 {
-  const factory = customFactory ?? defaultOpenAI;
+  const factory = customFactory ?? defaultFactory;
   return factory(model ?? defaultModel);
 }

--- a/packages/mcp-test-client/src/auth/oauth.ts
+++ b/packages/mcp-test-client/src/auth/oauth.ts
@@ -86,6 +86,7 @@ export class OAuthClient {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
+        "User-Agent": "Sentry MCP CLI",
       },
       body: JSON.stringify(registrationData),
     });


### PR DESCRIPTION
Add identifiable User-Agent headers to improve request tracking and API provider analytics:
- OpenAI API requests: "Sentry MCP Server"
- GitHub API requests (OTel namespace generation): "Sentry MCP Server"
- OAuth registration requests: "Sentry MCP CLI"

This follows best practices for HTTP clients and helps API providers identify and support Sentry MCP traffic.