### PR TITLE
docs: Add GitHub Copilot CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ For experimental features:
 claude plugin install sentry-mcp@sentry-mcp-experimental
 ```
 
+### GitHub Copilot CLI Plugin
+
+Install as a GitHub Copilot CLI plugin for automatic subagent delegation:
+
+```shell
+copilot
+/plugin marketplace add getsentry/sentry-mcp
+/plugin install sentry-mcp@sentry-mcp
+```
+
+This provides a `sentry-mcp` subagent that Copilot CLI automatically delegates to when you ask about Sentry errors, issues, traces, or performance.
+
 ### Stdio vs Remote
 
 While this repository is focused on acting as an MCP service, we also support a `stdio` transport. This is still a work in progress, but is the easiest way to adapt run the MCP against a self-hosted Sentry install.


### PR DESCRIPTION
Added instructions for GitHub Copilot CLI plugin installation.