### PR TITLE
fix(cloudflare): improve beta badge alignment in header

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/ui/header.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/header.tsx
@@ -17,13 +17,13 @@ export const Header: React.FC<HeaderProps> = ({ toggleChat, isChatOpen }) => {
       <div className="flex items-center justify-between w-full">
         <div className="flex items-center gap-2 flex-shrink-0">
           <SentryIcon className="h-8 w-8" />
-          <div className="flex items-baseline gap-2">
+          <div className="flex items-center gap-3">
             <h1 className="text-2xl font-semibold whitespace-nowrap">
               Sentry MCP
             </h1>
             <Badge
               variant="outline"
-              className="text-xs border border-violet-300/50 bg-background-3 font-normal"
+              className="text-xs bg-background-3 font-normal"
             >
               Beta
             </Badge>


### PR DESCRIPTION
Adjust beta badge styling to better align with the "Sentry MCP" title by using items-center and consistent gap spacing instead of items-baseline. Also removes custom border color to use default outline variant styling.