### PR TITLE
feat(cloudflare): add Amp and OpenCode IDE integrations

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/install-tabs.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/install-tabs.tsx
@@ -12,6 +12,8 @@ import { WindsurfIcon } from "../ui/icons/windsurf";
 import { CodexIcon } from "../ui/icons/codex";
 import { ClaudeIcon } from "../ui/icons/claude";
 import { CursorIcon } from "../ui/icons/cursor";
+import { OpenCodeIcon } from "../ui/icons/opencode";
+import { AmpIcon } from "../ui/icons/amp";
 
 export type TabProps = {
   id: string;
@@ -288,4 +290,6 @@ const iconsByID: Record<string, React.ReactNode> = {
   warp: <WarpIcon />,
   zed: <ZedIcon />,
   gemini: <GeminiIcon className="size-4" />,
+  opencode: <OpenCodeIcon />,
+  amp: <AmpIcon />,
 };

--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -92,6 +92,35 @@ export function RemoteSetupTabs() {
   );
   return (
     <InstallTabs>
+      <Tab id="claude-code" title="Claude Code">
+        <ol>
+          <li>Open your terminal to access the CLI.</li>
+          <li>
+            <CodeSnippet
+              noMargin
+              snippet={`claude mcp add --transport http sentry ${endpoint}`}
+            />
+          </li>
+          <li>
+            This will trigger an OAuth authentication flow to connect Claude
+            Code to your Sentry account.
+          </li>
+          <li>
+            You may need to manually authenticate if it doesnt happen
+            automatically, which can be done via <code>/mcp</code>.
+          </li>
+        </ol>
+        <p>
+          <small>
+            For more details, see the{" "}
+            <a href="https://docs.anthropic.com/en/docs/claude-code/mcp">
+              Claude Code MCP documentation
+            </a>
+            .
+          </small>
+        </p>
+      </Tab>
+
       <Tab id="cursor" title="Cursor">
         <Button
           variant="secondary"
@@ -137,35 +166,6 @@ export function RemoteSetupTabs() {
             <CodeSnippet noMargin snippet={`cursor-agent mcp login sentry`} />
           </li>
         </ol>
-      </Tab>
-
-      <Tab id="claude-code" title="Claude Code">
-        <ol>
-          <li>Open your terminal to access the CLI.</li>
-          <li>
-            <CodeSnippet
-              noMargin
-              snippet={`claude mcp add --transport http sentry ${endpoint}`}
-            />
-          </li>
-          <li>
-            This will trigger an OAuth authentication flow to connect Claude
-            Code to your Sentry account.
-          </li>
-          <li>
-            You may need to manually authenticate if it doesnt happen
-            automatically, which can be done via <code>/mcp</code>.
-          </li>
-        </ol>
-        <p>
-          <small>
-            For more details, see the{" "}
-            <a href="https://docs.anthropic.com/en/docs/claude-code/mcp">
-              Claude Code MCP documentation
-            </a>
-            .
-          </small>
-        </p>
       </Tab>
 
       <Tab id="vscode" title="Code">
@@ -245,6 +245,36 @@ export function RemoteSetupTabs() {
         </ol>
       </Tab>
 
+      <Tab id="amp" title="Amp">
+        <ol>
+          <li>
+            Open your terminal and use the Amp CLI to add the Sentry MCP server:
+            <CodeSnippet noMargin snippet={`amp mcp add sentry ${endpoint}`} />
+          </li>
+          <li>
+            Amp will automatically initiate OAuth authentication using Dynamic
+            Client Registration (DCR). Follow the browser prompts to authorize
+            the connection.
+          </li>
+          <li>
+            Once authenticated, the Sentry MCP server will be available in Amp.
+          </li>
+        </ol>
+        <p>
+          <small>
+            For more details, see the{" "}
+            <a
+              href="https://ampcode.com/manual#mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Amp MCP documentation
+            </a>
+            .
+          </small>
+        </p>
+      </Tab>
+
       <Tab id="gemini" title="Gemini CLI">
         <ol>
           <li>
@@ -288,23 +318,21 @@ export function RemoteSetupTabs() {
         </p>
       </Tab>
 
-      <Tab id="windsurf" title="Windsurf">
+      <Tab id="opencode" title="OpenCode">
         <ol>
-          <li>Open Windsurf Settings.</li>
           <li>
-            Under <strong>Cascade</strong>, you'll find{" "}
-            <strong>Model Context Protocol Servers</strong>.
-          </li>
-          <li>
-            Select <strong>Add Server</strong>.
-          </li>
-          <li>
+            Edit <code>~/.config/opencode/opencode.json</code> and add the
+            remote MCP server configuration:
             <CodeSnippet
               noMargin
               snippet={JSON.stringify(
                 {
-                  mcpServers: {
-                    sentry: coreConfig,
+                  $schema: "https://opencode.ai/config.json",
+                  mcp: {
+                    sentry: {
+                      type: "remote",
+                      url: endpoint,
+                    },
                   },
                 },
                 undefined,
@@ -312,7 +340,29 @@ export function RemoteSetupTabs() {
               )}
             />
           </li>
+          <li>Save the file and restart OpenCode.</li>
+          <li>
+            Authenticate with Sentry by running:
+            <CodeSnippet noMargin snippet="opencode mcp auth sentry" />
+          </li>
+          <li>
+            This will open a browser window to complete the OAuth flow and
+            connect OpenCode to your Sentry account.
+          </li>
         </ol>
+        <p>
+          <small>
+            For more details, see the{" "}
+            <a
+              href="https://opencode.ai/docs/mcp-servers"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              OpenCode MCP documentation
+            </a>
+            .
+          </small>
+        </p>
       </Tab>
 
       <Tab id="warp" title="Warp">
@@ -377,6 +427,33 @@ export function RemoteSetupTabs() {
             .
           </small>
         </p>
+      </Tab>
+
+      <Tab id="windsurf" title="Windsurf">
+        <ol>
+          <li>Open Windsurf Settings.</li>
+          <li>
+            Under <strong>Cascade</strong>, you'll find{" "}
+            <strong>Model Context Protocol Servers</strong>.
+          </li>
+          <li>
+            Select <strong>Add Server</strong>.
+          </li>
+          <li>
+            <CodeSnippet
+              noMargin
+              snippet={JSON.stringify(
+                {
+                  mcpServers: {
+                    sentry: coreConfig,
+                  },
+                },
+                undefined,
+                2,
+              )}
+            />
+          </li>
+        </ol>
       </Tab>
 
       <Tab id="zed" title="Zed">

--- a/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
@@ -203,6 +203,35 @@ export function StdioSetupTabs() {
     'env = { SENTRY_ACCESS_TOKEN = "sentry-user-token", SENTRY_HOST = "sentry.example.com", OPENAI_API_KEY = "your-openai-key" }';
   return (
     <InstallTabs>
+      <Tab id="claude-code" title="Claude Code">
+        <ol>
+          <li>Open your terminal to access the CLI.</li>
+          <li>
+            <CodeSnippet
+              noMargin
+              snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e OPENAI_API_KEY=your-openai-key -- ${mcpStdioSnippet}`}
+            />
+          </li>
+          <li>
+            Replace <code>sentry-user-token</code> with your actual User Auth
+            Token.
+          </li>
+          <li>
+            Connecting to self-hosted Sentry? Append
+            <code>-e SENTRY_HOST=your-hostname</code>.
+          </li>
+        </ol>
+        <p>
+          <small>
+            For more details, see the{" "}
+            <Link href="https://docs.anthropic.com/en/docs/claude-code/mcp">
+              Claude Code MCP documentation
+            </Link>
+            .
+          </small>
+        </p>
+      </Tab>
+
       <Tab id="cursor" title="Cursor">
         <ol>
           <li>
@@ -238,35 +267,6 @@ export function StdioSetupTabs() {
             />
           </li>
         </ol>
-      </Tab>
-
-      <Tab id="claude-code" title="Claude Code">
-        <ol>
-          <li>Open your terminal to access the CLI.</li>
-          <li>
-            <CodeSnippet
-              noMargin
-              snippet={`claude mcp add sentry -e SENTRY_ACCESS_TOKEN=sentry-user-token -e OPENAI_API_KEY=your-openai-key -- ${mcpStdioSnippet}`}
-            />
-          </li>
-          <li>
-            Replace <code>sentry-user-token</code> with your actual User Auth
-            Token.
-          </li>
-          <li>
-            Connecting to self-hosted Sentry? Append
-            <code>-e SENTRY_HOST=your-hostname</code>.
-          </li>
-        </ol>
-        <p>
-          <small>
-            For more details, see the{" "}
-            <Link href="https://docs.anthropic.com/en/docs/claude-code/mcp">
-              Claude Code MCP documentation
-            </Link>
-            .
-          </small>
-        </p>
       </Tab>
 
       <Tab id="vscode" title="Code">
@@ -336,6 +336,81 @@ export function StdioSetupTabs() {
         </ol>
       </Tab>
 
+      <Tab id="amp" title="Amp">
+        <ol>
+          <li>
+            Edit your settings file and add the MCP server configuration:
+            <ul>
+              <li>
+                <strong>macOS/Linux:</strong>{" "}
+                <code>~/.config/amp/settings.json</code>
+              </li>
+              <li>
+                <strong>Windows:</strong>{" "}
+                <code>%USERPROFILE%\.config\amp\settings.json</code>
+              </li>
+            </ul>
+            <CodeSnippet
+              noMargin
+              snippet={JSON.stringify(
+                {
+                  "amp.mcpServers": {
+                    sentry: {
+                      ...coreConfig,
+                      env: {
+                        ...coreConfig.env,
+                      },
+                    },
+                  },
+                },
+                undefined,
+                2,
+              )}
+            />
+          </li>
+          <li>
+            Replace <code>sentry-user-token</code> with your Sentry User Auth
+            Token.
+          </li>
+          <li>
+            For self-hosted Sentry, add <code>SENTRY_HOST</code> to the env
+            object:
+            <CodeSnippet
+              noMargin
+              snippet={JSON.stringify(
+                {
+                  "amp.mcpServers": {
+                    sentry: {
+                      ...coreConfig,
+                      env: {
+                        ...coreConfig.env,
+                        SENTRY_HOST: "sentry.example.com",
+                      },
+                    },
+                  },
+                },
+                undefined,
+                2,
+              )}
+            />
+          </li>
+          <li>Restart Amp to load the new configuration.</li>
+        </ol>
+        <p>
+          <small>
+            For more details, see the{" "}
+            <a
+              href="https://ampcode.com/manual#mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Amp MCP documentation
+            </a>
+            .
+          </small>
+        </p>
+      </Tab>
+
       <Tab id="gemini" title="Gemini CLI">
         <ol>
           <li>
@@ -396,6 +471,75 @@ export function StdioSetupTabs() {
               rel="noopener noreferrer"
             >
               Gemini CLI documentation
+            </a>
+            .
+          </small>
+        </p>
+      </Tab>
+
+      <Tab id="opencode" title="OpenCode">
+        <ol>
+          <li>
+            Edit <code>~/.config/opencode/opencode.json</code> and add the stdio
+            MCP server configuration:
+            <CodeSnippet
+              noMargin
+              snippet={JSON.stringify(
+                {
+                  $schema: "https://opencode.ai/config.json",
+                  mcp: {
+                    sentry: {
+                      type: "stdio",
+                      ...coreConfig,
+                      env: {
+                        ...coreConfig.env,
+                      },
+                    },
+                  },
+                },
+                undefined,
+                2,
+              )}
+            />
+          </li>
+          <li>
+            Replace <code>sentry-user-token</code> with your Sentry User Auth
+            Token.
+          </li>
+          <li>
+            For self-hosted Sentry, add <code>SENTRY_HOST</code> to the env
+            object:
+            <CodeSnippet
+              noMargin
+              snippet={JSON.stringify(
+                {
+                  mcp: {
+                    sentry: {
+                      type: "stdio",
+                      ...coreConfig,
+                      env: {
+                        ...coreConfig.env,
+                        SENTRY_HOST: "sentry.example.com",
+                      },
+                    },
+                  },
+                },
+                undefined,
+                2,
+              )}
+            />
+          </li>
+          <li>Restart OpenCode to load the new configuration.</li>
+        </ol>
+        <p>
+          <small>
+            For more details, see the{" "}
+            <a
+              href="https://opencode.ai/docs/mcp-servers"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              OpenCode MCP documentation
             </a>
             .
           </small>

--- a/packages/mcp-cloudflare/src/client/components/ui/icons/amp.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/icons/amp.tsx
@@ -1,0 +1,26 @@
+export function AmpIcon() {
+  return (
+    <svg
+      width="21"
+      height="21"
+      viewBox="0 0 21 21"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path
+        d="M3.76879 18.3015L8.49839 13.505L10.2196 20.0399L12.72 19.3561L10.2288 9.86749L0.890876 7.33844L0.22594 9.89331L6.65134 11.6388L1.94138 16.4282L3.76879 18.3015Z"
+        className="fill-current"
+      />
+      <path
+        d="M17.4074 12.7414L19.9078 12.0575L17.4167 2.56897L8.07873 0.0399246L7.4138 2.5948L15.2992 4.73685L17.4074 12.7414Z"
+        className="fill-current"
+      />
+      <path
+        d="M13.8184 16.3883L16.3188 15.7044L13.8276 6.21588L4.48971 3.68683L3.82477 6.24171L11.7101 8.38376L13.8184 16.3883Z"
+        className="fill-current"
+      />
+    </svg>
+  );
+}

--- a/packages/mcp-cloudflare/src/client/components/ui/icons/opencode.tsx
+++ b/packages/mcp-cloudflare/src/client/components/ui/icons/opencode.tsx
@@ -1,0 +1,21 @@
+export function OpenCodeIcon() {
+  return (
+    <svg
+      width="512"
+      height="512"
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path d="M320 224V352H192V224H320Z" className="fill-current opacity-60" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z"
+        className="fill-current"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
Adds installation instructions and icons for Amp and OpenCode IDE integrations, expanding MCP server compatibility.

### Key Changes
- Added `AmpIcon` and `OpenCodeIcon` components with proper SVG assets
- Added Amp setup instructions for both OAuth (remote) and stdio transports
- Added OpenCode setup instructions for both OAuth (remote) and stdio transports
- Reordered IDE tabs to prioritize Claude Code as the first option

### IDE Support
Both new IDEs support the full MCP integration:
- **Remote setup**: OAuth-based authentication with Dynamic Client Registration
- **Stdio setup**: User Auth Token configuration with environment variables
- Self-hosted Sentry support via `SENTRY_HOST` environment variable

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>