### PR TITLE
fix(cloudflare): Remove root protected resource metadata

### DIFF
--- a/docs/cloudflare/oauth-architecture.md
+++ b/docs/cloudflare/oauth-architecture.md
@@ -344,18 +344,15 @@ The 2-minute safety window prevents edge cases with clock skew and processing de
 
 ## Discovery Endpoints
 
-The MCP OAuth Provider automatically provides:
+The MCP worker exposes:
 
 - `/.well-known/oauth-authorization-server` - MCP OAuth server metadata
-- `/.well-known/oauth-protected-resource` - MCP resource server info for the origin resource
 - `/.well-known/oauth-protected-resource/mcp...` - Path-specific protected resource metadata per RFC 9728
 
-The worker serves both protected-resource endpoints self-consistently:
-- the root endpoint identifies the origin resource
-- path-specific endpoints preserve the `/mcp` path and any query parameters
-
-The authorization endpoint still accepts origin-only resource indicators for
-backward compatibility with clients that cached earlier metadata.
+The worker only serves path-specific protected-resource metadata for `/mcp...`
+resources. Each metadata document preserves the exact `/mcp` path and any query
+parameters so the advertised `resource` value matches the protected resource
+identifier used for discovery.
 
 Note: These describe the MCP OAuth server, not Sentry's OAuth endpoints.
 

--- a/packages/mcp-cloudflare/src/server/app.test.ts
+++ b/packages/mcp-cloudflare/src/server/app.test.ts
@@ -65,26 +65,13 @@ describe("app", () => {
   });
 
   describe("GET /.well-known/oauth-protected-resource", () => {
-    it("should return RFC 9728 protected resource metadata for root", async () => {
+    it("should not expose origin-level protected resource metadata", async () => {
       const res = await app.request(
         "https://mcp.sentry.dev/.well-known/oauth-protected-resource",
         { headers: TEST_HEADERS },
       );
 
-      expect(res.status).toBe(200);
-
-      const json = await res.json();
-      expect(json).toEqual({
-        resource: "https://mcp.sentry.dev",
-        authorization_servers: ["https://mcp.sentry.dev"],
-        scopes_supported: [
-          "org:read",
-          "project:write",
-          "team:write",
-          "event:write",
-        ],
-        bearer_methods_supported: ["header"],
-      });
+      expect(res.status).toBe(404);
     });
   });
 

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -152,14 +152,7 @@ const app = new Hono<{
       endpoint: `${baseUrl}/mcp`,
     });
   })
-  // RFC 9728: OAuth 2.0 Protected Resource Metadata
-  // ChatGPT and other clients query this to discover the authorization server
-  // Root endpoint for clients that try /.well-known/oauth-protected-resource first
-  .get(
-    "/.well-known/oauth-protected-resource",
-    handleOAuthProtectedResourceMetadata,
-  )
-  // Handles both /mcp and /mcp/* paths (e.g., /mcp/sentry/mcp-server)
+  // RFC 9728: OAuth 2.0 Protected Resource Metadata for /mcp resources.
   .get(
     "/.well-known/oauth-protected-resource/mcp",
     handleOAuthProtectedResourceMetadata,

--- a/packages/mcp-cloudflare/src/server/index.test.ts
+++ b/packages/mcp-cloudflare/src/server/index.test.ts
@@ -86,7 +86,7 @@ describe("worker entrypoint", () => {
     expect(MockOAuthProvider).not.toHaveBeenCalled();
   });
 
-  it("serves root protected resource metadata before the OAuth provider", async () => {
+  it("does not expose root protected resource metadata", async () => {
     const response = await handler.fetch!(
       new Request(
         "https://mcp.sentry.dev/.well-known/oauth-protected-resource",
@@ -95,19 +95,8 @@ describe("worker entrypoint", () => {
       ctx,
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
-    expect(await response.json()).toEqual({
-      resource: "https://mcp.sentry.dev",
-      authorization_servers: ["https://mcp.sentry.dev"],
-      scopes_supported: [
-        "org:read",
-        "project:write",
-        "team:write",
-        "event:write",
-      ],
-      bearer_methods_supported: ["header"],
-    });
     expect(MockOAuthProvider).not.toHaveBeenCalled();
   });
 

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -16,7 +16,6 @@ import {
   checkRateLimit,
   MCP_RATE_LIMIT_EXCEEDED_MESSAGE,
 } from "./utils/rate-limiter";
-import { createProtectedResourceMetadataResponse } from "./protected-resource-metadata";
 
 /**
  * RFC 9728 §3.1: Patch 401 responses on MCP routes to include a
@@ -65,8 +64,10 @@ const wrappedOAuthProvider = {
       return new Response(null, { status: 204 });
     }
 
+    // RFC 9728 metadata must be derived from the exact protected resource
+    // identifier. We expose only path-specific metadata for `/mcp...`.
     if (url.pathname === "/.well-known/oauth-protected-resource") {
-      return addCorsHeaders(createProtectedResourceMetadataResponse(url));
+      return addCorsHeaders(new Response("Not Found", { status: 404 }));
     }
 
     // --- Rate limiting (before any OAuth/MCP processing) ---

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -232,7 +232,7 @@ describe("oauth authorize routes", () => {
 
   describe("Resource parameter validation (RFC 8707)", () => {
     describe("GET /oauth/authorize", () => {
-      it("should allow request without resource parameter (backward compatibility)", async () => {
+      it("should allow request without resource parameter", async () => {
         mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
           clientId: "test-client",
           redirectUri: "https://example.com/callback",
@@ -278,7 +278,7 @@ describe("oauth authorize routes", () => {
         expect(response.status).toBe(200);
       });
 
-      it("should allow request with origin-only resource parameter", async () => {
+      it("should reject request with origin-only resource parameter", async () => {
         mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
           clientId: "test-client",
           redirectUri: "https://example.com/callback",
@@ -297,10 +297,13 @@ describe("oauth authorize routes", () => {
         );
         const response = await app.fetch(request, testEnv as Env);
 
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location");
+        const locationUrl = new URL(location!);
+        expect(locationUrl.searchParams.get("error")).toBe("invalid_target");
       });
 
-      it("should allow request with origin-only resource parameter and trailing slash", async () => {
+      it("should reject request with origin-only resource parameter and trailing slash", async () => {
         mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
           clientId: "test-client",
           redirectUri: "https://example.com/callback",
@@ -319,7 +322,10 @@ describe("oauth authorize routes", () => {
         const request = new Request(url, { method: "GET" });
         const response = await app.fetch(request, testEnv as Env);
 
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(302);
+        const location = response.headers.get("location");
+        const locationUrl = new URL(location!);
+        expect(locationUrl.searchParams.get("error")).toBe("invalid_target");
       });
 
       it("should allow request with path-specific query resource parameter", async () => {
@@ -549,7 +555,7 @@ describe("oauth authorize routes", () => {
         expect(location).toContain("sentry.io");
       });
 
-      it("should allow request with origin-only resource parameter", async () => {
+      it("should reject request with origin-only resource parameter", async () => {
         const oauthReqInfo = {
           clientId: "test-client",
           redirectUri: "https://example.com/callback",
@@ -575,7 +581,8 @@ describe("oauth authorize routes", () => {
 
         expect(response.status).toBe(302);
         const location = response.headers.get("location");
-        expect(location).toContain("sentry.io");
+        const locationUrl = new URL(location!);
+        expect(locationUrl.searchParams.get("error")).toBe("invalid_target");
       });
 
       it("should allow request with path-specific query resource parameter", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -355,22 +355,21 @@ describe("oauth callback routes", () => {
       }
     });
 
-    it("should allow callback with origin-only resource parameter and trailing slash", async () => {
+    it("should reject callback with origin-only resource parameter and trailing slash", async () => {
       mockOAuthProvider.lookupClient.mockResolvedValue({
         clientId: "test-client",
         clientName: "Test Client",
         redirectUris: ["https://example.com/callback"],
       });
 
-      const approvalFormData = new FormData();
-      const approvalState = await signState(
+      const validApprovalFormData = new FormData();
+      const validApprovalState = await signState(
         {
           req: {
             oauthReqInfo: {
               clientId: "test-client",
               redirectUri: "https://example.com/callback",
               scope: ["read"],
-              resource: "http://localhost/",
             },
           },
           iat: Date.now(),
@@ -378,13 +377,19 @@ describe("oauth callback routes", () => {
         },
         testEnv.COOKIE_SECRET!,
       );
-      approvalFormData.append("state", approvalState);
-      const approvalRequest = new Request("http://localhost/oauth/authorize", {
-        method: "POST",
-        body: approvalFormData,
-      });
-      const approvalResponse = await app.fetch(approvalRequest, testEnv as Env);
-      const setCookie = approvalResponse.headers.get("Set-Cookie");
+      validApprovalFormData.append("state", validApprovalState);
+      const validApprovalRequest = new Request(
+        "http://localhost/oauth/authorize",
+        {
+          method: "POST",
+          body: validApprovalFormData,
+        },
+      );
+      const validApprovalResponse = await app.fetch(
+        validApprovalRequest,
+        testEnv as Env,
+      );
+      const setCookie = validApprovalResponse.headers.get("Set-Cookie");
 
       const now = Date.now();
       const payload: OAuthState = {
@@ -411,10 +416,9 @@ describe("oauth callback routes", () => {
 
       const response = await app.fetch(request, testEnv as Env);
 
-      if (response.status === 400) {
-        const text = await response.text();
-        expect(text).not.toContain("Invalid resource parameter");
-      }
+      expect(response.status).toBe(400);
+      const text = await response.text();
+      expect(text).toContain("Invalid resource parameter");
     });
 
     it("should allow callback with path-specific query resource parameter", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -473,20 +473,20 @@ describe("validateResourceParameter", () => {
       expect(result).toBe(true);
     });
 
-    it("should allow same hostname with origin-only resource", () => {
+    it("should reject same hostname with origin-only resource", () => {
       const result = validateResourceParameter(
         "https://mcp.sentry.dev",
         "https://mcp.sentry.dev/oauth/authorize",
       );
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
-    it("should allow same hostname with origin-only resource and trailing slash", () => {
+    it("should reject same hostname with origin-only resource and trailing slash", () => {
       const result = validateResourceParameter(
         "https://mcp.sentry.dev/",
         "https://mcp.sentry.dev/oauth/authorize",
       );
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     it("should allow same hostname with nested /mcp path", () => {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -632,14 +632,6 @@ export function validateResourceParameter(
       return false;
     }
 
-    // Allow the origin-only resource as a compatibility alias for clients
-    // that cached older protected-resource metadata before we served exact
-    // path-specific RFC 9728 resource identifiers. The canonical resource
-    // shape is still `/mcp...`; this keeps older clients working.
-    if (rawPath === "/" || rawPath === "") {
-      return true;
-    }
-
     // Use the normalized pathname for the /mcp check so dot segments like
     // /mcp/../evil cannot bypass the prefix validation.
     return (

--- a/packages/mcp-cloudflare/src/server/protected-resource-metadata.ts
+++ b/packages/mcp-cloudflare/src/server/protected-resource-metadata.ts
@@ -4,11 +4,8 @@ const PROTECTED_RESOURCE_METADATA_PREFIX =
   "/.well-known/oauth-protected-resource";
 
 export function getProtectedResourceMetadata(requestUrl: URL) {
-  // RFC 9728 path-specific metadata should round-trip the exact protected
-  // resource path and query. The root metadata endpoint is less precise:
-  // `https://host` and `https://host/` both arrive here as `/`, so we
-  // normalize that case to the bare origin and rely on `/.well-known/
-  // oauth-protected-resource/mcp...` for exact MCP resource identifiers.
+  // RFC 9728 path-specific metadata must round-trip the exact protected
+  // resource path and query.
   const resourcePath = requestUrl.pathname.replace(
     PROTECTED_RESOURCE_METADATA_PREFIX,
     "",


### PR DESCRIPTION
Remove origin-level protected-resource metadata from the Cloudflare worker.

The worker was serving `/.well-known/oauth-protected-resource` even though the protected resources we actually expose live under `/mcp...`. That allowed clients to discover an origin resource identifier that did not match the exact MCP resource they were authenticating against, which is not correct under RFC 9728.

This change keeps discovery path-specific, rejects origin-only resource indicators during OAuth validation, and updates the tests and architecture docs to match the stricter behavior.