### PR TITLE
fix(cloudflare): move Sentry flush from onToolComplete to main handler

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -33,7 +33,7 @@ const addCorsHeaders = (response: Response): Response => {
 // Wrap OAuth Provider to restrict CORS headers on public metadata endpoints
 // OAuth Provider v0.0.12 adds overly permissive CORS (allows all methods/headers).
 // We override with secure headers for .well-known endpoints and add CORS to robots.txt/llms.txt.
-const corsWrappedOAuthProvider = {
+const wrappedOAuthProvider = {
   fetch: async (request: Request, env: Env, ctx: ExecutionContext) => {
     const url = new URL(request.url);
 
@@ -85,6 +85,9 @@ const corsWrappedOAuthProvider = {
 
     const response = await oAuthProvider.fetch(request, env, ctx);
 
+    // Flush buffered logs before Worker terminates
+    ctx.waitUntil(Sentry.flush(2000));
+
     // Add CORS headers to public metadata endpoints
     if (isPublicMetadataEndpoint(url.pathname)) {
       return addCorsHeaders(response);
@@ -96,5 +99,5 @@ const corsWrappedOAuthProvider = {
 
 export default Sentry.withSentry(
   getSentryConfig,
-  corsWrappedOAuthProvider,
+  wrappedOAuthProvider,
 ) satisfies ExportedHandler<Env>;

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -8,7 +8,6 @@
  * - No session state required - each request is independent
  */
 
-import * as Sentry from "@sentry/cloudflare";
 import { experimental_createMcpHandler as createMcpHandler } from "agents/mcp";
 import { buildServer } from "@sentry/mcp-server/server";
 import {
@@ -169,21 +168,12 @@ const mcpHandler: ExportedHandler<Env> = {
     const server = buildServer({
       context: serverContext,
       tools: isAgentMode ? agentTools : undefined,
-      onToolComplete: () => {
-        // Flush Sentry events after tool execution
-        ctx.waitUntil(Sentry.flush(2000));
-      },
     });
 
     // Run MCP handler - context already captured in closures
-    const response = await createMcpHandler(server, {
+    return createMcpHandler(server, {
       route: url.pathname,
     })(request, env, ctx);
-
-    // Flush buffered logs before Worker terminates
-    ctx.waitUntil(Sentry.flush(2000));
-
-    return response;
   },
 };
 


### PR DESCRIPTION
Refactors the Sentry flush approach to use the main OAuth provider wrapper instead of the onToolComplete callback. This ensures Sentry logs are flushed for all requests, not just MCP tool executions.

Changes:
- Remove onToolComplete callback from buildServer
- Remove duplicate Sentry.flush after createMcpHandler
- Add Sentry.flush in wrappedOAuthProvider for all requests
- Rename corsWrappedOAuthProvider to wrappedOAuthProvider for brevity