### PR TITLE
Revert MCP SDK upgrade to fix protocol version mismatch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^4.20251014.0
       version: 4.20251014.0
     '@modelcontextprotocol/sdk':
-      specifier: ^1.25.3
-      version: 1.25.3
+      specifier: ^1.21.0
+      version: 1.22.0
     '@radix-ui/react-accordion':
       specifier: ^1.2.11
       version: 1.2.11
@@ -227,7 +227,7 @@ importers:
         version: 0.0.12
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)
       '@radix-ui/react-accordion':
         specifier: 'catalog:'
         version: 1.2.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -242,7 +242,7 @@ importers:
         version: 10.35.0(react@19.1.0)
       agents:
         specifier: 'catalog:'
-        version: 0.2.23(@cloudflare/workers-types@4.20251014.0)(hono@4.11.4)(react@19.1.0)(typescript@5.8.3)
+        version: 0.2.23(@cloudflare/workers-types@4.20251014.0)(react@19.1.0)(typescript@5.8.3)
       ai:
         specifier: 'catalog:'
         version: 4.3.16(react@19.1.0)(zod@3.25.76)
@@ -290,7 +290,7 @@ importers:
         version: 1.3.5
       workers-mcp:
         specifier: 'catalog:'
-        version: 0.1.0-3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.1.0-3(@cfworker/json-schema@4.1.1)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -363,7 +363,7 @@ importers:
         version: 1.1.1(@logtape/logtape@1.1.1)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)
       '@sentry/core':
         specifier: 'catalog:'
         version: 10.35.0
@@ -400,7 +400,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)
       '@sentry/core':
         specifier: 'catalog:'
         version: 10.35.0
@@ -446,7 +446,7 @@ importers:
         version: 1.3.22(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)
       '@sentry/mcp-core':
         specifier: workspace:*
         version: link:../mcp-core
@@ -503,7 +503,7 @@ importers:
         version: 1.3.22(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)
       '@sentry/core':
         specifier: 'catalog:'
         version: 10.35.0
@@ -1200,12 +1200,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1385,12 +1379,11 @@ packages:
     peerDependencies:
       '@logtape/logtape': ^1.1.1
 
-  '@modelcontextprotocol/sdk@1.25.3':
-    resolution: {integrity: sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==}
+  '@modelcontextprotocol/sdk@1.22.0':
+    resolution: {integrity: sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -3292,9 +3285,6 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -3340,9 +3330,6 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5470,10 +5457,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@hono/node-server@1.19.9(hono@4.11.4)':
-    dependencies:
-      hono: 4.11.4
-
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
@@ -5649,9 +5632,8 @@ snapshots:
       '@logtape/logtape': 1.1.1
       '@sentry/core': 9.34.0
 
-  '@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.22.0(@cfworker/json-schema@4.1.1)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.4)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -5661,8 +5643,6 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
       zod: 3.25.76
@@ -5670,7 +5650,6 @@ snapshots:
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
-      - hono
       - supports-color
 
   '@mswjs/interceptors@0.39.2':
@@ -6699,11 +6678,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agents@0.2.23(@cloudflare/workers-types@4.20251014.0)(hono@4.11.4)(react@19.1.0)(typescript@5.8.3):
+  agents@0.2.23(@cloudflare/workers-types@4.20251014.0)(react@19.1.0)(typescript@5.8.3):
     dependencies:
       '@ai-sdk/openai': 2.0.64(zod@3.25.76)
       '@cfworker/json-schema': 4.1.1
-      '@modelcontextprotocol/sdk': 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.22.0(@cfworker/json-schema@4.1.1)
       ai: 5.0.89(zod@3.25.76)
       cron-schedule: 5.0.4
       json-schema: 0.4.0
@@ -6718,7 +6697,6 @@ snapshots:
       zod-to-ts: 2.0.0(typescript@5.8.3)(zod@3.25.76)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
-      - hono
       - supports-color
       - typescript
 
@@ -7602,8 +7580,6 @@ snapshots:
 
   jiti@2.4.2: {}
 
-  jose@6.1.3: {}
-
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
@@ -7663,8 +7639,6 @@ snapshots:
       tinyglobby: 0.2.15
 
   json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -9504,10 +9478,10 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20251011.0
       '@cloudflare/workerd-windows-64': 1.20251011.0
 
-  workers-mcp@0.1.0-3(@cfworker/json-schema@4.1.1)(zod@3.25.76):
+  workers-mcp@0.1.0-3(@cfworker/json-schema@4.1.1):
     dependencies:
       '@clack/prompts': 0.8.2
-      '@modelcontextprotocol/sdk': 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.22.0(@cfworker/json-schema@4.1.1)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.4.1
       fs-extra: 11.3.0
@@ -9523,7 +9497,6 @@ snapshots:
       - '@75lb/nature'
       - '@cfworker/json-schema'
       - supports-color
-      - zod
 
   wrangler@4.45.0(@cloudflare/workers-types@4.20251014.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@cloudflare/vitest-pool-workers": ^0.8.47
   "@cloudflare/workers-oauth-provider": ^0.0.12
   "@cloudflare/workers-types": ^4.20251014.0
-  "@modelcontextprotocol/sdk": ^1.25.3
+  "@modelcontextprotocol/sdk": ^1.21.0
   "@radix-ui/react-accordion": ^1.2.11
   "@radix-ui/react-slot": ^1.2.3
   "@sentry/cloudflare": 10.35.0


### PR DESCRIPTION
## Summary
Reverts #759 to restore MCP server functionality.

## Problem
The MCP SDK upgrade caused a **protocol version mismatch**:
- Claude Code sends: `MCP-Protocol-Version: 2025-11-25`
- Our server (via `agents@0.2.23`) only supports: `2025-03-26, 2025-06-18`

The SDK upgrade alone doesn't help because protocol version support comes from the `agents` package, not the MCP SDK.

## Root Cause
Supporting protocol `2025-11-25` requires:
- `agents@0.3.5+` (uses MCP SDK 1.25.2 with the newer protocol)
- `ai@6.x` (required by agents 0.3.x)
- This is a significant migration with breaking changes

## Next Steps
- AI SDK 6 migration tracked separately in #756
- This revert restores service for users on older Claude Code versions

Fixes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)