### PR TITLE
fix(cloudflare): Update CSRF config for hono 4.11.x compatibility

### DIFF
--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -43,11 +43,13 @@ const app = new Hono<{
     "*",
     csrf({
       origin: (origin, c) => {
-        if (!origin) {
-          return true;
-        }
+        // In hono 4.11.x+, this handler is only called when origin is defined
         const requestUrl = new URL(c.req.url);
         return origin === requestUrl.origin;
+      },
+      secFetchSite: (secFetchSite) => {
+        // Allow same-origin and same-site requests (handles requests without Origin header)
+        return secFetchSite === "same-origin" || secFetchSite === "same-site";
       },
     }),
   )


### PR DESCRIPTION
## Summary

Fixes CSRF validation failures that have been occurring since the hono 4.10.3 → 4.11.4 upgrade (PR #714, Jan 14th).

In hono 4.11.x, the CSRF middleware changed to always deny requests with missing `Origin` or `Sec-Fetch-Site` headers **before** calling custom handlers. Our previous config had `if (!origin) return true` to allow requests without Origin headers, but that code path was never reached.

**Root cause**: ~26k errors affecting 348 users since Jan 14th across:
- `/oauth/authorize` (5,878 errors)
- `/token` (5,288 errors)
- `/api/auth/logout` (1,069 errors)
- `/api/chat` (937 errors)

## Changes

- Add `secFetchSite` handler to allow `same-origin` and `same-site` requests
- Remove dead code (`if (!origin) return true`)

## Test plan

- [x] `pnpm run tsc` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (628 tests)
- [ ] Deploy and verify CSRF errors stop in Sentry (MCP-SERVER-F01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)