### PR TITLE
Fix(cloudflare): send logs again

### DIFF
--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -23,9 +23,7 @@ export default function getSentryConfig(env: Env): SentryConfig {
     environment:
       env.SENTRY_ENVIRONMENT ??
       (process.env.NODE_ENV !== "production" ? "development" : "production"),
-    _experiments: {
-      enableLogs: true,
-    },
+    enableLogs: true,
     integrations: [
       Sentry.consoleLoggingIntegration(),
       Sentry.zodErrorsIntegration(),


### PR DESCRIPTION
we upgraded sentry's sdk from `v9` to `v10` on #584 . On `v10` `enableLogs` is no longer a `_experimental` option (and was removed from there).

This should bring logs back. 

Tested locally.