### PR TITLE
Add mcpName for MCP registry listing

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sentry/mcp-server",
+  "mcpName": "io.github.getsentry/sentry-mcp",
   "version": "0.24.0",
   "type": "module",
   "packageManager": "pnpm@10.8.1",


### PR DESCRIPTION
This adds the `mcpName` field required to publish `@sentry/mcp-server` to the official MCP registry at https://registry.modelcontextprotocol.io

## Changes
- Added `mcpName: "io.github.getsentry/sentry-mcp"` to `packages/mcp-server/package.json`

## Next Steps
After this is merged and a new npm version is published, the server can be added to the MCP registry using `mcp-publisher`:

```bash
npm install -g mcp-publisher
cd packages/mcp-server
mcp-publisher init
mcp-publisher login github
mcp-publisher publish
```

## References
- [MCP Registry Quickstart](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx)