### PR TITLE
meta: Add dex task tracking integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -102,6 +102,7 @@
       "Bash(timeout:*)",
       "Bash(tee:*)",
       "Bash(xargs kill:*)",
+      "Bash(dex:*)",
       "WebFetch(domain:mcp.sentry.dev)",
       "WebFetch(domain:docs.sentry.io)",
       "WebFetch(domain:develop.sentry.dev)",
@@ -134,6 +135,7 @@
       "mcp__spotlight__get_errors",
       "mcp__spotlight__get_local_errors",
       "WebSearch",
+      "Skill(dex:dex)",
       "Skill(sentry-skills:commit)",
       "Skill(sentry-skills:create-pr)",
       "Skill(sentry-skills:code-review)",
@@ -146,6 +148,7 @@
     "deny": []
   },
   "enabledPlugins": {
+    "dex@dex": true,
     "sentry-skills@sentry-skills": true,
     "pr-review-toolkit@claude-plugins-official": true
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ pnpm run tsc && pnpm run lint && pnpm run test
 pnpm run measure-tokens                   # Check tool definition size
 ```
 
+## Task Management
+
+Use `/dex` skill to coordinate complex work. Create tasks with full context, break down into subtasks, complete with detailed results.
+
 ## Workflow
 
 1. Check neighboring files for existing patterns before writing new code.
@@ -81,15 +85,3 @@ AI commits MUST include:
 ```
 Co-Authored-By: (the agent model's name and attribution byline)
 ```
-
-## Skills
-
-| Skill | Purpose |
-|-------|---------|
-| `/commit` | Create commits following Sentry conventions |
-| `/create-pr` | Create pull requests following Sentry conventions |
-| `/code-review` | Review code following Sentry engineering practices |
-| `/find-bugs` | Find bugs and security issues in local changes |
-| `/iterate-pr` | Fix CI failures until all checks pass |
-| `/agents-md` | Maintain agent documentation |
-| `/claude-settings-audit` | Audit settings.json permissions |


### PR DESCRIPTION
Add minimal dex integration for coordinating complex workflows with task tracking.

This enables the `/dex` skill which allows agents to break down complex work into tasks, track progress, and maintain context across sessions. Following the pattern from the dex repo, this adds just the essentials:

- Enabled `dex@dex` plugin in Claude Code settings
- Added bash permission for `dex` CLI commands
- Added Task Management section to AGENTS.md
- Removed redundant Skills reference table (info already in settings.json)

The dex skill will be useful for multi-step features and coordinating work that spans multiple sessions.