### PR TITLE
feat: enable telemetry for embedded AI agents

### DIFF
--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
@@ -45,6 +45,10 @@ export async function callEmbeddedAgent<
     maxSteps: 5,
     temperature: 1, // GPT-5 only supports temperature of 1
     experimental_output: Output.object({ schema }),
+    experimental_telemetry: {
+      isEnabled: true,
+      functionId: "callEmbeddedAgent",
+    },
     // Disable strict schema validation for both output and tool parameter schemas.
     //
     // OpenAI's structured outputs have limitations:


### PR DESCRIPTION
Enable input/output recording in Vercel AI integration and add experimental telemetry to callEmbeddedAgent for better observability of AI-powered tool calls.
