### PR TITLE
fix: Wait for events to be flushed

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -21,6 +21,7 @@ import type { ServerContext } from "@sentry/mcp-core/types";
 import type { Env } from "../types";
 import { verifyConstraintsAccess } from "./constraint-utils";
 import type { ExportedHandler } from "@cloudflare/workers-types";
+import * as Sentry from "@sentry/cloudflare";
 
 /**
  * ExecutionContext with OAuth props injected by the OAuth provider.
@@ -168,6 +169,10 @@ const mcpHandler: ExportedHandler<Env> = {
     const server = buildServer({
       context: serverContext,
       agentMode: isAgentMode,
+      onToolComplete: () => {
+        // Flush Sentry events after tool execution
+        ctx.waitUntil(Sentry.flush(2000));
+      },
     });
 
     // Run MCP handler - context already captured in closures


### PR DESCRIPTION
Events which hold attributes such as `organization.slug` or `mcp.*` were not flushed correctly.

https://github.com/getsentry/sentry-mcp/blob/ce3ec0ffa5fd4b8d7402bb09120713c78e33a5d2/packages/mcp-core/src/server.ts#L281-L286

With this it will re-add these missing events, as it will wait with `waitUntil` that these events are flushed within the tool call.

Example of a tool call event

<img width="1377" height="357" alt="Screenshot 2025-11-21 at 11 03 16" src="https://github.com/user-attachments/assets/3267fa2e-bf7c-47d1-a22a-790467302b04" />
