### PR TITLE
feat: Add Cursor plugin alongside Claude Code plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "sentry-mcp",
+  "owner": { "name": "Sentry", "email": "oss@sentry.io" },
+  "plugins": [
+    {
+      "name": "sentry",
+      "description": "Sentry error tracking and performance monitoring - search issues, analyze errors, explore traces, and get AI-powered root cause analysis",
+      "author": { "name": "Sentry" },
+      "source": "./plugins/sentry-mcp",
+      "category": "monitoring"
+    },
+    {
+      "name": "sentry-experimental",
+      "description": "Sentry MCP with experimental features enabled - includes all stable tools plus bleeding-edge capabilities",
+      "author": { "name": "Sentry" },
+      "source": "./plugins/sentry-mcp-experimental",
+      "category": "monitoring"
+    }
+  ]
+}

--- a/plugins/sentry-mcp-experimental/.cursor-plugin/plugin.json
+++ b/plugins/sentry-mcp-experimental/.cursor-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "sentry-experimental",
+  "description": "Sentry MCP with experimental features enabled",
+  "author": { "name": "Sentry" }
+}

--- a/plugins/sentry-mcp-experimental/mcp.json
+++ b/plugins/sentry-mcp-experimental/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp?experimental=1"
+    }
+  }
+}

--- a/plugins/sentry-mcp/.cursor-plugin/plugin.json
+++ b/plugins/sentry-mcp/.cursor-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "sentry",
+  "description": "Sentry error tracking and performance monitoring via MCP",
+  "author": { "name": "Sentry" }
+}

--- a/plugins/sentry-mcp/mcp.json
+++ b/plugins/sentry-mcp/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Add Cursor plugin metadata and MCP config to the existing plugin directories, mirroring the Claude Code two-variant pattern (stable + experimental).

Each plugin dir gets a `.cursor-plugin/plugin.json` and `mcp.json` (Cursor's MCP format wraps servers in `mcpServers`). A repo-root `.cursor-plugin/marketplace.json` registers both variants.