### PR TITLE
fix(cloudflare): simplify OpenCode oauth config to empty object

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/remote-setup.tsx
@@ -332,9 +332,7 @@ export function RemoteSetupTabs() {
                     sentry: {
                       type: "remote",
                       url: endpoint,
-                      oauth: {
-                        scope: "tools:read tools:execute",
-                      },
+                      oauth: {},
                     },
                   },
                 },


### PR DESCRIPTION
## Summary
- Simplifies the OpenCode oauth config to use an empty object `{}` instead of specifying scopes
- The oauth block only needs to be present to trigger the OAuth flow, no specific scopes are required