### PR TITLE
fix(oauth): RFC 9728 compliance for protected resource metadata

### DIFF
--- a/packages/mcp-cloudflare/src/server/app.test.ts
+++ b/packages/mcp-cloudflare/src/server/app.test.ts
@@ -14,7 +14,14 @@ describe("app", () => {
 
       const text = await res.text();
       expect(text).toBe(
-        ["User-agent: *", "Allow: /$", "Disallow: /"].join("\n"),
+        [
+          "User-agent: *",
+          "Allow: /$",
+          "Allow: /.well-known/",
+          "Allow: /mcp.json",
+          "Allow: /llms.txt",
+          "Disallow: /",
+        ].join("\n"),
       );
     });
   });
@@ -51,6 +58,27 @@ describe("app", () => {
         message:
           "The SSE transport endpoint is no longer supported. Please use the HTTP transport at /mcp instead.",
         migrationGuide: "https://mcp.sentry.dev",
+      });
+    });
+  });
+
+  describe("GET /.well-known/oauth-protected-resource", () => {
+    it("should return RFC 9728 protected resource metadata for root", async () => {
+      const res = await app.request(
+        "https://mcp.sentry.dev/.well-known/oauth-protected-resource",
+        {
+          headers: {
+            "CF-Connecting-IP": "192.0.2.1",
+          },
+        },
+      );
+
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json).toEqual({
+        resource: "https://mcp.sentry.dev",
+        authorization_servers: ["https://mcp.sentry.dev"],
       });
     });
   });

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -68,7 +68,16 @@ const app = new Hono<{
     }),
   )
   .get("/robots.txt", (c) => {
-    return c.text(["User-agent: *", "Allow: /$", "Disallow: /"].join("\n"));
+    return c.text(
+      [
+        "User-agent: *",
+        "Allow: /$",
+        "Allow: /.well-known/",
+        "Allow: /mcp.json",
+        "Allow: /llms.txt",
+        "Disallow: /",
+      ].join("\n"),
+    );
   })
   .get("/llms.txt", (c) => {
     return c.text(
@@ -94,6 +103,11 @@ const app = new Hono<{
   })
   // RFC 9728: OAuth 2.0 Protected Resource Metadata
   // ChatGPT and other clients query this to discover the authorization server
+  // Root endpoint for clients that try /.well-known/oauth-protected-resource first
+  .get(
+    "/.well-known/oauth-protected-resource",
+    handleOAuthProtectedResourceMetadata,
+  )
   // Handles both /mcp and /mcp/* paths (e.g., /mcp/sentry/mcp-server)
   .get(
     "/.well-known/oauth-protected-resource/mcp",


### PR DESCRIPTION
Fix three RFC 9728 compliance gaps identified by [authprobe](https://github.com/authprobe/authprobe) scanning \`https://mcp.sentry.dev/mcp\` ([comment](https://github.com/getsentry/sentry-mcp/issues/780#issuecomment-3880284413)):

**Root PRM endpoint returns 404** — `/.well-known/oauth-protected-resource` had no route; only the path-specific `/mcp` variant existed. Clients that try root discovery first (before falling back to path-specific) would fail. Added the root route using the existing handler, which correctly produces `resource: "https://host"` for the empty path.

**Missing `resource_metadata` in WWW-Authenticate** — 401 responses from `/mcp` routes lacked the `resource_metadata` parameter required by RFC 9728 §3.1, preventing dynamic PRM discovery. Now intercepts 401 responses and appends `resource_metadata="<prm-url>"` to the existing `WWW-Authenticate` header, following the same response-interception pattern used for CORS headers.

**robots.txt blocks discovery endpoints** — The existing rules (`Allow: /$`, `Disallow: /`) blocked everything except the exact homepage, including `/.well-known/` paths that crawlers and OAuth clients need. Updated to explicitly allow `/.well-known/`, `/mcp.json`, and `/llms.txt`.

Fixes https://github.com/getsentry/sentry-mcp/issues/780