### PR TITLE
refactor(mcp-core): replace @sentry/node with @sentry/core

### DIFF
--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -11,9 +11,7 @@
   "author": "Sentry",
   "description": "Sentry MCP Core - Shared code for MCP transports",
   "homepage": "https://github.com/getsentry/sentry-mcp",
-  "keywords": [
-    "sentry"
-  ],
+  "keywords": ["sentry"],
   "bugs": {
     "url": "https://github.com/getsentry/sentry-mcp/issues"
   },
@@ -21,9 +19,7 @@
     "type": "git",
     "url": "git@github.com:getsentry/sentry-mcp.git"
   },
-  "files": [
-    "./dist/*"
-  ],
+  "files": ["./dist/*"],
   "exports": {
     "./api-client": {
       "types": "./dist/api-client/index.ts",
@@ -137,7 +133,6 @@
     "@logtape/sentry": "^1.1.1",
     "@modelcontextprotocol/sdk": "catalog:",
     "@sentry/core": "catalog:",
-    "@sentry/node": "catalog:",
     "ai": "catalog:",
     "dotenv": "catalog:",
     "zod": "catalog:"

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -1,10 +1,10 @@
 import type { SentryApiService } from "../../api-client";
+import { logInfo } from "../../telem/logging";
 import {
   type FlexibleEventData,
   getStringValue,
   isAggregateQuery,
 } from "./utils";
-import * as Sentry from "@sentry/node";
 
 /**
  * Format an explanation for how a natural language query was translated
@@ -62,16 +62,14 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
-    Sentry.logger.info(
-      Sentry.logger
-        .fmt`No error events found for query: ${naturalLanguageQuery}`,
-      {
+    logInfo(`No error events found for query: ${naturalLanguageQuery}`, {
+      extra: {
         query: sentryQuery,
         fields: fields,
         organizationSlug: organizationSlug,
         dataset: "errors",
       },
-    );
+    });
     output += `No results found.\n\n`;
     output += `Try being more specific or using different terms in your search.\n`;
     return output;
@@ -186,15 +184,14 @@ export function formatLogResults(params: FormatEventResultsParams): string {
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
-    Sentry.logger.info(
-      Sentry.logger.fmt`No log events found for query: ${naturalLanguageQuery}`,
-      {
+    logInfo(`No log events found for query: ${naturalLanguageQuery}`, {
+      extra: {
         query: sentryQuery,
         fields: fields,
         organizationSlug: organizationSlug,
         dataset: "logs",
       },
-    );
+    });
     output += `No results found.\n\n`;
     output += `Try being more specific or using different terms in your search.\n`;
     return output;
@@ -333,16 +330,14 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
   if (eventData.length === 0) {
-    Sentry.logger.info(
-      Sentry.logger
-        .fmt`No span events found for query: ${naturalLanguageQuery}`,
-      {
+    logInfo(`No span events found for query: ${naturalLanguageQuery}`, {
+      extra: {
         query: sentryQuery,
         fields: fields,
         organizationSlug: organizationSlug,
         dataset: "spans",
       },
-    );
+    });
     output += `No results found.\n\n`;
     output += `Try being more specific or using different terms in your search.\n`;
     return output;

--- a/packages/mcp-core/src/tools/search-issues/formatters.ts
+++ b/packages/mcp-core/src/tools/search-issues/formatters.ts
@@ -1,6 +1,6 @@
 import type { Issue } from "../../api-client";
+import { logInfo } from "../../telem/logging";
 import { getIssueUrl, getIssuesSearchUrl } from "../../utils/url-utils";
-import * as Sentry from "@sentry/node";
 
 /**
  * Format an explanation for how a natural language query was translated
@@ -55,16 +55,14 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
   }
 
   if (issues.length === 0) {
-    Sentry.logger.info(
-      Sentry.logger
-        .fmt`No issues found for query: ${naturalLanguageQuery || query}`,
-      {
+    logInfo(`No issues found for query: ${naturalLanguageQuery || query}`, {
+      extra: {
         query,
         organizationSlug,
         projectSlug: projectSlugOrId,
         naturalLanguageQuery,
       },
-    );
+    });
     output += "No issues found matching your search criteria.\n\n";
     output += "Try adjusting your search criteria or time range.";
     return output;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@biomejs/biome':
       specifier: ^1.9.4
       version: 1.9.4
+    '@cloudflare/vitest-pool-workers':
+      specifier: ^0.8.47
+      version: 0.8.71
     '@cloudflare/workers-oauth-provider':
       specifier: ^0.0.12
       version: 0.0.12
@@ -292,6 +295,9 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.13.15
         version: 1.13.15(vite@6.3.5(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0))(workerd@1.20251011.0)(wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0))
+      '@cloudflare/vitest-pool-workers':
+        specifier: 'catalog:'
+        version: 0.8.71(@cloudflare/workers-types@4.20251014.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.10)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0))
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20251014.0
@@ -356,9 +362,6 @@ importers:
         specifier: 'catalog:'
         version: 1.22.0(@cfworker/json-schema@4.1.1)
       '@sentry/core':
-        specifier: 'catalog:'
-        version: 10.28.0
-      '@sentry/node':
         specifier: 'catalog:'
         version: 10.28.0
       ai:
@@ -789,6 +792,15 @@ packages:
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
     engines: {node: '>=18.0.0'}
 
+  '@cloudflare/unenv-preset@2.7.3':
+    resolution: {integrity: sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.21
+      workerd: ^1.20250828.1
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
   '@cloudflare/unenv-preset@2.7.8':
     resolution: {integrity: sha512-Ky929MfHh+qPhwCapYrRPwPVHtA2Ioex/DbGZyskGyNRDe9Ru3WThYZivyNVaPy5ergQSgMs9OKrM9Ajtz9F6w==}
     peerDependencies:
@@ -804,10 +816,29 @@ packages:
       vite: ^6.1.0 || ^7.0.0
       wrangler: ^4.45.0
 
+  '@cloudflare/vitest-pool-workers@0.8.71':
+    resolution: {integrity: sha512-keu2HCLQfRNwbmLBCDXJgCFpANTaYnQpE01fBOo4CNwiWHUT7SZGN7w64RKiSWRHyYppStXBuE5Ng7F42+flpg==}
+    peerDependencies:
+      '@vitest/runner': 2.0.x - 3.2.x
+      '@vitest/snapshot': 2.0.x - 3.2.x
+      vitest: 2.0.x - 3.2.x
+
+  '@cloudflare/workerd-darwin-64@1.20250906.0':
+    resolution: {integrity: sha512-E+X/YYH9BmX0ew2j/mAWFif2z05NMNuhCTlNYEGLkqMe99K15UewBqajL9pMcMUKxylnlrEoK3VNxl33DkbnPA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-64@1.20251011.0':
     resolution: {integrity: sha512-0DirVP+Z82RtZLlK2B+VhLOkk+ShBqDYO/jhcRw4oVlp0TOvk3cOVZChrt3+y3NV8Y/PYgTEywzLKFSziK4wCg==}
     engines: {node: '>=16'}
     cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20250906.0':
+    resolution: {integrity: sha512-X5apsZ1SFW4FYTM19ISHf8005FJMPfrcf4U5rO0tdj+TeJgQgXuZ57IG0WeW7SpLVeBo8hM6WC8CovZh41AfnA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20251011.0':
@@ -816,10 +847,22 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-linux-64@1.20250906.0':
+    resolution: {integrity: sha512-rlKzWgsLnlQ5Nt9W69YBJKcmTmZbOGu0edUsenXPmc6wzULUxoQpi7ZE9k3TfTonJx4WoQsQlzCUamRYFsX+0Q==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-64@1.20251011.0':
     resolution: {integrity: sha512-BccMiBzFlWZyFghIw2szanmYJrJGBGHomw2y/GV6pYXChFzMGZkeCEMfmCyJj29xczZXxcZmUVJxNy4eJxO8QA==}
     engines: {node: '>=16'}
     cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20250906.0':
+    resolution: {integrity: sha512-DdedhiQ+SeLzpg7BpcLrIPEZ33QKioJQ1wvL4X7nuLzEB9rWzS37NNNahQzc1+44rhG4fyiHbXBPOeox4B9XVA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20251011.0':
@@ -827,6 +870,12 @@ packages:
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20250906.0':
+    resolution: {integrity: sha512-Q8Qjfs8jGVILnZL6vUpQ90q/8MTCYaGR3d1LGxZMBqte8Vr7xF3KFHPEy7tFs0j0mMjnqCYzlofmPNY+9ZaDRg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20251011.0':
     resolution: {integrity: sha512-RIXUQRchFdqEvaUqn1cXZXSKjpqMaSaVAkI5jNZ8XzAw/bw2bcdOVUtakrflgxDprltjFb0PTNtuss1FKtH9Jg==}
@@ -2483,6 +2532,9 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  birpc@0.2.14:
+    resolution: {integrity: sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==}
+
   birpc@2.4.0:
     resolution: {integrity: sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==}
 
@@ -2774,6 +2826,9 @@ packages:
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  devalue@5.6.1:
+    resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -3700,6 +3755,11 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  miniflare@4.20250906.0:
+    resolution: {integrity: sha512-T/RWn1sa0ien80s6NjU+Un/tj12gR6wqScZoiLeMJDD4/fK0UXfnbWXJDubnUED8Xjm7RPQ5ESYdE+mhPmMtuQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   miniflare@4.20251011.1:
     resolution: {integrity: sha512-Qbw1Z8HTYM1adWl6FAtzhrj34/6dPRDPwdYOx21dkae8a/EaxbMzRIPbb4HKVGMVvtqbK1FaRCgDLVLolNzGHg==}
@@ -4756,6 +4816,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20250906.0:
+    resolution: {integrity: sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workerd@1.20251011.0:
     resolution: {integrity: sha512-Dq35TLPEJAw7BuYQMkN3p9rge34zWMU2Gnd4DSJFeVqld4+DAO2aPG7+We2dNIAyM97S8Y9BmHulbQ00E0HC7Q==}
     engines: {node: '>=16'}
@@ -4765,6 +4830,16 @@ packages:
     resolution: {integrity: sha512-PCgcGZnFvtk0WkbUsA9nDd5qqwv310L7on0/hlJZ9hQZkJMntGf5v3L2X3mLSDs9WSDF6jSedxlvWCtIXrKbEg==}
     engines: {node: '>=16.17.0'}
     hasBin: true
+
+  wrangler@4.35.0:
+    resolution: {integrity: sha512-HbyXtbrh4Fi3mU8ussY85tVdQ74qpVS1vctUgaPc+bPrXBTqfDLkZ6VRtHAVF/eBhz4SFmhJtCQpN1caY2Ak8A==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20250906.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
 
   wrangler@4.45.0:
     resolution: {integrity: sha512-2qM6bHw8l7r89Z9Y5A7Wn4L9U+dFoLjYgEUVpqy7CcmXpppL3QIYqU6rU5lre7/SRzBuPu/H93Vwfh538gZ3iw==}
@@ -5154,6 +5229,12 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
+  '@cloudflare/unenv-preset@2.7.3(unenv@2.0.0-rc.21)(workerd@1.20250906.0)':
+    dependencies:
+      unenv: 2.0.0-rc.21
+    optionalDependencies:
+      workerd: 1.20250906.0
+
   '@cloudflare/unenv-preset@2.7.8(unenv@2.0.0-rc.21)(workerd@1.20251011.0)':
     dependencies:
       unenv: 2.0.0-rc.21
@@ -5177,16 +5258,48 @@ snapshots:
       - utf-8-validate
       - workerd
 
+  '@cloudflare/vitest-pool-workers@0.8.71(@cloudflare/workers-types@4.20251014.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.10)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      birpc: 0.2.14
+      cjs-module-lexer: 1.4.3
+      devalue: 5.6.1
+      miniflare: 4.20250906.0
+      semver: 7.7.2
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.10)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.10)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0)
+      wrangler: 4.35.0(@cloudflare/workers-types@4.20251014.0)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/workerd-darwin-64@1.20250906.0':
+    optional: true
+
   '@cloudflare/workerd-darwin-64@1.20251011.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20250906.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20251011.0':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20250906.0':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20251011.0':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20250906.0':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20251011.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20250906.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20251011.0':
@@ -6768,6 +6881,8 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
+  birpc@0.2.14: {}
+
   birpc@2.4.0: {}
 
   bl@4.1.0:
@@ -7026,6 +7141,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.0.4: {}
+
+  devalue@5.6.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -8176,6 +8293,24 @@ snapshots:
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  miniflare@4.20250906.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.2
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      sharp: 0.33.5
+      stoppable: 1.1.0
+      undici: 7.14.0
+      workerd: 1.20250906.0
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   miniflare@4.20251011.1:
     dependencies:
@@ -9424,6 +9559,14 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20250906.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20250906.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250906.0
+      '@cloudflare/workerd-linux-64': 1.20250906.0
+      '@cloudflare/workerd-linux-arm64': 1.20250906.0
+      '@cloudflare/workerd-windows-64': 1.20250906.0
+
   workerd@1.20251011.0:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20251011.0
@@ -9451,6 +9594,23 @@ snapshots:
       - '@75lb/nature'
       - '@cfworker/json-schema'
       - supports-color
+
+  wrangler@4.35.0(@cloudflare/workers-types@4.20251014.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.0
+      '@cloudflare/unenv-preset': 2.7.3(unenv@2.0.0-rc.21)(workerd@1.20250906.0)
+      blake3-wasm: 2.1.5
+      esbuild: 0.25.4
+      miniflare: 4.20250906.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.21
+      workerd: 1.20250906.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20251014.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0):
     dependencies:


### PR DESCRIPTION
Remove @sentry/node dependency which pulls in OpenTelemetry and Node.js- specific modules (node:os). This was causing issues with Cloudflare Workers' workerd runtime since vitest-pool-workers doesn't respect package.json browser field redirects.

The Sentry.logger API is available from @sentry/core and works in both Node.js and Workers environments, making mcp-core truly transport-agnostic.

Also updates formatters to use logInfo() helpers instead of direct sentryLogger calls, so "no results found" diagnostics appear in both console (for development) and Sentry Logs (for production).