### PR TITLE
fix(ci): handle fork PR permissions for check runs and comments

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Create eval status check
         uses: actions/github-script@v7
-        # Skip for fork PRs (no write permissions) but still run for pushes and same-repo PRs
-        if: ${{ !cancelled() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        # Skip for fork PRs (no write permissions) but still run for pushes, workflow_dispatch, and same-repo PRs
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         continue-on-error: true # Don't fail workflow if check creation fails
         with:
           script: |

--- a/.github/workflows/token-cost.yml
+++ b/.github/workflows/token-cost.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Create check run
         uses: actions/github-script@v7
         # Skip for fork PRs (no write permissions) but still run for pushes and same-repo PRs
-        if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         continue-on-error: true # Don't fail workflow if check creation fails
         with:
           script: |


### PR DESCRIPTION
## Summary

Fixes failing checks on fork PRs (like #697) caused by GitHub's security model restricting write permissions for fork PRs.

### Problem

Fork PRs cannot have write permissions to the repository. This causes:
- `eval` workflow → "Create eval status check" step fails
- `measure-tokens` workflow → "Create check run" and "Comment on PR" steps fail

Both fail with: `HttpError: Resource not accessible by integration` (403, requires `checks=write`)

### Solution

1. **Conditional skip** - Only attempt write operations for pushes and same-repo PRs:
   ```yaml
   if: github.event.pull_request.head.repo.full_name == github.repository
   ```

2. **Fallback safety** - Add `continue-on-error: true` in case other edge cases arise

### What Still Works for Fork PRs

- ✅ Tests run
- ✅ Evals run  
- ✅ Token measurement runs
- ✅ Results visible in job logs and summaries
- ❌ Custom check annotations (skipped)
- ❌ PR comments (skipped)

Co-Authored-By: Claude Code <noreply@anthropic.com>