### PR TITLE
feat: Auto-calculate release version from semver bump type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
           version: ${{ steps.version.outputs.version }}
-          force: ${{ inputs.force }}
+          force: ${{ inputs.force && 'true' || '' }}


### PR DESCRIPTION
Replace the free-text version input in the release workflow with a
patch/minor/major dropdown. The workflow now reads the current version
from `packages/mcp-server/package.json` and computes the next version
automatically using `npx semver`, matching the pattern used in
[warden](https://github.com/getsentry/warden).

This eliminates a class of human error (typos, forgetting the current
version, picking the wrong next number) and makes releasing a one-click
operation.