### PR TITLE
fix(cloudflare): Set KV lock TTL to 60s minimum required by Cloudflare

### DIFF
--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -219,7 +219,7 @@ describe("tokenExchangeCallback", () => {
     expect(mockKV.put).toHaveBeenCalledWith(
       "refresh-lock:user-id",
       expect.any(String),
-      expect.objectContaining({ expirationTtl: 30 }),
+      expect.objectContaining({ expirationTtl: 60 }),
     );
     expect(mockKV.delete).toHaveBeenCalledWith("refresh-lock:user-id");
   });

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -217,7 +217,8 @@ export async function refreshAccessToken({
 // with the same refresh token, the first wins and the second gets
 // invalid_grant. The lock + result cache ensures only one isolate refreshes
 // per user; others wait and reuse the cached result.
-const LOCK_TTL_SECONDS = 30;
+// NOTE: Cloudflare KV requires expirationTtl >= 60 seconds.
+const LOCK_TTL_SECONDS = 60;
 const RESULT_TTL_SECONDS = 60;
 const LOCK_WAIT_MS = 2000;
 


### PR DESCRIPTION
## Summary
- Cloudflare KV requires `expirationTtl` >= 60 seconds, but the OAuth refresh lock TTL was set to 30s
- Every OAuth token refresh was failing with `KV PUT failed: 400 Invalid expiration_ttl of 30`
- 332 occurrences affecting 42 users since the lock was introduced in #778

## Changes
- Bumped `LOCK_TTL_SECONDS` from 30 to 60
- Added comment documenting the Cloudflare KV minimum
- Updated test assertion

Fixes MCP-SERVER-F2H

## Test plan
- [x] Existing tests pass with updated TTL value
- [ ] Deploy and verify OAuth token refreshes succeed in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)