### PR TITLE
chore(cloudflare): upgrade OAuth provider to v0.1.0 with graceful token refresh fallback

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -31,7 +31,7 @@ const addCorsHeaders = (response: Response): Response => {
 };
 
 // Wrap OAuth Provider to restrict CORS headers on public metadata endpoints
-// OAuth Provider v0.0.12 adds overly permissive CORS (allows all methods/headers).
+// OAuth Provider v0.1.0 adds overly permissive CORS (allows all methods/headers).
 // We override with secure headers for .well-known endpoints and add CORS to robots.txt/llms.txt.
 const wrappedOAuthProvider = {
   fetch: async (request: Request, env: Env, ctx: ExecutionContext) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^1.9.4
       version: 1.9.4
     '@cloudflare/workers-oauth-provider':
-      specifier: ^0.0.12
-      version: 0.0.12
+      specifier: ^0.1.0
+      version: 0.1.0
     '@cloudflare/workers-types':
       specifier: ^4.20251014.0
       version: 4.20251014.0
@@ -221,7 +221,7 @@ importers:
         version: 1.2.12(react@19.1.0)(zod@3.25.76)
       '@cloudflare/workers-oauth-provider':
         specifier: 'catalog:'
-        version: 0.0.12
+        version: 0.1.0
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.22.0(@cfworker/json-schema@4.1.1)
@@ -834,8 +834,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-oauth-provider@0.0.12':
-    resolution: {integrity: sha512-A/qTfCFusZBUcb/D62y610p9IcuZ3TBwmP1yYOUstroUIWfx1q0Y8NmbFN7++4ZWTHzVnFoyU6/iTIrC0lDqFA==}
+  '@cloudflare/workers-oauth-provider@0.1.0':
+    resolution: {integrity: sha512-wok0RqyZlxkaKJCmGGXKyWkN0znRs9SFfTOJ1/TJxnv6N/lfXbCYr5hCbsgmOdvVi8JsKKYWj/qkqOLZybgAyQ==}
 
   '@cloudflare/workers-types@4.20251014.0':
     resolution: {integrity: sha512-tEW98J/kOa0TdylIUOrLKRdwkUw0rvvYVlo+Ce0mqRH3c8kSoxLzUH9gfCvwLe0M89z1RkzFovSKAW2Nwtyn3w==}
@@ -5192,7 +5192,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20251011.0':
     optional: true
 
-  '@cloudflare/workers-oauth-provider@0.0.12': {}
+  '@cloudflare/workers-oauth-provider@0.1.0': {}
 
   '@cloudflare/workers-types@4.20251014.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ catalog:
   "@biomejs/biome": ^1.9.4
   "@cloudflare/vite-plugin": ^1.13.15
   "@cloudflare/vitest-pool-workers": ^0.8.47
-  "@cloudflare/workers-oauth-provider": ^0.0.12
+  "@cloudflare/workers-oauth-provider": ^0.1.0
   "@cloudflare/workers-types": ^4.20251014.0
   "@modelcontextprotocol/sdk": ^1.21.0
   "@radix-ui/react-accordion": ^1.2.11


### PR DESCRIPTION
Upgrades @cloudflare/workers-oauth-provider from v0.0.12 to v0.1.0 and improves token refresh resilience when upstream refresh fails.

Key changes:
- Upgrade OAuth provider dependency to v0.1.0
- Add graceful fallback when token refresh fails but token has >1 min TTL
- Prevent race condition corruption by not returning newProps on fallback
- Add comprehensive tests for fallback scenarios
- Improve logging for token reuse and refresh failures

The fallback strategy reuses cached tokens when upstream refresh fails but significant TTL remains (>1 minute), avoiding service disruption from transient upstream failures. Does not return newProps to prevent overwriting fresher tokens saved by concurrent requests in race conditions.