### PR TITLE
feat(tools): Add hideInExperimentalMode for tool consolidation

### DIFF
--- a/packages/mcp-core/src/tools/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.ts
@@ -30,6 +30,7 @@ export default defineTool({
   name: "get_issue_details",
   skills: ["inspect", "triage", "seer"], // Available in inspect, triage, and seer skills
   requiredScopes: ["event:read"],
+  hideInExperimentalMode: true, // Replaced by get_sentry_resource in experimental mode
   description: [
     "Get detailed information about a specific Sentry issue by ID.",
     "",

--- a/packages/mcp-core/src/tools/get-profile.ts
+++ b/packages/mcp-core/src/tools/get-profile.ts
@@ -64,7 +64,7 @@ export default defineTool({
   skills: ["inspect"],
   requiredScopes: ["event:read"],
   requiredCapabilities: ["profiles"],
-  experimental: true,
+  hideInExperimentalMode: true, // Replaced by get_sentry_resource in experimental mode
 
   description: [
     "Analyze CPU profiling data to identify performance bottlenecks and detect regressions.",

--- a/packages/mcp-core/src/tools/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/get-trace-details.ts
@@ -16,6 +16,7 @@ export default defineTool({
   skills: ["inspect"], // Only available in inspect skill
   requiredScopes: ["event:read"],
   requiredCapabilities: ["traces"],
+  hideInExperimentalMode: true, // Replaced by get_sentry_resource in experimental mode
   description: [
     "Get detailed information about a specific Sentry trace by ID.",
     "",

--- a/packages/mcp-core/src/tools/types.ts
+++ b/packages/mcp-core/src/tools/types.ts
@@ -8,15 +8,57 @@ import type {
   EmbeddedResource,
 } from "@modelcontextprotocol/sdk/types.js";
 
+/**
+ * Context passed to dynamic description functions.
+ * Allows tool descriptions to vary based on server mode.
+ */
+export interface DescriptionContext {
+  experimentalMode: boolean;
+}
+
+/**
+ * Tool description can be a static string or a function that returns
+ * a string based on the server context (e.g., experimental mode).
+ */
+export type ToolDescription =
+  | string
+  | ((context: DescriptionContext) => string);
+
+/**
+ * Resolves a tool description to a string.
+ * Handles both static strings and dynamic description functions.
+ */
+export function resolveDescription(
+  description: ToolDescription,
+  context: DescriptionContext,
+): string {
+  return typeof description === "function" ? description(context) : description;
+}
+
+/**
+ * Determines if a tool should be visible based on experimental mode.
+ * - Tools with `experimental: true` are only visible when experimentalMode is true
+ * - Tools with `hideInExperimentalMode: true` are hidden when experimentalMode is true
+ */
+export function isToolVisibleInMode(
+  tool: { experimental?: boolean; hideInExperimentalMode?: boolean },
+  experimentalMode: boolean,
+): boolean {
+  if (tool.experimental && !experimentalMode) return false;
+  if (tool.hideInExperimentalMode && experimentalMode) return false;
+  return true;
+}
+
 export interface ToolConfig<
   TSchema extends Record<string, z.ZodType> = Record<string, z.ZodType>,
 > {
   name: string;
-  description: string;
+  description: ToolDescription;
   inputSchema: TSchema;
   skills: Skill[]; // Which skill categories this tool belongs to
   requiredScopes: Scope[]; // LEGACY: Which API scopes needed (deprecated, for backward compatibility)
-  experimental?: boolean; // Mark tool as experimental (hidden by default)
+  experimental?: boolean; // Mark tool as experimental (only shown in experimental mode)
+  hideInExperimentalMode?: boolean; // Hide tool when experimental mode is active (for tools replaced by unified tools)
   requiredCapabilities?: (keyof ProjectCapabilities)[]; // Project capabilities required for this tool
   annotations: {
     readOnlyHint?: boolean;

--- a/packages/mcp-core/src/tools/use-sentry/handler.test.ts
+++ b/packages/mcp-core/src/tools/use-sentry/handler.test.ts
@@ -58,9 +58,9 @@ describe("use_sentry handler", () => {
       }),
     });
 
-    // Verify all 21 tools were provided (26 total - use_sentry - 3 list_* tools - 1 experimental)
+    // Verify all 22 tools were provided (27 total - use_sentry - 3 list_* tools - 1 experimental)
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
-    expect(Object.keys(toolsArg)).toHaveLength(21);
+    expect(Object.keys(toolsArg)).toHaveLength(22);
 
     // Verify result is returned
     expect(result).toBe("Agent executed tools successfully");
@@ -107,8 +107,8 @@ describe("use_sentry handler", () => {
     // Verify use_sentry is NOT in the list
     expect(toolNames).not.toContain("use_sentry");
 
-    // Verify we have exactly 21 tools (26 total - use_sentry - 3 list_* tools - 1 experimental)
-    expect(toolNames).toHaveLength(21);
+    // Verify we have exactly 22 tools (27 total - use_sentry - 3 list_* tools - 1 experimental)
+    expect(toolNames).toHaveLength(22);
   });
 
   it("filters find_organizations when organizationSlug constraint is set", async () => {
@@ -134,8 +134,8 @@ describe("use_sentry handler", () => {
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
     expect(toolsArg).toBeDefined();
 
-    // With only org constraint, find_organizations is filtered (21 - 1 = 20)
-    expect(Object.keys(toolsArg)).toHaveLength(20);
+    // With only org constraint, find_organizations is filtered (22 - 1 = 21)
+    expect(Object.keys(toolsArg)).toHaveLength(21);
 
     // Verify find_organizations is filtered but find_projects remains
     expect(toolsArg.find_organizations).toBeUndefined();
@@ -167,8 +167,8 @@ describe("use_sentry handler", () => {
     expect(toolsArg).toBeDefined();
 
     // When both org and project constraints are present,
-    // find_organizations and find_projects are filtered out (21 - 2 = 19)
-    expect(Object.keys(toolsArg)).toHaveLength(19);
+    // find_organizations and find_projects are filtered out (22 - 2 = 20)
+    expect(Object.keys(toolsArg)).toHaveLength(20);
 
     // Verify both find tools are filtered
     expect(toolsArg.find_organizations).toBeUndefined();

--- a/packages/mcp-core/src/tools/use-sentry/handler.ts
+++ b/packages/mcp-core/src/tools/use-sentry/handler.ts
@@ -6,6 +6,7 @@ import type { ServerContext } from "../../types";
 import { useSentryAgent } from "./agent";
 import { buildServer } from "../../server";
 import tools, { SIMPLE_REPLACEMENT_TOOLS } from "../index";
+import { isToolVisibleInMode } from "../types";
 import type { ToolCall } from "../../internal/agents/callEmbeddedAgent";
 
 /**
@@ -94,7 +95,7 @@ export default defineTool({
 
     // Exclude use_sentry (to prevent recursion) and simple replacement tools
     // (since use_sentry only runs when an agent provider is available, list_* tools aren't needed)
-    // Also exclude experimental tools unless experimentalMode is enabled
+    // Also filter by experimental mode visibility
     const toolsToExclude = new Set<string>([
       "use_sentry",
       ...SIMPLE_REPLACEMENT_TOOLS,
@@ -103,7 +104,7 @@ export default defineTool({
       Object.entries(tools).filter(
         ([key, tool]) =>
           !toolsToExclude.has(key) &&
-          (context.experimentalMode || !tool.experimental),
+          isToolVisibleInMode(tool, context.experimentalMode ?? false),
       ),
     );
 

--- a/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
+++ b/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
@@ -8,7 +8,7 @@
 import { z } from "zod";
 import { agentTool } from "../../internal/agents/tools/utils";
 import type { ServerContext } from "../../types";
-import type { ToolConfig } from "../types";
+import { type ToolConfig, resolveDescription } from "../types";
 
 /**
  * Options for wrapping a tool
@@ -74,8 +74,13 @@ export function wrapToolForAgent<TSchema extends Record<string, z.ZodType>>(
   tool: ToolConfig<TSchema>,
   options: WrapToolOptions,
 ) {
+  // Resolve dynamic descriptions based on context
+  const resolved = resolveDescription(tool.description, {
+    experimentalMode: options.context.experimentalMode ?? false,
+  });
+
   return agentTool({
-    description: tool.description,
+    description: resolved,
     parameters: z.object(tool.inputSchema),
     execute: async (params: unknown) => {
       // Type safety: params is validated by agentTool's Zod schema before reaching here


### PR DESCRIPTION
Add `hideInExperimentalMode` property to consolidate resource tools via `get_sentry_resource` in experimental mode.

## Motivation

With the unified `get_sentry_resource` tool now available, we want to reduce tool count in experimental mode by hiding the specialized tools it replaces (`get_issue_details`, `get_trace_details`, `get_profile`). This keeps the specialized tools available in non-experimental mode for backward compatibility while testing the consolidated approach.

## Changes

**New type system additions** (`tools/types.ts`):
- `DescriptionContext` interface for dynamic description functions
- `ToolDescription` type supporting static strings or context-aware functions
- `resolveDescription()` helper to resolve descriptions at registration time
- `isToolVisibleInMode()` helper to centralize visibility logic

**Tool visibility behavior**:
| Mode | Visible Tools |
|------|---------------|
| Non-experimental | `get_issue_details`, `get_trace_details`, `get_profile` |
| Experimental | `get_sentry_resource` only |

**Other changes**:
- Promoted `get_profile` from experimental-only to non-experimental (now visible by default)
- Experimental filtering now applies consistently to all tools, including custom tools passed to `buildServer()`

## Notes

- `get_issue_tag_values` remains separate in both modes (subresource pattern not yet supported)
- Dynamic descriptions are wired up but not yet used by any tools (ready for future use)