### PR TITLE
feat(mcp-core): add assignedTo field to get_issue_details output

### DIFF
--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -1726,6 +1726,17 @@ export function formatIssueOutput({
     output += `**Substatus**: ${issue.substatus}\n`;
   }
 
+  // Add assignee information if assigned
+  if (issue.assignedTo) {
+    if (typeof issue.assignedTo === "string") {
+      output += `**Assigned To**: ${issue.assignedTo}\n`;
+    } else {
+      const assignee = issue.assignedTo;
+      const type = assignee.type === "team" ? "Team" : "User";
+      output += `**Assigned To**: ${assignee.name} (${type})\n`;
+    }
+  }
+
   // Add issue type and category for performance/metric issues
   if (issue.issueType) {
     output += `**Issue Type**: ${issue.issueType}\n`;

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -187,6 +187,7 @@ describe("get_issue_details", () => {
       **Users Impacted**: 1
       **Status**: unresolved
       **Substatus**: ongoing
+      **Assigned To**: Jane Developer (User)
       **Issue Type**: error
       **Issue Category**: error
       **Platform**: javascript
@@ -254,6 +255,64 @@ describe("get_issue_details", () => {
     `);
   });
 
+  it("displays team assignment correctly", async () => {
+    // Override the issue fixture with a team assignment
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/TEAM-ISSUE-001/",
+        () =>
+          HttpResponse.json({
+            id: "123456789",
+            shortId: "TEAM-ISSUE-001",
+            title: "Test issue with team assignment",
+            firstSeen: "2025-04-03T22:51:19.403Z",
+            lastSeen: "2025-04-12T11:34:11Z",
+            count: "10",
+            userCount: 5,
+            permalink:
+              "https://sentry-mcp-evals.sentry.io/issues/TEAM-ISSUE-001",
+            project: {
+              id: "4509062593708032",
+              slug: "test-project",
+              name: "Test Project",
+            },
+            platform: "javascript",
+            status: "unresolved",
+            substatus: "ongoing",
+            culprit: "app.main",
+            type: "error",
+            issueType: "error",
+            issueCategory: "error",
+            assignedTo: {
+              type: "team",
+              id: "99999",
+              name: "Platform Team",
+            },
+          }),
+        { once: true },
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/TEAM-ISSUE-001/events/latest/",
+        () => HttpResponse.json(createDefaultEvent()),
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "TEAM-ISSUE-001",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    // Verify that team assignment is displayed with "(Team)" suffix
+    expect(result).toContain("**Assigned To**: Platform Team (Team)");
+  });
+
   it("serializes with issueUrl", async () => {
     const result = await getIssueDetails.handler(
       {
@@ -283,6 +342,7 @@ describe("get_issue_details", () => {
       **Users Impacted**: 1
       **Status**: unresolved
       **Substatus**: ongoing
+      **Assigned To**: Jane Developer (User)
       **Issue Type**: error
       **Issue Category**: error
       **Platform**: javascript
@@ -558,6 +618,7 @@ describe("get_issue_details", () => {
       **Users Impacted**: 1
       **Status**: unresolved
       **Substatus**: ongoing
+      **Assigned To**: Jane Developer (User)
       **Issue Type**: error
       **Issue Category**: error
       **Platform**: javascript

--- a/packages/mcp-core/src/tools/update-issue.test.ts
+++ b/packages/mcp-core/src/tools/update-issue.test.ts
@@ -33,7 +33,7 @@ describe("update_issue", () => {
       ## Current Status
 
       **Status**: resolved
-      **Assigned To**: Unassigned
+      **Assigned To**: Jane Developer
 
       # Using this information
 
@@ -70,7 +70,7 @@ describe("update_issue", () => {
 
       ## Changes Made
 
-      **Assigned To**: Unassigned → **john.doe**
+      **Assigned To**: Jane Developer → **john.doe**
 
       ## Current Status
 
@@ -112,7 +112,7 @@ describe("update_issue", () => {
       ## Changes Made
 
       **Status**: unresolved → **resolved**
-      **Assigned To**: Unassigned → **You**
+      **Assigned To**: Jane Developer → **You**
 
       ## Current Status
 

--- a/packages/mcp-server-mocks/src/fixtures/issue.json
+++ b/packages/mcp-server-mocks/src/fixtures/issue.json
@@ -35,7 +35,12 @@
     "title": "Error: Tool list_organizations is already registered"
   },
   "numComments": 0,
-  "assignedTo": null,
+  "assignedTo": {
+    "type": "user",
+    "id": "12345",
+    "name": "Jane Developer",
+    "email": "jane@example.com"
+  },
   "isBookmarked": false,
   "isSubscribed": false,
   "subscriptionDetails": null,


### PR DESCRIPTION
## Summary

Adds the `assignedTo` field to the `get_issue_details` tool output, displaying whether an issue is assigned to a user or team.

Closes #657

### Key Changes

- Added `assignedTo` display logic in `formatIssueOutput()` - shows assignee name with "(User)" or "(Team)" suffix
- Updated issue fixture to include a user assignment for testing
- Added test case for team assignment formatting
- Updated existing test snapshots to include the new field

### Example Output

When assigned to a user:
```
**Assigned To**: Jane Developer (User)
```

When assigned to a team:
```
**Assigned To**: Platform Team (Team)
```

Co-Authored-By: Claude <noreply@anthropic.com>