### PR TITLE
fix(cloudflare): add WWW-Authenticate header to 401 responses

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -144,9 +144,10 @@ describe("mcp-handler", () => {
       legacyCtx as any,
     );
 
-    // Verify 401 response with re-auth message
+    // Verify 401 response with re-auth message and WWW-Authenticate header
     expect(response.status).toBe(401);
     expect(await response.text()).toContain("re-authorize");
+    expect(response.headers.get("WWW-Authenticate")).toContain("invalid_token");
 
     // Verify waitUntil was called for background grant revocation
     expect(legacyCtx.waitUntil).toHaveBeenCalled();

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -113,7 +113,13 @@ const mcpHandler: ExportedHandler<Env> = {
 
       return new Response(
         "Your authorization has expired. Please re-authorize to continue using Sentry MCP.",
-        { status: 401 },
+        {
+          status: 401,
+          headers: {
+            "WWW-Authenticate":
+              'Bearer realm="Sentry MCP", error="invalid_token", error_description="Token requires re-authorization"',
+          },
+        },
       );
     }
 


### PR DESCRIPTION
Include proper RFC 6750 Bearer token error response when authorization expires, helping clients understand the token is invalid and needs re-authorization.