### PR TITLE
Correct spelling of 'Github' to 'GitHub'

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/home-layout/footer.tsx
+++ b/packages/mcp-cloudflare/src/client/components/home-layout/footer.tsx
@@ -24,19 +24,19 @@ export default function Footer({ isChatOpen }: { isChatOpen: boolean }) {
             className="relative hover:underline opacity-80 hover:opacity-100 group/link"
           >
             <div className="absolute inset-0 size-full text-violet-500 group-hover/link:opacity-50 group-hover/link:delay-0 delay-300">
-              Github
+              GitHub
             </div>
             <div
               className="absolute inset-0 size-full group-hover/link:opacity-50 group-hover/link:delay-0 duration-300 motion-safe:group-hover/link:translate-y-1 group-hover/link:-translate-x-1"
               aria-hidden="true"
             >
-              Github
+              GitHub
             </div>
             <div
               className="perspective-distant transform-3d duration-300 motion-safe:group-hover/link:translate-y-2 group-hover/link:-translate-x-2"
               role="presentation"
             >
-              Github
+              GitHub
             </div>
           </a>
           <a


### PR DESCRIPTION
Fixes:

<img width="434" height="136" alt="image" src="https://github.com/user-attachments/assets/9c923e9a-9f04-4060-9bfb-797b445f4626" />
