### PR TITLE
fix(mcp-core): Tolerate malformed event tags in issue details

### DIFF
--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -371,4 +371,25 @@ describe("EventSchema", () => {
     const result = EventSchema.parse(transactionEvent);
     expect(result.type).toBe("transaction");
   });
+
+  it("should ignore malformed tags with null keys", () => {
+    const eventWithMalformedTag = {
+      id: "abc123",
+      title: "TypeError: Cannot read property 'x'",
+      message: "Cannot read property 'x' of undefined",
+      platform: "javascript",
+      type: "error",
+      entries: [],
+      contexts: {},
+      tags: [
+        { key: null, value: "production" },
+        { key: "level", value: "error" },
+      ],
+      culprit: "app.js",
+      dateCreated: "2025-01-01T00:00:00Z",
+    };
+
+    const result = EventSchema.parse(eventWithMalformedTag);
+    expect(result.tags).toEqual([{ key: "level", value: "error" }]);
+  });
 });

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -327,6 +327,32 @@ export const BreadcrumbsEntrySchema = z
   })
   .partial();
 
+const EventTagSchema = z.object({
+  key: z.string(),
+  value: z.string().nullable(),
+});
+
+const EventTagsSchema = z.preprocess((value) => {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  // Sentry can occasionally return malformed tag entries (e.g. null keys).
+  // Drop invalid tags so event parsing can still succeed.
+  return value.filter((tag) => {
+    if (typeof tag !== "object" || tag === null) {
+      return false;
+    }
+
+    const maybeTag = tag as { key?: unknown; value?: unknown };
+    const hasValidKey = typeof maybeTag.key === "string";
+    const hasValidValue =
+      typeof maybeTag.value === "string" || maybeTag.value === null;
+
+    return hasValidKey && hasValidValue;
+  });
+}, z.array(EventTagSchema));
+
 const BaseEventSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -384,14 +410,7 @@ const BaseEventSchema = z.object({
   // "context" (singular) is the legacy "extra" field for arbitrary user-defined data
   // This is different from "contexts" (plural) which are structured contexts
   context: z.record(z.string(), z.unknown()).optional(),
-  tags: z
-    .array(
-      z.object({
-        key: z.string(),
-        value: z.string().nullable(),
-      }),
-    )
-    .optional(),
+  tags: EventTagsSchema.optional(),
   // The _meta field contains metadata about fields in the response
   // It's safer to type as unknown since its structure varies
   _meta: z.unknown().optional(),

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -1071,6 +1071,80 @@ describe("get_issue_details", () => {
     expect(result).toContain("**Document URI**: https://blog.sentry.io");
   });
 
+  it("handles malformed event tags with null keys", async () => {
+    const eventWithMalformedTags = {
+      id: "abc123def456",
+      type: "error",
+      title: "TypeError",
+      culprit: "app.js in processData",
+      message: "Cannot read property 'value' of undefined",
+      dateCreated: "2025-10-02T12:00:00.000Z",
+      platform: "javascript",
+      entries: [
+        {
+          type: "message",
+          data: {
+            formatted: "Cannot read property 'value' of undefined",
+          },
+        },
+      ],
+      contexts: {},
+      tags: [
+        { key: null, value: "production" },
+        { key: "level", value: "error" },
+      ],
+    };
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/MALFORMED-TAGS-001/",
+        () =>
+          HttpResponse.json({
+            id: "123456",
+            shortId: "MALFORMED-TAGS-001",
+            title: "TypeError",
+            firstSeen: "2025-10-02T10:00:00.000Z",
+            lastSeen: "2025-10-02T12:00:00.000Z",
+            count: "5",
+            userCount: 2,
+            permalink: "https://sentry-mcp-evals.sentry.io/issues/123456/",
+            project: {
+              id: "4509062593708032",
+              name: "TEST-PROJECT",
+              slug: "test-project",
+              platform: "javascript",
+            },
+            status: "unresolved",
+            culprit: "app.js in processData",
+            type: "error",
+            platform: "javascript",
+          }),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/MALFORMED-TAGS-001/events/latest/",
+        () => HttpResponse.json(eventWithMalformedTags),
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "MALFORMED-TAGS-001",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    expect(result).toContain(
+      "# Issue MALFORMED-TAGS-001 in **sentry-mcp-evals**",
+    );
+    expect(result).toContain("### Tags");
+    expect(result).toContain("**level**: error");
+    expect(result).not.toContain("**null**");
+  });
+
   it("displays context (extra) data when present", async () => {
     const eventWithContext = {
       id: "abc123def456",


### PR DESCRIPTION
Handle malformed event tags from Sentry without failing get_issue_details.

Sentry can occasionally return tag entries with unexpected shapes (for example key: null). Our event schema required every tag key to be a string, so one malformed tag could cause full event parsing to fail and prevent issue details from being returned.

This change makes tag parsing defensive by filtering malformed tag entries while preserving strict types for valid tags. The output continues to include valid tags, and malformed ones are safely ignored.

Also adds regression coverage at two levels:

- EventSchema parsing test for malformed tag keys
- get_issue_details integration test proving the tool still returns details when malformed tags are present

- Fixes #825