### PR TITLE
fix(tools): handle null values in IssueTagValuesSchema

### DIFF
--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -672,9 +672,9 @@ export const EventAttachmentListSchema = z.array(EventAttachmentSchema);
  * Represents a single value's occurrence count and percentage within a tag.
  */
 export const IssueTagValueSchema = z.object({
-  key: z.string().optional(),
-  name: z.string().optional(),
-  value: z.string(),
+  key: z.string().nullable().optional(),
+  name: z.string().nullable().optional(),
+  value: z.string().nullable(),
   count: z.number(),
   lastSeen: z.string().datetime().nullable().optional(),
   firstSeen: z.string().datetime().nullable().optional(),

--- a/packages/mcp-core/src/tools/get-issue-tag-values.ts
+++ b/packages/mcp-core/src/tools/get-issue-tag-values.ts
@@ -154,11 +154,11 @@ export default defineTool({
       const lastSeen = value.lastSeen
         ? new Date(value.lastSeen).toISOString().split("T")[0]
         : "-";
+      // Handle null values (can occur with certain tag types)
+      const rawValue = value.value ?? "(null)";
       // Truncate long values for readability
       let displayValue =
-        value.value.length > 60
-          ? `${value.value.substring(0, 57)}...`
-          : value.value;
+        rawValue.length > 60 ? `${rawValue.substring(0, 57)}...` : rawValue;
       // Escape markdown table special characters (backslashes first)
       displayValue = displayValue
         .replace(/\\/g, "\\\\")


### PR DESCRIPTION
## Summary

Fixes ZodError validation failures in the `get_issue_tag_values` tool when Sentry API returns null values for `name` and `value` fields in the `topValues` array.

**Issue:** https://sentry.sentry.io/issues/7181206453/

### Key Changes

- Made `name`, `value`, and `key` fields nullable in `IssueTagValueSchema` to match actual API responses
- Added null fallback in handler to display `"(null)"` for null values
- Added test case to verify null value handling

### Root Cause

The Sentry API can return `null` for tag value entries (observed in production with 19 occurrences affecting 14 users). The Zod schema expected strings, causing validation failures.

Fixes MCP-SERVER-EZR