### PR TITLE
fix(cloudflare): track Sentry flush promise in onToolComplete callback

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -171,7 +171,7 @@ const mcpHandler: ExportedHandler<Env> = {
       tools: isAgentMode ? agentTools : undefined,
       onToolComplete: () => {
         // Flush Sentry events after tool execution
-        Sentry.flush(2000);
+        ctx.waitUntil(Sentry.flush(2000));
       },
     });
 


### PR DESCRIPTION
Logs and traces were missing from Sentry because the Sentry.flush() call in onToolComplete was not wrapped with ctx.waitUntil(). This caused the Worker to potentially terminate before the flush completed, losing buffered events.

Now both flush calls (in onToolComplete and at the end of the handler) use ctx.waitUntil() to ensure the Worker stays alive until all Sentry events are sent.