### PR TITLE
fix: Remove unsupported temperature parameter for GPT-5

### DIFF
--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
@@ -54,10 +54,6 @@ export async function callEmbeddedAgent<
     prompt,
     tools,
     stopWhen: stepCountIs(5),
-    // Only include temperature if provider specifies one (e.g., GPT-5 requires temperature=1)
-    ...(provider.getTemperature() !== undefined && {
-      temperature: provider.getTemperature(),
-    }),
     experimental_output: Output.object({ schema }),
     experimental_telemetry: {
       isEnabled: true,

--- a/packages/mcp-core/src/internal/agents/openai-provider.integration.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.integration.test.ts
@@ -10,7 +10,7 @@
  *
  * This catches issues like:
  * - #623: structuredOutputs causing validation errors with nullable fields
- * - 405 errors from unsupported parameters (reasoningEffort, temperature)
+ * - 405 errors from unsupported parameters (reasoningEffort)
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { http, HttpResponse } from "msw";

--- a/packages/mcp-core/src/internal/agents/provider-factory.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.ts
@@ -72,8 +72,6 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
         getModel: getAnthropicModel,
         // Anthropic doesn't need the structuredOutputs workaround
         getProviderOptions: () => ({}),
-        // Anthropic supports flexible temperature values, use default
-        getTemperature: () => undefined,
       };
     case "openai":
       return {
@@ -87,8 +85,6 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
             strictJsonSchema: false,
           },
         }),
-        // GPT-5 only supports temperature=1 (AI SDK defaults to 0)
-        getTemperature: () => 1,
       };
   }
 }

--- a/packages/mcp-core/src/internal/agents/types.ts
+++ b/packages/mcp-core/src/internal/agents/types.ts
@@ -23,7 +23,4 @@ export interface EmbeddedAgentProvider {
 
   /** Get provider-specific options for generateText calls */
   getProviderOptions(): ProviderOptions;
-
-  /** Get the temperature value for this provider, or undefined to use default */
-  getTemperature(): number | undefined;
 }


### PR DESCRIPTION
GPT-5 does not support the temperature parameter, causing warnings when the AI SDK sends it. Since neither provider used a non-default temperature, remove the getTemperature() abstraction entirely.

https://sentry.sentry.io/issues/7279456586/?project=1

Fixes SENTRY-5K44

Note: I don't have an OpenAI key set up locally to run integration tests - those should probably be verified manually before we merge this.