### PR TITLE
fix: Exclude use_sentry from plugin allowedTools

### DIFF
--- a/packages/mcp-core/scripts/generate-definitions.ts
+++ b/packages/mcp-core/scripts/generate-definitions.ts
@@ -261,7 +261,20 @@ async function main() {
     writeJson(path.join(outDir, "skillDefinitions.json"), skills);
 
     // Sync allowedTools in agent frontmatter
-    const toolNames = tools.map((t) => t.name);
+    // Exclude agent-only tools (e.g., use_sentry) since plugins don't use agent mode
+    const agentOnlyToolNames = new Set(
+      Object.values(
+        toolsModule.default as Record<
+          string,
+          { name: string; agentOnly?: boolean }
+        >,
+      )
+        .filter((t) => t.agentOnly)
+        .map((t) => t.name),
+    );
+    const toolNames = tools
+      .map((t) => t.name)
+      .filter((name) => !agentOnlyToolNames.has(name));
 
     let agentsSynced = 0;
     for (const agentPath of agentPaths()) {

--- a/packages/mcp-core/src/tools/types.ts
+++ b/packages/mcp-core/src/tools/types.ts
@@ -59,6 +59,7 @@ export interface ToolConfig<
   requiredScopes: Scope[]; // LEGACY: Which API scopes needed (deprecated, for backward compatibility)
   experimental?: boolean; // Mark tool as experimental (only shown in experimental mode)
   hideInExperimentalMode?: boolean; // Hide tool when experimental mode is active (for tools replaced by unified tools)
+  agentOnly?: boolean; // Tool is only available in agent mode (excluded from plugin allowedTools)
   requiredCapabilities?: (keyof ProjectCapabilities)[]; // Project capabilities required for this tool
   annotations: {
     readOnlyHint?: boolean;

--- a/packages/mcp-core/src/tools/use-sentry/handler.ts
+++ b/packages/mcp-core/src/tools/use-sentry/handler.ts
@@ -39,6 +39,7 @@ export default defineTool({
   name: "use_sentry",
   skills: [], // Only available in agent mode - bypasses authorization
   requiredScopes: [], // No specific scopes - uses authentication token
+  agentOnly: true,
   description: [
     "Natural language interface to Sentry via an embedded AI agent.",
     "",

--- a/plugins/sentry-mcp-experimental/agents/sentry-mcp.md
+++ b/plugins/sentry-mcp-experimental/agents/sentry-mcp.md
@@ -31,7 +31,6 @@ allowedTools:
   - search_issues
   - update_issue
   - update_project
-  - use_sentry
   - whoami
 ---
 

--- a/plugins/sentry-mcp/agents/sentry-mcp.md
+++ b/plugins/sentry-mcp/agents/sentry-mcp.md
@@ -31,7 +31,6 @@ allowedTools:
   - search_issues
   - update_issue
   - update_project
-  - use_sentry
   - whoami
 ---
 


### PR DESCRIPTION
The `use_sentry` tool is only available in agent mode (`?agent=1`), but the
`generate-definitions` script was including it in the plugin agent frontmatter's
`allowedTools` list. This meant the Claude Code plugin declared a tool that the
server would never register in normal (non-agent) mode.

Adds an `agentOnly` flag to `ToolConfig` and sets it on `use_sentry`, then
filters agent-only tools when syncing plugin `allowedTools` during definition
generation.