### PR TITLE
docs: Add sentry-skills plugin config and documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -140,9 +140,14 @@
       "Skill(sentry-skills:find-bugs)",
       "Skill(sentry-skills:deslop)",
       "Skill(sentry-skills:iterate-pr)",
-      "Skill(sentry-skills:claude-settings-audit)"
+      "Skill(sentry-skills:claude-settings-audit)",
+      "Skill(sentry-skills:agents-md)"
     ],
     "deny": []
+  },
+  "enabledPlugins": {
+    "sentry-skills@sentry-skills": true,
+    "pr-review-toolkit@claude-plugins-official": true
   },
   "enableAllProjectMcpServers": true,
   "includeCoAuthoredBy": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,22 @@ pnpm run measure-tokens                   # Check tool definition size
 2. Update relevant docs when changing functionality.
 3. Follow @docs/error-handling.md for error types.
 4. Follow @docs/pr-management.md for commits and PRs.
+
+## Commit Attribution
+
+AI commits MUST include:
+```
+Co-Authored-By: (the agent model's name and attribution byline)
+```
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/commit` | Create commits following Sentry conventions |
+| `/create-pr` | Create pull requests following Sentry conventions |
+| `/code-review` | Review code following Sentry engineering practices |
+| `/find-bugs` | Find bugs and security issues in local changes |
+| `/iterate-pr` | Fix CI failures until all checks pass |
+| `/agents-md` | Maintain agent documentation |
+| `/claude-settings-audit` | Audit settings.json permissions |


### PR DESCRIPTION
Enable sentry-skills and pr-review-toolkit plugins in Claude Code settings
to provide standardized workflows for commits, PRs, code review, and
documentation maintenance.

Changes:
- Add `sentry-skills:agents-md` permission to settings.json
- Add `enabledPlugins` section to explicitly enable sentry-skills and pr-review-toolkit
- Document available skills in AGENTS.md Skills table
- Add Commit Attribution section requiring Co-Authored-By for AI commits

This aligns the repo's Claude Code configuration with the pattern used in
other Sentry projects.