### PR TITLE
feat(telem): Tag events with agent and experimental mode

### DIFF
--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -309,6 +309,8 @@ function configureServer({
         if (context.clientId) {
           setTag("client.id", context.clientId);
         }
+        setTag("mode.agent", agentMode);
+        setTag("mode.experimental", experimentalMode);
 
         try {
           // Apply constraints as parameters, handling aliases (e.g., projectSlug → projectSlugOrId)


### PR DESCRIPTION
Add `mode.agent` and `mode.experimental` Sentry tags to all tool call events so we can filter and segment telemetry by server mode.

Previously we only tagged `client.id` and `user.id` globally. The agent and experimental mode flags were used for tool filtering but never propagated to Sentry, making it hard to distinguish event sources.