### PR TITLE
fix(agents): Add user-friendly error for OpenAI region restrictions

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -25,9 +25,12 @@ ApiError (base class)
 ### Application Error Classes (from errors.ts)
 
 - `UserInputError` - User-facing error for validation failures
-  - Parameter validation failures  
+  - Parameter validation failures
   - Any user-correctable error
 - `ConfigurationError` - Missing/invalid configuration
+- `LLMProviderError` - LLM provider availability issues (e.g., region restrictions)
+  - OpenAI rejecting requests from unsupported regions
+  - Provider service availability issues that cannot be resolved by retrying
 
 ### Error Categories
 
@@ -35,9 +38,10 @@ ApiError (base class)
 - All `ApiClientError` subclasses
 - `UserInputError`
 - `ConfigurationError`
+- `LLMProviderError`
 
 **System Errors (Should be captured by Sentry):**
-- `ApiServerError` 
+- `ApiServerError`
 - Network failures
 - Unexpected runtime errors
 
@@ -309,8 +313,10 @@ When using Cloudflare Workers with Sentry integration:
 ### Error Message Formats:
 
 - **UserInputError to Agent:** `{ error: "Input Error: {message}. You may be able to resolve this by addressing the concern and trying again." }`
+- **LLMProviderError to Agent:** `{ error: "AI Provider Error: {message}. This is a service availability issue that cannot be resolved by retrying." }`
 - **ApiClientError to Agent:** `{ error: "Input Error: {toUserMessage()}. You may be able to resolve this by addressing the concern and trying again." }`
 - **ApiServerError to Agent:** `{ error: "Server Error (5xx): {message}. Event ID: {eventId}. This is a system error that cannot be resolved by retrying." }`
+- **LLMProviderError to MCP User:** Formatted with "**AI Provider Error**" header
 - **ApiClientError to MCP User:** Formatted with "**Input Error**" header and toUserMessage()
 - **ApiServerError to MCP User:** Formatted with "**Error**" header + Event ID (logged to Sentry)
 

--- a/packages/mcp-core/src/errors.test.ts
+++ b/packages/mcp-core/src/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { UserInputError, ConfigurationError } from "./errors";
+import { UserInputError, ConfigurationError, LLMProviderError } from "./errors";
 
 describe("UserInputError", () => {
   it("should create a UserInputError with the correct message and name", () => {
@@ -54,6 +54,37 @@ describe("ConfigurationError", () => {
     const error = new ConfigurationError("Unable to connect to server", {
       cause,
     });
+
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("LLMProviderError", () => {
+  it("should create an LLMProviderError with the correct message and name", () => {
+    const message = "Region not supported";
+    const error = new LLMProviderError(message);
+
+    expect(error.message).toBe(message);
+    expect(error.name).toBe("LLMProviderError");
+    expect(error instanceof Error).toBe(true);
+    expect(error instanceof LLMProviderError).toBe(true);
+  });
+
+  it("should be distinguishable from other error types", () => {
+    const llmError = new LLMProviderError("LLM provider error");
+    const configError = new ConfigurationError("Config error");
+    const userInputError = new UserInputError("User input error");
+    const regularError = new Error("Regular error");
+
+    expect(llmError instanceof LLMProviderError).toBe(true);
+    expect(configError instanceof LLMProviderError).toBe(false);
+    expect(userInputError instanceof LLMProviderError).toBe(false);
+    expect(regularError instanceof LLMProviderError).toBe(false);
+  });
+
+  it("should support error cause", () => {
+    const cause = new Error("OpenAI API rejected the request");
+    const error = new LLMProviderError("Region not supported", { cause });
 
     expect(error.cause).toBe(cause);
   });

--- a/packages/mcp-core/src/errors.ts
+++ b/packages/mcp-core/src/errors.ts
@@ -20,3 +20,15 @@ export class ConfigurationError extends Error {
     this.name = "ConfigurationError";
   }
 }
+
+/**
+ * Error thrown when an LLM provider (OpenAI, Anthropic, etc.) rejects a request
+ * due to service availability issues like region restrictions.
+ * These errors should be returned to the user directly without logging to Sentry.
+ */
+export class LLMProviderError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LLMProviderError";
+  }
+}

--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateText, APICallError } from "ai";
+import { z } from "zod";
+import { callEmbeddedAgent } from "./callEmbeddedAgent";
+import { LLMProviderError } from "../../errors";
+
+// Mock the AI SDK
+vi.mock("@ai-sdk/openai", () => {
+  const mockModel = vi.fn(() => "mocked-model");
+  return {
+    openai: mockModel,
+    createOpenAI: vi.fn(() => mockModel),
+  };
+});
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: vi.fn(),
+    Output: { object: vi.fn(() => ({})) },
+  };
+});
+
+describe("callEmbeddedAgent", () => {
+  const mockGenerateText = vi.mocked(generateText);
+  const testSchema = z.object({
+    result: z.string(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENAI_API_KEY = "test-key";
+  });
+
+  it("throws LLMProviderError for OpenAI region restriction", async () => {
+    // Create an APICallError simulating OpenAI's region restriction
+    const regionError = new APICallError({
+      message: "Country, region, or territory not supported",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 403,
+      isRetryable: false,
+    });
+
+    mockGenerateText.mockRejectedValue(regionError);
+
+    await expect(
+      callEmbeddedAgent({
+        system: "You are a test agent",
+        prompt: "Test prompt",
+        tools: {},
+        schema: testSchema,
+      }),
+    ).rejects.toThrow(LLMProviderError);
+
+    await expect(
+      callEmbeddedAgent({
+        system: "You are a test agent",
+        prompt: "Test prompt",
+        tools: {},
+        schema: testSchema,
+      }),
+    ).rejects.toThrow(
+      /does not support requests from your region.*contact support/,
+    );
+  });
+
+  it("re-throws other APICallErrors unchanged", async () => {
+    // Create an APICallError for a different error (e.g., rate limit)
+    const rateLimitError = new APICallError({
+      message: "Rate limit exceeded",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 429,
+      isRetryable: true,
+    });
+
+    mockGenerateText.mockRejectedValue(rateLimitError);
+
+    await expect(
+      callEmbeddedAgent({
+        system: "You are a test agent",
+        prompt: "Test prompt",
+        tools: {},
+        schema: testSchema,
+      }),
+    ).rejects.toThrow(APICallError);
+
+    await expect(
+      callEmbeddedAgent({
+        system: "You are a test agent",
+        prompt: "Test prompt",
+        tools: {},
+        schema: testSchema,
+      }),
+    ).rejects.toThrow("Rate limit exceeded");
+  });
+
+  it("re-throws non-APICallError errors unchanged", async () => {
+    const genericError = new Error("Something went wrong");
+
+    mockGenerateText.mockRejectedValue(genericError);
+
+    await expect(
+      callEmbeddedAgent({
+        system: "You are a test agent",
+        prompt: "Test prompt",
+        tools: {},
+        schema: testSchema,
+      }),
+    ).rejects.toThrow("Something went wrong");
+  });
+});

--- a/packages/mcp-core/src/internal/error-handling.ts
+++ b/packages/mcp-core/src/internal/error-handling.ts
@@ -1,4 +1,8 @@
-import { UserInputError, ConfigurationError } from "../errors";
+import {
+  UserInputError,
+  ConfigurationError,
+  LLMProviderError,
+} from "../errors";
 import { ApiError, ApiClientError, ApiServerError } from "../api-client";
 import { logIssue } from "../telem/logging";
 
@@ -16,6 +20,13 @@ export function isConfigurationError(
   error: unknown,
 ): error is ConfigurationError {
   return error instanceof ConfigurationError;
+}
+
+/**
+ * Type guard to identify LLM provider errors.
+ */
+export function isLLMProviderError(error: unknown): error is LLMProviderError {
+  return error instanceof LLMProviderError;
 }
 
 /**
@@ -62,6 +73,15 @@ export async function formatErrorForUser(error: unknown): Promise<string> {
       "There appears to be a configuration issue with your setup.",
       error.message,
       `Please check your environment configuration and try again.`,
+    ].join("\n\n");
+  }
+
+  if (isLLMProviderError(error)) {
+    return [
+      "**AI Provider Error**",
+      "The AI provider service is not available for this request.",
+      error.message,
+      `This is a service availability issue that cannot be resolved by retrying.`,
     ].join("\n\n");
   }
 

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -360,10 +360,11 @@ function configureServer({
           // NOT thrown as exceptions. This ensures consistent error handling
           // and prevents the MCP client from receiving raw error objects.
           //
-          // The logAndFormatError function provides user-friendly error messages
+          // The formatErrorForUser function provides user-friendly error messages
           // with appropriate formatting for different error types:
           // - UserInputError: Clear guidance for fixing input problems
           // - ConfigurationError: Clear guidance for fixing configuration issues
+          // - LLMProviderError: Clear messaging for AI provider availability issues
           // - ApiError: HTTP status context with helpful messaging
           // - System errors: Sentry event IDs for debugging
           //


### PR DESCRIPTION
Add user-friendly error handling for OpenAI region restrictions

When users connect from regions not supported by OpenAI (e.g., Vietnam, 
Iran, etc.), the embedded agent calls fail with a cryptic `AI_APICallError: 
Country, region, or territory not supported` error. This change catches 
that specific error and provides a clear, actionable message explaining 
the limitation.

The new `LLMProviderError` class is treated like `ConfigurationError` - 
it's returned to users without creating Sentry issues, since this is an 
expected service limitation rather than a bug.

Error flow:
- `callEmbeddedAgent` catches OpenAI's region restriction error
- Throws `LLMProviderError` with clear messaging
- `formatErrorForUser` formats it with "AI Provider Error" header
- `agentTool` wrapper also handles it for nested agent calls

Users now see:
```
**AI Provider Error**

The AI provider service is not available for this request.

The AI provider (OpenAI) does not support requests from your region.
This is a restriction imposed by OpenAI on certain countries and territories.
Please contact support if you believe this is an error.

This is a service availability issue that cannot be resolved by retrying.
```

Fixes MCP-SERVER-F02
Fixes #749