### PR TITLE
fix(mcp-core): handle null regionUrl parameters in tool handlers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run build
         run: pnpm build
 
+      - name: Run type checking
+        run: pnpm -w run tsc
+
       - name: Run linter
         run: pnpm lint
 

--- a/packages/mcp-core/src/tools/analyze-issue-with-seer.ts
+++ b/packages/mcp-core/src/tools/analyze-issue-with-seer.ts
@@ -85,7 +85,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const { organizationSlug: orgSlug, issueId: parsedIssueId } =
       parseIssueParams({

--- a/packages/mcp-core/src/tools/create-dsn.ts
+++ b/packages/mcp-core/src/tools/create-dsn.ts
@@ -53,7 +53,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 

--- a/packages/mcp-core/src/tools/create-project.ts
+++ b/packages/mcp-core/src/tools/create-project.ts
@@ -60,7 +60,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 

--- a/packages/mcp-core/src/tools/create-team.ts
+++ b/packages/mcp-core/src/tools/create-team.ts
@@ -42,7 +42,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 

--- a/packages/mcp-core/src/tools/find-dsns.ts
+++ b/packages/mcp-core/src/tools/find-dsns.ts
@@ -34,7 +34,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 

--- a/packages/mcp-core/src/tools/find-organizations.ts
+++ b/packages/mcp-core/src/tools/find-organizations.ts
@@ -32,7 +32,7 @@ export default defineTool({
     // as they must always query the main API server, not region-specific servers
     const apiService = apiServiceFromContext(context);
     const organizations = await apiService.listOrganizations({
-      query: params.query,
+      query: params.query ?? undefined,
     });
 
     let output = "# Organizations\n\n";

--- a/packages/mcp-core/src/tools/find-projects.ts
+++ b/packages/mcp-core/src/tools/find-projects.ts
@@ -37,7 +37,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 
@@ -50,7 +50,7 @@ export default defineTool({
     setTag("organization.slug", organizationSlug);
 
     const projects = await apiService.listProjects(organizationSlug, {
-      query: params.query,
+      query: params.query ?? undefined,
     });
 
     let output = `# Projects in **${organizationSlug}**\n\n`;

--- a/packages/mcp-core/src/tools/find-releases.ts
+++ b/packages/mcp-core/src/tools/find-releases.ts
@@ -56,7 +56,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 
@@ -64,8 +64,8 @@ export default defineTool({
 
     const releases = await apiService.listReleases({
       organizationSlug,
-      projectSlug: params.projectSlug,
-      query: params.query,
+      projectSlug: params.projectSlug ?? undefined,
+      query: params.query ?? undefined,
     });
     let output = `# Releases in **${organizationSlug}${params.projectSlug ? `/${params.projectSlug}` : ""}**\n\n`;
     if (releases.length === 0) {

--- a/packages/mcp-core/src/tools/find-teams.ts
+++ b/packages/mcp-core/src/tools/find-teams.ts
@@ -36,7 +36,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 
@@ -49,7 +49,7 @@ export default defineTool({
     setTag("organization.slug", organizationSlug);
 
     const teams = await apiService.listTeams(organizationSlug, {
-      query: params.query,
+      query: params.query ?? undefined,
     });
 
     let output = `# Teams in **${organizationSlug}**\n\n`;

--- a/packages/mcp-core/src/tools/get-event-attachment.ts
+++ b/packages/mcp-core/src/tools/get-event-attachment.ts
@@ -61,7 +61,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
 
     setTag("organization.slug", params.organizationSlug);
@@ -97,7 +97,6 @@ export default defineTool({
           contentParts.push(image);
         } else {
           const resource: EmbeddedResource = {
-            id: params.attachmentId,
             type: "resource",
             resource: {
               uri: `file://${attachment.filename}`,

--- a/packages/mcp-core/src/tools/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.ts
@@ -84,7 +84,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
 
     if (params.eventId) {

--- a/packages/mcp-core/src/tools/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/get-trace-details.ts
@@ -62,7 +62,7 @@ export default defineTool({
     }
 
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
 
     setTag("organization.slug", params.organizationSlug);

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -85,7 +85,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 

--- a/packages/mcp-core/src/tools/search-issues/handler.ts
+++ b/packages/mcp-core/src/tools/search-issues/handler.ts
@@ -81,7 +81,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
 
     setTag("organization.slug", params.organizationSlug);
@@ -123,8 +123,8 @@ export default defineTool({
     // Execute the search - listIssues accepts projectSlug directly
     const issues = await apiService.listIssues({
       organizationSlug: params.organizationSlug,
-      projectSlug: params.projectSlugOrId,
-      query: translatedQuery.query,
+      projectSlug: params.projectSlugOrId ?? undefined,
+      query: translatedQuery.query ?? undefined,
       sortBy: translatedQuery.sort || "date",
       limit: params.limit,
     });
@@ -155,9 +155,9 @@ export default defineTool({
       output += formatIssueResults({
         issues,
         organizationSlug: params.organizationSlug,
-        projectSlugOrId: params.projectSlugOrId,
+        projectSlugOrId: params.projectSlugOrId ?? undefined,
         query: translatedQuery.query,
-        regionUrl: params.regionUrl,
+        regionUrl: params.regionUrl ?? undefined,
         naturalLanguageQuery: params.naturalLanguageQuery,
         skipHeader: true,
       });
@@ -166,9 +166,9 @@ export default defineTool({
       output = formatIssueResults({
         issues,
         organizationSlug: params.organizationSlug,
-        projectSlugOrId: params.projectSlugOrId,
+        projectSlugOrId: params.projectSlugOrId ?? undefined,
         query: translatedQuery.query,
-        regionUrl: params.regionUrl,
+        regionUrl: params.regionUrl ?? undefined,
         naturalLanguageQuery: params.naturalLanguageQuery,
         skipHeader: false,
       });

--- a/packages/mcp-core/src/tools/update-issue.ts
+++ b/packages/mcp-core/src/tools/update-issue.ts
@@ -78,7 +78,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
 
     // Validate that we have the minimum required parameters

--- a/packages/mcp-core/src/tools/update-project.ts
+++ b/packages/mcp-core/src/tools/update-project.ts
@@ -88,7 +88,7 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl,
+      regionUrl: params.regionUrl ?? undefined,
     });
     const organizationSlug = params.organizationSlug;
 


### PR DESCRIPTION
Fix type errors where null regionUrl values from tool definitions weren't properly handled by tool handlers. Add null coalescing (?? undefined) to convert null to undefined when passing to apiServiceFromContext.