### PR TITLE
feat(server): filter find_organizations and find_projects when constrained

### DIFF
--- a/docs/specs/subpath-constraints.md
+++ b/docs/specs/subpath-constraints.md
@@ -21,11 +21,12 @@ Examples:
 /sse/sentry/my-project
 ```
 
-## What you’ll experience
+## What you'll experience
 
 - Tools automatically use the constrained organization/project as defaults
 - You can still pass explicit `organizationSlug`/`projectSlug` to override defaults per call
-- If you don’t provide a scope, tools work across your accessible organizations when supported
+- If you don't provide a scope, tools work across your accessible organizations when supported
+- Some tools are filtered when not useful: `find_organizations` is hidden when scoped to an org, and `find_projects` is hidden when scoped to a project
 
 ## Access verification
 

--- a/docs/testing-remote.md
+++ b/docs/testing-remote.md
@@ -222,6 +222,10 @@ pnpm -w run cli --mcp-host=http://localhost:5173/mcp/sentry "find_projects()"
 pnpm -w run cli --mcp-host=http://localhost:5173/mcp/sentry "find_projects(organizationSlug='other-org')"
 ```
 
+**Note:** When testing with constraints, some tools are automatically filtered:
+- With org constraint: `find_organizations` is not available (18 tools instead of 19)
+- With org + project constraints: both `find_organizations` and `find_projects` are not available (17 tools instead of 19)
+
 ## Testing with Web Chat Interface
 
 The web UI provides a chat interface for testing the MCP server.

--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -29,6 +29,14 @@ export default function RemoteSetup() {
           </li>
         </ul>
         <p>
+          <small>
+            Note: When using path constraints, some tools are automatically
+            hidden: <code>find_organizations</code> is excluded with org
+            constraints, and <code>find_projects</code> is excluded with project
+            constraints.
+          </small>
+        </p>
+        <p>
           <strong>Agent Mode:</strong> Reduce context by exposing a single{" "}
           <code>use_sentry</code> tool instead of individual skills. The
           embedded AI agent handles natural language requests and automatically

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -41,6 +41,15 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.example.com
 npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://proxy.example.com/v1
 ```
 
+### Constraint-Based Tool Exclusion
+
+When a session is scoped to a specific organization or project (tenant-bound context), certain list tools are automatically excluded since they cannot query other resources:
+
+- **`find_organizations`** is hidden when the session is constrained to a specific organization (`organizationSlug` constraint)
+- **`find_projects`** is hidden when the session is constrained to a specific project (`projectSlug` constraint)
+
+This ensures that only relevant tools are available in constrained contexts. When constraints are not set, all tools are available based on your granted skills.
+
 ### Environment Variables
 
 You can also use environment variables:

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -241,6 +241,17 @@ function configureServer({
       continue;
     }
 
+    // Skip list tools when context is constrained to a specific tenant/project
+    // When organizationSlug is constrained, find_organizations is not useful
+    // When projectSlug is constrained, find_projects is not useful
+    if (
+      (toolKey === "find_organizations" &&
+        context.constraints.organizationSlug) ||
+      (toolKey === "find_projects" && context.constraints.projectSlug)
+    ) {
+      continue;
+    }
+
     // Filter out constraint parameters from schema that will be auto-injected
     // Only filter parameters that are ACTUALLY constrained in the current context
     // to avoid breaking tools when constraints are not set

--- a/packages/mcp-server/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-server/src/tools/get-issue-details.test.ts
@@ -375,7 +375,7 @@ describe("get_issue_details", () => {
             'db - SELECT "sentry_fileblob"."id", "sentry_fileblob"."path", "sentry_fileblob"."size", "sentry_fileblob"."checksum", "sentry_fileblob"."timestamp" FROM "sentry_fileblob" WHERE "sentry_fileblob"."checksum" = %s LIMIT 21',
           ];
           const spansEntry = event.entries.find(
-            (entry) => entry.type === "spans",
+            (entry: { type: string; data?: unknown }) => entry.type === "spans",
           );
           if (spansEntry?.data) {
             spansEntry.data = spansEntry.data.slice(0, 4);
@@ -465,7 +465,7 @@ describe("get_issue_details", () => {
             'db - SELECT "sentry_fileblob"."id", "sentry_fileblob"."path", "sentry_fileblob"."size", "sentry_fileblob"."checksum", "sentry_fileblob"."timestamp" FROM "sentry_fileblob" WHERE "sentry_fileblob"."checksum" = %s LIMIT 21',
           ];
           const spansEntry = event.entries.find(
-            (entry) => entry.type === "spans",
+            (entry: { type: string; data?: unknown }) => entry.type === "spans",
           );
           if (spansEntry?.data) {
             spansEntry.data = spansEntry.data.slice(0, 4);


### PR DESCRIPTION
When sessions are tenant-bound, list tools that query outside the constraint are now automatically excluded from the tool list:

- find_organizations: excluded when organizationSlug constraint is set
- find_projects: excluded when projectSlug constraint is set

This prevents agents from attempting to use tools that cannot return meaningful results in constrained contexts, improving usability and reducing token overhead.