### PR TITLE
chore: Expand Claude Code default permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -133,7 +133,14 @@
       "mcp__sentry-dev__whoami",
       "mcp__spotlight__get_errors",
       "mcp__spotlight__get_local_errors",
-      "WebSearch"
+      "WebSearch",
+      "Skill(sentry-skills:commit)",
+      "Skill(sentry-skills:create-pr)",
+      "Skill(sentry-skills:code-review)",
+      "Skill(sentry-skills:find-bugs)",
+      "Skill(sentry-skills:deslop)",
+      "Skill(sentry-skills:iterate-pr)",
+      "Skill(sentry-skills:claude-settings-audit)"
     ],
     "deny": []
   },


### PR DESCRIPTION
Expands the default allowed permissions in `.claude/settings.json` from 17 to 136 entries, covering common development workflows for this repository.

The previous settings were minimal and required frequent manual approval for standard operations. This update pre-approves read-only and commonly-used commands to improve developer experience with Claude Code.

**Added permissions:**
- File/directory operations (ls, find, cat, tree, mkdir, rm, mv, chmod)
- Full git command coverage (status, log, diff, show, branch, stash, fetch, pull, add, commit, push, checkout, restore, reset, rebase, bisect, rm, clone)
- GitHub CLI for PRs, issues, runs, and workflows
- pnpm/Node.js toolchain (run, test, build, dev, install, add, list, why, outdated, update, exec, workspace/filter commands, turbo, vitest, tsx)
- TypeScript and Biome linting commands
- Cloudflare Wrangler deployment commands
- Utility commands (grep, rg, jq, sort, awk, sed, curl, lsof, ps, pkill, timeout, tee)
- WebFetch domains for framework documentation (Cloudflare, Hono, React, Zod, Vercel AI SDK, GitHub, npm)
- MCP tool permissions for Sentry integrations
- WebSearch capability

Excludes npm/npx commands since this repo uses pnpm exclusively.