### PR TITLE
feat(tools): add get_issue_external_links tool for Jira/GitHub integration

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -16,6 +16,7 @@ import {
   IssueListSchema,
   IssueSchema,
   IssueTagValuesSchema,
+  ExternalIssueListSchema,
   EventSchema,
   EventAttachmentListSchema,
   ErrorsSearchResponseSchema,
@@ -44,6 +45,7 @@ import type {
   Issue,
   IssueList,
   IssueTagValues,
+  ExternalIssueList,
   OrganizationList,
   Project,
   ProjectList,
@@ -1591,6 +1593,42 @@ export class SentryApiService {
       opts,
     );
     return IssueTagValuesSchema.parse(body);
+  }
+
+  /**
+   * Retrieves external issue links for a specific issue.
+   *
+   * Returns a list of external issue tracking links (e.g., Jira, GitHub Issues)
+   * that are connected to the given Sentry issue.
+   *
+   * @param params - Parameters including organization slug and issue ID
+   * @param opts - Optional request options
+   * @returns Promise resolving to list of external issue links
+   *
+   * @example
+   * ```typescript
+   * const externalIssues = await apiService.getIssueExternalLinks({
+   *   organizationSlug: "my-org",
+   *   issueId: "PROJECT-123",
+   * });
+   * ```
+   */
+  async getIssueExternalLinks(
+    {
+      organizationSlug,
+      issueId,
+    }: {
+      organizationSlug: string;
+      issueId: string;
+    },
+    opts?: RequestOptions,
+  ): Promise<ExternalIssueList> {
+    const body = await this.requestJSON(
+      `/organizations/${organizationSlug}/issues/${issueId}/external-issues/`,
+      undefined,
+      opts,
+    );
+    return ExternalIssueListSchema.parse(body);
   }
 
   async getEventForIssue(

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -694,6 +694,22 @@ export const IssueTagValuesSchema = z.object({
 });
 
 /**
+ * Schema for external issue link (e.g., Jira, GitHub Issues).
+ *
+ * Represents a link between a Sentry issue and an external issue tracking
+ * system like Jira, GitHub Issues, GitLab, etc.
+ */
+export const ExternalIssueSchema = z.object({
+  id: z.string(),
+  issueId: z.string(),
+  serviceType: z.string(),
+  displayName: z.string(),
+  webUrl: z.string(),
+});
+
+export const ExternalIssueListSchema = z.array(ExternalIssueSchema);
+
+/**
  * Schema for Sentry trace metadata response.
  *
  * Contains high-level statistics about a trace including span counts,

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -56,6 +56,8 @@ import type {
   IssueListSchema,
   IssueSchema,
   IssueTagValuesSchema,
+  ExternalIssueSchema,
+  ExternalIssueListSchema,
   OrganizationListSchema,
   OrganizationSchema,
   ProjectListSchema,
@@ -120,3 +122,7 @@ export type Trace = z.infer<typeof TraceSchema>;
 
 // Issue tag values
 export type IssueTagValues = z.infer<typeof IssueTagValuesSchema>;
+
+// External issue links (Jira, GitHub, etc.)
+export type ExternalIssue = z.infer<typeof ExternalIssueSchema>;
+export type ExternalIssueList = z.infer<typeof ExternalIssueListSchema>;

--- a/packages/mcp-core/src/tools/get-issue-external-links.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-external-links.test.ts
@@ -1,0 +1,185 @@
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import getIssueExternalLinks from "./get-issue-external-links";
+import { getServerContext } from "../test-helpers/server";
+
+describe("get-issue-external-links tool", () => {
+  beforeEach(() => {
+    getServerContext().reset();
+  });
+
+  describe("successful calls", () => {
+    it("should fetch external issue links for an issue", async () => {
+      const mockExternalIssues = [
+        {
+          id: "123",
+          issueId: "456",
+          serviceType: "jira",
+          displayName: "AMP-12345",
+          webUrl: "https://amplitude.atlassian.net/browse/AMP-12345",
+        },
+        {
+          id: "124",
+          issueId: "456",
+          serviceType: "github",
+          displayName: "getsentry/sentry#12345",
+          webUrl: "https://github.com/getsentry/sentry/issues/12345",
+        },
+      ];
+
+      const server = getServerContext();
+      server.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/test-org/issues/PROJECT-123/external-issues/",
+          () => {
+            return HttpResponse.json(mockExternalIssues);
+          },
+        ),
+      );
+
+      const result = await getIssueExternalLinks.handler(
+        {
+          organizationSlug: "test-org",
+          issueId: "PROJECT-123",
+          regionUrl: null,
+        },
+        server.context,
+      );
+
+      expect(result).toContain("# External Issue Links for PROJECT-123");
+      expect(result).toContain("Found 2 external issue link(s)");
+      expect(result).toContain("## AMP-12345");
+      expect(result).toContain("**Type**: jira");
+      expect(result).toContain(
+        "https://amplitude.atlassian.net/browse/AMP-12345",
+      );
+      expect(result).toContain("## getsentry/sentry#12345");
+      expect(result).toContain("**Type**: github");
+      expect(result).toContain(
+        "https://github.com/getsentry/sentry/issues/12345",
+      );
+    });
+
+    it("should return message when no external issues are linked", async () => {
+      const server = getServerContext();
+      server.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/test-org/issues/PROJECT-456/external-issues/",
+          () => {
+            return HttpResponse.json([]);
+          },
+        ),
+      );
+
+      const result = await getIssueExternalLinks.handler(
+        {
+          organizationSlug: "test-org",
+          issueId: "PROJECT-456",
+          regionUrl: null,
+        },
+        server.context,
+      );
+
+      expect(result).toContain("# No External Issues Found");
+      expect(result).toContain(
+        "No external issue tracking links (Jira, GitHub, etc.)",
+      );
+      expect(result).toContain("**Issue ID**: PROJECT-456");
+      expect(result).toContain("**Organization**: test-org");
+    });
+  });
+
+  describe("issueUrl parameter", () => {
+    it("should extract organization and issue ID from Sentry URL", async () => {
+      const mockExternalIssues = [
+        {
+          id: "789",
+          issueId: "999",
+          serviceType: "jira",
+          displayName: "DASH-1Q3H",
+          webUrl: "https://amplitude.atlassian.net/browse/DASH-1Q3H",
+        },
+      ];
+
+      const server = getServerContext();
+      server.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/my-org/issues/ISSUE-789/external-issues/",
+          () => {
+            return HttpResponse.json(mockExternalIssues);
+          },
+        ),
+      );
+
+      const result = await getIssueExternalLinks.handler(
+        {
+          issueUrl: "https://my-org.sentry.io/issues/ISSUE-789/",
+          regionUrl: null,
+        },
+        server.context,
+      );
+
+      expect(result).toContain("# External Issue Links for ISSUE-789");
+      expect(result).toContain("## DASH-1Q3H");
+      expect(result).toContain("**Type**: jira");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw error when neither issueId nor issueUrl is provided", async () => {
+      const server = getServerContext();
+
+      await expect(
+        getIssueExternalLinks.handler(
+          {
+            organizationSlug: "test-org",
+            regionUrl: null,
+          },
+          server.context,
+        ),
+      ).rejects.toThrow("Either `issueId` or `issueUrl` must be provided");
+    });
+
+    it("should throw error when organizationSlug is missing with issueId", async () => {
+      const server = getServerContext();
+
+      await expect(
+        getIssueExternalLinks.handler(
+          {
+            issueId: "PROJECT-123",
+            regionUrl: null,
+          },
+          server.context,
+        ),
+      ).rejects.toThrow(
+        "`organizationSlug` is required when providing `issueId`",
+      );
+    });
+
+    it("should handle 404 errors gracefully", async () => {
+      const server = getServerContext();
+      server.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/test-org/issues/NONEXISTENT/external-issues/",
+          () => {
+            return HttpResponse.json(
+              { detail: "The requested resource does not exist" },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(
+        getIssueExternalLinks.handler(
+          {
+            organizationSlug: "test-org",
+            issueId: "NONEXISTENT",
+            regionUrl: null,
+          },
+          server.context,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/mcp-core/src/tools/get-issue-external-links.ts
+++ b/packages/mcp-core/src/tools/get-issue-external-links.ts
@@ -1,0 +1,146 @@
+import { setTag } from "@sentry/core";
+import { defineTool } from "../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../internal/tool-helpers/api";
+import { parseIssueParams } from "../internal/tool-helpers/issue";
+import { enhanceNotFoundError } from "../internal/tool-helpers/enhance-error";
+import { ApiNotFoundError } from "../api-client";
+import type { ServerContext } from "../types";
+import { UserInputError } from "../errors";
+import {
+  ParamOrganizationSlug,
+  ParamRegionUrl,
+  ParamIssueShortId,
+  ParamIssueUrl,
+} from "../schema";
+
+export default defineTool({
+  name: "get_issue_external_links",
+  skills: ["inspect", "triage"], // Available in inspect and triage skills
+  requiredScopes: ["event:read"],
+  description: [
+    "Get external issue links (Jira, GitHub Issues, etc.) for a specific Sentry issue.",
+    "",
+    "USE THIS TOOL WHEN USERS:",
+    "- Want to know if a Jira ticket is linked to a Sentry issue",
+    "- Ask 'is there a Jira for this?', 'what's the Jira ticket?'",
+    "- Need to find GitHub/GitLab issues linked to a Sentry issue",
+    "- Want to see all external issue tracking links",
+    "",
+    "DO NOT USE for:",
+    "- Creating new external issues (not yet implemented)",
+    "- General issue searching (use search_issues)",
+    "",
+    "TRIGGER PATTERNS:",
+    "- 'Is there a Jira for ISSUE-123?' → use get_issue_external_links",
+    "- 'What external issues are linked?' → use get_issue_external_links",
+    "- 'Show me the Jira ticket for this error' → use get_issue_external_links",
+    "",
+    "<examples>",
+    "### With Sentry URL (recommended)",
+    "```",
+    "get_issue_external_links(issueUrl='https://sentry.io/issues/PROJECT-123/')",
+    "```",
+    "",
+    "### With issue ID and organization",
+    "```",
+    "get_issue_external_links(organizationSlug='my-organization', issueId='PROJECT-123')",
+    "```",
+    "</examples>",
+    "",
+    "<hints>",
+    "- **IMPORTANT**: If user provides a Sentry URL, pass the ENTIRE URL to issueUrl parameter unchanged",
+    "- Returns empty array if no external issues are linked",
+    "- Includes serviceType (e.g., 'jira', 'github'), displayName (e.g., 'AMP-12345'), and webUrl",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug.optional(),
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    issueId: ParamIssueShortId.optional(),
+    issueUrl: ParamIssueUrl.optional(),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? undefined,
+    });
+
+    // Validate that we have the minimum required parameters
+    if (!params.issueUrl && !params.issueId) {
+      throw new UserInputError(
+        "Either `issueId` or `issueUrl` must be provided",
+      );
+    }
+
+    if (!params.issueUrl && !params.organizationSlug) {
+      throw new UserInputError(
+        "`organizationSlug` is required when providing `issueId`",
+      );
+    }
+
+    const { organizationSlug: orgSlug, issueId: parsedIssueId } =
+      parseIssueParams({
+        organizationSlug: params.organizationSlug,
+        issueId: params.issueId,
+        issueUrl: params.issueUrl,
+      });
+
+    setTag("organization.slug", orgSlug);
+
+    // Fetch external issue links
+    let externalIssues;
+    try {
+      externalIssues = await apiService.getIssueExternalLinks({
+        organizationSlug: orgSlug,
+        issueId: parsedIssueId!,
+      });
+    } catch (error) {
+      if (error instanceof ApiNotFoundError) {
+        throw enhanceNotFoundError(error, {
+          organizationSlug: orgSlug,
+          issueId: parsedIssueId,
+        });
+      }
+      throw error;
+    }
+
+    // Format the output
+    if (externalIssues.length === 0) {
+      return [
+        `# No External Issues Found`,
+        ``,
+        `No external issue tracking links (Jira, GitHub, etc.) are connected to this Sentry issue.`,
+        ``,
+        `**Issue ID**: ${parsedIssueId}`,
+        `**Organization**: ${orgSlug}`,
+      ].join("\n");
+    }
+
+    const lines = [
+      `# External Issue Links for ${parsedIssueId}`,
+      ``,
+      `Found ${externalIssues.length} external issue link(s) connected to this Sentry issue:`,
+      ``,
+    ];
+
+    for (const issue of externalIssues) {
+      lines.push(`## ${issue.displayName}`);
+      lines.push(``);
+      lines.push(`- **Type**: ${issue.serviceType}`);
+      lines.push(`- **URL**: ${issue.webUrl}`);
+      lines.push(`- **ID**: ${issue.id}`);
+      lines.push(``);
+    }
+
+    lines.push(`---`);
+    lines.push(``);
+    lines.push(
+      `Use these external issue links to track the status in your issue tracking system.`,
+    );
+
+    return lines.join("\n");
+  },
+});

--- a/packages/mcp-core/src/tools/index.ts
+++ b/packages/mcp-core/src/tools/index.ts
@@ -5,6 +5,7 @@ import findProjects from "./find-projects";
 import findReleases from "./find-releases";
 import getIssueDetails from "./get-issue-details";
 import getIssueTagValues from "./get-issue-tag-values";
+import getIssueExternalLinks from "./get-issue-external-links";
 import getTraceDetails from "./get-trace-details";
 import getEventAttachment from "./get-event-attachment";
 import updateIssue from "./update-issue";
@@ -30,6 +31,7 @@ export default {
   find_releases: findReleases,
   get_issue_details: getIssueDetails,
   get_issue_tag_values: getIssueTagValues,
+  get_issue_external_links: getIssueExternalLinks,
   get_trace_details: getTraceDetails,
   get_event_attachment: getEventAttachment,
   update_issue: updateIssue,


### PR DESCRIPTION
## Summary

Adds new MCP tool `get_issue_external_links` to retrieve external issue tracking links (Jira, GitHub Issues, GitLab, etc.) connected to Sentry issues.

### Context

Currently, when analyzing Sentry issues, there's no way to determine if a Jira ticket or other external issue tracker link exists. This makes it difficult to coordinate between error tracking and project management systems.

### Key Changes

- **API Client**: Added `getIssueExternalLinks()` method calling `GET /api/0/organizations/{org}/issues/{id}/external-issues/`
- **Schema**: Added `ExternalIssueSchema` and `ExternalIssueListSchema` for response validation
- **Types**: Added `ExternalIssue` and `ExternalIssueList` type exports
- **New Tool**: Created `get_issue_external_links` tool with full documentation, examples, and hints
- **Tests**: Added comprehensive test coverage for success, error, and URL parameter cases
- **Scopes**: Requires `event:read` permission

### Use Cases

This tool enables users to:
- Check if a Jira ticket exists for a Sentry issue
- Find linked GitHub/GitLab issues
- View all external issue tracking links
- Coordinate between error tracking and project management

### Testing

Added comprehensive unit tests covering:
- Successful retrieval of multiple external issues
- Empty response handling
- URL parameter extraction
- Error validation (missing parameters, 404 errors)

Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>