### PR TITLE
fix(ci): build mcp-core before mcp-cloudflare in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,8 +51,7 @@ jobs:
 
       # === BUILD AND DEPLOY CANARY WORKER ===
       - name: Build
-        working-directory: packages/mcp-cloudflare
-        run: pnpm build
+        run: pnpm -w run build
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 


### PR DESCRIPTION
The deploy workflow was failing because it only built mcp-cloudflare without first building its dependency mcp-core. This caused TypeScript compilation errors like 'Cannot find module @sentry/mcp-core/types'.

Changed from:
  working-directory: packages/mcp-cloudflare
  run: pnpm build

To:
  run: pnpm -w run build

This now builds all packages in dependency order using Turbo, ensuring mcp-core is built before mcp-cloudflare.