### PR TITLE
fix(mcp-core): rescue Anthropic JSON responses wrapped in markdown code blocks

### DIFF
--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
@@ -372,6 +372,28 @@ describe("callEmbeddedAgent", () => {
       });
     });
 
+    it("rescues NoObjectGeneratedError when prose has unmatched quotes before the JSON object", async () => {
+      const error = new NoObjectGeneratedError({
+        ...noObjectErrorOpts,
+        message: "response did not match schema",
+        text: 'The 5" pipe needs attention. Actual output: {"query": "is:unresolved", "explanation": "valid JSON"}',
+      });
+
+      mockGenerateText.mockRejectedValue(error);
+
+      const result = await callEmbeddedAgent({
+        system: "You are a test agent",
+        prompt: "Test prompt",
+        tools: {},
+        schema: schemaWithDefault,
+      });
+
+      expect(result.result).toEqual({
+        query: "is:unresolved",
+        explanation: "valid JSON",
+      });
+    });
+
     it("throws UserInputError when text is not parseable JSON", async () => {
       const error = new NoObjectGeneratedError({
         ...noObjectErrorOpts,

--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
@@ -171,6 +171,16 @@ function extractBalancedJsonObjects(text: string): string[] {
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
 
+    if (depth === 0) {
+      if (ch === "{") {
+        start = i;
+        depth = 1;
+        inString = false;
+        escaped = false;
+      }
+      continue;
+    }
+
     if (escaped) {
       escaped = false;
       continue;
@@ -188,18 +198,17 @@ function extractBalancedJsonObjects(text: string): string[] {
     }
 
     if (ch === "{") {
-      if (depth === 0) {
-        start = i;
-      }
       depth++;
       continue;
     }
 
-    if (ch === "}" && depth > 0) {
+    if (ch === "}") {
       depth--;
       if (depth === 0 && start !== -1) {
         objects.push(text.slice(start, i + 1));
         start = -1;
+        inString = false;
+        escaped = false;
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #819

When using the Anthropic provider (Claude), the LLM sometimes wraps its JSON response in explanatory prose or markdown code blocks instead of returning raw JSON. This caused `rescueFromText()` to fail with a plain `JSON.parse(text)`, which then bubbled up as a `UserInputError` — and since the transport is `http`, users see the generic **"Feature Unavailable"** message.

### Root cause

`rescueFromText()` only attempted direct `JSON.parse(text)`, so responses like:

\`\`\`
Based on the available fields, I can translate this query as follows:

\`\`\`json
{"query": "is:unresolved", "sort": "date", "explanation": "Unresolved issues"}
\`\`\`
\`\`\`

...would fail to parse and be silently discarded.

### Fix

Added `extractJsonCandidates()` to try multiple extraction strategies in order:

1. **Direct parse** — existing behavior, unchanged
2. **Markdown code block** — extracts content from ` ```json ``` ` or ` ``` ``` ` blocks
3. **Embedded JSON object** — finds the first `{...}` in prose via regex

`rescueFromText()` now iterates over all candidates and returns the first one that parses and validates against the schema.

## Test plan

- [x] Existing tests still pass (no regression)
- [x] Added test: JSON in ` ```json ``` ` markdown code block
- [x] Added test: JSON in plain ` ``` ``` ` code block
- [x] Added test: JSON object embedded in prose
- [x] All 757 tests pass