### PR TITLE
feat(cloudflare): add HMAC-signed state for CSRF protection in OAuth flow

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderApprovalDialog } from "./approval-dialog";
+import { renderApprovalDialog, parseRedirectApproval } from "./approval-dialog";
+import { signState } from "../oauth/state";
 
 describe("approval-dialog", () => {
+  const TEST_SECRET = "test-cookie-secret-32-chars-long";
+
+  const mockClient = {
+    clientId: "test-client-id",
+    clientName: "Test Client",
+    redirectUris: ["https://example.com/callback"],
+    tokenEndpointAuthMethod: "client_secret_basic",
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -12,20 +22,12 @@ describe("approval-dialog", () => {
         method: "GET",
       });
 
-      const options = {
-        client: {
-          clientId: "test-client-id",
-          clientName: "Test Client",
-          redirectUris: ["https://example.com/callback"],
-          tokenEndpointAuthMethod: "client_secret_basic",
-        },
-        server: {
-          name: "Test Server",
-        },
+      const response = await renderApprovalDialog(mockRequest, {
+        client: mockClient,
+        server: { name: "Test Server" },
         state: { oauthReqInfo: { clientId: "test-client" } },
-      };
-
-      const response = await renderApprovalDialog(mockRequest, options);
+        cookieSecret: TEST_SECRET,
+      });
       const html = await response.text();
 
       // Check that state is included in the form
@@ -38,20 +40,17 @@ describe("approval-dialog", () => {
         method: "GET",
       });
 
-      const options = {
+      const response = await renderApprovalDialog(mockRequest, {
         client: {
           clientId: "test-client-id",
           clientName: "<script>alert('xss')</script>",
           redirectUris: ["https://example.com/callback"],
           tokenEndpointAuthMethod: "client_secret_basic",
         },
-        server: {
-          name: "Test Server",
-        },
+        server: { name: "Test Server" },
         state: { test: "data" },
-      };
-
-      const response = await renderApprovalDialog(mockRequest, options);
+        cookieSecret: TEST_SECRET,
+      });
       const html = await response.text();
 
       // Check that script tags in client name are escaped and no script tags are present
@@ -64,8 +63,172 @@ describe("approval-dialog", () => {
     });
   });
 
-  // parseRedirectApproval behavior (form parsing, cookies, permissions) is
-  // validated at the route level in oauth/authorize.test.ts to keep concerns
-  // consolidated around HTTP behavior. This test file focuses on pure
-  // rendering concerns of the dialog itself.
+  describe("CSRF protection with HMAC-signed state", () => {
+    it("should reject tampered state in form submission", async () => {
+      const originalOauthReqInfo = {
+        clientId: "legitimate-client",
+        redirectUri: "https://legitimate.com/callback",
+        scope: ["read"],
+      };
+
+      // Step 1: Render the approval dialog
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Sentry MCP" },
+          state: { oauthReqInfo: originalOauthReqInfo },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+
+      const html = await response.text();
+
+      // Extract the signed state from the HTML form
+      const stateMatch = html.match(/name="state" value="([^"]+)"/);
+      expect(stateMatch).toBeTruthy();
+      const signedState = stateMatch![1];
+
+      // Step 2: Tamper with the state (try to change clientId)
+      const [sig, b64] = signedState.split(".");
+      const payload = JSON.parse(atob(b64));
+
+      // Modify the clientId to a malicious one
+      payload.req.oauthReqInfo.clientId = "evil-client";
+
+      // Create tampered state with original signature (signature won't match)
+      const tamperedState = `${sig}.${btoa(JSON.stringify(payload))}`;
+
+      // Step 3: Try to submit the tampered form
+      const formData = new FormData();
+      formData.append("state", tamperedState);
+      formData.append("skill", "inspect");
+
+      const tamperedRequest = new Request(
+        "https://example.com/oauth/authorize",
+        {
+          method: "POST",
+          body: formData,
+        },
+      );
+
+      // Should throw because signature verification fails
+      await expect(
+        parseRedirectApproval(tamperedRequest, TEST_SECRET),
+      ).rejects.toThrow(/invalid signature|expired/i);
+    });
+
+    it("should reject expired state", async () => {
+      const oauthReqInfo = {
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+      };
+
+      // Create a state that's already expired (exp in the past)
+      const now = Date.now();
+      const expiredPayload = {
+        req: { oauthReqInfo },
+        iat: now - 15 * 60 * 1000, // 15 minutes ago
+        exp: now - 5 * 60 * 1000, // Expired 5 minutes ago
+      };
+
+      const expiredState = await signState(expiredPayload, TEST_SECRET);
+
+      // Try to submit with expired state
+      const formData = new FormData();
+      formData.append("state", expiredState);
+      formData.append("skill", "inspect");
+
+      const request = new Request("https://example.com/oauth/authorize", {
+        method: "POST",
+        body: formData,
+      });
+
+      await expect(parseRedirectApproval(request, TEST_SECRET)).rejects.toThrow(
+        /expired/i,
+      );
+    });
+
+    it("should accept valid signed state", async () => {
+      const oauthReqInfo = {
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+      };
+
+      // Step 1: Render approval dialog to get valid signed state
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Sentry MCP" },
+          state: { oauthReqInfo },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+
+      const html = await response.text();
+      const stateMatch = html.match(/name="state" value="([^"]+)"/);
+      const signedState = stateMatch![1];
+
+      // Step 2: Submit valid form
+      const formData = new FormData();
+      formData.append("state", signedState);
+      formData.append("skill", "inspect");
+      formData.append("skill", "docs");
+
+      const request = new Request("https://example.com/oauth/authorize", {
+        method: "POST",
+        headers: {
+          Cookie: "mcp-approved-clients=test",
+        },
+        body: formData,
+      });
+
+      // Should succeed with valid state
+      const result = await parseRedirectApproval(request, TEST_SECRET);
+
+      expect(result.state).toBeDefined();
+      expect(result.state.oauthReqInfo).toEqual(oauthReqInfo);
+      expect(result.skills).toEqual(["inspect", "docs"]);
+    });
+
+    it("should reject state with wrong secret", async () => {
+      const oauthReqInfo = {
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+      };
+
+      // Sign with one secret
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Sentry MCP" },
+          state: { oauthReqInfo },
+          cookieSecret: "secret-1",
+        },
+      );
+
+      const html = await response.text();
+      const stateMatch = html.match(/name="state" value="([^"]+)"/);
+      const signedState = stateMatch![1];
+
+      // Try to verify with different secret
+      const formData = new FormData();
+      formData.append("state", signedState);
+      formData.append("skill", "inspect");
+
+      const request = new Request("https://example.com/oauth/authorize", {
+        method: "POST",
+        body: formData,
+      });
+
+      await expect(parseRedirectApproval(request, "secret-2")).rejects.toThrow(
+        /invalid signature/i,
+      );
+    });
+  });
 });

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -7,6 +7,11 @@ import { sanitizeHtml } from "./html-utils";
 import skillDefinitions, {
   type SkillDefinition,
 } from "@sentry/mcp-server/skillDefinitions";
+import {
+  signState,
+  verifyAndParseState,
+  type OAuthState,
+} from "../oauth/state";
 
 const COOKIE_NAME = "mcp-approved-clients";
 const ONE_YEAR_IN_SECONDS = 31536000;
@@ -192,19 +197,27 @@ export interface ApprovalDialogOptions {
    * Will be encoded in the form and returned when approval is complete
    */
   state: Record<string, any>;
+  /**
+   * HMAC secret key for signing state parameters
+   */
+  cookieSecret: string;
 }
 
 /**
- * Encodes arbitrary data to a URL-safe base64 string.
+ * Encodes and signs arbitrary data to a HMAC-signed compact string.
  * @param data - The data to encode (will be stringified).
- * @returns A URL-safe base64 encoded string.
+ * @param secret - HMAC secret key for signing.
+ * @returns A HMAC-signed compact string (signature.base64payload).
  */
-function encodeState(data: any): string {
+async function encodeState(data: any, secret: string): Promise<string> {
   try {
-    const jsonString = JSON.stringify(data);
-    // Use btoa for simplicity, assuming Worker environment supports it well enough
-    // For complex binary data, a Buffer/Uint8Array approach might be better
-    return btoa(jsonString);
+    const now = Date.now();
+    const payload: OAuthState = {
+      req: data as Record<string, unknown>,
+      iat: now,
+      exp: now + 10 * 60 * 1000, // 10 minute expiry
+    };
+    return await signState(payload, secret);
   } catch (error) {
     logError(error, {
       loggerScope: ["cloudflare", "approval-dialog"],
@@ -217,22 +230,28 @@ function encodeState(data: any): string {
 }
 
 /**
- * Decodes a URL-safe base64 string back to its original data.
- * @param encoded - The URL-safe base64 encoded string.
+ * Decodes and verifies a HMAC-signed string back to its original data.
+ * @param encoded - The HMAC-signed compact string.
+ * @param secret - HMAC secret key for verification.
  * @returns The original data.
+ * @throws Error if signature is invalid or state has expired.
  */
-function decodeState<T = any>(encoded: string): T {
+async function decodeState<T = any>(
+  encoded: string,
+  secret: string,
+): Promise<T> {
   try {
-    const jsonString = atob(encoded);
-    return JSON.parse(jsonString);
+    const parsed = await verifyAndParseState(encoded, secret);
+    return parsed.req as T;
   } catch (error) {
     logError(error, {
       loggerScope: ["cloudflare", "approval-dialog"],
       extra: {
-        message: "Error decoding approval dialog state",
+        message:
+          "Error decoding approval dialog state - signature verification failed or expired",
       },
     });
-    throw new Error("Could not decode state");
+    throw new Error("Could not decode state - invalid signature or expired");
   }
 }
 
@@ -249,7 +268,7 @@ export async function renderApprovalDialog(
   request: Request,
   options: ApprovalDialogOptions,
 ): Promise<Response> {
-  const { client, server, state } = options;
+  const { client, server, state, cookieSecret } = options;
 
   // Use static skill definitions bundled at build time
   const skills: SkillDefinition[] = skillDefinitions as SkillDefinition[];
@@ -273,8 +292,8 @@ export async function renderApprovalDialog(
     )
     .join("");
 
-  // Encode state for form submission
-  const encodedState = encodeState(state);
+  // Encode state for form submission (HMAC-signed to prevent tampering)
+  const encodedState = await encodeState(state, cookieSecret);
 
   // Sanitize any untrusted content
   const serverName = sanitizeHtml(server.name);
@@ -873,7 +892,10 @@ export async function parseRedirectApproval(
       throw new Error("Missing or invalid 'state' in form data.");
     }
 
-    state = decodeState<{ oauthReqInfo?: AuthRequest }>(encodedState); // Decode the state
+    state = await decodeState<{ oauthReqInfo?: AuthRequest }>(
+      encodedState,
+      cookieSecret,
+    ); // Decode and verify the state
     clientId = state?.oauthReqInfo?.clientId; // Extract clientId from within the state
 
     if (!clientId) {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -96,6 +96,7 @@ export default new Hono<{ Bindings: Env }>()
         name: "Sentry MCP",
       },
       state: { oauthReqInfo }, // arbitrary data that flows through the form submission below
+      cookieSecret: c.env.COOKIE_SECRET,
     });
   })
 


### PR DESCRIPTION
Replace base64-encoded state parameters with HMAC-signed compact format to prevent tampering and replay attacks during OAuth approval flow.

Key changes:
- State parameters now include signature, issued-at, and expiry timestamps
- 10-minute expiry window prevents replay attacks
- Signature verification ensures state integrity
- Comprehensive tests for tampering, expiry, and secret validation

Security improvements:
- CSRF protection via cryptographic signatures
- Time-bound state prevents stale approval attempts
- Tamper detection for clientId and other OAuth parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)