### PR TITLE
feat(cloudflare): Add RFC 9728 OAuth protected resource metadata endpoint

### DIFF
--- a/packages/mcp-cloudflare/src/server/app.test.ts
+++ b/packages/mcp-cloudflare/src/server/app.test.ts
@@ -54,4 +54,44 @@ describe("app", () => {
       });
     });
   });
+
+  describe("GET /.well-known/oauth-protected-resource/mcp", () => {
+    it("should return RFC 9728 protected resource metadata", async () => {
+      const res = await app.request(
+        "/.well-known/oauth-protected-resource/mcp",
+        {
+          headers: {
+            "CF-Connecting-IP": "192.0.2.1",
+          },
+        },
+      );
+
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json).toEqual({
+        resource: "http://localhost/mcp",
+        authorization_servers: ["http://localhost"],
+      });
+    });
+
+    it("should return correct URLs for custom host", async () => {
+      const res = await app.request(
+        "https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp",
+        {
+          headers: {
+            "CF-Connecting-IP": "192.0.2.1",
+          },
+        },
+      );
+
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json).toEqual({
+        resource: "https://mcp.sentry.dev/mcp",
+        authorization_servers: ["https://mcp.sentry.dev"],
+      });
+    });
+  });
 });

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -76,6 +76,16 @@ const app = new Hono<{
       endpoint: `${requestUrl.protocol}//${requestUrl.host}/mcp`,
     });
   })
+  // RFC 9728: OAuth 2.0 Protected Resource Metadata
+  // ChatGPT and other clients query this to discover the authorization server
+  .get("/.well-known/oauth-protected-resource/mcp", (c) => {
+    const requestUrl = new URL(c.req.url);
+    const baseUrl = `${requestUrl.protocol}//${requestUrl.host}`;
+    return c.json({
+      resource: `${baseUrl}/mcp`,
+      authorization_servers: [baseUrl],
+    });
+  })
   .route("/oauth", sentryOauth)
   .route("/api/auth", chatOauth)
   .route("/api/chat", chat)


### PR DESCRIPTION
Add `/.well-known/oauth-protected-resource/mcp` endpoint to enable ChatGPT and other OAuth 2.1 clients to discover the authorization server.

ChatGPT's MCP integration requires this endpoint per RFC 9728 (OAuth 2.0 Protected Resource Metadata). The OAuth flow is:

1. Client queries `/.well-known/oauth-protected-resource/mcp` to discover auth server
2. Client queries `/.well-known/oauth-authorization-server` for full OAuth metadata
3. Client registers via DCR and initiates PKCE flow

We already had step 2 (provided by `@cloudflare/workers-oauth-provider`), but step 1 was missing. This adds the missing endpoint which returns:

```json
{
  "resource": "https://mcp.sentry.dev/mcp",
  "authorization_servers": ["https://mcp.sentry.dev"]
}
```

The path `/mcp` is appended after `/.well-known/oauth-protected-resource` per RFC 9728 Section 3, which specifies that the well-known string is inserted between the host and path components of the resource identifier.

Refs #742