### PR TITLE
feat(ci): Add WARDEN_SENTRY_DSN to Warden workflow

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Expose `WARDEN_SENTRY_DSN` secret as an environment variable in the Warden
GitHub Actions workflow so Warden can report errors to Sentry.