### PR TITLE
fix(cloudflare): add oauth scope to OpenCode remote config

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -332,6 +332,9 @@ export function RemoteSetupTabs() {
                     sentry: {
                       type: "remote",
                       url: endpoint,
+                      oauth: {
+                        scope: "tools:read tools:execute",
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
## Summary
- Adds the missing `oauth` block with `tools:read tools:execute` scope to the OpenCode remote MCP server configuration example
- This ensures users can properly authenticate when setting up the Sentry MCP server in OpenCode