### PR TITLE
fix: enforce required fields in agent output schemas

### DIFF
--- a/packages/mcp-server/src/tools/agent-output-schema.test.ts
+++ b/packages/mcp-server/src/tools/agent-output-schema.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "vitest";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { ZodTypeAny } from "zod";
+import { searchEventsAgentOutputSchema } from "./search-events/agent";
+import { searchIssuesAgentOutputSchema } from "./search-issues/agent";
+
+describe("agent output schemas", () => {
+  function expectRequiredFields(
+    name: string,
+    schema: ZodTypeAny,
+    expected: string[],
+  ) {
+    const jsonSchema = zodToJsonSchema(schema, {
+      $refStrategy: "none",
+    }) as { required?: string[] };
+    const required = jsonSchema.required ?? [];
+    const missing = expected.filter((field) => !required.includes(field));
+    const unexpected = required.filter((field) => !expected.includes(field));
+
+    if (missing.length || unexpected.length) {
+      throw new Error(
+        `${name} schema mismatch. Missing: ${missing.join(", ") || "none"}. Unexpected: ${unexpected.join(", ") || "none"}. Required fields: ${required.join(", ")}`,
+      );
+    }
+  }
+
+  it("marks all search_events fields as required", () => {
+    expectRequiredFields("search_events", searchEventsAgentOutputSchema, [
+      "dataset",
+      "query",
+      "fields",
+      "sort",
+      "timeRange",
+      "explanation",
+    ]);
+  });
+
+  it("marks all search_issues fields as required", () => {
+    expectRequiredFields("search_issues", searchIssuesAgentOutputSchema, [
+      "query",
+      "sort",
+      "explanation",
+    ]);
+  });
+});

--- a/packages/mcp-server/src/tools/search-events/handler.ts
+++ b/packages/mcp-server/src/tools/search-events/handler.ts
@@ -115,8 +115,8 @@ export default defineTool({
 
     const parsed = agentResult.result;
 
-    // Get the dataset chosen by the agent (should be defined when no error)
-    const dataset = parsed.dataset!;
+    // Get the dataset chosen by the agent
+    const dataset = parsed.dataset;
 
     // Get recommended fields for this dataset (for fallback when no fields are provided)
     const recommendedFields = RECOMMENDED_FIELDS[dataset];

--- a/packages/mcp-test-client/src/mcp-test-client.ts
+++ b/packages/mcp-test-client/src/mcp-test-client.ts
@@ -25,10 +25,7 @@ export async function connectToMCPServer(
       },
       async (span) => {
         try {
-          const args = [
-            `--access-token=${config.accessToken}`,
-            "--all-scopes", // Ensure all tools are available in local stdio runs
-          ];
+          const args = [`--access-token=${config.accessToken}`];
           if (config.host) {
             args.push(`--host=${config.host}`);
           }


### PR DESCRIPTION
Remove .optional() and .default() from search_events and search_issues agent output schemas. OpenAI's structured outputs require all properties in the 'required' array, but Zod's .optional() and .default() break this.

Changes:
- Use z.nullable() instead of .optional()/.nullish() for optional fields
- Add runtime validation in callEmbeddedAgent to catch missing fields
- Update tests to expect UserInputError on schema validation failures
- Add agent-output-schema.test.ts to verify all fields are required
