### PR TITLE
feat(replay): add get_replay_details tool

### DIFF
--- a/docs/adding-tools.md
+++ b/docs/adding-tools.md
@@ -151,7 +151,7 @@ async handler(params, context: ServerContext) {
 
 ### Response Formatting
 
-See `common-patterns.md#response-formatting` for:
+See [common-patterns.md](common-patterns.md#response-formatting) for:
 - Markdown structure
 - ID/URL formatting
 - Next steps guidance
@@ -187,8 +187,8 @@ describe("your_tool_name", () => {
 ```
 
 **Testing Requirements:**
-- Input validation (see `testing.md#testing-error-cases`)
-- Error handling (use patterns from `common-patterns.md#error-handling`)
+- Input validation (see [testing.md](testing.md#testing-error-cases))
+- Error handling (use patterns from [error-handling.md](error-handling.md))
 - Output formatting with snapshots
 - At least one happy-path test must snapshot the full formatted handler
   response with `toMatchInlineSnapshot()`; partial `toContain()` assertions are
@@ -221,7 +221,7 @@ In `packages/mcp-server-mocks/src/handlers/`:
 }
 ```
 
-See `api-patterns.md#mock-patterns` for validation examples.
+See [api-patterns.md](api-patterns.md#mock-patterns) for validation examples.
 
 ## Step 5: Add Evaluation Tests (Sparingly)
 
@@ -397,10 +397,10 @@ This pattern works with both Cloudflare-hosted and stdio transports.
 
 ## Common Patterns
 
-- Error handling: `common-patterns.md#error-handling`
+- Error handling: [error-handling.md](error-handling.md)
 - API usage: `api-patterns.md`
 - Testing: `testing.md`
-- Response formatting: `common-patterns.md#response-formatting`
+- Response formatting: [common-patterns.md](common-patterns.md#response-formatting)
 
 ## References
 

--- a/docs/adding-tools.md
+++ b/docs/adding-tools.md
@@ -2,17 +2,25 @@
 
 Step-by-step guide for adding new tools to the Sentry MCP server.
 
+## Tool Visibility & Selection
+
+Not every tool is exposed to every consumer. We rely on several mechanisms to keep the active tool set manageable:
+
+- **`requiredCapabilities`** — Tools declare which project capabilities they need (e.g. `profiles`, `replays`, `traces`). If the upstream project doesn't have a capability enabled, the tool is automatically hidden.
+- **`internalOnly`** — Composition primitives (e.g. `get_issue_details`, `get_trace_details`) that are only called by other tools like `get_sentry_resource`, never exposed directly via MCP.
+- **`experimental` / `hideInExperimentalMode`** — Feature flags for tools that are being tested or replaced.
+- **Skills & constraints** — The server filters tools based on granted skills and org/project constraints.
+
+We also expect upstream consumers (Claude Code plugins, Cursor, etc.) to use **tool selection** or **progressive disclosure** on their end. The total registered tool count can exceed what any single session needs because consumers pick a relevant subset.
+
 ## Tool Count Limits
 
-**IMPORTANT**: AI agents have a hard cap of 45 total tools available. Since Sentry MCP cannot consume all available tool slots:
-- **Target**: Keep total tool count around 20
-- **Maximum**: Absolutely no more than 25 tools
-- **Constraint**: This limit exists in Cursor and possibly other tools
+Target ~20 publicly visible tools. Never exceed 25. AI agents have limited tool slots (Cursor caps at 45 total across all providers), so Sentry MCP cannot consume all available slots.
 
 Before adding a new tool, consider if it could be:
 1. Combined with an existing tool
 2. Implemented as a parameter variant
-3. Truly necessary for core functionality
+3. Gated behind `requiredCapabilities` if only relevant to some projects
 
 ## Tool Structure
 

--- a/docs/adding-tools.md
+++ b/docs/adding-tools.md
@@ -190,6 +190,9 @@ describe("your_tool_name", () => {
 - Input validation (see `testing.md#testing-error-cases`)
 - Error handling (use patterns from `common-patterns.md#error-handling`)
 - Output formatting with snapshots
+- At least one happy-path test must snapshot the full formatted handler
+  response with `toMatchInlineSnapshot()`; partial `toContain()` assertions are
+  supplemental only
 - API integration with MSW mocks
 
 **After changing output, update snapshots:**

--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -1,46 +1,10 @@
 # Common Patterns
 
-Reusable patterns used throughout the Sentry MCP codebase. Reference these instead of duplicating.
+Reusable patterns used throughout the Sentry MCP codebase.
 
 ## Error Handling
 
-### UserInputError Pattern
-
-For invalid user input that needs clear feedback:
-
-```typescript
-if (!params.organizationSlug) {
-  throw new UserInputError(
-    "Organization slug is required. Please provide an organizationSlug parameter. " +
-    "You can find available organizations using the `find_organizations()` tool."
-  );
-}
-```
-
-See implementation: `packages/mcp-server/src/errors.ts`
-
-### API Error Wrapping
-
-When external API calls fail:
-
-```typescript
-try {
-  const data = await apiService.issues.list(params);
-  return data;
-} catch (error) {
-  throw new Error(`Failed to fetch issues: ${error.message}`);
-}
-```
-
-### Error Message Transformation
-
-Make error messages LLM-friendly:
-
-```typescript
-if (message.includes("You do not have the multi project stream feature enabled")) {
-  return "You do not have access to query across multiple projects. Please select a project for your query.";
-}
-```
+See [error-handling.md](error-handling.md) for the complete error hierarchy, `UserInputError` patterns, and API error wrapping.
 
 ## Zod Schema Patterns
 
@@ -61,7 +25,7 @@ export const ParamRegionUrl = z
   .describe("Sentry region URL. If not provided, uses default region.");
 ```
 
-See: `packages/mcp-server/src/schema.ts`
+See: `packages/mcp-core/src/schema.ts`
 
 ### Flexible Schema Patterns
 
@@ -81,75 +45,6 @@ IssueSchema.partial().passthrough()
 ```typescript
 export type Organization = z.infer<typeof OrganizationSchema>;
 export type ToolParams<T> = z.infer<typeof toolDefinitions[T].parameters>;
-```
-
-## Testing Patterns
-
-For comprehensive testing guidance, see `testing.md` and `adding-tools.md#step-3-add-tests`.
-
-### Unit Test Structure
-
-```typescript
-describe("tool_name", () => {
-  it("returns formatted output", async () => {
-    const result = await TOOL_HANDLERS.tool_name(mockContext, {
-      organizationSlug: "test-org",
-    });
-    
-    expect(result).toMatchInlineSnapshot(`
-      "# Results in **test-org**
-      
-      Expected formatted output here"
-    `);
-  });
-});
-```
-
-### Snapshot Updates
-
-When tool output changes:
-
-```bash
-cd packages/mcp-server
-pnpm vitest --run -u
-```
-
-### Mock Server Setup
-
-```typescript
-beforeAll(() => mswServer.listen());
-afterEach(() => mswServer.resetHandlers());
-afterAll(() => mswServer.close());
-```
-
-See: `packages/mcp-server/src/test-utils/setup.ts`
-
-## API Patterns
-
-For complete API usage patterns, see `api-patterns.md`.
-
-### Service Creation
-
-```typescript
-const apiService = apiServiceFromContext(context, {
-  regionUrl: params.regionUrl,
-});
-```
-
-See: `packages/mcp-server/src/api-utils.ts:apiServiceFromContext`
-
-### Multi-Region Support
-
-```typescript
-if (opts.regionUrl) {
-  try {
-    host = new URL(opts.regionUrl).host;
-  } catch (error) {
-    throw new UserInputError(
-      `Invalid regionUrl provided: ${opts.regionUrl}. Must be a valid URL.`
-    );
-  }
-}
 ```
 
 ## Response Formatting
@@ -214,47 +109,6 @@ if (params.issueUrl) {
 }
 ```
 
-## Mock Patterns
-
-### Basic Handler
-
-```typescript
-{
-  method: "get",
-  path: "/api/0/organizations/:orgSlug/issues/",
-  fetch: ({ params }) => {
-    return HttpResponse.json(issueListFixture);
-  },
-}
-```
-
-### Request Validation
-
-```typescript
-fetch: ({ request, params }) => {
-  const url = new URL(request.url);
-  const sort = url.searchParams.get("sort");
-  
-  if (sort && !["date", "freq", "new"].includes(sort)) {
-    return HttpResponse.json("Invalid sort parameter", { status: 400 });
-  }
-  
-  return HttpResponse.json(data);
-}
-```
-
-See: `packages/mcp-server-mocks/src/handlers/`
-
-## Quality Checks
-
-Required before any commit:
-
-```bash
-pnpm -w run lint:fix    # Fix linting issues
-pnpm tsc --noEmit       # TypeScript type checking
-pnpm test               # Run all tests
-```
-
 ## TypeScript Helpers
 
 ### Generic Type Utilities
@@ -272,8 +126,7 @@ export type ToolName = typeof TOOL_NAMES[number];
 
 ## References
 
-- Error handling: `packages/mcp-server/src/errors.ts`
-- Schema definitions: `packages/mcp-server/src/schema.ts`
-- API utilities: `packages/mcp-server/src/api-utils.ts`
-- Test setup: `packages/mcp-server/src/test-utils/`
-- Mock handlers: `packages/mcp-server-mocks/src/handlers/`
+- Error handling: [error-handling.md](error-handling.md)
+- API patterns: [api-patterns.md](api-patterns.md)
+- Testing: [testing.md](testing.md)
+- Quality checks: [quality-checks.md](quality-checks.md)

--- a/docs/quality-checks.md
+++ b/docs/quality-checks.md
@@ -1,80 +1,27 @@
 # Quality Checks
 
-Required quality checks that MUST pass before completing any code changes.
+Required checks before completing any code changes.
 
-## Critical Quality Checks
-
-**After ANY code changes, you MUST run:**
+## Required Commands
 
 ```bash
-pnpm -w run lint:fix    # Fix linting issues
-pnpm tsc --noEmit       # Check TypeScript types
-pnpm test               # Run all tests
+pnpm run tsc && pnpm run lint && pnpm run test
 ```
 
-**DO NOT proceed if any check fails.**
-
-## Tool Testing Requirements
-
-**ALL tools MUST have comprehensive tests that verify:**
-
-- **Input validation** - Required/optional parameters, type checking, edge cases
-- **Output formatting** - Markdown structure, content accuracy, error messages
-- **API integration** - Mock server responses, error handling, parameter passing
-- **Snapshot testing** - Use inline snapshots to verify formatted output, with
-  at least one full happy-path response snapshot per tool
-
-**Required test patterns:**
-- Unit tests in individual `{tool-name}.test.ts` files using Vitest and MSW mocks
-- Input/output validation with inline snapshots
-- At least one `toMatchInlineSnapshot()` assertion that captures the complete
-  formatted response for a representative successful tool call
-- Error case testing (API failures, invalid params)
-- Mock server setup in `packages/mcp-server-mocks`
-
-See `docs/testing.md` for detailed testing patterns and `docs/adding-tools.md` for the testing workflow.
+Do not proceed if any check fails.
 
 ## Tool Count Limits
 
-**IMPORTANT**: AI agents have a hard cap of 45 total tools. Sentry MCP must:
-- Target ~20 tools (current best practice)
-- Never exceed 25 tools (absolute maximum)
-- This limit exists in Cursor and possibly other tools
+See [adding-tools.md](adding-tools.md#tool-count-limits) for current limits and guidance on when to add vs. combine tools.
 
-**Current status**: 19 tools (within target range)
+## Testing Requirements
 
-## Build Verification
-
-Ensure the build process works correctly:
-
-```bash
-npm run build              # Build all packages
-npm run generate-tool-definitions  # Generate tool definitions
-```
-
-Tool definitions must generate without errors for client consumption.
-
-## Code Quality Standards
-
-- **TypeScript strict mode** - All code must compile without errors
-- **Linting compliance** - Follow established code style patterns
-- **Test coverage** - All new tools must have comprehensive tests
-- **Error handling** - Use patterns from `common-patterns.md#error-handling`
-- **API patterns** - Follow patterns from `api-patterns.md`
+See [testing.md](testing.md) for testing philosophy, patterns, and snapshot guidelines. Every tool must have at least one happy-path inline snapshot test.
 
 ## Pre-Commit Checklist
 
-Before completing any task:
-
-- [ ] All quality checks pass (`pnpm -w run lint:fix`, `pnpm tsc --noEmit`, `pnpm test`)
-- [ ] Tool count within limits (≤20 target, ≤25 absolute max)
-- [ ] New tools have comprehensive tests
-- [ ] Build process generates tool definitions successfully
+- [ ] Quality checks pass (`pnpm run tsc && pnpm run lint && pnpm run test`)
+- [ ] Tool count within limits
+- [ ] New tools have tests with inline snapshots
+- [ ] Tool/skill definitions regenerated if tools changed (`pnpm run --filter @sentry/mcp-core generate-definitions`)
 - [ ] Documentation updated if patterns changed
-
-## References
-
-- Testing patterns: `testing.md`
-- Tool development: `adding-tools.md`
-- Code patterns: `common-patterns.md`
-- API usage: `api-patterns.md`

--- a/docs/quality-checks.md
+++ b/docs/quality-checks.md
@@ -21,11 +21,14 @@ pnpm test               # Run all tests
 - **Input validation** - Required/optional parameters, type checking, edge cases
 - **Output formatting** - Markdown structure, content accuracy, error messages
 - **API integration** - Mock server responses, error handling, parameter passing
-- **Snapshot testing** - Use inline snapshots to verify formatted output
+- **Snapshot testing** - Use inline snapshots to verify formatted output, with
+  at least one full happy-path response snapshot per tool
 
 **Required test patterns:**
 - Unit tests in individual `{tool-name}.test.ts` files using Vitest and MSW mocks
 - Input/output validation with inline snapshots
+- At least one `toMatchInlineSnapshot()` assertion that captures the complete
+  formatted response for a representative successful tool call
 - Error case testing (API failures, invalid params)
 - Mock server setup in `packages/mcp-server-mocks`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,6 +75,10 @@ Fast, focused tests of actual functionality:
 - Mock external APIs only (Sentry API, OpenAI) with MSW
 - Use real implementations for internal code
 - Test through public APIs rather than implementation details
+- For tools, include at least one happy-path test that snapshots the full
+  formatted handler response with `toMatchInlineSnapshot()`. Supplemental
+  `toContain()` assertions are fine, but they do not replace a full-response
+  snapshot.
 
 ### 2. Evaluation Tests
 Real-world scenarios with LLM:
@@ -192,6 +196,12 @@ Use inline snapshots for:
 - Error message text
 - Markdown responses
 - JSON structure validation
+
+For MCP tools specifically:
+- Every tool test suite must include at least one representative successful call
+  that snapshots the full handler response.
+- Use targeted substring assertions only for additional branch-specific checks,
+  not as the only output coverage.
 
 ### Updating Snapshots
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,7 +136,7 @@ describe("tool_name", () => {
 });
 ```
 
-**NOTE**: Follow error handling patterns from `common-patterns.md#error-handling` when testing error cases.
+**NOTE**: Follow error handling patterns from [error-handling.md](error-handling.md) when testing error cases.
 
 ### Testing Error Cases
 
@@ -161,31 +161,7 @@ it("handles API errors gracefully", async () => {
 
 ## Mock Server Setup
 
-Use MSW patterns from `api-patterns.md#mock-patterns` for API mocking.
-
-### Test Configuration
-
-```typescript
-// packages/mcp-server/src/test-utils/setup.ts
-import { setupMockServer } from "@sentry-mcp/mocks";
-
-export const mswServer = setupMockServer();
-
-// Global test setup
-beforeAll(() => mswServer.listen({ onUnhandledRequest: "error" }));
-afterEach(() => mswServer.resetHandlers());
-afterAll(() => mswServer.close());
-```
-
-### Mock Context
-
-```typescript
-export const mockContext: ServerContext = {
-  host: "sentry.io",
-  accessToken: "test-token",
-  organizationSlug: "test-org"
-};
-```
+See [api-patterns.md](api-patterns.md) for MSW mock setup, handler patterns, and request validation examples.
 
 ## Snapshot Testing
 
@@ -316,11 +292,7 @@ it("streams large responses efficiently", async () => {
 
 ## Common Testing Patterns
 
-See `common-patterns.md` for:
-- Mock server setup
-- Error handling tests
-- Parameter validation
-- Response formatting
+See [common-patterns.md](common-patterns.md) for parameter validation and response formatting patterns, [error-handling.md](error-handling.md) for error testing, and [api-patterns.md](api-patterns.md) for mock setup.
 
 ## CI/CD Integration
 

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -1,5 +1,7 @@
+import { z } from "zod";
 import {
   getIssueUrl as getIssueUrlUtil,
+  getReplayUrl as getReplayUrlUtil,
   getTraceUrl as getTraceUrlUtil,
   isSentryHost,
 } from "../utils/url-utils";
@@ -32,6 +34,8 @@ import {
   UserRegionsSchema,
   FlamegraphSchema,
   ProfileChunkResponseSchema,
+  ReplayDetailsSchema,
+  ReplayRecordingSegmentsSchema,
 } from "./schema";
 import { ConfigurationError } from "../errors";
 import { createApiError, ApiNotFoundError, ApiValidationError } from "./errors";
@@ -60,6 +64,8 @@ import type {
   User,
   Flamegraph,
   ProfileChunk,
+  ReplayDetails,
+  ReplayRecordingSegments,
 } from "./types";
 // TODO: this is shared - so ideally, for safety, it uses @sentry/core, but currently
 // logger isnt exposed (or rather, it is, but its not the right logger)
@@ -512,6 +518,10 @@ export class SentryApiService {
    */
   getTraceUrl(organizationSlug: string, traceId: string): string {
     return getTraceUrlUtil(this.host, organizationSlug, traceId);
+  }
+
+  getReplayUrl(organizationSlug: string, replayId: string): string {
+    return getReplayUrlUtil(this.host, organizationSlug, replayId);
   }
 
   // ================================================================================
@@ -1865,6 +1875,44 @@ export class SentryApiService {
       filename: attachment.name,
       blob: await downloadResponse.blob(),
     };
+  }
+
+  async getReplayDetails(
+    {
+      organizationSlug,
+      replayId,
+    }: {
+      organizationSlug: string;
+      replayId: string;
+    },
+    opts?: RequestOptions,
+  ): Promise<ReplayDetails> {
+    const body = await this.requestJSON(
+      `/organizations/${organizationSlug}/replays/${replayId}/`,
+      undefined,
+      opts,
+    );
+    return z.object({ data: ReplayDetailsSchema }).parse(body).data;
+  }
+
+  async getReplayRecordingSegments(
+    {
+      organizationSlug,
+      projectSlugOrId,
+      replayId,
+    }: {
+      organizationSlug: string;
+      projectSlugOrId: string;
+      replayId: string;
+    },
+    opts?: RequestOptions,
+  ): Promise<ReplayRecordingSegments> {
+    const body = await this.requestJSON(
+      `/projects/${organizationSlug}/${projectSlugOrId}/replays/${replayId}/recording-segments/?download=true`,
+      undefined,
+      opts,
+    );
+    return ReplayRecordingSegmentsSchema.parse(body);
   }
 
   async updateIssue(

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -196,19 +196,6 @@ export const ReplayDetailsSchema = z
   })
   .passthrough();
 
-export const ReplayRecordingSegmentMetadataSchema = z
-  .object({
-    replayId: z.string(),
-    segmentId: z.number(),
-    projectId: z.union([z.string(), z.number()]),
-    dateAdded: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const ReplayRecordingSegmentMetadataListSchema = z.array(
-  ReplayRecordingSegmentMetadataSchema,
-);
-
 export const ReplayRecordingSegmentsSchema = z.array(z.array(z.unknown()));
 
 export const ClientKeySchema = z

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -123,6 +123,94 @@ export const ProjectSchema = z
 
 export const ProjectListSchema = z.array(ProjectSchema);
 
+export const ReplayDetailsSchema = z
+  .object({
+    activity: z.number().nullable().optional(),
+    browser: z
+      .object({
+        name: z.string().nullable().optional(),
+        version: z.string().nullable().optional(),
+      })
+      .nullish()
+      .default({}),
+    count_dead_clicks: z.number().nullable().optional(),
+    count_errors: z.number().nullable().optional(),
+    count_infos: z.number().nullable().optional(),
+    count_rage_clicks: z.number().nullable().optional(),
+    count_segments: z.number().nullable().optional(),
+    count_urls: z.number().nullable().optional(),
+    count_warnings: z.number().nullable().optional(),
+    device: z
+      .object({
+        brand: z.string().nullable().optional(),
+        family: z.string().nullable().optional(),
+        model: z.string().nullable().optional(),
+        model_id: z.string().nullable().optional(),
+        name: z.string().nullable().optional(),
+      })
+      .nullish()
+      .default({}),
+    dist: z.string().nullable().optional(),
+    duration: z.number().nullable().optional(),
+    environment: z.string().nullable().optional(),
+    error_ids: z.array(z.string()).optional().default([]),
+    finished_at: z.string().nullable().optional(),
+    has_viewed: z.boolean().nullable().optional(),
+    id: z.string(),
+    info_ids: z.array(z.string()).optional().default([]),
+    is_archived: z.boolean().nullable().optional(),
+    os: z
+      .object({
+        name: z.string().nullable().optional(),
+        version: z.string().nullable().optional(),
+      })
+      .nullish()
+      .default({}),
+    platform: z.string().nullable().optional(),
+    project_id: z.union([z.string(), z.number()]).nullable().optional(),
+    releases: z.array(z.string()).nullable().optional(),
+    replay_type: z.string().nullable().optional(),
+    sdk: z
+      .object({
+        name: z.string().nullable().optional(),
+        version: z.string().nullable().optional(),
+      })
+      .nullish()
+      .default({}),
+    started_at: z.string().nullable().optional(),
+    tags: z.record(z.string(), z.array(z.string())).optional().default({}),
+    trace_ids: z.array(z.string()).optional().default([]),
+    urls: z.array(z.string()).optional().default([]),
+    user: z
+      .object({
+        display_name: z.string().nullable().optional(),
+        email: z.string().nullable().optional(),
+        id: z.string().nullable().optional(),
+        ip: z.string().nullable().optional(),
+        username: z.string().nullable().optional(),
+        geo: z.record(z.string(), z.string()).optional(),
+      })
+      .nullish()
+      .default({}),
+    warning_ids: z.array(z.string()).optional().default([]),
+  })
+  .passthrough();
+
+export const ReplayRecordingSegmentMetadataSchema = z
+  .object({
+    replayId: z.string(),
+    segmentId: z.number(),
+    projectId: z.union([z.string(), z.number()]),
+    dateAdded: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const ReplayRecordingSegmentMetadataListSchema = z.array(
+  ReplayRecordingSegmentMetadataSchema,
+);
+
+export const ReplayRecordingSegmentsSchema = z.array(z.array(z.unknown()));
+
 export const ClientKeySchema = z
   .object({
     id: z.union([z.string(), z.number()]),

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -58,6 +58,10 @@ import type {
   IssueTagValuesSchema,
   ExternalIssueSchema,
   ExternalIssueListSchema,
+  ReplayDetailsSchema,
+  ReplayRecordingSegmentMetadataSchema,
+  ReplayRecordingSegmentMetadataListSchema,
+  ReplayRecordingSegmentsSchema,
   OrganizationListSchema,
   OrganizationSchema,
   ProjectListSchema,
@@ -113,6 +117,16 @@ export type Tag = z.infer<typeof TagSchema>;
 export type AutofixRun = z.infer<typeof AutofixRunSchema>;
 export type AutofixRunState = z.infer<typeof AutofixRunStateSchema>;
 export type AssignedTo = z.infer<typeof AssignedToSchema>;
+export type ReplayDetails = z.infer<typeof ReplayDetailsSchema>;
+export type ReplayRecordingSegmentMetadata = z.infer<
+  typeof ReplayRecordingSegmentMetadataSchema
+>;
+export type ReplayRecordingSegmentMetadataList = z.infer<
+  typeof ReplayRecordingSegmentMetadataListSchema
+>;
+export type ReplayRecordingSegments = z.infer<
+  typeof ReplayRecordingSegmentsSchema
+>;
 
 export type OrganizationList = z.infer<typeof OrganizationListSchema>;
 export type TeamList = z.infer<typeof TeamListSchema>;

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -59,8 +59,6 @@ import type {
   ExternalIssueSchema,
   ExternalIssueListSchema,
   ReplayDetailsSchema,
-  ReplayRecordingSegmentMetadataSchema,
-  ReplayRecordingSegmentMetadataListSchema,
   ReplayRecordingSegmentsSchema,
   OrganizationListSchema,
   OrganizationSchema,
@@ -118,12 +116,6 @@ export type AutofixRun = z.infer<typeof AutofixRunSchema>;
 export type AutofixRunState = z.infer<typeof AutofixRunStateSchema>;
 export type AssignedTo = z.infer<typeof AssignedToSchema>;
 export type ReplayDetails = z.infer<typeof ReplayDetailsSchema>;
-export type ReplayRecordingSegmentMetadata = z.infer<
-  typeof ReplayRecordingSegmentMetadataSchema
->;
-export type ReplayRecordingSegmentMetadataList = z.infer<
-  typeof ReplayRecordingSegmentMetadataListSchema
->;
 export type ReplayRecordingSegments = z.infer<
   typeof ReplayRecordingSegmentsSchema
 >;

--- a/packages/mcp-core/src/schema.ts
+++ b/packages/mcp-core/src/schema.ts
@@ -66,6 +66,19 @@ export const ParamIssueUrl = z
     "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43",
   );
 
+export const ParamReplayId = z
+  .string()
+  .trim()
+  .describe("The replay ID. e.g. `7e07485f-12f9-416b-8b14-26260799b51f`");
+
+export const ParamReplayUrl = z
+  .string()
+  .url()
+  .trim()
+  .describe(
+    "The URL of the replay. e.g. https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/",
+  );
+
 export const ParamTraceId = z
   .string()
   .trim()

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Search for errors, analyze traces, and explore event details",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 15,
+    "toolCount": 16,
     "tools": [
       {
         "name": "find_organizations",
@@ -40,6 +40,11 @@
       {
         "name": "get_profile_details",
         "description": "Retrieve raw profile chunk data to inspect individual function calls, threads, and stack traces.\n\nUSE THIS TOOL WHEN:\n- User wants to inspect raw profiling samples for a specific profiler session\n- User needs to see individual thread activity and stack traces\n- User wants detailed frame-level data (function names, file locations, call counts)\n\nRETURNS:\n- Profile chunk metadata (platform, release, environment)\n- Per-thread sample counts and names\n- Top frames by occurrence with file locations\n- User code vs library code breakdown\n\nNOTE: This tool requires a `profilerId` which identifies a specific profiling session.\nUse `get_profile` for aggregated flamegraph analysis by transaction name.\n\n<examples>\n### Inspect a profiler session\n```\nget_profile_details(\n  organizationSlug='my-org',\n  projectSlugOrId='backend',\n  profilerId='041bde57b9844e36b8b7e5734efae5f7',\n  start='2024-01-01T00:00:00',\n  end='2024-01-01T01:00:00'\n)\n```\n</examples>\n\n<hints>\n- Use `focusOnUserCode: true` (default) to filter out library/system frames\n- The profilerId can be found in Sentry profile URLs or event data\n</hints>",
+        "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "get_replay_details",
+        "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
         "requiredScopes": ["event:read"]
       },
       {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Search for errors, analyze traces, and explore event details",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 16,
+    "toolCount": 15,
     "tools": [
       {
         "name": "find_organizations",
@@ -40,11 +40,6 @@
       {
         "name": "get_profile_details",
         "description": "Retrieve raw profile chunk data to inspect individual function calls, threads, and stack traces.\n\nUSE THIS TOOL WHEN:\n- User wants to inspect raw profiling samples for a specific profiler session\n- User needs to see individual thread activity and stack traces\n- User wants detailed frame-level data (function names, file locations, call counts)\n\nRETURNS:\n- Profile chunk metadata (platform, release, environment)\n- Per-thread sample counts and names\n- Top frames by occurrence with file locations\n- User code vs library code breakdown\n\nNOTE: This tool requires a `profilerId` which identifies a specific profiling session.\nUse `get_profile` for aggregated flamegraph analysis by transaction name.\n\n<examples>\n### Inspect a profiler session\n```\nget_profile_details(\n  organizationSlug='my-org',\n  projectSlugOrId='backend',\n  profilerId='041bde57b9844e36b8b7e5734efae5f7',\n  start='2024-01-01T00:00:00',\n  end='2024-01-01T01:00:00'\n)\n```\n</examples>\n\n<hints>\n- Use `focusOnUserCode: true` (default) to filter out library/system frames\n- The profilerId can be found in Sentry profile URLs or event data\n</hints>",
-        "requiredScopes": ["event:read"]
-      },
-      {
-        "name": "get_replay_details",
-        "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
         "requiredScopes": ["event:read"]
       },
       {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Search for errors, analyze traces, and explore event details",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 15,
+    "toolCount": 16,
     "tools": [
       {
         "name": "find_organizations",
@@ -39,12 +39,17 @@
       },
       {
         "name": "get_profile_details",
-        "description": "Retrieve raw profile chunk data to inspect individual function calls, threads, and stack traces.\n\nUSE THIS TOOL WHEN:\n- User wants to inspect raw profiling samples for a specific profiler session\n- User needs to see individual thread activity and stack traces\n- User wants detailed frame-level data (function names, file locations, call counts)\n\nRETURNS:\n- Profile chunk metadata (platform, release, environment)\n- Per-thread sample counts and names\n- Top frames by occurrence with file locations\n- User code vs library code breakdown\n\nNOTE: This tool requires a `profilerId` which identifies a specific profiling session.\nUse `get_profile` for aggregated flamegraph analysis by transaction name.\n\n<examples>\n### Inspect a profiler session\n```\nget_profile_details(\n  organizationSlug='my-org',\n  projectSlugOrId='backend',\n  profilerId='041bde57b9844e36b8b7e5734efae5f7',\n  start='2024-01-01T00:00:00',\n  end='2024-01-01T01:00:00'\n)\n```\n</examples>\n\n<hints>\n- Use `focusOnUserCode: true` (default) to filter out library/system frames\n- The profilerId can be found in Sentry profile URLs or event data\n</hints>",
+        "description": "PLACEHOLDER - will be regenerated",
+        "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "get_replay_details",
+        "description": "PLACEHOLDER - will be regenerated",
         "requiredScopes": ["event:read"]
       },
       {
         "name": "get_sentry_resource",
-        "description": "Fetch a Sentry resource by URL or by type and ID.\n\n<examples>\n### From a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\n\n### Breadcrumbs from a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/', resourceType='breadcrumbs')\n\n### By type and ID\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\n</examples>",
+        "description": "PLACEHOLDER - will be regenerated",
         "requiredScopes": ["event:read"]
       },
       {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -39,17 +39,17 @@
       },
       {
         "name": "get_profile_details",
-        "description": "PLACEHOLDER - will be regenerated",
+        "description": "Retrieve raw profile chunk data to inspect individual function calls, threads, and stack traces.\n\nUSE THIS TOOL WHEN:\n- User wants to inspect raw profiling samples for a specific profiler session\n- User needs to see individual thread activity and stack traces\n- User wants detailed frame-level data (function names, file locations, call counts)\n\nRETURNS:\n- Profile chunk metadata (platform, release, environment)\n- Per-thread sample counts and names\n- Top frames by occurrence with file locations\n- User code vs library code breakdown\n\nNOTE: This tool requires a `profilerId` which identifies a specific profiling session.\nUse `get_profile` for aggregated flamegraph analysis by transaction name.\n\n<examples>\n### Inspect a profiler session\n```\nget_profile_details(\n  organizationSlug='my-org',\n  projectSlugOrId='backend',\n  profilerId='041bde57b9844e36b8b7e5734efae5f7',\n  start='2024-01-01T00:00:00',\n  end='2024-01-01T01:00:00'\n)\n```\n</examples>\n\n<hints>\n- Use `focusOnUserCode: true` (default) to filter out library/system frames\n- The profilerId can be found in Sentry profile URLs or event data\n</hints>",
         "requiredScopes": ["event:read"]
       },
       {
         "name": "get_replay_details",
-        "description": "PLACEHOLDER - will be regenerated",
+        "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
         "requiredScopes": ["event:read"]
       },
       {
         "name": "get_sentry_resource",
-        "description": "PLACEHOLDER - will be regenerated",
+        "description": "Fetch a Sentry resource by URL or by type and ID.\n\n<examples>\n### From a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\n\n### Breadcrumbs from a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/', resourceType='breadcrumbs')\n\n### By type and ID\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\n</examples>",
         "requiredScopes": ["event:read"]
       },
       {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -535,6 +535,31 @@
     "requiredScopes": ["event:read"]
   },
   {
+    "name": "get_replay_details",
+    "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "replayUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the replay. e.g. https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/"
+        },
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "replayId": {
+          "type": "string",
+          "description": "The replay ID. e.g. `7e07485f-12f9-416b-8b14-26260799b51f`"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"]
+  },
+  {
     "name": "get_sentry_resource",
     "description": "Fetch a Sentry resource by URL or by type and ID.\n\n<examples>\n### From a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\n\n### Breadcrumbs from a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/', resourceType='breadcrumbs')\n\n### By type and ID\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\n</examples>",
     "inputSchema": {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -535,6 +535,31 @@
     "requiredScopes": ["event:read"]
   },
   {
+    "name": "get_replay_details",
+    "description": "Get detailed information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want replay overview details and a concise activity timeline\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "replayUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the replay. e.g. https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/"
+        },
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "replayId": {
+          "type": "string",
+          "description": "The replay ID. e.g. `7e07485f-12f9-416b-8b14-26260799b51f`"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"]
+  },
+  {
     "name": "get_sentry_resource",
     "description": "Fetch a Sentry resource by URL or by type and ID.\n\n<examples>\n### From a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\n\n### Breadcrumbs from a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/', resourceType='breadcrumbs')\n\n### By type and ID\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\n</examples>",
     "inputSchema": {
@@ -547,7 +572,7 @@
         },
         "resourceType": {
           "type": "string",
-          "enum": ["issue", "event", "trace", "breadcrumbs"],
+          "enum": ["issue", "event", "trace", "breadcrumbs", "replay"],
           "description": "Resource type. With a URL, overrides the auto-detected type (e.g., 'breadcrumbs' on an issue URL)."
         },
         "resourceId": {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -535,31 +535,6 @@
     "requiredScopes": ["event:read"]
   },
   {
-    "name": "get_replay_details",
-    "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "replayUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "The URL of the replay. e.g. https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/"
-        },
-        "organizationSlug": {
-          "type": "string",
-          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
-        },
-        "replayId": {
-          "type": "string",
-          "description": "The replay ID. e.g. `7e07485f-12f9-416b-8b14-26260799b51f`"
-        }
-      },
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    },
-    "requiredScopes": ["event:read"]
-  },
-  {
     "name": "get_sentry_resource",
     "description": "Fetch a Sentry resource by URL or by type and ID.\n\n<examples>\n### From a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\n\n### Breadcrumbs from a Sentry URL\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/', resourceType='breadcrumbs')\n\n### By type and ID\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\n</examples>",
     "inputSchema": {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -536,7 +536,7 @@
   },
   {
     "name": "get_replay_details",
-    "description": "Get detailed information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want replay overview details and a concise activity timeline\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
+    "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
     "inputSchema": {
       "type": "object",
       "properties": {

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -265,4 +265,49 @@ describe("get_replay_details", () => {
       `[UserInputError: Provide either \`replayUrl\` or both \`organizationSlug\` and \`replayId\`.]`,
     );
   });
+
+  it("does not repeat explicit payload fields in generic replay events", async () => {
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        () =>
+          HttpResponse.json([
+            [
+              {
+                type: 5,
+                timestamp: 1744027205000,
+                data: {
+                  tag: "console",
+                  payload: {
+                    message: "Payment request failed",
+                    description: "POST /api/orders returned 500",
+                    category: "network",
+                    type: "error",
+                    endpoint: "/api/orders",
+                    status: 500,
+                  },
+                },
+              },
+            ],
+          ]),
+        { once: true },
+      ),
+    );
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        replayId: replayDetailsFixture.id,
+      },
+      getServerContext(),
+    );
+
+    expect(result).toContain(
+      '- T+0s · `console` · message="Payment request failed" · description="POST /api/orders returned 500" · category="network" · type="error" · payload="endpoint=/api/orders, status=500"',
+    );
+    expect(result).not.toContain('payload="message=Payment request failed');
+    expect(result).not.toContain(
+      'payload="description=POST /api/orders returned 500',
+    );
+  });
 });

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { mswServer } from "@sentry/mcp-server-mocks";
+import getReplayDetails from "./get-replay-details.js";
+import { getServerContext } from "../test-setup.js";
+
+const replayDetailsFixture = {
+  id: "7e07485f-12f9-416b-8b14-26260799b51f",
+  project_id: "4509062593708032",
+  started_at: "2025-04-07T12:00:00.000Z",
+  finished_at: "2025-04-07T12:05:00.000Z",
+  duration: 300,
+  is_archived: false,
+  environment: "production",
+  platform: "javascript",
+  count_errors: 1,
+  count_warnings: 2,
+  count_infos: 3,
+  count_dead_clicks: 1,
+  count_rage_clicks: 0,
+  count_segments: 2,
+  count_urls: 2,
+  urls: ["/login", "/checkout"],
+  trace_ids: ["a4d1aae7216b47ff8117cf4e09ce9d0a"],
+  error_ids: ["err-1"],
+  browser: { name: "Chrome", version: "123.0" },
+  os: { name: "macOS", version: "14.4" },
+  device: { family: "Mac", model: "MacBook Pro", name: "MacBook Pro" },
+  sdk: { name: "@sentry/browser", version: "8.0.0" },
+  user: {
+    display_name: "Taylor Example",
+    email: "taylor@example.com",
+    id: "user-1",
+  },
+};
+
+const replaySegmentsFixture = [
+  [
+    {
+      type: 4,
+      timestamp: 1744027200000,
+      data: { href: "https://example.com/login", width: 1440, height: 900 },
+    },
+    {
+      type: 5,
+      timestamp: 1744027210,
+      data: {
+        tag: "performanceSpan",
+        payload: {
+          op: "navigation.navigate",
+          description: "https://example.com/checkout",
+          data: { duration: 710 },
+        },
+      },
+    },
+  ],
+  [
+    {
+      type: 5,
+      timestamp: 1744027220,
+      data: {
+        tag: "ui.click",
+        payload: {
+          message: "Clicked submit order",
+        },
+      },
+    },
+  ],
+];
+
+function mockReplayApis({
+  replay = replayDetailsFixture,
+  segments = replaySegmentsFixture,
+}: {
+  replay?: Record<string, unknown>;
+  segments?: unknown[][];
+} = {}) {
+  mswServer.use(
+    http.get(
+      `https://sentry.io/api/0/organizations/test-org/replays/${replay.id}/`,
+      () => HttpResponse.json({ data: replay }),
+      { once: true },
+    ),
+    http.get(
+      `https://sentry.io/api/0/projects/test-org/${replay.project_id}/replays/${replay.id}/recording-segments/`,
+      () => HttpResponse.json(segments),
+      { once: true },
+    ),
+  );
+}
+
+describe("get_replay_details", () => {
+  it("loads replay details from replayUrl", async () => {
+    mockReplayApis();
+
+    const result = await getReplayDetails.handler(
+      {
+        replayUrl: `https://test-org.sentry.io/replays/${replayDetailsFixture.id}/`,
+      },
+      getServerContext(),
+    );
+
+    expect(result).toContain(
+      `# Replay ${replayDetailsFixture.id} in **test-org**`,
+    );
+    expect(result).toContain("**User**: Taylor Example");
+    expect(result).toContain("view loaded https://example.com/login");
+    expect(result).toContain("Clicked submit order");
+  });
+
+  it("loads replay details from organizationSlug and replayId", async () => {
+    mockReplayApis();
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "test-org",
+        replayId: replayDetailsFixture.id,
+      },
+      getServerContext(),
+    );
+
+    expect(result).toContain("**Project ID**: 4509062593708032");
+    expect(result).toContain("**Trace IDs**: a4d1aae7216b47ff8117cf4e09ce9d0a");
+  });
+
+  it("skips segment-derived timeline for archived replays", async () => {
+    const archivedReplay = {
+      ...replayDetailsFixture,
+      is_archived: true,
+    };
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/organizations/test-org/replays/${archivedReplay.id}/`,
+        () => HttpResponse.json({ data: archivedReplay }),
+        { once: true },
+      ),
+    );
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "test-org",
+        replayId: archivedReplay.id,
+      },
+      getServerContext(),
+    );
+
+    expect(result).toContain("Replay recording data is archived");
+    expect(result).not.toContain("view loaded https://example.com/login");
+  });
+
+  it("degrades gracefully when segment fetch fails", async () => {
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/organizations/test-org/replays/${replayDetailsFixture.id}/`,
+        () => HttpResponse.json({ data: replayDetailsFixture }),
+        { once: true },
+      ),
+      http.get(
+        `https://sentry.io/api/0/projects/test-org/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        () =>
+          HttpResponse.json(
+            { detail: "Replay recording segment not found." },
+            { status: 404 },
+          ),
+        { once: true },
+      ),
+    );
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "test-org",
+        replayId: replayDetailsFixture.id,
+      },
+      getServerContext(),
+    );
+
+    expect(result).toContain(
+      "Replay details loaded, but the deeper recording data could not be fetched",
+    );
+    expect(result).toContain("Replay recording segment not found.");
+  });
+
+  it("throws for invalid direct input", async () => {
+    await expect(
+      getReplayDetails.handler({}, getServerContext()),
+    ).rejects.toThrow(
+      "Provide either `replayUrl` or both `organizationSlug` and `replayId`.",
+    );
+  });
+});

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -4,8 +4,44 @@ import { mswServer, replayDetailsFixture } from "@sentry/mcp-server-mocks";
 import getReplayDetails from "./get-replay-details.js";
 import { getServerContext } from "../test-setup.js";
 
+const replayIssueAutofixState = {
+  autofix: {
+    run_id: 1,
+    request: {},
+    updated_at: "2025-04-07T12:05:30.000Z",
+    status: "COMPLETED" as const,
+    steps: [
+      {
+        type: "root_cause_analysis" as const,
+        key: "root_cause_analysis",
+        index: 0,
+        status: "COMPLETED" as const,
+        title: "Root Cause Analysis",
+        output_stream: null,
+        progress: [],
+        causes: [
+          {
+            description:
+              "The issue is triggered when the tool registry registers list_organizations twice during startup.",
+            id: 0,
+            root_cause_reproduction: [],
+          },
+        ],
+      },
+    ],
+  },
+};
+
 describe("get_replay_details", () => {
   it("loads replay details from replayUrl", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/autofix/",
+        () => HttpResponse.json(replayIssueAutofixState),
+        { once: true },
+      ),
+    );
+
     const result = await getReplayDetails.handler(
       {
         replayUrl: `https://sentry-mcp-evals.sentry.io/replays/${replayDetailsFixture.id}/`,
@@ -13,15 +49,65 @@ describe("get_replay_details", () => {
       getServerContext(),
     );
 
-    expect(result).toContain(
-      `# Replay ${replayDetailsFixture.id} in **sentry-mcp-evals**`,
-    );
-    expect(result).toContain("**User**: Taylor Example");
-    expect(result).toContain("view loaded https://example.com/login");
-    expect(result).toContain("Clicked submit order");
+    expect(result).toMatchInlineSnapshot(`
+      "# Replay 7e07485f-12f9-416b-8b14-26260799b51f in **sentry-mcp-evals**
+
+      ## Summary
+
+      - **Replay URL**: https://sentry-mcp-evals.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/
+      - **Started**: 2025-04-07T12:00:00.000Z
+      - **Finished**: 2025-04-07T12:05:00.000Z
+      - **Duration**: 5m
+      - **Archived**: No
+      - **Environment**: production
+      - **Platform**: javascript
+      - **Browser**: Chrome 123.0
+      - **User**: Taylor Example
+      - **URLs**: /login, /checkout
+      - **Device**: MacBook Pro
+      - **Signal Counts**: errors=1, warnings=2, infos=3, dead_clicks=1, rage_clicks=0, segments=2
+
+      ## Events
+
+      - T+0s · \`page.view\` · href=https://example.com/login
+      - T+10s · \`navigation.navigate\` · description=https://example.com/checkout · duration_ms=710
+      - T+20s · \`ui.click\` · message="Clicked submit order"
+      - metadata · \`error\` · event_id=7ca573c0f4814912aaa9bdc77d1a7d51 · issue_id=CLOUDFLARE-MCP-41 · title="Error: Tool list_organizations is already registered"
+      - metadata · \`dead_click\` · count=1
+      - metadata · \`warning\` · count=2
+      - metadata · \`info\` · count=3
+
+      ## Related
+
+      ### Error Event \`7ca573c0f4814912aaa9bdc77d1a7d51\`
+      **Issue ID**: CLOUDFLARE-MCP-41
+      **Summary**: Error: Tool list_organizations is already registered
+      **Status**: unresolved
+      **Cached Seer Summary**: The issue is triggered when the tool registry registers list_organizations twice during startup.
+      **Next Step**: \`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='7ca573c0f4814912aaa9bdc77d1a7d51')\`
+      **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
+
+      ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
+      **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
+      **Next Step**: \`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
+      "
+    `);
   });
 
-  it("loads replay details from organizationSlug and replayId", async () => {
+  it("includes next-step guidance when only raw replay IDs are available", async () => {
+    const replayWithUnresolvedError = {
+      ...replayDetailsFixture,
+      error_ids: ["replay-only-event-id"],
+    };
+
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        () => HttpResponse.json({ data: replayWithUnresolvedError }),
+        { once: true },
+      ),
+    );
+
     const result = await getReplayDetails.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -30,10 +116,14 @@ describe("get_replay_details", () => {
       getServerContext(),
     );
 
+    expect(result).toContain("### Error Event `replay-only-event-id`");
     expect(result).toContain(
-      `**Project ID**: ${replayDetailsFixture.project_id}`,
+      "`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='replay-only-event-id')`",
     );
-    expect(result).toContain("**Trace IDs**: a4d1aae7216b47ff8117cf4e09ce9d0a");
+    expect(result).toContain("### Trace `a4d1aae7216b47ff8117cf4e09ce9d0a`");
+    expect(result).toContain(
+      "`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')`",
+    );
   });
 
   it("skips segment-derived timeline for archived replays", async () => {
@@ -41,6 +131,7 @@ describe("get_replay_details", () => {
       ...replayDetailsFixture,
       is_archived: true,
     };
+
     mswServer.use(
       http.get(
         `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${archivedReplay.id}/`,
@@ -57,8 +148,46 @@ describe("get_replay_details", () => {
       getServerContext(),
     );
 
-    expect(result).toContain("Replay recording data is archived");
-    expect(result).not.toContain("view loaded https://example.com/login");
+    expect(result).toMatchInlineSnapshot(`
+      "# Replay 7e07485f-12f9-416b-8b14-26260799b51f in **sentry-mcp-evals**
+
+      ## Summary
+
+      - **Replay URL**: https://sentry-mcp-evals.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/
+      - **Started**: 2025-04-07T12:00:00.000Z
+      - **Finished**: 2025-04-07T12:05:00.000Z
+      - **Duration**: 5m
+      - **Archived**: Yes
+      - **Environment**: production
+      - **Platform**: javascript
+      - **Browser**: Chrome 123.0
+      - **User**: Taylor Example
+      - **URLs**: /login, /checkout
+      - **Device**: MacBook Pro
+      - **Signal Counts**: errors=1, warnings=2, infos=3, dead_clicks=1, rage_clicks=0, segments=2
+
+      ## Events
+
+      - \`recording_segments\` · status=archived
+      - metadata · \`error\` · event_id=7ca573c0f4814912aaa9bdc77d1a7d51 · issue_id=CLOUDFLARE-MCP-41 · title="Error: Tool list_organizations is already registered"
+      - metadata · \`dead_click\` · count=1
+      - metadata · \`warning\` · count=2
+      - metadata · \`info\` · count=3
+
+      ## Related
+
+      ### Error Event \`7ca573c0f4814912aaa9bdc77d1a7d51\`
+      **Issue ID**: CLOUDFLARE-MCP-41
+      **Summary**: Error: Tool list_organizations is already registered
+      **Status**: unresolved
+      **Next Step**: \`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='7ca573c0f4814912aaa9bdc77d1a7d51')\`
+      **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
+
+      ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
+      **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
+      **Next Step**: \`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
+      "
+    `);
   });
 
   it("degrades gracefully when segment fetch fails", async () => {
@@ -87,17 +216,53 @@ describe("get_replay_details", () => {
       getServerContext(),
     );
 
-    expect(result).toContain(
-      "Replay details loaded, but the deeper recording data could not be fetched",
-    );
-    expect(result).toContain("Replay recording segment not found.");
+    expect(result).toMatchInlineSnapshot(`
+      "# Replay 7e07485f-12f9-416b-8b14-26260799b51f in **sentry-mcp-evals**
+
+      ## Summary
+
+      - **Replay URL**: https://sentry-mcp-evals.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/
+      - **Started**: 2025-04-07T12:00:00.000Z
+      - **Finished**: 2025-04-07T12:05:00.000Z
+      - **Duration**: 5m
+      - **Archived**: No
+      - **Environment**: production
+      - **Platform**: javascript
+      - **Browser**: Chrome 123.0
+      - **User**: Taylor Example
+      - **URLs**: /login, /checkout
+      - **Device**: MacBook Pro
+      - **Signal Counts**: errors=1, warnings=2, infos=3, dead_clicks=1, rage_clicks=0, segments=2
+
+      ## Events
+
+      - \`recording_segments\` · status=unavailable · detail="Replay recording segment not found."
+      - metadata · \`error\` · event_id=7ca573c0f4814912aaa9bdc77d1a7d51 · issue_id=CLOUDFLARE-MCP-41 · title="Error: Tool list_organizations is already registered"
+      - metadata · \`dead_click\` · count=1
+      - metadata · \`warning\` · count=2
+      - metadata · \`info\` · count=3
+
+      ## Related
+
+      ### Error Event \`7ca573c0f4814912aaa9bdc77d1a7d51\`
+      **Issue ID**: CLOUDFLARE-MCP-41
+      **Summary**: Error: Tool list_organizations is already registered
+      **Status**: unresolved
+      **Next Step**: \`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='7ca573c0f4814912aaa9bdc77d1a7d51')\`
+      **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
+
+      ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
+      **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
+      **Next Step**: \`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
+      "
+    `);
   });
 
   it("throws for invalid direct input", async () => {
     await expect(
       getReplayDetails.handler({}, getServerContext()),
-    ).rejects.toThrow(
-      "Provide either `replayUrl` or both `organizationSlug` and `replayId`.",
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[UserInputError: Provide either \`replayUrl\` or both \`organizationSlug\` and \`replayId\`.]`,
     );
   });
 });

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -84,12 +84,12 @@ describe("get_replay_details", () => {
       **Summary**: Error: Tool list_organizations is already registered
       **Status**: unresolved
       **Cached Seer Summary**: The issue is triggered when the tool registry registers list_organizations twice during startup.
-      **Next Step**: \`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='7ca573c0f4814912aaa9bdc77d1a7d51')\`
+      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='CLOUDFLARE-MCP-41')\`
       **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
 
       ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
       **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
-      **Next Step**: \`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
+      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
       "
     `);
   });
@@ -118,11 +118,11 @@ describe("get_replay_details", () => {
 
     expect(result).toContain("### Error Event `replay-only-event-id`");
     expect(result).toContain(
-      "`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='replay-only-event-id')`",
+      "`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='replay-only-event-id')`",
     );
     expect(result).toContain("### Trace `a4d1aae7216b47ff8117cf4e09ce9d0a`");
     expect(result).toContain(
-      "`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')`",
+      "`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')`",
     );
   });
 
@@ -180,12 +180,12 @@ describe("get_replay_details", () => {
       **Issue ID**: CLOUDFLARE-MCP-41
       **Summary**: Error: Tool list_organizations is already registered
       **Status**: unresolved
-      **Next Step**: \`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='7ca573c0f4814912aaa9bdc77d1a7d51')\`
+      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='CLOUDFLARE-MCP-41')\`
       **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
 
       ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
       **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
-      **Next Step**: \`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
+      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
       "
     `);
   });
@@ -248,12 +248,12 @@ describe("get_replay_details", () => {
       **Issue ID**: CLOUDFLARE-MCP-41
       **Summary**: Error: Tool list_organizations is already registered
       **Status**: unresolved
-      **Next Step**: \`get_issue_details(organizationSlug='sentry-mcp-evals', eventId='7ca573c0f4814912aaa9bdc77d1a7d51')\`
+      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='CLOUDFLARE-MCP-41')\`
       **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
 
       ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
       **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
-      **Next Step**: \`get_trace_details(organizationSlug='sentry-mcp-evals', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
+      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
       "
     `);
   });

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -310,4 +310,37 @@ describe("get_replay_details", () => {
       'payload="description=POST /api/orders returned 500',
     );
   });
+
+  it("ignores array payloads instead of rendering numeric keys", async () => {
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        () =>
+          HttpResponse.json([
+            [
+              {
+                type: 5,
+                timestamp: 1744027205000,
+                data: {
+                  tag: "console",
+                  payload: ["alpha", "beta"],
+                },
+              },
+            ],
+          ]),
+        { once: true },
+      ),
+    );
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        replayId: replayDetailsFixture.id,
+      },
+      getServerContext(),
+    );
+
+    expect(result).not.toContain("- T+0s · `console`");
+    expect(result).not.toContain('payload="0=');
+  });
 });

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -1,107 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
-import { mswServer } from "@sentry/mcp-server-mocks";
+import { mswServer, replayDetailsFixture } from "@sentry/mcp-server-mocks";
 import getReplayDetails from "./get-replay-details.js";
 import { getServerContext } from "../test-setup.js";
 
-const replayDetailsFixture = {
-  id: "7e07485f-12f9-416b-8b14-26260799b51f",
-  project_id: "4509062593708032",
-  started_at: "2025-04-07T12:00:00.000Z",
-  finished_at: "2025-04-07T12:05:00.000Z",
-  duration: 300,
-  is_archived: false,
-  environment: "production",
-  platform: "javascript",
-  count_errors: 1,
-  count_warnings: 2,
-  count_infos: 3,
-  count_dead_clicks: 1,
-  count_rage_clicks: 0,
-  count_segments: 2,
-  count_urls: 2,
-  urls: ["/login", "/checkout"],
-  trace_ids: ["a4d1aae7216b47ff8117cf4e09ce9d0a"],
-  error_ids: ["err-1"],
-  browser: { name: "Chrome", version: "123.0" },
-  os: { name: "macOS", version: "14.4" },
-  device: { family: "Mac", model: "MacBook Pro", name: "MacBook Pro" },
-  sdk: { name: "@sentry/browser", version: "8.0.0" },
-  user: {
-    display_name: "Taylor Example",
-    email: "taylor@example.com",
-    id: "user-1",
-  },
-};
-
-const replaySegmentsFixture = [
-  [
-    {
-      type: 4,
-      timestamp: 1744027200000,
-      data: { href: "https://example.com/login", width: 1440, height: 900 },
-    },
-    {
-      type: 5,
-      timestamp: 1744027210,
-      data: {
-        tag: "performanceSpan",
-        payload: {
-          op: "navigation.navigate",
-          description: "https://example.com/checkout",
-          data: { duration: 710 },
-        },
-      },
-    },
-  ],
-  [
-    {
-      type: 5,
-      timestamp: 1744027220,
-      data: {
-        tag: "ui.click",
-        payload: {
-          message: "Clicked submit order",
-        },
-      },
-    },
-  ],
-];
-
-function mockReplayApis({
-  replay = replayDetailsFixture,
-  segments = replaySegmentsFixture,
-}: {
-  replay?: Record<string, unknown>;
-  segments?: unknown[][];
-} = {}) {
-  mswServer.use(
-    http.get(
-      `https://sentry.io/api/0/organizations/test-org/replays/${replay.id}/`,
-      () => HttpResponse.json({ data: replay }),
-      { once: true },
-    ),
-    http.get(
-      `https://sentry.io/api/0/projects/test-org/${replay.project_id}/replays/${replay.id}/recording-segments/`,
-      () => HttpResponse.json(segments),
-      { once: true },
-    ),
-  );
-}
-
 describe("get_replay_details", () => {
   it("loads replay details from replayUrl", async () => {
-    mockReplayApis();
-
     const result = await getReplayDetails.handler(
       {
-        replayUrl: `https://test-org.sentry.io/replays/${replayDetailsFixture.id}/`,
+        replayUrl: `https://sentry-mcp-evals.sentry.io/replays/${replayDetailsFixture.id}/`,
       },
       getServerContext(),
     );
 
     expect(result).toContain(
-      `# Replay ${replayDetailsFixture.id} in **test-org**`,
+      `# Replay ${replayDetailsFixture.id} in **sentry-mcp-evals**`,
     );
     expect(result).toContain("**User**: Taylor Example");
     expect(result).toContain("view loaded https://example.com/login");
@@ -109,17 +22,17 @@ describe("get_replay_details", () => {
   });
 
   it("loads replay details from organizationSlug and replayId", async () => {
-    mockReplayApis();
-
     const result = await getReplayDetails.handler(
       {
-        organizationSlug: "test-org",
+        organizationSlug: "sentry-mcp-evals",
         replayId: replayDetailsFixture.id,
       },
       getServerContext(),
     );
 
-    expect(result).toContain("**Project ID**: 4509062593708032");
+    expect(result).toContain(
+      `**Project ID**: ${replayDetailsFixture.project_id}`,
+    );
     expect(result).toContain("**Trace IDs**: a4d1aae7216b47ff8117cf4e09ce9d0a");
   });
 
@@ -130,7 +43,7 @@ describe("get_replay_details", () => {
     };
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/organizations/test-org/replays/${archivedReplay.id}/`,
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${archivedReplay.id}/`,
         () => HttpResponse.json({ data: archivedReplay }),
         { once: true },
       ),
@@ -138,7 +51,7 @@ describe("get_replay_details", () => {
 
     const result = await getReplayDetails.handler(
       {
-        organizationSlug: "test-org",
+        organizationSlug: "sentry-mcp-evals",
         replayId: archivedReplay.id,
       },
       getServerContext(),
@@ -151,12 +64,12 @@ describe("get_replay_details", () => {
   it("degrades gracefully when segment fetch fails", async () => {
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/organizations/test-org/replays/${replayDetailsFixture.id}/`,
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
         () => HttpResponse.json({ data: replayDetailsFixture }),
         { once: true },
       ),
       http.get(
-        `https://sentry.io/api/0/projects/test-org/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
         () =>
           HttpResponse.json(
             { detail: "Replay recording segment not found." },
@@ -168,7 +81,7 @@ describe("get_replay_details", () => {
 
     const result = await getReplayDetails.handler(
       {
-        organizationSlug: "test-org",
+        organizationSlug: "sentry-mcp-evals",
         replayId: replayDetailsFixture.id,
       },
       getServerContext(),

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -4,44 +4,8 @@ import { mswServer, replayDetailsFixture } from "@sentry/mcp-server-mocks";
 import getReplayDetails from "./get-replay-details.js";
 import { getServerContext } from "../test-setup.js";
 
-const replayIssueAutofixState = {
-  autofix: {
-    run_id: 1,
-    request: {},
-    updated_at: "2025-04-07T12:05:30.000Z",
-    status: "COMPLETED" as const,
-    steps: [
-      {
-        type: "root_cause_analysis" as const,
-        key: "root_cause_analysis",
-        index: 0,
-        status: "COMPLETED" as const,
-        title: "Root Cause Analysis",
-        output_stream: null,
-        progress: [],
-        causes: [
-          {
-            description:
-              "The issue is triggered when the tool registry registers list_organizations twice during startup.",
-            id: 0,
-            root_cause_reproduction: [],
-          },
-        ],
-      },
-    ],
-  },
-};
-
 describe("get_replay_details", () => {
   it("loads replay details from replayUrl", async () => {
-    mswServer.use(
-      http.get(
-        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/autofix/",
-        () => HttpResponse.json(replayIssueAutofixState),
-        { once: true },
-      ),
-    );
-
     const result = await getReplayDetails.handler(
       {
         replayUrl: `https://sentry-mcp-evals.sentry.io/replays/${replayDetailsFixture.id}/`,
@@ -55,46 +19,31 @@ describe("get_replay_details", () => {
       ## Summary
 
       - **Replay URL**: https://sentry-mcp-evals.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/
-      - **Started**: 2025-04-07T12:00:00.000Z
-      - **Finished**: 2025-04-07T12:05:00.000Z
       - **Duration**: 5m
-      - **Archived**: No
       - **Environment**: production
-      - **Platform**: javascript
       - **Browser**: Chrome 123.0
+      - **OS**: macOS 14.4
       - **User**: Taylor Example
       - **URLs**: /login, /checkout
       - **Device**: MacBook Pro
-      - **Signal Counts**: errors=1, warnings=2, infos=3, dead_clicks=1, rage_clicks=0, segments=2
+      - **Release**: frontend@1.2.3
 
-      ## Events
+      ## Activity
 
       - T+0s · \`page.view\` · href=https://example.com/login
       - T+10s · \`navigation.navigate\` · description=https://example.com/checkout · duration_ms=710
       - T+20s · \`ui.click\` · message="Clicked submit order"
-      - metadata · \`error\` · event_id=7ca573c0f4814912aaa9bdc77d1a7d51 · issue_id=CLOUDFLARE-MCP-41 · title="Error: Tool list_organizations is already registered"
-      - metadata · \`dead_click\` · count=1
-      - metadata · \`warning\` · count=2
-      - metadata · \`info\` · count=3
 
       ## Related
 
-      ### Error Event \`7ca573c0f4814912aaa9bdc77d1a7d51\`
-      **Issue ID**: CLOUDFLARE-MCP-41
-      **Summary**: Error: Tool list_organizations is already registered
-      **Status**: unresolved
-      **Cached Seer Summary**: The issue is triggered when the tool registry registers list_organizations twice during startup.
-      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='CLOUDFLARE-MCP-41')\`
-      **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
+      - **CLOUDFLARE-MCP-41**: Error: Tool list_organizations is already registered
+      - Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\` (112 spans)
 
-      ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
-      **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
-      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
-      "
+      Use \`get_sentry_resource\` to inspect any issue or trace listed above."
     `);
   });
 
-  it("includes next-step guidance when only raw replay IDs are available", async () => {
+  it("shows unresolved error events by event ID", async () => {
     const replayWithUnresolvedError = {
       ...replayDetailsFixture,
       error_ids: ["replay-only-event-id"],
@@ -116,17 +65,11 @@ describe("get_replay_details", () => {
       getServerContext(),
     );
 
-    expect(result).toContain("### Error Event `replay-only-event-id`");
-    expect(result).toContain(
-      "`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='replay-only-event-id')`",
-    );
-    expect(result).toContain("### Trace `a4d1aae7216b47ff8117cf4e09ce9d0a`");
-    expect(result).toContain(
-      "`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')`",
-    );
+    expect(result).toContain("- Event `replay-only-event-id`");
+    expect(result).toContain("Use `get_sentry_resource`");
   });
 
-  it("skips segment-derived timeline for archived replays", async () => {
+  it("handles archived replays", async () => {
     const archivedReplay = {
       ...replayDetailsFixture,
       is_archived: true,
@@ -154,39 +97,25 @@ describe("get_replay_details", () => {
       ## Summary
 
       - **Replay URL**: https://sentry-mcp-evals.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/
-      - **Started**: 2025-04-07T12:00:00.000Z
-      - **Finished**: 2025-04-07T12:05:00.000Z
       - **Duration**: 5m
-      - **Archived**: Yes
       - **Environment**: production
-      - **Platform**: javascript
       - **Browser**: Chrome 123.0
+      - **OS**: macOS 14.4
       - **User**: Taylor Example
       - **URLs**: /login, /checkout
       - **Device**: MacBook Pro
-      - **Signal Counts**: errors=1, warnings=2, infos=3, dead_clicks=1, rage_clicks=0, segments=2
+      - **Release**: frontend@1.2.3
 
-      ## Events
+      ## Activity
 
-      - \`recording_segments\` · status=archived
-      - metadata · \`error\` · event_id=7ca573c0f4814912aaa9bdc77d1a7d51 · issue_id=CLOUDFLARE-MCP-41 · title="Error: Tool list_organizations is already registered"
-      - metadata · \`dead_click\` · count=1
-      - metadata · \`warning\` · count=2
-      - metadata · \`info\` · count=3
+      Recording is archived and not available for playback.
 
       ## Related
 
-      ### Error Event \`7ca573c0f4814912aaa9bdc77d1a7d51\`
-      **Issue ID**: CLOUDFLARE-MCP-41
-      **Summary**: Error: Tool list_organizations is already registered
-      **Status**: unresolved
-      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='CLOUDFLARE-MCP-41')\`
-      **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
+      - **CLOUDFLARE-MCP-41**: Error: Tool list_organizations is already registered
+      - Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\` (112 spans)
 
-      ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
-      **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
-      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
-      "
+      Use \`get_sentry_resource\` to inspect any issue or trace listed above."
     `);
   });
 
@@ -222,39 +151,25 @@ describe("get_replay_details", () => {
       ## Summary
 
       - **Replay URL**: https://sentry-mcp-evals.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/
-      - **Started**: 2025-04-07T12:00:00.000Z
-      - **Finished**: 2025-04-07T12:05:00.000Z
       - **Duration**: 5m
-      - **Archived**: No
       - **Environment**: production
-      - **Platform**: javascript
       - **Browser**: Chrome 123.0
+      - **OS**: macOS 14.4
       - **User**: Taylor Example
       - **URLs**: /login, /checkout
       - **Device**: MacBook Pro
-      - **Signal Counts**: errors=1, warnings=2, infos=3, dead_clicks=1, rage_clicks=0, segments=2
+      - **Release**: frontend@1.2.3
 
-      ## Events
+      ## Activity
 
-      - \`recording_segments\` · status=unavailable · detail="Replay recording segment not found."
-      - metadata · \`error\` · event_id=7ca573c0f4814912aaa9bdc77d1a7d51 · issue_id=CLOUDFLARE-MCP-41 · title="Error: Tool list_organizations is already registered"
-      - metadata · \`dead_click\` · count=1
-      - metadata · \`warning\` · count=2
-      - metadata · \`info\` · count=3
+      No activity events recorded.
 
       ## Related
 
-      ### Error Event \`7ca573c0f4814912aaa9bdc77d1a7d51\`
-      **Issue ID**: CLOUDFLARE-MCP-41
-      **Summary**: Error: Tool list_organizations is already registered
-      **Status**: unresolved
-      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='issue', resourceId='CLOUDFLARE-MCP-41')\`
-      **Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41')\`
+      - **CLOUDFLARE-MCP-41**: Error: Tool list_organizations is already registered
+      - Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\` (112 spans)
 
-      ### Trace \`a4d1aae7216b47ff8117cf4e09ce9d0a\`
-      **High-level Stats**: 112 spans, 0 errors, 0 performance issues, 0 logs
-      **Next Step**: \`get_sentry_resource(organizationSlug='sentry-mcp-evals', resourceType='trace', resourceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\`
-      "
+      Use \`get_sentry_resource\` to inspect any issue or trace listed above."
     `);
   });
 
@@ -304,10 +219,6 @@ describe("get_replay_details", () => {
 
     expect(result).toContain(
       '- T+0s · `console` · message="Payment request failed" · description="POST /api/orders returned 500" · category="network" · type="error" · payload="endpoint=/api/orders, status=500"',
-    );
-    expect(result).not.toContain('payload="message=Payment request failed');
-    expect(result).not.toContain(
-      'payload="description=POST /api/orders returned 500',
     );
   });
 

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -1,0 +1,370 @@
+import { setTag } from "@sentry/core";
+import type { ReplayDetails, ReplayRecordingSegments } from "../api-client";
+import { defineTool } from "../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../internal/tool-helpers/api";
+import { parseSentryUrl } from "../internal/url-helpers";
+import { UserInputError } from "../errors";
+import type { ServerContext } from "../types";
+import {
+  ParamOrganizationSlug,
+  ParamReplayId,
+  ParamReplayUrl,
+} from "../schema";
+
+interface ResolvedReplayParams {
+  organizationSlug: string;
+  replayId: string;
+}
+
+export default defineTool({
+  name: "get_replay_details",
+  skills: ["inspect"],
+  requiredScopes: ["event:read"],
+  requiredCapabilities: ["replays"],
+  hideInExperimentalMode: true,
+  description: [
+    "Get detailed information about a specific Sentry replay by URL or replay ID.",
+    "",
+    "USE THIS TOOL WHEN USERS:",
+    "- Share a replay URL",
+    "- Ask what happened in a specific replay",
+    "- Want replay overview details and a concise activity timeline",
+    "",
+    "<examples>",
+    "### With replay URL",
+    "```",
+    "get_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')",
+    "```",
+    "",
+    "### With organization and replay ID",
+    "```",
+    "get_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')",
+    "```",
+    "</examples>",
+  ].join("\n"),
+  inputSchema: {
+    replayUrl: ParamReplayUrl.optional(),
+    organizationSlug: ParamOrganizationSlug.optional(),
+    replayId: ParamReplayId.optional(),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const resolved = resolveReplayParams(params);
+    const apiService = apiServiceFromContext(context);
+
+    setTag("organization.slug", resolved.organizationSlug);
+    setTag("replay.id", resolved.replayId);
+
+    const replay = await apiService.getReplayDetails({
+      organizationSlug: resolved.organizationSlug,
+      replayId: resolved.replayId,
+    });
+
+    let segments: ReplayRecordingSegments | null = null;
+    let segmentsError: string | null = null;
+
+    const isArchived = replay.is_archived === true;
+    const projectId =
+      replay.project_id !== null && replay.project_id !== undefined
+        ? String(replay.project_id)
+        : null;
+    const hasSegments = (replay.count_segments ?? 0) > 0;
+
+    if (!isArchived && projectId && hasSegments) {
+      try {
+        segments = await apiService.getReplayRecordingSegments({
+          organizationSlug: resolved.organizationSlug,
+          projectSlugOrId: projectId,
+          replayId: resolved.replayId,
+        });
+      } catch (error) {
+        segmentsError =
+          error instanceof Error
+            ? error.message
+            : "Unknown segment download error";
+      }
+    }
+
+    return formatReplayOutput({
+      replay,
+      organizationSlug: resolved.organizationSlug,
+      replayUrl:
+        params.replayUrl ??
+        apiService.getReplayUrl(resolved.organizationSlug, replay.id),
+      segments,
+      segmentsError,
+    });
+  },
+});
+
+export function resolveReplayParams(params: {
+  replayUrl?: string | null;
+  organizationSlug?: string | null;
+  replayId?: string | null;
+}): ResolvedReplayParams {
+  if (params.replayUrl) {
+    const parsed = parseSentryUrl(params.replayUrl);
+    if (parsed.type !== "replay" || !parsed.replayId) {
+      throw new UserInputError(
+        "Invalid replay URL. URL must point to a Sentry replay resource.",
+      );
+    }
+    return {
+      organizationSlug: parsed.organizationSlug,
+      replayId: parsed.replayId,
+    };
+  }
+
+  if (!params.organizationSlug || !params.replayId) {
+    throw new UserInputError(
+      "Provide either `replayUrl` or both `organizationSlug` and `replayId`.",
+    );
+  }
+
+  return {
+    organizationSlug: params.organizationSlug,
+    replayId: params.replayId,
+  };
+}
+
+function formatReplayOutput({
+  replay,
+  organizationSlug,
+  replayUrl,
+  segments,
+  segmentsError,
+}: {
+  replay: ReplayDetails;
+  organizationSlug: string;
+  replayUrl: string;
+  segments: ReplayRecordingSegments | null;
+  segmentsError: string | null;
+}): string {
+  const lines: string[] = [];
+  const isArchived = replay.is_archived === true;
+  const user =
+    replay.user?.display_name ??
+    replay.user?.email ??
+    replay.user?.username ??
+    replay.user?.id ??
+    "Anonymous User";
+  const device =
+    replay.device?.name ??
+    replay.device?.model ??
+    replay.device?.family ??
+    "Unknown";
+
+  lines.push(`# Replay ${replay.id} in **${organizationSlug}**`);
+  lines.push("");
+  lines.push(`**Replay URL**: ${replayUrl}`);
+  lines.push(`**Project ID**: ${replay.project_id ?? "Unknown"}`);
+  lines.push(`**Started**: ${replay.started_at ?? "Unknown"}`);
+  lines.push(`**Finished**: ${replay.finished_at ?? "Unknown"}`);
+  if (replay.duration !== null && replay.duration !== undefined) {
+    lines.push(`**Duration**: ${formatDurationSeconds(replay.duration)}`);
+  }
+  lines.push(`**Archived**: ${isArchived ? "Yes" : "No"}`);
+  lines.push("");
+
+  lines.push("## Session");
+  lines.push("");
+  lines.push(`- **User**: ${user}`);
+  lines.push(`- **Environment**: ${replay.environment ?? "Unknown"}`);
+  lines.push(`- **Platform**: ${replay.platform ?? "Unknown"}`);
+  lines.push(
+    `- **Browser**: ${formatNameVersion(replay.browser?.name, replay.browser?.version)}`,
+  );
+  lines.push(
+    `- **OS**: ${formatNameVersion(replay.os?.name, replay.os?.version)}`,
+  );
+  lines.push(`- **Device**: ${device}`);
+  lines.push(
+    `- **SDK**: ${formatNameVersion(replay.sdk?.name, replay.sdk?.version)}`,
+  );
+
+  lines.push("");
+  lines.push("## Signals");
+  lines.push("");
+  lines.push(`- **Errors**: ${replay.count_errors ?? 0}`);
+  lines.push(`- **Warnings**: ${replay.count_warnings ?? 0}`);
+  lines.push(`- **Infos**: ${replay.count_infos ?? 0}`);
+  lines.push(`- **Dead Clicks**: ${replay.count_dead_clicks ?? 0}`);
+  lines.push(`- **Rage Clicks**: ${replay.count_rage_clicks ?? 0}`);
+  lines.push(`- **Segments**: ${replay.count_segments ?? 0}`);
+  lines.push(`- **URLs Visited**: ${replay.count_urls ?? replay.urls.length}`);
+
+  if (replay.urls.length > 0) {
+    lines.push("");
+    lines.push("## URLs");
+    lines.push("");
+    for (const url of replay.urls.slice(0, 5)) {
+      lines.push(`- ${url}`);
+    }
+  }
+
+  if (replay.trace_ids.length > 0 || replay.error_ids.length > 0) {
+    lines.push("");
+    lines.push("## Related IDs");
+    lines.push("");
+    if (replay.trace_ids.length > 0) {
+      lines.push(`- **Trace IDs**: ${replay.trace_ids.join(", ")}`);
+    }
+    if (replay.error_ids.length > 0) {
+      lines.push(`- **Error IDs**: ${replay.error_ids.join(", ")}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("## What Happened");
+  lines.push("");
+
+  if (isArchived) {
+    lines.push(
+      "Replay recording data is archived, so no segment timeline is available.",
+    );
+  } else if (segments && segments.length > 0) {
+    const highlights = summarizeReplaySegments(segments);
+    if (highlights.length > 0) {
+      for (const highlight of highlights) {
+        lines.push(`- ${highlight}`);
+      }
+    } else {
+      lines.push(
+        `Downloaded ${segments.length} replay segment(s), but they did not contain recognizable high-signal events.`,
+      );
+    }
+  } else if (segmentsError) {
+    lines.push(
+      `Replay details loaded, but the deeper recording data could not be fetched: ${segmentsError}`,
+    );
+  } else if ((replay.count_segments ?? 0) === 0) {
+    lines.push("This replay does not have any recording segments.");
+  } else {
+    lines.push("Replay details loaded, but no segment data was available.");
+  }
+
+  return lines.join("\n");
+}
+
+function formatDurationSeconds(durationSeconds: number): string {
+  if (durationSeconds < 60) {
+    return `${durationSeconds}s`;
+  }
+
+  const minutes = Math.floor(durationSeconds / 60);
+  const seconds = durationSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+function formatNameVersion(
+  name?: string | null,
+  version?: string | null,
+): string {
+  if (name && version) {
+    return `${name} ${version}`;
+  }
+  return name ?? version ?? "Unknown";
+}
+
+function summarizeReplaySegments(segments: ReplayRecordingSegments): string[] {
+  const highlights: string[] = [];
+
+  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
+    const segment = segments[segmentIndex]!;
+    for (const event of segment) {
+      const highlight = summarizeReplayEvent(event, segmentIndex);
+      if (highlight) {
+        highlights.push(highlight);
+      }
+      if (highlights.length >= 12) {
+        return highlights;
+      }
+    }
+  }
+
+  return highlights;
+}
+
+function summarizeReplayEvent(
+  event: unknown,
+  segmentIndex: number,
+): string | null {
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const timestamp = formatEventTimestamp(event.timestamp);
+  const data = isRecord(event.data) ? event.data : null;
+  const tag = typeof data?.tag === "string" ? data.tag : "";
+  const payload = isRecord(data?.payload) ? data.payload : null;
+
+  if (tag) {
+    const primary =
+      tag === "performanceSpan"
+        ? (firstString(payload?.op, payload?.description) ?? "operation")
+        : tag;
+    const detail =
+      tag === "performanceSpan"
+        ? firstString(payload?.description)
+        : (firstString(
+            payload?.message,
+            payload?.description,
+            payload?.category,
+            payload?.type,
+          ) ?? summarizeObject(payload));
+    const duration =
+      tag === "performanceSpan" &&
+      isRecord(payload?.data) &&
+      typeof payload.data.duration === "number"
+        ? ` (${payload.data.duration}ms)`
+        : "";
+
+    return `${timestamp} segment ${segmentIndex}: ${primary}${detail && detail !== primary ? ` - ${detail}` : ""}${duration}`;
+  }
+
+  if (typeof event.type === "number" && data) {
+    const href = typeof data.href === "string" ? data.href : null;
+    if (href) {
+      return `${timestamp} segment ${segmentIndex}: view loaded ${href}`;
+    }
+  }
+
+  return null;
+}
+
+function formatEventTimestamp(value: unknown): string {
+  if (typeof value !== "number") {
+    return "Unknown time";
+  }
+  const millis = value > 1e12 ? value : value * 1000;
+  return new Date(millis).toISOString();
+}
+
+function summarizeObject(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const entries = Object.entries(value)
+    .filter(
+      ([, nested]) => typeof nested === "string" || typeof nested === "number",
+    )
+    .slice(0, 3)
+    .map(([key, nested]) => `${key}=${nested}`);
+  return entries.length > 0 ? entries.join(", ") : null;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -1,7 +1,15 @@
 import { setTag } from "@sentry/core";
-import type { ReplayDetails, ReplayRecordingSegments } from "../api-client";
+import type {
+  AutofixRunState,
+  Issue,
+  ReplayDetails,
+  ReplayRecordingSegments,
+  SentryApiService,
+  TraceMeta,
+} from "../api-client";
 import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
+import { getSeerActionabilityLabel } from "../internal/formatting";
 import { parseSentryUrl } from "../internal/url-helpers";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
@@ -16,6 +24,29 @@ interface ResolvedReplayParams {
   replayId: string;
 }
 
+interface ReplayActivityEvent {
+  timestampMs: number | null;
+  label: string;
+  details: string[];
+}
+
+interface RelatedReplayIssue {
+  eventId: string;
+  issue: Issue | null;
+  seerSummary: string | null;
+}
+
+interface RelatedReplayTrace {
+  traceId: string;
+  traceMeta: TraceMeta | null;
+}
+
+type AutofixStep = NonNullable<AutofixRunState["autofix"]>["steps"][number];
+
+const MAX_ACTIVITY_EVENTS = 6;
+const MAX_RELATED_ERRORS = 3;
+const MAX_RELATED_TRACES = 2;
+
 export default defineTool({
   name: "get_replay_details",
   skills: ["inspect"],
@@ -23,12 +54,12 @@ export default defineTool({
   requiredCapabilities: ["replays"],
   hideInExperimentalMode: true,
   description: [
-    "Get detailed information about a specific Sentry replay by URL or replay ID.",
+    "Get high-level information about a specific Sentry replay by URL or replay ID.",
     "",
     "USE THIS TOOL WHEN USERS:",
     "- Share a replay URL",
     "- Ask what happened in a specific replay",
-    "- Want replay overview details and a concise activity timeline",
+    "- Want a concise replay summary plus the next issue or trace lookups to run",
     "",
     "<examples>",
     "### With replay URL",
@@ -63,9 +94,6 @@ export default defineTool({
       replayId: resolved.replayId,
     });
 
-    let segments: ReplayRecordingSegments | null = null;
-    let segmentsError: string | null = null;
-
     const isArchived = replay.is_archived === true;
     const projectId =
       replay.project_id !== null && replay.project_id !== undefined
@@ -73,20 +101,27 @@ export default defineTool({
         : null;
     const hasSegments = (replay.count_segments ?? 0) > 0;
 
-    if (!isArchived && projectId && hasSegments) {
-      try {
-        segments = await apiService.getReplayRecordingSegments({
+    const [{ segments, segmentsError }, relatedIssues, relatedTraces] =
+      await Promise.all([
+        fetchReplaySegments({
+          apiService,
           organizationSlug: resolved.organizationSlug,
-          projectSlugOrId: projectId,
           replayId: resolved.replayId,
-        });
-      } catch (error) {
-        segmentsError =
-          error instanceof Error
-            ? error.message
-            : "Unknown segment download error";
-      }
-    }
+          projectId,
+          isArchived,
+          hasSegments,
+        }),
+        fetchReplayIssues({
+          apiService,
+          organizationSlug: resolved.organizationSlug,
+          errorIds: replay.error_ids,
+        }),
+        fetchReplayTraces({
+          apiService,
+          organizationSlug: resolved.organizationSlug,
+          traceIds: replay.trace_ids,
+        }),
+      ]);
 
     return formatReplayOutput({
       replay,
@@ -96,6 +131,8 @@ export default defineTool({
         apiService.getReplayUrl(resolved.organizationSlug, replay.id),
       segments,
       segmentsError,
+      relatedIssues,
+      relatedTraces,
     });
   },
 });
@@ -136,12 +173,16 @@ function formatReplayOutput({
   replayUrl,
   segments,
   segmentsError,
+  relatedIssues,
+  relatedTraces,
 }: {
   replay: ReplayDetails;
   organizationSlug: string;
   replayUrl: string;
   segments: ReplayRecordingSegments | null;
   segmentsError: string | null;
+  relatedIssues: RelatedReplayIssue[];
+  relatedTraces: RelatedReplayTrace[];
 }): string {
   const lines: string[] = [];
   const isArchived = replay.is_archived === true;
@@ -156,94 +197,126 @@ function formatReplayOutput({
     replay.device?.model ??
     replay.device?.family ??
     "Unknown";
+  const activityEvents = extractReplayActivityEvents(segments);
+  const metadataEvents = buildReplayMetadataEvents({
+    replay,
+    relatedIssues,
+    isArchived,
+    segmentsError,
+  });
 
   lines.push(`# Replay ${replay.id} in **${organizationSlug}**`);
   lines.push("");
-  lines.push(`**Replay URL**: ${replayUrl}`);
-  lines.push(`**Project ID**: ${replay.project_id ?? "Unknown"}`);
-  lines.push(`**Started**: ${replay.started_at ?? "Unknown"}`);
-  lines.push(`**Finished**: ${replay.finished_at ?? "Unknown"}`);
-  if (replay.duration !== null && replay.duration !== undefined) {
-    lines.push(`**Duration**: ${formatDurationSeconds(replay.duration)}`);
-  }
-  lines.push(`**Archived**: ${isArchived ? "Yes" : "No"}`);
+  lines.push("## Summary");
   lines.push("");
-
-  lines.push("## Session");
-  lines.push("");
-  lines.push(`- **User**: ${user}`);
+  lines.push(`- **Replay URL**: ${replayUrl}`);
+  lines.push(`- **Started**: ${replay.started_at ?? "Unknown"}`);
+  lines.push(`- **Finished**: ${replay.finished_at ?? "Unknown"}`);
+  lines.push(
+    `- **Duration**: ${
+      replay.duration !== null && replay.duration !== undefined
+        ? formatDurationSeconds(replay.duration)
+        : "Unknown"
+    }`,
+  );
+  lines.push(`- **Archived**: ${isArchived ? "Yes" : "No"}`);
   lines.push(`- **Environment**: ${replay.environment ?? "Unknown"}`);
   lines.push(`- **Platform**: ${replay.platform ?? "Unknown"}`);
   lines.push(
     `- **Browser**: ${formatNameVersion(replay.browser?.name, replay.browser?.version)}`,
   );
-  lines.push(
-    `- **OS**: ${formatNameVersion(replay.os?.name, replay.os?.version)}`,
-  );
-  lines.push(`- **Device**: ${device}`);
-  lines.push(
-    `- **SDK**: ${formatNameVersion(replay.sdk?.name, replay.sdk?.version)}`,
-  );
-
-  lines.push("");
-  lines.push("## Signals");
-  lines.push("");
-  lines.push(`- **Errors**: ${replay.count_errors ?? 0}`);
-  lines.push(`- **Warnings**: ${replay.count_warnings ?? 0}`);
-  lines.push(`- **Infos**: ${replay.count_infos ?? 0}`);
-  lines.push(`- **Dead Clicks**: ${replay.count_dead_clicks ?? 0}`);
-  lines.push(`- **Rage Clicks**: ${replay.count_rage_clicks ?? 0}`);
-  lines.push(`- **Segments**: ${replay.count_segments ?? 0}`);
-  lines.push(`- **URLs Visited**: ${replay.count_urls ?? replay.urls.length}`);
-
+  lines.push(`- **User**: ${user}`);
   if (replay.urls.length > 0) {
-    lines.push("");
-    lines.push("## URLs");
-    lines.push("");
-    for (const url of replay.urls.slice(0, 5)) {
-      lines.push(`- ${url}`);
+    lines.push(`- **URLs**: ${replay.urls.slice(0, 3).join(", ")}`);
+  }
+  if (device !== "Unknown") {
+    lines.push(`- **Device**: ${device}`);
+  }
+  lines.push(
+    `- **Signal Counts**: errors=${replay.count_errors ?? 0}, warnings=${replay.count_warnings ?? 0}, infos=${replay.count_infos ?? 0}, dead_clicks=${replay.count_dead_clicks ?? 0}, rage_clicks=${replay.count_rage_clicks ?? 0}, segments=${replay.count_segments ?? 0}`,
+  );
+
+  lines.push("");
+  lines.push("## Events");
+  lines.push("");
+
+  if (activityEvents.length > 0) {
+    const startTime = activityEvents[0]?.timestampMs ?? null;
+    for (const event of activityEvents) {
+      const prefix =
+        event.timestampMs !== null && startTime !== null
+          ? `${formatRelativeTime(event.timestampMs - startTime)} · `
+          : "";
+      const details =
+        event.details.length > 0 ? ` · ${event.details.join(" · ")}` : "";
+      lines.push(`- ${prefix}\`${event.label}\`${details}`);
     }
   }
 
-  if (replay.trace_ids.length > 0 || replay.error_ids.length > 0) {
-    lines.push("");
-    lines.push("## Related IDs");
-    lines.push("");
-    if (replay.trace_ids.length > 0) {
-      lines.push(`- **Trace IDs**: ${replay.trace_ids.join(", ")}`);
+  if (metadataEvents.length > 0) {
+    for (const metadataEvent of metadataEvents) {
+      lines.push(metadataEvent);
     }
-    if (replay.error_ids.length > 0) {
-      lines.push(`- **Error IDs**: ${replay.error_ids.join(", ")}`);
-    }
-  }
-
-  lines.push("");
-  lines.push("## What Happened");
-  lines.push("");
-
-  if (isArchived) {
-    lines.push(
-      "Replay recording data is archived, so no segment timeline is available.",
-    );
-  } else if (segments && segments.length > 0) {
-    const highlights = summarizeReplaySegments(segments);
-    if (highlights.length > 0) {
-      for (const highlight of highlights) {
-        lines.push(`- ${highlight}`);
-      }
-    } else {
-      lines.push(
-        `Downloaded ${segments.length} replay segment(s), but they did not contain recognizable high-signal events.`,
-      );
-    }
-  } else if (segmentsError) {
-    lines.push(
-      `Replay details loaded, but the deeper recording data could not be fetched: ${segmentsError}`,
-    );
   } else if ((replay.count_segments ?? 0) === 0) {
-    lines.push("This replay does not have any recording segments.");
-  } else {
-    lines.push("Replay details loaded, but no segment data was available.");
+    lines.push("- `recording_segments` · count=0");
+  }
+
+  if (replay.error_ids.length > 0 || replay.trace_ids.length > 0) {
+    lines.push("");
+    lines.push("## Related");
+    lines.push("");
+  }
+
+  if (replay.error_ids.length > 0) {
+    for (const relatedIssue of relatedIssues) {
+      lines.push(`### Error Event \`${relatedIssue.eventId}\``);
+      if (relatedIssue.issue) {
+        lines.push(`**Issue ID**: ${relatedIssue.issue.shortId}`);
+        lines.push(`**Summary**: ${relatedIssue.issue.title}`);
+        lines.push(`**Status**: ${relatedIssue.issue.status}`);
+        if (relatedIssue.issue.seerFixabilityScore != null) {
+          lines.push(
+            `**Seer Actionability**: ${getSeerActionabilityLabel(relatedIssue.issue.seerFixabilityScore)}`,
+          );
+        }
+        if (relatedIssue.seerSummary) {
+          lines.push(`**Cached Seer Summary**: ${relatedIssue.seerSummary}`);
+        }
+        lines.push(
+          `**Next Step**: \`get_issue_details(organizationSlug='${organizationSlug}', eventId='${relatedIssue.eventId}')\``,
+        );
+        lines.push(
+          `**Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='${organizationSlug}', issueId='${relatedIssue.issue.shortId}')\``,
+        );
+      } else {
+        lines.push(
+          "**Summary**: Replay metadata references this error, but issue details were not resolved from the replay payload alone.",
+        );
+        lines.push(
+          `**Next Step**: \`get_issue_details(organizationSlug='${organizationSlug}', eventId='${relatedIssue.eventId}')\``,
+        );
+      }
+      lines.push("");
+    }
+  }
+
+  if (replay.trace_ids.length > 0) {
+    for (const relatedTrace of relatedTraces) {
+      lines.push(`### Trace \`${relatedTrace.traceId}\``);
+      if (relatedTrace.traceMeta) {
+        lines.push(
+          `**High-level Stats**: ${formatTraceMetaSummary(relatedTrace.traceMeta)}`,
+        );
+      } else {
+        lines.push(
+          "**High-level Stats**: Trace metadata was not available from this replay lookup.",
+        );
+      }
+      lines.push(
+        `**Next Step**: \`get_trace_details(organizationSlug='${organizationSlug}', traceId='${relatedTrace.traceId}')\``,
+      );
+      lines.push("");
+    }
   }
 
   return lines.join("\n");
@@ -259,6 +332,198 @@ function formatDurationSeconds(durationSeconds: number): string {
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
+function buildReplayMetadataEvents({
+  replay,
+  relatedIssues,
+  isArchived,
+  segmentsError,
+}: {
+  replay: ReplayDetails;
+  relatedIssues: RelatedReplayIssue[];
+  isArchived: boolean;
+  segmentsError: string | null;
+}): string[] {
+  const lines: string[] = [];
+
+  if (isArchived) {
+    lines.push("- `recording_segments` · status=archived");
+  } else if (segmentsError) {
+    lines.push(
+      `- \`recording_segments\` · status=unavailable · detail=${quoteDetail(segmentsError)}`,
+    );
+  } else if ((replay.count_segments ?? 0) === 0) {
+    lines.push("- `recording_segments` · count=0");
+  }
+
+  if (relatedIssues.length > 0) {
+    for (const relatedIssue of relatedIssues) {
+      const details = [`event_id=${relatedIssue.eventId}`];
+      if (relatedIssue.issue) {
+        details.push(`issue_id=${relatedIssue.issue.shortId}`);
+        details.push(`title=${quoteDetail(relatedIssue.issue.title)}`);
+      }
+      lines.push(`- metadata · \`error\` · ${details.join(" · ")}`);
+    }
+  } else if ((replay.count_errors ?? 0) > 0) {
+    lines.push(`- metadata · \`error\` · count=${replay.count_errors}`);
+  }
+
+  if ((replay.count_dead_clicks ?? 0) > 0) {
+    lines.push(
+      `- metadata · \`dead_click\` · count=${replay.count_dead_clicks}`,
+    );
+  }
+
+  if ((replay.count_rage_clicks ?? 0) > 0) {
+    lines.push(
+      `- metadata · \`rage_click\` · count=${replay.count_rage_clicks}`,
+    );
+  }
+
+  if ((replay.count_warnings ?? 0) > 0) {
+    lines.push(`- metadata · \`warning\` · count=${replay.count_warnings}`);
+  }
+
+  if ((replay.count_infos ?? 0) > 0) {
+    lines.push(`- metadata · \`info\` · count=${replay.count_infos}`);
+  }
+
+  return lines;
+}
+
+async function fetchReplaySegments({
+  apiService,
+  organizationSlug,
+  replayId,
+  projectId,
+  isArchived,
+  hasSegments,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  replayId: string;
+  projectId: string | null;
+  isArchived: boolean;
+  hasSegments: boolean;
+}): Promise<{
+  segments: ReplayRecordingSegments | null;
+  segmentsError: string | null;
+}> {
+  if (isArchived || !projectId || !hasSegments) {
+    return { segments: null, segmentsError: null };
+  }
+
+  try {
+    const segments = await apiService.getReplayRecordingSegments({
+      organizationSlug,
+      projectSlugOrId: projectId,
+      replayId,
+    });
+    return { segments, segmentsError: null };
+  } catch (error) {
+    return {
+      segments: null,
+      segmentsError:
+        error instanceof Error
+          ? error.message
+          : "Unknown segment download error",
+    };
+  }
+}
+
+async function fetchReplayIssues({
+  apiService,
+  organizationSlug,
+  errorIds,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  errorIds: string[];
+}): Promise<RelatedReplayIssue[]> {
+  const ids = errorIds.slice(0, MAX_RELATED_ERRORS);
+
+  return Promise.all(
+    ids.map(async (eventId) => {
+      try {
+        const [issue] = await apiService.listIssues({
+          organizationSlug,
+          query: eventId,
+          limit: 1,
+        });
+
+        const resolvedIssue =
+          issue ??
+          (await maybeGetIssueById(apiService, organizationSlug, eventId));
+        const autofixState = resolvedIssue
+          ? await apiService
+              .getAutofixState({
+                organizationSlug,
+                issueId: resolvedIssue.shortId,
+              })
+              .catch(() => undefined)
+          : undefined;
+
+        return {
+          eventId,
+          issue: resolvedIssue ?? null,
+          seerSummary: getCachedSeerSummary(autofixState),
+        };
+      } catch {
+        return {
+          eventId,
+          issue: null,
+          seerSummary: null,
+        };
+      }
+    }),
+  );
+}
+
+async function maybeGetIssueById(
+  apiService: SentryApiService,
+  organizationSlug: string,
+  errorId: string,
+): Promise<Issue | null> {
+  if (!looksLikeDirectIssueId(errorId)) {
+    return null;
+  }
+
+  try {
+    return await apiService.getIssue({
+      organizationSlug,
+      issueId: errorId,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function fetchReplayTraces({
+  apiService,
+  organizationSlug,
+  traceIds,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  traceIds: string[];
+}): Promise<RelatedReplayTrace[]> {
+  const ids = traceIds.slice(0, MAX_RELATED_TRACES);
+
+  return Promise.all(
+    ids.map(async (traceId) => {
+      try {
+        const traceMeta = await apiService.getTraceMeta({
+          organizationSlug,
+          traceId,
+        });
+        return { traceId, traceMeta };
+      } catch {
+        return { traceId, traceMeta: null };
+      }
+    }),
+  );
+}
+
 function formatNameVersion(
   name?: string | null,
   version?: string | null,
@@ -269,91 +534,234 @@ function formatNameVersion(
   return name ?? version ?? "Unknown";
 }
 
-function summarizeReplaySegments(segments: ReplayRecordingSegments): string[] {
-  const highlights: string[] = [];
+function extractReplayActivityEvents(
+  segments: ReplayRecordingSegments | null,
+): ReplayActivityEvent[] {
+  if (!segments) {
+    return [];
+  }
 
-  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
-    const segment = segments[segmentIndex]!;
+  const events: ReplayActivityEvent[] = [];
+
+  for (const segment of segments) {
     for (const event of segment) {
-      const highlight = summarizeReplayEvent(event, segmentIndex);
-      if (highlight) {
-        highlights.push(highlight);
+      const replayEvent = summarizeReplayEvent(event);
+      if (replayEvent) {
+        events.push(replayEvent);
       }
-      if (highlights.length >= 12) {
-        return highlights;
+      if (events.length >= MAX_ACTIVITY_EVENTS) {
+        return events;
       }
     }
   }
 
-  return highlights;
+  return events;
 }
 
-function summarizeReplayEvent(
-  event: unknown,
-  segmentIndex: number,
-): string | null {
+function summarizeReplayEvent(event: unknown): ReplayActivityEvent | null {
   if (!isRecord(event)) {
     return null;
   }
 
-  const timestamp = formatEventTimestamp(event.timestamp);
+  const timestampMs = getEventTimestampMillis(event.timestamp);
   const data = isRecord(event.data) ? event.data : null;
   const tag = typeof data?.tag === "string" ? data.tag : "";
   const payload = isRecord(data?.payload) ? data.payload : null;
 
   if (tag) {
-    const primary =
-      tag === "performanceSpan"
-        ? (firstString(payload?.op, payload?.description) ?? "operation")
-        : tag;
-    const detail =
-      tag === "performanceSpan"
-        ? firstString(payload?.description)
-        : (firstString(
-            payload?.message,
-            payload?.description,
-            payload?.category,
-            payload?.type,
-          ) ?? summarizeObject(payload));
-    const duration =
-      tag === "performanceSpan" &&
-      isRecord(payload?.data) &&
-      typeof payload.data.duration === "number"
-        ? ` (${payload.data.duration}ms)`
-        : "";
-
-    return `${timestamp} segment ${segmentIndex}: ${primary}${detail && detail !== primary ? ` - ${detail}` : ""}${duration}`;
+    const replayEvent = summarizeTaggedReplayEvent(tag, payload);
+    if (replayEvent) {
+      return { timestampMs, ...replayEvent };
+    }
   }
 
   if (typeof event.type === "number" && data) {
     const href = typeof data.href === "string" ? data.href : null;
     if (href) {
-      return `${timestamp} segment ${segmentIndex}: view loaded ${href}`;
+      return {
+        timestampMs,
+        label: "page.view",
+        details: [`href=${href}`],
+      };
     }
   }
 
   return null;
 }
 
-function formatEventTimestamp(value: unknown): string {
-  if (typeof value !== "number") {
-    return "Unknown time";
+function summarizeTaggedReplayEvent(
+  tag: string,
+  payload: Record<string, unknown> | null,
+): Omit<ReplayActivityEvent, "timestampMs"> | null {
+  if (tag === "performanceSpan") {
+    const op = firstString(payload?.op);
+    const description = firstString(payload?.description);
+    const durationMs =
+      isRecord(payload?.data) && typeof payload.data.duration === "number"
+        ? payload.data.duration
+        : null;
+
+    if (description || op) {
+      return {
+        label: op ?? "performanceSpan",
+        details: [
+          description ? `description=${description}` : null,
+          durationMs !== null ? `duration_ms=${durationMs}` : null,
+        ].filter((value): value is string => value !== null),
+      };
+    }
   }
-  const millis = value > 1e12 ? value : value * 1000;
-  return new Date(millis).toISOString();
+
+  if (tag === "ui.click") {
+    const message = firstString(payload?.message, payload?.description);
+    if (message) {
+      return {
+        label: tag,
+        details: [`message=${quoteDetail(message)}`],
+      };
+    }
+  }
+
+  const details = [
+    firstString(payload?.message)
+      ? `message=${quoteDetail(firstString(payload?.message)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      : null,
+    firstString(payload?.description)
+      ? `description=${quoteDetail(firstString(payload?.description)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      : null,
+    firstString(payload?.category)
+      ? `category=${quoteDetail(firstString(payload?.category)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      : null,
+    firstString(payload?.type)
+      ? `type=${quoteDetail(firstString(payload?.type)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      : null,
+    summarizeObject(payload),
+  ].filter((value): value is string => value !== null);
+
+  return details.length > 0 ? { label: tag, details } : null;
+}
+
+function getEventTimestampMillis(value: unknown): number | null {
+  if (typeof value !== "number") {
+    return null;
+  }
+  return value > 1e12 ? value : value * 1000;
+}
+
+function formatRelativeTime(offsetMs: number): string {
+  const offsetSeconds = Math.max(0, Math.round(offsetMs / 1000));
+  if (offsetSeconds < 60) {
+    return `T+${offsetSeconds}s`;
+  }
+
+  const minutes = Math.floor(offsetSeconds / 60);
+  const seconds = offsetSeconds % 60;
+  return seconds > 0 ? `T+${minutes}m ${seconds}s` : `T+${minutes}m`;
+}
+
+function formatTraceMetaSummary(traceMeta: TraceMeta): string {
+  return [
+    `${traceMeta.span_count} spans`,
+    `${traceMeta.errors} errors`,
+    `${traceMeta.performance_issues} performance issues`,
+    `${traceMeta.logs} logs`,
+  ].join(", ");
+}
+
+function getCachedSeerSummary(
+  autofixState: AutofixRunState | undefined,
+): string | null {
+  const autofix = autofixState?.autofix;
+  if (!autofix) {
+    return null;
+  }
+
+  const completedSteps = autofix.steps.filter(
+    (step) => step.status === "COMPLETED",
+  );
+  const rootCauseStep = completedSteps.find(
+    (step) => step.type === "root_cause_analysis",
+  );
+  if (rootCauseStep && hasRootCauseCauses(rootCauseStep)) {
+    const description = rootCauseStep.causes.find((cause) =>
+      cause.description.trim(),
+    )?.description;
+    if (description) {
+      return truncateSummary(description);
+    }
+  }
+
+  const solutionStep = completedSteps.find((step) => step.type === "solution");
+  if (solutionStep && hasSolutionDescription(solutionStep)) {
+    return truncateSummary(solutionStep.description);
+  }
+
+  const insightStep = completedSteps.find(hasInsights);
+  if (insightStep) {
+    const insight = insightStep.insights.find((entry) =>
+      entry.insight.trim(),
+    )?.insight;
+    if (insight) {
+      return truncateSummary(insight);
+    }
+  }
+
+  return null;
+}
+
+function hasRootCauseCauses(step: AutofixStep): step is AutofixStep & {
+  type: "root_cause_analysis";
+  causes: Array<{ description: string }>;
+} {
+  return (
+    step.type === "root_cause_analysis" &&
+    Array.isArray((step as { causes?: unknown }).causes)
+  );
+}
+
+function hasSolutionDescription(step: AutofixStep): step is AutofixStep & {
+  type: "solution";
+  description: string;
+} {
+  return (
+    step.type === "solution" &&
+    typeof (step as { description?: unknown }).description === "string"
+  );
+}
+
+function hasInsights(step: AutofixStep): step is AutofixStep & {
+  type: "default";
+  insights: Array<{ insight: string }>;
+} {
+  return (
+    step.type === "default" &&
+    Array.isArray((step as { insights?: unknown }).insights)
+  );
+}
+
+function truncateSummary(value: string, maxLength = 220): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 3).trimEnd()}...`;
 }
 
 function summarizeObject(value: unknown): string | null {
   if (!isRecord(value)) {
     return null;
   }
+
   const entries = Object.entries(value)
     .filter(
       ([, nested]) => typeof nested === "string" || typeof nested === "number",
     )
     .slice(0, 3)
     .map(([key, nested]) => `${key}=${nested}`);
-  return entries.length > 0 ? entries.join(", ") : null;
+
+  return entries.length > 0
+    ? `payload=${quoteDetail(entries.join(", "))}`
+    : null;
 }
 
 function firstString(...values: unknown[]): string | null {
@@ -365,6 +773,17 @@ function firstString(...values: unknown[]): string | null {
   return null;
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
+function looksLikeDirectIssueId(value: string): boolean {
+  return (
+    /^\d+$/.test(value) ||
+    (value.includes("-") && value === value.toUpperCase())
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function quoteDetail(value: string): string {
+  return JSON.stringify(value.trim());
 }

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -52,7 +52,7 @@ export default defineTool({
   skills: ["inspect"],
   requiredScopes: ["event:read"],
   requiredCapabilities: ["replays"],
-  hideInExperimentalMode: true,
+  internalOnly: true, // Retained as a composition primitive behind get_sentry_resource. Do not expose directly via MCP.
   description: [
     "Get high-level information about a specific Sentry replay by URL or replay ID.",
     "",

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -252,12 +252,8 @@ function formatReplayOutput({
     }
   }
 
-  if (metadataEvents.length > 0) {
-    for (const metadataEvent of metadataEvents) {
-      lines.push(metadataEvent);
-    }
-  } else if ((replay.count_segments ?? 0) === 0) {
-    lines.push("- `recording_segments` · count=0");
+  for (const metadataEvent of metadataEvents) {
+    lines.push(metadataEvent);
   }
 
   if (replay.error_ids.length > 0 || replay.trace_ids.length > 0) {
@@ -282,7 +278,7 @@ function formatReplayOutput({
           lines.push(`**Cached Seer Summary**: ${relatedIssue.seerSummary}`);
         }
         lines.push(
-          `**Next Step**: \`get_issue_details(organizationSlug='${organizationSlug}', eventId='${relatedIssue.eventId}')\``,
+          `**Next Step**: \`get_sentry_resource(organizationSlug='${organizationSlug}', resourceType='issue', resourceId='${relatedIssue.issue.shortId}')\``,
         );
         lines.push(
           `**Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='${organizationSlug}', issueId='${relatedIssue.issue.shortId}')\``,
@@ -292,7 +288,7 @@ function formatReplayOutput({
           "**Summary**: Replay metadata references this error, but issue details were not resolved from the replay payload alone.",
         );
         lines.push(
-          `**Next Step**: \`get_issue_details(organizationSlug='${organizationSlug}', eventId='${relatedIssue.eventId}')\``,
+          `**Next Step**: \`get_sentry_resource(organizationSlug='${organizationSlug}', resourceType='issue', resourceId='${relatedIssue.eventId}')\``,
         );
       }
       lines.push("");
@@ -312,7 +308,7 @@ function formatReplayOutput({
         );
       }
       lines.push(
-        `**Next Step**: \`get_trace_details(organizationSlug='${organizationSlug}', traceId='${relatedTrace.traceId}')\``,
+        `**Next Step**: \`get_sentry_resource(organizationSlug='${organizationSlug}', resourceType='trace', resourceId='${relatedTrace.traceId}')\``,
       );
       lines.push("");
     }
@@ -621,24 +617,18 @@ function summarizeTaggedReplayEvent(
     }
   }
 
-  const details = [
-    firstString(payload?.message)
-      ? `message=${quoteDetail(firstString(payload?.message)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      : null,
-    firstString(payload?.description)
-      ? `description=${quoteDetail(firstString(payload?.description)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      : null,
-    firstString(payload?.category)
-      ? `category=${quoteDetail(firstString(payload?.category)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      : null,
-    firstString(payload?.type)
-      ? `type=${quoteDetail(firstString(payload?.type)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      : null,
-    summarizeObject(
-      payload,
-      new Set(["message", "description", "category", "type"]),
-    ),
-  ].filter((value): value is string => value !== null);
+  const knownKeys = ["message", "description", "category", "type"] as const;
+  const details: string[] = [];
+  for (const key of knownKeys) {
+    const value = firstString(payload?.[key]);
+    if (value) {
+      details.push(`${key}=${quoteDetail(value)}`);
+    }
+  }
+  const extra = summarizeObject(payload, new Set<string>(knownKeys));
+  if (extra) {
+    details.push(extra);
+  }
 
   return details.length > 0 ? { label: tag, details } : null;
 }

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -52,7 +52,6 @@ export default defineTool({
   skills: ["inspect"],
   requiredScopes: ["event:read"],
   requiredCapabilities: ["replays"],
-  internalOnly: true, // Retained as a composition primitive behind get_sentry_resource. Do not expose directly via MCP.
   description: [
     "Get high-level information about a specific Sentry replay by URL or replay ID.",
     "",

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -41,8 +41,6 @@ interface RelatedReplayTrace {
   traceMeta: TraceMeta | null;
 }
 
-type AutofixStep = NonNullable<AutofixRunState["autofix"]>["steps"][number];
-
 const MAX_ACTIVITY_EVENTS = 6;
 const MAX_RELATED_ERRORS = 3;
 const MAX_RELATED_TRACES = 2;
@@ -95,9 +93,7 @@ export default defineTool({
 
     const isArchived = replay.is_archived === true;
     const projectId =
-      replay.project_id !== null && replay.project_id !== undefined
-        ? String(replay.project_id)
-        : null;
+      replay.project_id != null ? String(replay.project_id) : null;
     const hasSegments = (replay.count_segments ?? 0) > 0;
 
     const [{ segments, segmentsError }, relatedIssues, relatedTraces] =
@@ -212,11 +208,7 @@ function formatReplayOutput({
   lines.push(`- **Started**: ${replay.started_at ?? "Unknown"}`);
   lines.push(`- **Finished**: ${replay.finished_at ?? "Unknown"}`);
   lines.push(
-    `- **Duration**: ${
-      replay.duration !== null && replay.duration !== undefined
-        ? formatDurationSeconds(replay.duration)
-        : "Unknown"
-    }`,
+    `- **Duration**: ${replay.duration != null ? formatDurationSeconds(replay.duration) : "Unknown"}`,
   );
   lines.push(`- **Archived**: ${isArchived ? "Yes" : "No"}`);
   lines.push(`- **Environment**: ${replay.environment ?? "Unknown"}`);
@@ -446,21 +438,18 @@ async function fetchReplayIssues({
           limit: 1,
         });
 
-        const resolvedIssue =
-          issue ??
-          (await maybeGetIssueById(apiService, organizationSlug, eventId));
-        const autofixState = resolvedIssue
+        const autofixState = issue
           ? await apiService
               .getAutofixState({
                 organizationSlug,
-                issueId: resolvedIssue.shortId,
+                issueId: issue.shortId,
               })
               .catch(() => undefined)
           : undefined;
 
         return {
           eventId,
-          issue: resolvedIssue ?? null,
+          issue: issue ?? null,
           seerSummary: getCachedSeerSummary(autofixState),
         };
       } catch {
@@ -472,25 +461,6 @@ async function fetchReplayIssues({
       }
     }),
   );
-}
-
-async function maybeGetIssueById(
-  apiService: SentryApiService,
-  organizationSlug: string,
-  errorId: string,
-): Promise<Issue | null> {
-  if (!looksLikeDirectIssueId(errorId)) {
-    return null;
-  }
-
-  try {
-    return await apiService.getIssue({
-      organizationSlug,
-      issueId: errorId,
-    });
-  } catch {
-    return null;
-  }
 }
 
 async function fetchReplayTraces({
@@ -671,71 +641,35 @@ function getCachedSeerSummary(
   const completedSteps = autofix.steps.filter(
     (step) => step.status === "COMPLETED",
   );
-  const rootCauseStep = completedSteps.find(
-    (step) => step.type === "root_cause_analysis",
-  );
-  if (rootCauseStep && hasRootCauseCauses(rootCauseStep)) {
-    const description = rootCauseStep.causes.find((cause) =>
-      cause.description.trim(),
-    )?.description;
-    if (description) {
-      return truncateSummary(description);
+
+  for (const step of completedSteps) {
+    const raw = step as Record<string, unknown>;
+
+    if (step.type === "root_cause_analysis" && Array.isArray(raw.causes)) {
+      const desc = (raw.causes as Array<{ description?: string }>).find((c) =>
+        c.description?.trim(),
+      )?.description;
+      if (desc) return truncate(desc);
     }
-  }
 
-  const solutionStep = completedSteps.find((step) => step.type === "solution");
-  if (solutionStep && hasSolutionDescription(solutionStep)) {
-    return truncateSummary(solutionStep.description);
-  }
+    if (step.type === "solution" && typeof raw.description === "string") {
+      return truncate(raw.description);
+    }
 
-  const insightStep = completedSteps.find(hasInsights);
-  if (insightStep) {
-    const insight = insightStep.insights.find((entry) =>
-      entry.insight.trim(),
-    )?.insight;
-    if (insight) {
-      return truncateSummary(insight);
+    if (step.type === "default" && Array.isArray(raw.insights)) {
+      const insight = (raw.insights as Array<{ insight?: string }>).find((i) =>
+        i.insight?.trim(),
+      )?.insight;
+      if (insight) return truncate(insight);
     }
   }
 
   return null;
 }
 
-function hasRootCauseCauses(step: AutofixStep): step is AutofixStep & {
-  type: "root_cause_analysis";
-  causes: Array<{ description: string }>;
-} {
-  return (
-    step.type === "root_cause_analysis" &&
-    Array.isArray((step as { causes?: unknown }).causes)
-  );
-}
-
-function hasSolutionDescription(step: AutofixStep): step is AutofixStep & {
-  type: "solution";
-  description: string;
-} {
-  return (
-    step.type === "solution" &&
-    typeof (step as { description?: unknown }).description === "string"
-  );
-}
-
-function hasInsights(step: AutofixStep): step is AutofixStep & {
-  type: "default";
-  insights: Array<{ insight: string }>;
-} {
-  return (
-    step.type === "default" &&
-    Array.isArray((step as { insights?: unknown }).insights)
-  );
-}
-
-function truncateSummary(value: string, maxLength = 220): string {
+function truncate(value: string, maxLength = 220): string {
   const normalized = value.replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
+  if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, maxLength - 3).trimEnd()}...`;
 }
 
@@ -768,13 +702,6 @@ function firstString(...values: unknown[]): string | null {
     }
   }
   return null;
-}
-
-function looksLikeDirectIssueId(value: string): boolean {
-  return (
-    /^\d+$/.test(value) ||
-    (value.includes("-") && value === value.toUpperCase())
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -1,6 +1,5 @@
 import { setTag } from "@sentry/core";
 import type {
-  AutofixRunState,
   Issue,
   ReplayDetails,
   ReplayRecordingSegments,
@@ -9,7 +8,6 @@ import type {
 } from "../api-client";
 import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
-import { getSeerActionabilityLabel } from "../internal/formatting";
 import { parseSentryUrl } from "../internal/url-helpers";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
@@ -33,7 +31,6 @@ interface ReplayActivityEvent {
 interface RelatedReplayIssue {
   eventId: string;
   issue: Issue | null;
-  seerSummary: string | null;
 }
 
 interface RelatedReplayTrace {
@@ -96,27 +93,26 @@ export default defineTool({
       replay.project_id != null ? String(replay.project_id) : null;
     const hasSegments = (replay.count_segments ?? 0) > 0;
 
-    const [{ segments, segmentsError }, relatedIssues, relatedTraces] =
-      await Promise.all([
-        fetchReplaySegments({
-          apiService,
-          organizationSlug: resolved.organizationSlug,
-          replayId: resolved.replayId,
-          projectId,
-          isArchived,
-          hasSegments,
-        }),
-        fetchReplayIssues({
-          apiService,
-          organizationSlug: resolved.organizationSlug,
-          errorIds: replay.error_ids,
-        }),
-        fetchReplayTraces({
-          apiService,
-          organizationSlug: resolved.organizationSlug,
-          traceIds: replay.trace_ids,
-        }),
-      ]);
+    const [{ segments }, relatedIssues, relatedTraces] = await Promise.all([
+      fetchReplaySegments({
+        apiService,
+        organizationSlug: resolved.organizationSlug,
+        replayId: resolved.replayId,
+        projectId,
+        isArchived,
+        hasSegments,
+      }),
+      fetchReplayIssues({
+        apiService,
+        organizationSlug: resolved.organizationSlug,
+        errorIds: replay.error_ids,
+      }),
+      fetchReplayTraces({
+        apiService,
+        organizationSlug: resolved.organizationSlug,
+        traceIds: replay.trace_ids,
+      }),
+    ]);
 
     return formatReplayOutput({
       replay,
@@ -125,7 +121,7 @@ export default defineTool({
         params.replayUrl ??
         apiService.getReplayUrl(resolved.organizationSlug, replay.id),
       segments,
-      segmentsError,
+      isArchived,
       relatedIssues,
       relatedTraces,
     });
@@ -167,7 +163,7 @@ function formatReplayOutput({
   organizationSlug,
   replayUrl,
   segments,
-  segmentsError,
+  isArchived,
   relatedIssues,
   relatedTraces,
 }: {
@@ -175,12 +171,11 @@ function formatReplayOutput({
   organizationSlug: string;
   replayUrl: string;
   segments: ReplayRecordingSegments | null;
-  segmentsError: string | null;
+  isArchived: boolean;
   relatedIssues: RelatedReplayIssue[];
   relatedTraces: RelatedReplayTrace[];
 }): string {
   const lines: string[] = [];
-  const isArchived = replay.is_archived === true;
   const user =
     replay.user?.display_name ??
     replay.user?.email ??
@@ -191,47 +186,44 @@ function formatReplayOutput({
     replay.device?.name ??
     replay.device?.model ??
     replay.device?.family ??
-    "Unknown";
+    null;
   const activityEvents = extractReplayActivityEvents(segments);
-  const metadataEvents = buildReplayMetadataEvents({
-    replay,
-    relatedIssues,
-    isArchived,
-    segmentsError,
-  });
 
+  // Summary
   lines.push(`# Replay ${replay.id} in **${organizationSlug}**`);
   lines.push("");
   lines.push("## Summary");
   lines.push("");
   lines.push(`- **Replay URL**: ${replayUrl}`);
-  lines.push(`- **Started**: ${replay.started_at ?? "Unknown"}`);
-  lines.push(`- **Finished**: ${replay.finished_at ?? "Unknown"}`);
   lines.push(
     `- **Duration**: ${replay.duration != null ? formatDurationSeconds(replay.duration) : "Unknown"}`,
   );
-  lines.push(`- **Archived**: ${isArchived ? "Yes" : "No"}`);
   lines.push(`- **Environment**: ${replay.environment ?? "Unknown"}`);
-  lines.push(`- **Platform**: ${replay.platform ?? "Unknown"}`);
   lines.push(
     `- **Browser**: ${formatNameVersion(replay.browser?.name, replay.browser?.version)}`,
+  );
+  lines.push(
+    `- **OS**: ${formatNameVersion(replay.os?.name, replay.os?.version)}`,
   );
   lines.push(`- **User**: ${user}`);
   if (replay.urls.length > 0) {
     lines.push(`- **URLs**: ${replay.urls.slice(0, 3).join(", ")}`);
   }
-  if (device !== "Unknown") {
+  if (device) {
     lines.push(`- **Device**: ${device}`);
   }
-  lines.push(
-    `- **Signal Counts**: errors=${replay.count_errors ?? 0}, warnings=${replay.count_warnings ?? 0}, infos=${replay.count_infos ?? 0}, dead_clicks=${replay.count_dead_clicks ?? 0}, rage_clicks=${replay.count_rage_clicks ?? 0}, segments=${replay.count_segments ?? 0}`,
-  );
+  if (replay.releases && replay.releases.length > 0) {
+    lines.push(`- **Release**: ${replay.releases[0]}`);
+  }
 
+  // Activity
   lines.push("");
-  lines.push("## Events");
+  lines.push("## Activity");
   lines.push("");
 
-  if (activityEvents.length > 0) {
+  if (isArchived) {
+    lines.push("Recording is archived and not available for playback.");
+  } else if (activityEvents.length > 0) {
     const startTime = activityEvents[0]?.timestampMs ?? null;
     for (const event of activityEvents) {
       const prefix =
@@ -242,68 +234,36 @@ function formatReplayOutput({
         event.details.length > 0 ? ` · ${event.details.join(" · ")}` : "";
       lines.push(`- ${prefix}\`${event.label}\`${details}`);
     }
+  } else {
+    lines.push("No activity events recorded.");
   }
 
-  for (const metadataEvent of metadataEvents) {
-    lines.push(metadataEvent);
-  }
-
-  if (replay.error_ids.length > 0 || replay.trace_ids.length > 0) {
+  // Related
+  const hasRelated = relatedIssues.length > 0 || relatedTraces.length > 0;
+  if (hasRelated) {
     lines.push("");
     lines.push("## Related");
     lines.push("");
-  }
 
-  if (replay.error_ids.length > 0) {
-    for (const relatedIssue of relatedIssues) {
-      lines.push(`### Error Event \`${relatedIssue.eventId}\``);
-      if (relatedIssue.issue) {
-        lines.push(`**Issue ID**: ${relatedIssue.issue.shortId}`);
-        lines.push(`**Summary**: ${relatedIssue.issue.title}`);
-        lines.push(`**Status**: ${relatedIssue.issue.status}`);
-        if (relatedIssue.issue.seerFixabilityScore != null) {
-          lines.push(
-            `**Seer Actionability**: ${getSeerActionabilityLabel(relatedIssue.issue.seerFixabilityScore)}`,
-          );
-        }
-        if (relatedIssue.seerSummary) {
-          lines.push(`**Cached Seer Summary**: ${relatedIssue.seerSummary}`);
-        }
-        lines.push(
-          `**Next Step**: \`get_sentry_resource(organizationSlug='${organizationSlug}', resourceType='issue', resourceId='${relatedIssue.issue.shortId}')\``,
-        );
-        lines.push(
-          `**Root Cause Analysis**: \`analyze_issue_with_seer(organizationSlug='${organizationSlug}', issueId='${relatedIssue.issue.shortId}')\``,
-        );
+    for (const ri of relatedIssues) {
+      if (ri.issue) {
+        lines.push(`- **${ri.issue.shortId}**: ${ri.issue.title}`);
       } else {
-        lines.push(
-          "**Summary**: Replay metadata references this error, but issue details were not resolved from the replay payload alone.",
-        );
-        lines.push(
-          `**Next Step**: \`get_sentry_resource(organizationSlug='${organizationSlug}', resourceType='issue', resourceId='${relatedIssue.eventId}')\``,
-        );
+        lines.push(`- Event \`${ri.eventId}\``);
       }
-      lines.push("");
     }
-  }
 
-  if (replay.trace_ids.length > 0) {
-    for (const relatedTrace of relatedTraces) {
-      lines.push(`### Trace \`${relatedTrace.traceId}\``);
-      if (relatedTrace.traceMeta) {
-        lines.push(
-          `**High-level Stats**: ${formatTraceMetaSummary(relatedTrace.traceMeta)}`,
-        );
-      } else {
-        lines.push(
-          "**High-level Stats**: Trace metadata was not available from this replay lookup.",
-        );
-      }
-      lines.push(
-        `**Next Step**: \`get_sentry_resource(organizationSlug='${organizationSlug}', resourceType='trace', resourceId='${relatedTrace.traceId}')\``,
-      );
-      lines.push("");
+    for (const rt of relatedTraces) {
+      const spanInfo = rt.traceMeta
+        ? ` (${rt.traceMeta.span_count} spans)`
+        : "";
+      lines.push(`- Trace \`${rt.traceId}\`${spanInfo}`);
     }
+
+    lines.push("");
+    lines.push(
+      "Use `get_sentry_resource` to inspect any issue or trace listed above.",
+    );
   }
 
   return lines.join("\n");
@@ -317,65 +277,6 @@ function formatDurationSeconds(durationSeconds: number): string {
   const minutes = Math.floor(durationSeconds / 60);
   const seconds = durationSeconds % 60;
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
-}
-
-function buildReplayMetadataEvents({
-  replay,
-  relatedIssues,
-  isArchived,
-  segmentsError,
-}: {
-  replay: ReplayDetails;
-  relatedIssues: RelatedReplayIssue[];
-  isArchived: boolean;
-  segmentsError: string | null;
-}): string[] {
-  const lines: string[] = [];
-
-  if (isArchived) {
-    lines.push("- `recording_segments` · status=archived");
-  } else if (segmentsError) {
-    lines.push(
-      `- \`recording_segments\` · status=unavailable · detail=${quoteDetail(segmentsError)}`,
-    );
-  } else if ((replay.count_segments ?? 0) === 0) {
-    lines.push("- `recording_segments` · count=0");
-  }
-
-  if (relatedIssues.length > 0) {
-    for (const relatedIssue of relatedIssues) {
-      const details = [`event_id=${relatedIssue.eventId}`];
-      if (relatedIssue.issue) {
-        details.push(`issue_id=${relatedIssue.issue.shortId}`);
-        details.push(`title=${quoteDetail(relatedIssue.issue.title)}`);
-      }
-      lines.push(`- metadata · \`error\` · ${details.join(" · ")}`);
-    }
-  } else if ((replay.count_errors ?? 0) > 0) {
-    lines.push(`- metadata · \`error\` · count=${replay.count_errors}`);
-  }
-
-  if ((replay.count_dead_clicks ?? 0) > 0) {
-    lines.push(
-      `- metadata · \`dead_click\` · count=${replay.count_dead_clicks}`,
-    );
-  }
-
-  if ((replay.count_rage_clicks ?? 0) > 0) {
-    lines.push(
-      `- metadata · \`rage_click\` · count=${replay.count_rage_clicks}`,
-    );
-  }
-
-  if ((replay.count_warnings ?? 0) > 0) {
-    lines.push(`- metadata · \`warning\` · count=${replay.count_warnings}`);
-  }
-
-  if ((replay.count_infos ?? 0) > 0) {
-    lines.push(`- metadata · \`info\` · count=${replay.count_infos}`);
-  }
-
-  return lines;
 }
 
 async function fetchReplaySegments({
@@ -394,10 +295,9 @@ async function fetchReplaySegments({
   hasSegments: boolean;
 }): Promise<{
   segments: ReplayRecordingSegments | null;
-  segmentsError: string | null;
 }> {
   if (isArchived || !projectId || !hasSegments) {
-    return { segments: null, segmentsError: null };
+    return { segments: null };
   }
 
   try {
@@ -406,15 +306,9 @@ async function fetchReplaySegments({
       projectSlugOrId: projectId,
       replayId,
     });
-    return { segments, segmentsError: null };
-  } catch (error) {
-    return {
-      segments: null,
-      segmentsError:
-        error instanceof Error
-          ? error.message
-          : "Unknown segment download error",
-    };
+    return { segments };
+  } catch {
+    return { segments: null };
   }
 }
 
@@ -437,27 +331,9 @@ async function fetchReplayIssues({
           query: eventId,
           limit: 1,
         });
-
-        const autofixState = issue
-          ? await apiService
-              .getAutofixState({
-                organizationSlug,
-                issueId: issue.shortId,
-              })
-              .catch(() => undefined)
-          : undefined;
-
-        return {
-          eventId,
-          issue: issue ?? null,
-          seerSummary: getCachedSeerSummary(autofixState),
-        };
+        return { eventId, issue: issue ?? null };
       } catch {
-        return {
-          eventId,
-          issue: null,
-          seerSummary: null,
-        };
+        return { eventId, issue: null };
       }
     }),
   );
@@ -619,58 +495,6 @@ function formatRelativeTime(offsetMs: number): string {
   const minutes = Math.floor(offsetSeconds / 60);
   const seconds = offsetSeconds % 60;
   return seconds > 0 ? `T+${minutes}m ${seconds}s` : `T+${minutes}m`;
-}
-
-function formatTraceMetaSummary(traceMeta: TraceMeta): string {
-  return [
-    `${traceMeta.span_count} spans`,
-    `${traceMeta.errors} errors`,
-    `${traceMeta.performance_issues} performance issues`,
-    `${traceMeta.logs} logs`,
-  ].join(", ");
-}
-
-function getCachedSeerSummary(
-  autofixState: AutofixRunState | undefined,
-): string | null {
-  const autofix = autofixState?.autofix;
-  if (!autofix) {
-    return null;
-  }
-
-  const completedSteps = autofix.steps.filter(
-    (step) => step.status === "COMPLETED",
-  );
-
-  for (const step of completedSteps) {
-    const raw = step as Record<string, unknown>;
-
-    if (step.type === "root_cause_analysis" && Array.isArray(raw.causes)) {
-      const desc = (raw.causes as Array<{ description?: string }>).find((c) =>
-        c.description?.trim(),
-      )?.description;
-      if (desc) return truncate(desc);
-    }
-
-    if (step.type === "solution" && typeof raw.description === "string") {
-      return truncate(raw.description);
-    }
-
-    if (step.type === "default" && Array.isArray(raw.insights)) {
-      const insight = (raw.insights as Array<{ insight?: string }>).find((i) =>
-        i.insight?.trim(),
-      )?.insight;
-      if (insight) return truncate(insight);
-    }
-  }
-
-  return null;
-}
-
-function truncate(value: string, maxLength = 220): string {
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength - 3).trimEnd()}...`;
 }
 
 function summarizeObject(

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -635,7 +635,10 @@ function summarizeTaggedReplayEvent(
     firstString(payload?.type)
       ? `type=${quoteDetail(firstString(payload?.type)!)}` // eslint-disable-line @typescript-eslint/no-non-null-assertion
       : null,
-    summarizeObject(payload),
+    summarizeObject(
+      payload,
+      new Set(["message", "description", "category", "type"]),
+    ),
   ].filter((value): value is string => value !== null);
 
   return details.length > 0 ? { label: tag, details } : null;
@@ -747,14 +750,19 @@ function truncateSummary(value: string, maxLength = 220): string {
   return `${normalized.slice(0, maxLength - 3).trimEnd()}...`;
 }
 
-function summarizeObject(value: unknown): string | null {
+function summarizeObject(
+  value: unknown,
+  excludedKeys: ReadonlySet<string> = new Set(),
+): string | null {
   if (!isRecord(value)) {
     return null;
   }
 
   const entries = Object.entries(value)
     .filter(
-      ([, nested]) => typeof nested === "string" || typeof nested === "number",
+      ([key, nested]) =>
+        !excludedKeys.has(key) &&
+        (typeof nested === "string" || typeof nested === "number"),
     )
     .slice(0, 3)
     .map(([key, nested]) => `${key}=${nested}`);

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -789,7 +789,7 @@ function looksLikeDirectIssueId(value: string): boolean {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function quoteDetail(value: string): string {

--- a/packages/mcp-core/src/tools/get-sentry-resource-resolve.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource-resolve.test.ts
@@ -611,14 +611,18 @@ describe("resolveResourceParams", () => {
       ).toThrow("Invalid resourceType: profile");
     });
 
-    it("throws for unsupported explicit resourceType (replay)", () => {
-      expect(() =>
+    it("accepts replay as an explicit resourceType", () => {
+      expect(
         resolveResourceParams({
           resourceType: "replay",
           organizationSlug: "my-org",
           resourceId: "something",
         }),
-      ).toThrow("Invalid resourceType: replay");
+      ).toEqual<ResolvedResourceParams>({
+        type: "replay",
+        organizationSlug: "my-org",
+        replayId: "something",
+      });
     });
 
     it("throws for unsupported explicit resourceType (monitor)", () => {

--- a/packages/mcp-core/src/tools/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import {
   mswServer,
+  replayDetailsFixture,
   traceMetaFixture,
   traceFixture,
   eventFixture,
@@ -186,63 +187,13 @@ describe("get_sentry_resource", () => {
   // ─── URL mode: recognized-only types (guidance messages) ──────────────────
   describe("URL mode — recognized types (guidance messages)", () => {
     it("delegates replay URL to get_replay_details", async () => {
-      mswServer.use(
-        http.get(
-          "https://sentry.io/api/0/organizations/my-org/replays/abc123def456/",
-          () =>
-            HttpResponse.json({
-              data: {
-                id: "abc123def456",
-                project_id: "123",
-                started_at: "2025-04-07T12:00:00.000Z",
-                finished_at: "2025-04-07T12:05:00.000Z",
-                duration: 300,
-                is_archived: false,
-                environment: "production",
-                platform: "javascript",
-                count_errors: 0,
-                count_warnings: 0,
-                count_infos: 0,
-                count_dead_clicks: 0,
-                count_rage_clicks: 0,
-                count_segments: 1,
-                count_urls: 1,
-                urls: ["/login"],
-                trace_ids: [],
-                error_ids: [],
-                browser: { name: "Chrome", version: "123.0" },
-                os: { name: "macOS", version: "14.4" },
-                device: { name: "MacBook Pro" },
-                sdk: { name: "@sentry/browser", version: "8.0.0" },
-                user: { display_name: "Taylor Example" },
-              },
-            }),
-          { once: true },
-        ),
-        http.get(
-          "https://sentry.io/api/0/projects/my-org/123/replays/abc123def456/recording-segments/",
-          () =>
-            HttpResponse.json([
-              [
-                {
-                  type: 5,
-                  timestamp: 1744027220,
-                  data: {
-                    tag: "ui.click",
-                    payload: { message: "Clicked login" },
-                  },
-                },
-              ],
-            ]),
-          { once: true },
-        ),
-      );
-
       const result = await callHandler({
-        url: "https://my-org.sentry.io/replays/abc123def456/",
+        url: `https://sentry-mcp-evals.sentry.io/replays/${replayDetailsFixture.id}/`,
       });
-      expect(result).toContain("# Replay abc123def456 in **my-org**");
-      expect(result).toContain("Clicked login");
+      expect(result).toContain(
+        `# Replay ${replayDetailsFixture.id} in **sentry-mcp-evals**`,
+      );
+      expect(result).toContain("Clicked submit order");
     });
 
     it("returns guidance for monitor URL (simple slug)", async () => {
@@ -488,65 +439,15 @@ describe("get_sentry_resource", () => {
     });
 
     it("fetches replay by replayId", async () => {
-      mswServer.use(
-        http.get(
-          "https://sentry.io/api/0/organizations/test-org/replays/replay-123/",
-          () =>
-            HttpResponse.json({
-              data: {
-                id: "replay-123",
-                project_id: "123",
-                started_at: "2025-04-07T12:00:00.000Z",
-                finished_at: "2025-04-07T12:05:00.000Z",
-                duration: 300,
-                is_archived: false,
-                environment: "production",
-                platform: "javascript",
-                count_errors: 1,
-                count_warnings: 0,
-                count_infos: 0,
-                count_dead_clicks: 0,
-                count_rage_clicks: 0,
-                count_segments: 1,
-                count_urls: 1,
-                urls: ["/checkout"],
-                trace_ids: ["trace-1"],
-                error_ids: ["error-1"],
-                browser: { name: "Chrome", version: "123.0" },
-                os: { name: "macOS", version: "14.4" },
-                device: { name: "MacBook Pro" },
-                sdk: { name: "@sentry/browser", version: "8.0.0" },
-                user: { display_name: "Taylor Example" },
-              },
-            }),
-          { once: true },
-        ),
-        http.get(
-          "https://sentry.io/api/0/projects/test-org/123/replays/replay-123/recording-segments/",
-          () =>
-            HttpResponse.json([
-              [
-                {
-                  type: 5,
-                  timestamp: 1744027220,
-                  data: {
-                    tag: "ui.click",
-                    payload: { message: "Submitted order" },
-                  },
-                },
-              ],
-            ]),
-          { once: true },
-        ),
-      );
-
       const result = await callHandler({
         resourceType: "replay",
-        organizationSlug: "test-org",
-        resourceId: "replay-123",
+        organizationSlug: "sentry-mcp-evals",
+        resourceId: replayDetailsFixture.id,
       });
-      expect(result).toContain("# Replay replay-123 in **test-org**");
-      expect(result).toContain("Submitted order");
+      expect(result).toContain(
+        `# Replay ${replayDetailsFixture.id} in **sentry-mcp-evals**`,
+      );
+      expect(result).toContain("Clicked submit order");
     });
   });
 

--- a/packages/mcp-core/src/tools/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.test.ts
@@ -18,7 +18,7 @@ const baseContext = {
 
 function callHandler(params: {
   url?: string;
-  resourceType?: "issue" | "event" | "trace" | "breadcrumbs";
+  resourceType?: "issue" | "event" | "trace" | "breadcrumbs" | "replay";
   resourceId?: string;
   organizationSlug?: string;
 }) {
@@ -185,22 +185,64 @@ describe("get_sentry_resource", () => {
 
   // ─── URL mode: recognized-only types (guidance messages) ──────────────────
   describe("URL mode — recognized types (guidance messages)", () => {
-    it("returns guidance for replay URL", async () => {
+    it("delegates replay URL to get_replay_details", async () => {
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/my-org/replays/abc123def456/",
+          () =>
+            HttpResponse.json({
+              data: {
+                id: "abc123def456",
+                project_id: "123",
+                started_at: "2025-04-07T12:00:00.000Z",
+                finished_at: "2025-04-07T12:05:00.000Z",
+                duration: 300,
+                is_archived: false,
+                environment: "production",
+                platform: "javascript",
+                count_errors: 0,
+                count_warnings: 0,
+                count_infos: 0,
+                count_dead_clicks: 0,
+                count_rage_clicks: 0,
+                count_segments: 1,
+                count_urls: 1,
+                urls: ["/login"],
+                trace_ids: [],
+                error_ids: [],
+                browser: { name: "Chrome", version: "123.0" },
+                os: { name: "macOS", version: "14.4" },
+                device: { name: "MacBook Pro" },
+                sdk: { name: "@sentry/browser", version: "8.0.0" },
+                user: { display_name: "Taylor Example" },
+              },
+            }),
+          { once: true },
+        ),
+        http.get(
+          "https://sentry.io/api/0/projects/my-org/123/replays/abc123def456/recording-segments/",
+          () =>
+            HttpResponse.json([
+              [
+                {
+                  type: 5,
+                  timestamp: 1744027220,
+                  data: {
+                    tag: "ui.click",
+                    payload: { message: "Clicked login" },
+                  },
+                },
+              ],
+            ]),
+          { once: true },
+        ),
+      );
+
       const result = await callHandler({
         url: "https://my-org.sentry.io/replays/abc123def456/",
       });
-      expect(result).toMatchInlineSnapshot(`
-        "# Replay Detected
-
-        **Organization**: my-org
-        **Replay ID**: abc123def456
-
-        Session replay support is coming soon. In the meantime:
-
-        - **View in Sentry**: [Open Replay](https://my-org.sentry.io/replays/abc123def456/)
-        - **Find related issues**: Use \`search_issues\` with the replay's time range
-        - **Search events**: Use \`search_events\` with query \`replay_id:abc123def456\` to find events associated with this replay"
-      `);
+      expect(result).toContain("# Replay abc123def456 in **my-org**");
+      expect(result).toContain("Clicked login");
     });
 
     it("returns guidance for monitor URL (simple slug)", async () => {
@@ -444,6 +486,68 @@ describe("get_sentry_resource", () => {
       });
       expect(result).toContain("# Breadcrumbs for CLOUDFLARE-MCP-41");
     });
+
+    it("fetches replay by replayId", async () => {
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/test-org/replays/replay-123/",
+          () =>
+            HttpResponse.json({
+              data: {
+                id: "replay-123",
+                project_id: "123",
+                started_at: "2025-04-07T12:00:00.000Z",
+                finished_at: "2025-04-07T12:05:00.000Z",
+                duration: 300,
+                is_archived: false,
+                environment: "production",
+                platform: "javascript",
+                count_errors: 1,
+                count_warnings: 0,
+                count_infos: 0,
+                count_dead_clicks: 0,
+                count_rage_clicks: 0,
+                count_segments: 1,
+                count_urls: 1,
+                urls: ["/checkout"],
+                trace_ids: ["trace-1"],
+                error_ids: ["error-1"],
+                browser: { name: "Chrome", version: "123.0" },
+                os: { name: "macOS", version: "14.4" },
+                device: { name: "MacBook Pro" },
+                sdk: { name: "@sentry/browser", version: "8.0.0" },
+                user: { display_name: "Taylor Example" },
+              },
+            }),
+          { once: true },
+        ),
+        http.get(
+          "https://sentry.io/api/0/projects/test-org/123/replays/replay-123/recording-segments/",
+          () =>
+            HttpResponse.json([
+              [
+                {
+                  type: 5,
+                  timestamp: 1744027220,
+                  data: {
+                    tag: "ui.click",
+                    payload: { message: "Submitted order" },
+                  },
+                },
+              ],
+            ]),
+          { once: true },
+        ),
+      );
+
+      const result = await callHandler({
+        resourceType: "replay",
+        organizationSlug: "test-org",
+        resourceId: "replay-123",
+      });
+      expect(result).toContain("# Replay replay-123 in **test-org**");
+      expect(result).toContain("Submitted order");
+    });
   });
 
   // ─── Breadcrumbs output formatting ────────────────────────────────────────
@@ -596,14 +700,46 @@ describe("get_sentry_resource", () => {
       ).rejects.toThrow("Invalid resourceType: profile");
     });
 
-    it("throws for unsupported explicit resourceType (replay)", async () => {
-      await expect(
-        callHandler({
-          resourceType: "replay" as "issue",
-          organizationSlug: "my-org",
-          resourceId: "something",
-        }),
-      ).rejects.toThrow("Invalid resourceType: replay");
+    it("accepts replay as explicit resourceType", async () => {
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/my-org/replays/something/",
+          () =>
+            HttpResponse.json({
+              data: {
+                id: "something",
+                project_id: "123",
+                started_at: "2025-04-07T12:00:00.000Z",
+                finished_at: "2025-04-07T12:05:00.000Z",
+                duration: 300,
+                is_archived: true,
+                count_segments: 0,
+                count_errors: 0,
+                count_warnings: 0,
+                count_infos: 0,
+                count_dead_clicks: 0,
+                count_rage_clicks: 0,
+                count_urls: 0,
+                urls: [],
+                trace_ids: [],
+                error_ids: [],
+                browser: {},
+                os: {},
+                device: {},
+                sdk: {},
+                user: {},
+              },
+            }),
+          { once: true },
+        ),
+      );
+
+      const result = await callHandler({
+        resourceType: "replay",
+        organizationSlug: "my-org",
+        resourceId: "something",
+      });
+      expect(result).toContain("# Replay something in **my-org**");
     });
   });
 

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -12,6 +12,7 @@ import { fetchAndFormatBreadcrumbs } from "../internal/tool-helpers/breadcrumbs"
 import getIssueDetails from "./get-issue-details";
 import getTraceDetails from "./get-trace-details";
 import getProfile from "./get-profile";
+import getReplayDetails from "./get-replay-details";
 
 /** Types with full API integration. */
 export const FULLY_SUPPORTED_TYPES = [
@@ -19,11 +20,12 @@ export const FULLY_SUPPORTED_TYPES = [
   "event",
   "trace",
   "breadcrumbs",
+  "replay",
 ] as const;
 export type FullySupportedType = (typeof FULLY_SUPPORTED_TYPES)[number];
 
 /** Recognized from URLs but not yet fully supported -- return guidance messages. */
-export type RecognizedType = "replay" | "monitor" | "release";
+export type RecognizedType = "monitor" | "release";
 
 /**
  * All resource types. Profile is URL-only (requires transactionName,
@@ -125,6 +127,13 @@ export function resolveResourceParams(params: {
         type: "breadcrumbs",
         organizationSlug,
         issueId: resourceId.toUpperCase(),
+      };
+
+    case "replay":
+      return {
+        type: "replay",
+        organizationSlug,
+        replayId: resourceId,
       };
   }
 }
@@ -256,22 +265,6 @@ function generateUnsupportedResourceMessage(
   const { type, organizationSlug } = resolved;
 
   switch (type) {
-    case "replay": {
-      const replayUrl = `https://${organizationSlug}.sentry.io/replays/${resolved.replayId}/`;
-      return [
-        "# Replay Detected",
-        "",
-        `**Organization**: ${organizationSlug}`,
-        `**Replay ID**: ${resolved.replayId}`,
-        "",
-        "Session replay support is coming soon. In the meantime:",
-        "",
-        `- **View in Sentry**: [Open Replay](${replayUrl})`,
-        "- **Find related issues**: Use `search_issues` with the replay's time range",
-        `- **Search events**: Use \`search_events\` with query \`replay_id:${resolved.replayId}\` to find events associated with this replay`,
-      ].join("\n");
-    }
-
     case "monitor": {
       // Include projectSlug in URL when present
       const monitorPath = resolved.projectSlug
@@ -346,7 +339,7 @@ export default defineTool({
       ),
 
     resourceType: z
-      .enum(["issue", "event", "trace", "breadcrumbs"])
+      .enum(["issue", "event", "trace", "breadcrumbs", "replay"])
       .optional()
       .describe(
         "Resource type. With a URL, overrides the auto-detected type (e.g., 'breadcrumbs' on an issue URL).",
@@ -377,11 +370,7 @@ export default defineTool({
     setTag("organization.slug", resolved.organizationSlug);
 
     // Recognized but not yet fully supported types return guidance messages
-    if (
-      resolved.type === "replay" ||
-      resolved.type === "monitor" ||
-      resolved.type === "release"
-    ) {
+    if (resolved.type === "monitor" || resolved.type === "release") {
       return generateUnsupportedResourceMessage(resolved);
     }
 
@@ -435,6 +424,16 @@ export default defineTool({
           throw error;
         }
       }
+
+      case "replay":
+        return getReplayDetails.handler(
+          {
+            replayUrl: params.url,
+            organizationSlug: resolved.organizationSlug,
+            replayId: resolved.replayId,
+          },
+          context,
+        );
 
       case "profile":
         return getProfile.handler(

--- a/packages/mcp-core/src/tools/index.ts
+++ b/packages/mcp-core/src/tools/index.ts
@@ -6,6 +6,7 @@ import findReleases from "./find-releases";
 import getIssueDetails from "./get-issue-details";
 import getIssueTagValues from "./get-issue-tag-values";
 import getTraceDetails from "./get-trace-details";
+import getReplayDetails from "./get-replay-details";
 import getEventAttachment from "./get-event-attachment";
 import updateIssue from "./update-issue";
 import searchEvents from "./search-events";
@@ -59,6 +60,7 @@ export default {
   get_issue_details: getIssueDetails,
   get_issue_tag_values: getIssueTagValues,
   get_trace_details: getTraceDetails,
+  get_replay_details: getReplayDetails,
   get_event_attachment: getEventAttachment,
   update_issue: updateIssue,
   search_events: searchEvents,

--- a/packages/mcp-core/src/tools/use-sentry/handler.test.ts
+++ b/packages/mcp-core/src/tools/use-sentry/handler.test.ts
@@ -59,9 +59,9 @@ describe("use_sentry handler", () => {
       }),
     });
 
-    // Verify all 21 tools were provided (27 total - use_sentry - 3 list_* tools - 2 internal-only detail tools)
+    // Verify all tools were provided (total - use_sentry - 3 list_* tools - internal-only detail tools)
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
-    expect(Object.keys(toolsArg)).toHaveLength(21);
+    expect(Object.keys(toolsArg)).toHaveLength(22);
 
     // Verify result is returned
     expect(result).toBe("Agent executed tools successfully");
@@ -110,8 +110,8 @@ describe("use_sentry handler", () => {
     // Verify use_sentry is NOT in the list
     expect(toolNames).not.toContain("use_sentry");
 
-    // Verify we have exactly 21 tools (27 total - use_sentry - 3 list_* tools - 2 internal-only detail tools)
-    expect(toolNames).toHaveLength(21);
+    // Verify tool count (total - use_sentry - 3 list_* tools - internal-only detail tools)
+    expect(toolNames).toHaveLength(22);
   });
 
   it("filters find_organizations when organizationSlug constraint is set", async () => {
@@ -137,8 +137,8 @@ describe("use_sentry handler", () => {
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
     expect(toolsArg).toBeDefined();
 
-    // With only org constraint, find_organizations is filtered (21 - 1 = 20)
-    expect(Object.keys(toolsArg)).toHaveLength(20);
+    // With only org constraint, find_organizations is filtered (22 - 1 = 21)
+    expect(Object.keys(toolsArg)).toHaveLength(21);
 
     // Verify find_organizations is filtered but find_projects remains
     expect(toolsArg.find_organizations).toBeUndefined();
@@ -170,8 +170,8 @@ describe("use_sentry handler", () => {
     expect(toolsArg).toBeDefined();
 
     // When both org and project constraints are present,
-    // find_organizations and find_projects are filtered out (21 - 2 = 19)
-    expect(Object.keys(toolsArg)).toHaveLength(19);
+    // find_organizations and find_projects are filtered out (22 - 2 = 20)
+    expect(Object.keys(toolsArg)).toHaveLength(20);
 
     // Verify both find tools are filtered
     expect(toolsArg.find_organizations).toBeUndefined();

--- a/packages/mcp-core/src/tools/use-sentry/handler.test.ts
+++ b/packages/mcp-core/src/tools/use-sentry/handler.test.ts
@@ -61,7 +61,7 @@ describe("use_sentry handler", () => {
 
     // Verify all tools were provided (total - use_sentry - 3 list_* tools - internal-only detail tools)
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
-    expect(Object.keys(toolsArg)).toHaveLength(21);
+    expect(Object.keys(toolsArg)).toHaveLength(22);
 
     // Verify result is returned
     expect(result).toBe("Agent executed tools successfully");
@@ -111,7 +111,7 @@ describe("use_sentry handler", () => {
     expect(toolNames).not.toContain("use_sentry");
 
     // Verify tool count (total - use_sentry - 3 list_* tools - internal-only detail tools)
-    expect(toolNames).toHaveLength(21);
+    expect(toolNames).toHaveLength(22);
   });
 
   it("filters find_organizations when organizationSlug constraint is set", async () => {
@@ -137,8 +137,8 @@ describe("use_sentry handler", () => {
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
     expect(toolsArg).toBeDefined();
 
-    // With only org constraint, find_organizations is filtered (21 - 1 = 20)
-    expect(Object.keys(toolsArg)).toHaveLength(20);
+    // With only org constraint, find_organizations is filtered (22 - 1 = 21)
+    expect(Object.keys(toolsArg)).toHaveLength(21);
 
     // Verify find_organizations is filtered but find_projects remains
     expect(toolsArg.find_organizations).toBeUndefined();
@@ -170,8 +170,8 @@ describe("use_sentry handler", () => {
     expect(toolsArg).toBeDefined();
 
     // When both org and project constraints are present,
-    // find_organizations and find_projects are filtered out (21 - 2 = 19)
-    expect(Object.keys(toolsArg)).toHaveLength(19);
+    // find_organizations and find_projects are filtered out (22 - 2 = 20)
+    expect(Object.keys(toolsArg)).toHaveLength(20);
 
     // Verify both find tools are filtered
     expect(toolsArg.find_organizations).toBeUndefined();

--- a/packages/mcp-core/src/tools/use-sentry/handler.test.ts
+++ b/packages/mcp-core/src/tools/use-sentry/handler.test.ts
@@ -61,7 +61,7 @@ describe("use_sentry handler", () => {
 
     // Verify all tools were provided (total - use_sentry - 3 list_* tools - internal-only detail tools)
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
-    expect(Object.keys(toolsArg)).toHaveLength(22);
+    expect(Object.keys(toolsArg)).toHaveLength(21);
 
     // Verify result is returned
     expect(result).toBe("Agent executed tools successfully");
@@ -111,7 +111,7 @@ describe("use_sentry handler", () => {
     expect(toolNames).not.toContain("use_sentry");
 
     // Verify tool count (total - use_sentry - 3 list_* tools - internal-only detail tools)
-    expect(toolNames).toHaveLength(22);
+    expect(toolNames).toHaveLength(21);
   });
 
   it("filters find_organizations when organizationSlug constraint is set", async () => {
@@ -137,8 +137,8 @@ describe("use_sentry handler", () => {
     const toolsArg = mockUseSentryAgent.mock.calls[0][0].tools;
     expect(toolsArg).toBeDefined();
 
-    // With only org constraint, find_organizations is filtered (22 - 1 = 21)
-    expect(Object.keys(toolsArg)).toHaveLength(21);
+    // With only org constraint, find_organizations is filtered (21 - 1 = 20)
+    expect(Object.keys(toolsArg)).toHaveLength(20);
 
     // Verify find_organizations is filtered but find_projects remains
     expect(toolsArg.find_organizations).toBeUndefined();
@@ -170,8 +170,8 @@ describe("use_sentry handler", () => {
     expect(toolsArg).toBeDefined();
 
     // When both org and project constraints are present,
-    // find_organizations and find_projects are filtered out (22 - 2 = 20)
-    expect(Object.keys(toolsArg)).toHaveLength(20);
+    // find_organizations and find_projects are filtered out (21 - 2 = 19)
+    expect(Object.keys(toolsArg)).toHaveLength(19);
 
     // Verify both find tools are filtered
     expect(toolsArg.find_organizations).toBeUndefined();

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -88,6 +88,25 @@ export function getTraceUrl(
 }
 
 /**
+ * Generates a Sentry replay URL.
+ * @param host The Sentry host (may include regional subdomain for API access)
+ * @param organizationSlug Organization identifier
+ * @param replayId Replay identifier
+ * @returns The complete replay URL
+ */
+export function getReplayUrl(
+  host: string,
+  organizationSlug: string,
+  replayId: string,
+): string {
+  const isSaas = isSentryHost(host);
+  const webHost = isSaas ? "sentry.io" : host;
+  return isSaas
+    ? `https://${organizationSlug}.${webHost}/replays/${replayId}/`
+    : `https://${host}/organizations/${organizationSlug}/replays/${replayId}/`;
+}
+
+/**
  * Generates a Sentry events explorer URL.
  * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier

--- a/packages/mcp-core/vitest.config.ts
+++ b/packages/mcp-core/vitest.config.ts
@@ -7,12 +7,29 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {
-    alias: {
-      "@sentry/mcp-server-mocks": path.resolve(
-        __dirname,
-        "../mcp-server-mocks/src/index.ts",
-      ),
-    },
+    alias: [
+      {
+        find: /^@sentry\/mcp-server-mocks\/payloads$/,
+        replacement: path.resolve(
+          __dirname,
+          "../mcp-server-mocks/src/payloads.ts",
+        ),
+      },
+      {
+        find: /^@sentry\/mcp-server-mocks\/utils$/,
+        replacement: path.resolve(
+          __dirname,
+          "../mcp-server-mocks/src/utils.ts",
+        ),
+      },
+      {
+        find: /^@sentry\/mcp-server-mocks$/,
+        replacement: path.resolve(
+          __dirname,
+          "../mcp-server-mocks/src/index.ts",
+        ),
+      },
+    ],
   },
   test: {
     include: ["**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],

--- a/packages/mcp-core/vitest.config.ts
+++ b/packages/mcp-core/vitest.config.ts
@@ -1,7 +1,19 @@
 /// <reference types="vitest" />
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@sentry/mcp-server-mocks": path.resolve(
+        __dirname,
+        "../mcp-server-mocks/src/index.ts",
+      ),
+    },
+  },
   test: {
     include: ["**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     coverage: {

--- a/packages/mcp-server-mocks/src/fixtures/replay-details.json
+++ b/packages/mcp-server-mocks/src/fixtures/replay-details.json
@@ -39,5 +39,6 @@
     "email": "taylor@example.com",
     "id": "user-1"
   },
-  "tags": {}
+  "tags": {},
+  "releases": ["frontend@1.2.3"]
 }

--- a/packages/mcp-server-mocks/src/fixtures/replay-details.json
+++ b/packages/mcp-server-mocks/src/fixtures/replay-details.json
@@ -16,7 +16,7 @@
   "count_urls": 2,
   "urls": ["/login", "/checkout"],
   "trace_ids": ["a4d1aae7216b47ff8117cf4e09ce9d0a"],
-  "error_ids": ["err-1"],
+  "error_ids": ["7ca573c0f4814912aaa9bdc77d1a7d51"],
   "browser": {
     "name": "Chrome",
     "version": "123.0"

--- a/packages/mcp-server-mocks/src/fixtures/replay-details.json
+++ b/packages/mcp-server-mocks/src/fixtures/replay-details.json
@@ -1,0 +1,43 @@
+{
+  "id": "7e07485f-12f9-416b-8b14-26260799b51f",
+  "project_id": "4509109104082945",
+  "started_at": "2025-04-07T12:00:00.000Z",
+  "finished_at": "2025-04-07T12:05:00.000Z",
+  "duration": 300,
+  "is_archived": false,
+  "environment": "production",
+  "platform": "javascript",
+  "count_errors": 1,
+  "count_warnings": 2,
+  "count_infos": 3,
+  "count_dead_clicks": 1,
+  "count_rage_clicks": 0,
+  "count_segments": 2,
+  "count_urls": 2,
+  "urls": ["/login", "/checkout"],
+  "trace_ids": ["a4d1aae7216b47ff8117cf4e09ce9d0a"],
+  "error_ids": ["err-1"],
+  "browser": {
+    "name": "Chrome",
+    "version": "123.0"
+  },
+  "os": {
+    "name": "macOS",
+    "version": "14.4"
+  },
+  "device": {
+    "family": "Mac",
+    "model": "MacBook Pro",
+    "name": "MacBook Pro"
+  },
+  "sdk": {
+    "name": "@sentry/browser",
+    "version": "8.0.0"
+  },
+  "user": {
+    "display_name": "Taylor Example",
+    "email": "taylor@example.com",
+    "id": "user-1"
+  },
+  "tags": {}
+}

--- a/packages/mcp-server-mocks/src/fixtures/replay-recording-segments.json
+++ b/packages/mcp-server-mocks/src/fixtures/replay-recording-segments.json
@@ -1,0 +1,39 @@
+[
+  [
+    {
+      "type": 4,
+      "timestamp": 1744027200000,
+      "data": {
+        "href": "https://example.com/login",
+        "width": 1440,
+        "height": 900
+      }
+    },
+    {
+      "type": 5,
+      "timestamp": 1744027210,
+      "data": {
+        "tag": "performanceSpan",
+        "payload": {
+          "op": "navigation.navigate",
+          "description": "https://example.com/checkout",
+          "data": {
+            "duration": 710
+          }
+        }
+      }
+    }
+  ],
+  [
+    {
+      "type": 5,
+      "timestamp": 1744027220,
+      "data": {
+        "tag": "ui.click",
+        "payload": {
+          "message": "Clicked submit order"
+        }
+      }
+    }
+  ]
+]

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -70,6 +70,15 @@ import traceEventFixture from "./fixtures/trace-event.json" with {
 import traceItemsAttributesLogsNumberFixture from "./fixtures/trace-items-attributes-logs-number.json" with {
   type: "json",
 };
+import replayDetailsFixture from "./fixtures/replay-details.json" with {
+  type: "json",
+};
+import replayRecordingSegmentsFixture from "./fixtures/replay-recording-segments.json" with {
+  type: "json",
+};
+import flamegraphFixture from "./fixtures/flamegraph.json" with {
+  type: "json",
+};
 import traceItemsAttributesLogsStringFixture from "./fixtures/trace-items-attributes-logs-string.json" with {
   type: "json",
 };
@@ -524,6 +533,16 @@ export const restHandlers = buildHandlers([
     method: "get",
     path: "/api/0/organizations/sentry-mcp-evals/issues/6507376926/",
     fetch: () => HttpResponse.json(issueFixture2),
+  },
+  {
+    method: "get",
+    path: `/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+    fetch: () => HttpResponse.json({ data: replayDetailsFixture }),
+  },
+  {
+    method: "get",
+    path: `/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+    fetch: () => HttpResponse.json(replayRecordingSegmentsFixture),
   },
 
   // Trace endpoints
@@ -1200,6 +1219,8 @@ export const mswServer = setupServer(
 export {
   autofixStateFixture,
   eventsFixture as eventFixture,
+  replayDetailsFixture,
+  replayRecordingSegmentsFixture,
   traceMetaFixture,
   traceMetaWithNullsFixture,
   performanceEventFixture,

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -76,9 +76,6 @@ import replayDetailsFixture from "./fixtures/replay-details.json" with {
 import replayRecordingSegmentsFixture from "./fixtures/replay-recording-segments.json" with {
   type: "json",
 };
-import flamegraphFixture from "./fixtures/flamegraph.json" with {
-  type: "json",
-};
 import traceItemsAttributesLogsStringFixture from "./fixtures/trace-items-attributes-logs-string.json" with {
   type: "json",
 };

--- a/packages/mcp-server-mocks/src/payloads.ts
+++ b/packages/mcp-server-mocks/src/payloads.ts
@@ -13,7 +13,7 @@ import clientKeyFixture from "./fixtures/client-key.json" with { type: "json" };
 import eventAttachmentsFixture from "./fixtures/event-attachments.json" with {
   type: "json",
 };
-import eventsFixture from "./fixtures/event.json" with { type: "json" };
+import eventFixture from "./fixtures/event.json" with { type: "json" };
 import eventsErrorsEmptyFixture from "./fixtures/events-errors-empty.json" with {
   type: "json",
 };
@@ -30,6 +30,9 @@ import flamegraphFixture from "./fixtures/flamegraph.json" with {
   type: "json",
 };
 import issueFixture from "./fixtures/issue.json" with { type: "json" };
+import issueTagValuesFixture from "./fixtures/issue-tag-values.json" with {
+  type: "json",
+};
 import organizationFixture from "./fixtures/organization.json" with {
   type: "json",
 };
@@ -38,6 +41,12 @@ import performanceEventFixture from "./fixtures/performance-event.json" with {
 };
 import projectFixture from "./fixtures/project.json" with { type: "json" };
 import releaseFixture from "./fixtures/release.json" with { type: "json" };
+import replayDetailsFixture from "./fixtures/replay-details.json" with {
+  type: "json",
+};
+import replayRecordingSegmentsFixture from "./fixtures/replay-recording-segments.json" with {
+  type: "json",
+};
 import tagsFixture from "./fixtures/tags.json" with { type: "json" };
 import teamFixture from "./fixtures/team.json" with { type: "json" };
 import traceEventFixture from "./fixtures/trace-event.json" with {
@@ -81,15 +90,26 @@ const issueFixture2 = {
 // Export all fixtures
 export {
   autofixStateFixture,
+  clientKeyFixture,
+  eventAttachmentsFixture,
+  eventFixture,
+  eventsErrorsEmptyFixture,
+  eventsErrorsFixture,
+  eventsSpansEmptyFixture,
+  eventsSpansFixture,
+  flamegraphFixture,
   issueFixture,
   issueFixture2,
-  eventsFixture,
+  issueTagValuesFixture,
+  organizationFixture,
   performanceEventFixture,
-  eventAttachmentsFixture,
-  flamegraphFixture,
-  tagsFixture,
   projectFixture,
+  releaseFixture,
+  replayDetailsFixture,
+  replayRecordingSegmentsFixture,
+  tagsFixture,
   teamFixture,
+  traceEventFixture,
   traceItemsAttributesFixture,
   traceItemsAttributesSpansStringFixture,
   traceItemsAttributesSpansNumberFixture,
@@ -99,15 +119,7 @@ export {
   traceMetaWithNullsFixture,
   traceFixture,
   traceMixedFixture,
-  traceEventFixture,
-  organizationFixture,
-  releaseFixture,
-  clientKeyFixture,
   userFixture,
-  eventsErrorsFixture,
-  eventsErrorsEmptyFixture,
-  eventsSpansFixture,
-  eventsSpansEmptyFixture,
 };
 
 // Re-export fixture factories

--- a/packages/mcp-server-mocks/src/utils.ts
+++ b/packages/mcp-server-mocks/src/utils.ts
@@ -1,5 +1,6 @@
 import { setupServer } from "msw/node";
 import type { SetupServer } from "msw/node";
+import { mswServer } from "./index.js";
 
 export function setupMockServer(handlers: Array<any> = []): SetupServer {
   return setupServer(...handlers);
@@ -13,9 +14,6 @@ export function startMockServer(options?: {
   ignoreOpenAI?: boolean;
 }): void {
   const { ignoreOpenAI = true } = options || {};
-
-  // Import here to avoid circular dependency
-  const { mswServer } = require("./index");
 
   mswServer.listen({
     onUnhandledRequest: (req: any, print: any) => {

--- a/plugins/sentry-mcp-experimental/agents/sentry-mcp.md
+++ b/plugins/sentry-mcp-experimental/agents/sentry-mcp.md
@@ -20,6 +20,7 @@ allowedTools:
   - get_event_attachment
   - get_issue_tag_values
   - get_profile_details
+  - get_replay_details
   - get_sentry_resource
   - list_events
   - list_issue_events

--- a/plugins/sentry-mcp-experimental/agents/sentry-mcp.md
+++ b/plugins/sentry-mcp-experimental/agents/sentry-mcp.md
@@ -20,7 +20,6 @@ allowedTools:
   - get_event_attachment
   - get_issue_tag_values
   - get_profile_details
-  - get_replay_details
   - get_sentry_resource
   - list_events
   - list_issue_events

--- a/plugins/sentry-mcp/agents/sentry-mcp.md
+++ b/plugins/sentry-mcp/agents/sentry-mcp.md
@@ -20,6 +20,7 @@ allowedTools:
   - get_event_attachment
   - get_issue_tag_values
   - get_profile_details
+  - get_replay_details
   - get_sentry_resource
   - list_events
   - list_issue_events

--- a/plugins/sentry-mcp/agents/sentry-mcp.md
+++ b/plugins/sentry-mcp/agents/sentry-mcp.md
@@ -20,7 +20,6 @@ allowedTools:
   - get_event_attachment
   - get_issue_tag_values
   - get_profile_details
-  - get_replay_details
   - get_sentry_resource
   - list_events
   - list_issue_events


### PR DESCRIPTION
Add a public `get_replay_details` tool that fetches replay metadata and
recording segments, then formats a concise activity timeline. The tool is
gated by `requiredCapabilities: ["replays"]` so it only appears when the
upstream project has replays enabled. Replay URLs are also routed through
`get_sentry_resource` so users can paste a link and get results immediately.

The output includes:
- Session facts (duration, browser, OS, URLs visited, error/click counts)
- Activity timeline extracted from recording segments (page views,
  navigation, clicks, performance spans)
- Related issues with Seer summaries and next-step `get_sentry_resource`
  / `analyze_issue_with_seer` calls
- Related traces with span/error counts

Also consolidates docs to reduce duplication: `quality-checks.md` and
`common-patterns.md` now cross-link to canonical sources instead of
repeating content from `testing.md`, `error-handling.md`, and
`api-patterns.md`. Adds a "Tool Visibility & Selection" section to
`adding-tools.md` documenting `requiredCapabilities`, `internalOnly`,
and the expectation that consumers use progressive disclosure.