### PR TITLE
fix(cloudflare): Add resource_metadata to OAuth 401 response

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -91,8 +91,10 @@ const wrappedOAuthProvider = {
         const resourceMetadataUrl = `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
         const existingAuth =
           headers["WWW-Authenticate"] ?? headers["www-authenticate"] ?? "";
-        const newAuth = existingAuth
-          ? `resource_metadata="${resourceMetadataUrl}", ${existingAuth}`
+        // RFC 7235: challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]
+        // resource_metadata must appear as a param within the Bearer challenge
+        const newAuth = existingAuth.startsWith("Bearer ")
+          ? `Bearer resource_metadata="${resourceMetadataUrl}", ${existingAuth.slice("Bearer ".length)}`
           : `Bearer resource_metadata="${resourceMetadataUrl}"`;
         return new Response(
           JSON.stringify({ error: code, error_description: description }),


### PR DESCRIPTION
## Summary

- Adds `resource_metadata` parameter to the `WWW-Authenticate` header in 401 responses per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728), giving MCP clients a direct pointer to the OAuth protected resource metadata endpoint
- Eliminates one discovery round-trip for clients that use the `resource_metadata` hint
- URL is constructed dynamically to support `/mcp`, `/mcp/:org`, and `/mcp/:org/:project` paths

Refs #780

## Context

Cursor IDE fails to complete the MCP OAuth flow — the root cause is a Cursor client bug (it doesn't wait for the browser callback). While this change won't fix Cursor, it makes our 401 response spec-compliant and may help better-behaved clients.

## Test plan

- [x] `pnpm run tsc && pnpm run lint && pnpm run test` passes
- [ ] `curl -s -D - https://mcp.sentry.dev/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"initialize","id":1}'` — verify `WWW-Authenticate` header includes `resource_metadata`
- [ ] Authenticated requests still work: `pnpm -w run cli "who am I?"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)