### PR TITLE
fix(cloudflare): Use correct Sentry account KV namespace IDs

### DIFF
--- a/packages/mcp-cloudflare/wrangler.canary.jsonc
+++ b/packages/mcp-cloudflare/wrangler.canary.jsonc
@@ -51,7 +51,7 @@
     },
     {
       "binding": "MCP_CACHE",
-      "id": "aa6a2c04faa24a018c456e487712b79f"
+      "id": "963817ecb25c4761a2710d3aedc6478d"
     }
   ],
   "ai": {

--- a/packages/mcp-cloudflare/wrangler.jsonc
+++ b/packages/mcp-cloudflare/wrangler.jsonc
@@ -63,7 +63,7 @@
     },
     {
       "binding": "MCP_CACHE",
-      "id": "2cdd07ef24264437b87f66512fce5c4d"
+      "id": "01b5b45e9f3c4edaa9ef357b4f9949db"
     }
   ],
   "ai": {


### PR DESCRIPTION
The MCP_CACHE KV namespace IDs were created in a personal Cloudflare account instead of the Sentry org account, causing deployment failures.

This updates both production and canary configs with the correct namespace IDs created in the Sentry account.