### PR TITLE
chore: Upgrade @modelcontextprotocol/sdk to ^1.25.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20251014.0
       version: 4.20251014.0
     '@modelcontextprotocol/sdk':
-      specifier: ^1.21.0
-      version: 1.22.0
+      specifier: ^1.25.3
+      version: 1.25.3
     '@radix-ui/react-accordion':
       specifier: ^1.2.11
       version: 1.2.11
@@ -227,7 +227,7 @@ importers:
         version: 0.0.12
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)
+        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       '@radix-ui/react-accordion':
         specifier: 'catalog:'
         version: 1.2.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -242,7 +242,7 @@ importers:
         version: 10.35.0(react@19.1.0)
       agents:
         specifier: 'catalog:'
-        version: 0.2.23(@cloudflare/workers-types@4.20251014.0)(react@19.1.0)(typescript@5.8.3)
+        version: 0.2.23(@cloudflare/workers-types@4.20251014.0)(hono@4.11.4)(react@19.1.0)(typescript@5.8.3)
       ai:
         specifier: 'catalog:'
         version: 4.3.16(react@19.1.0)(zod@3.25.76)
@@ -290,7 +290,7 @@ importers:
         version: 1.3.5
       workers-mcp:
         specifier: 'catalog:'
-        version: 0.1.0-3(@cfworker/json-schema@4.1.1)
+        version: 0.1.0-3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -363,7 +363,7 @@ importers:
         version: 1.1.1(@logtape/logtape@1.1.1)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)
+        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       '@sentry/core':
         specifier: 'catalog:'
         version: 10.35.0
@@ -400,7 +400,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)
+        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       '@sentry/core':
         specifier: 'catalog:'
         version: 10.35.0
@@ -446,7 +446,7 @@ importers:
         version: 1.3.22(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)
+        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       '@sentry/mcp-core':
         specifier: workspace:*
         version: link:../mcp-core
@@ -503,7 +503,7 @@ importers:
         version: 1.3.22(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)
+        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       '@sentry/core':
         specifier: 'catalog:'
         version: 10.35.0
@@ -1200,6 +1200,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1379,11 +1385,12 @@ packages:
     peerDependencies:
       '@logtape/logtape': ^1.1.1
 
-  '@modelcontextprotocol/sdk@1.22.0':
-    resolution: {integrity: sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==}
+  '@modelcontextprotocol/sdk@1.25.3':
+    resolution: {integrity: sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -3285,6 +3292,9 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -3330,6 +3340,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5457,6 +5470,10 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
+  '@hono/node-server@1.19.9(hono@4.11.4)':
+    dependencies:
+      hono: 4.11.4
+
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
@@ -5632,8 +5649,9 @@ snapshots:
       '@logtape/logtape': 1.1.1
       '@sentry/core': 9.34.0
 
-  '@modelcontextprotocol/sdk@1.22.0(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)':
     dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.4)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -5643,6 +5661,8 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
       zod: 3.25.76
@@ -5650,6 +5670,7 @@ snapshots:
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
+      - hono
       - supports-color
 
   '@mswjs/interceptors@0.39.2':
@@ -6678,11 +6699,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agents@0.2.23(@cloudflare/workers-types@4.20251014.0)(react@19.1.0)(typescript@5.8.3):
+  agents@0.2.23(@cloudflare/workers-types@4.20251014.0)(hono@4.11.4)(react@19.1.0)(typescript@5.8.3):
     dependencies:
       '@ai-sdk/openai': 2.0.64(zod@3.25.76)
       '@cfworker/json-schema': 4.1.1
-      '@modelcontextprotocol/sdk': 1.22.0(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       ai: 5.0.89(zod@3.25.76)
       cron-schedule: 5.0.4
       json-schema: 0.4.0
@@ -6697,6 +6718,7 @@ snapshots:
       zod-to-ts: 2.0.0(typescript@5.8.3)(zod@3.25.76)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
+      - hono
       - supports-color
       - typescript
 
@@ -7580,6 +7602,8 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  jose@6.1.3: {}
+
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
@@ -7639,6 +7663,8 @@ snapshots:
       tinyglobby: 0.2.15
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -9478,10 +9504,10 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20251011.0
       '@cloudflare/workerd-windows-64': 1.20251011.0
 
-  workers-mcp@0.1.0-3(@cfworker/json-schema@4.1.1):
+  workers-mcp@0.1.0-3(@cfworker/json-schema@4.1.1)(zod@3.25.76):
     dependencies:
       '@clack/prompts': 0.8.2
-      '@modelcontextprotocol/sdk': 1.22.0(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.4.1
       fs-extra: 11.3.0
@@ -9497,6 +9523,7 @@ snapshots:
       - '@75lb/nature'
       - '@cfworker/json-schema'
       - supports-color
+      - zod
 
   wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@cloudflare/vitest-pool-workers": ^0.8.47
   "@cloudflare/workers-oauth-provider": ^0.0.12
   "@cloudflare/workers-types": ^4.20251014.0
-  "@modelcontextprotocol/sdk": ^1.21.0
+  "@modelcontextprotocol/sdk": ^1.25.3
   "@radix-ui/react-accordion": ^1.2.11
   "@radix-ui/react-slot": ^1.2.3
   "@sentry/cloudflare": 10.35.0


### PR DESCRIPTION
## Summary
- Upgrades `@modelcontextprotocol/sdk` from `^1.21.0` to `^1.25.3`
- Part of investigation into #756 - retrying the SDK upgrade with diagnostic logging in place from #758
- All 628 tests pass locally

## Changes
This is a minimal upgrade that only bumps the MCP SDK version. The `agents` package remains at `0.2.23` to avoid requiring the AI SDK v6 upgrade that `agents` 0.3.x requires.

## Key SDK changes (1.21.0 → 1.25.3)
Notable changes from the [changelog](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/CHANGELOG.md):
- **v1.25.0**: SPEC COMPLIANCE - Remove loose/passthrough types not allowed/defined by MCP spec
- Various bug fixes and improvements

## Risk Assessment
- **Low risk** - Tests pass, no API changes affecting our usage
- Diagnostic logging from #758 will capture any runtime issues with `grantedSkills`

## Test plan
- [x] All unit tests pass (628 tests)
- [x] Type checking passes
- [ ] Deploy to staging and verify MCP connections work
- [ ] Monitor Sentry logs for any 400 errors with empty grantedSkills

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)