### PR TITLE
ci(release): Switch from action-prepare-release to Craft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           run_install: false
 
       - name: Prepare release
-        uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
+        uses: getsentry/craft@c6e2f04939b6ee67030588afbb5af76b127d8203 # v2
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
## Summary

This PR migrates from the deprecated `action-prepare-release` to the new Craft GitHub Actions.

## Changes

- Migrated `.github/workflows/release.yml` to Craft reusable workflow

## Documentation

See https://getsentry.github.io/craft/github-actions/ for more information.
