### PR TITLE
Sanitize URI schemes in Oauth

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
@@ -231,4 +231,77 @@ describe("approval-dialog", () => {
       );
     });
   });
+
+  describe("XSS prevention for URI fields", () => {
+    const renderDialog = async (clientOverrides: Record<string, unknown>) => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: { ...mockClient, ...clientOverrides },
+          server: { name: "Sentry MCP" },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+      return response.text();
+    };
+
+    it("should strip javascript: clientUri and render name as plain text", async () => {
+      const html = await renderDialog({
+        clientUri: "javascript:alert(document.domain)",
+      });
+
+      expect(html).not.toContain('href="javascript:');
+      expect(html).toContain("Test Client");
+      // Name should NOT be wrapped in an anchor tag
+      expect(html).not.toMatch(/<a [^>]*>Test Client<\/a>/);
+    });
+
+    it("should strip javascript: policyUri and omit policy link", async () => {
+      const html = await renderDialog({
+        policyUri: "javascript:alert(1)",
+      });
+
+      expect(html).not.toContain('href="javascript:');
+      expect(html).not.toContain("Privacy Policy");
+    });
+
+    it("should strip javascript: tosUri and omit ToS link", async () => {
+      const html = await renderDialog({
+        tosUri: "javascript:alert(1)",
+      });
+
+      expect(html).not.toContain('href="javascript:');
+      expect(html).not.toContain("Terms of Service");
+    });
+
+    it("should strip data: URI from clientUri", async () => {
+      const html = await renderDialog({
+        clientUri: "data:text/html,<script>alert(1)</script>",
+      });
+
+      expect(html).not.toContain('href="data:');
+    });
+
+    it("should render valid https clientUri as a link", async () => {
+      const html = await renderDialog({
+        clientUri: "https://github.com/getsentry/sentry-mcp",
+      });
+
+      expect(html).toContain('href="https://github.com/getsentry/sentry-mcp"');
+      expect(html).toContain("Test Client</a>");
+    });
+
+    it("should render valid https policyUri and tosUri as links", async () => {
+      const html = await renderDialog({
+        policyUri: "https://example.com/privacy",
+        tosUri: "https://example.com/tos",
+      });
+
+      expect(html).toContain('href="https://example.com/privacy"');
+      expect(html).toContain("Privacy Policy");
+      expect(html).toContain('href="https://example.com/tos"');
+      expect(html).toContain("Terms of Service");
+    });
+  });
 });

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -3,7 +3,7 @@ import type {
   ClientInfo,
 } from "@cloudflare/workers-oauth-provider";
 import { logError, logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
-import { sanitizeHtml } from "./html-utils";
+import { sanitizeHtml, sanitizeHrefUrl } from "./html-utils";
 import skillDefinitions, {
   type SkillDefinition,
 } from "@sentry/mcp-core/skillDefinitions";
@@ -300,10 +300,15 @@ export async function renderApprovalDialog(
     ? sanitizeHtml(client.clientName)
     : "Unknown MCP Client";
 
-  // Safe URLs
-  const clientUri = client?.clientUri ? sanitizeHtml(client.clientUri) : "";
-  const policyUri = client?.policyUri ? sanitizeHtml(client.policyUri) : "";
-  const tosUri = client?.tosUri ? sanitizeHtml(client.tosUri) : "";
+  const clientUri = client?.clientUri
+    ? sanitizeHtml(sanitizeHrefUrl(client.clientUri))
+    : "";
+  const policyUri = client?.policyUri
+    ? sanitizeHtml(sanitizeHrefUrl(client.policyUri))
+    : "";
+  const tosUri = client?.tosUri
+    ? sanitizeHtml(sanitizeHrefUrl(client.tosUri))
+    : "";
 
   // Get redirect URIs
   const redirectUris =

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHrefUrl, sanitizeHtml } from "./html-utils";
+
+describe("sanitizeHrefUrl", () => {
+  describe("blocks dangerous URI schemes", () => {
+    it.each([
+      [
+        "javascript:alert(document.domain)",
+        "javascript: (exact exploit payload)",
+      ],
+      ["javascript:alert(1)", "javascript: minimal"],
+      ["JAVASCRIPT:alert(1)", "javascript: uppercase"],
+      ["JaVaScRiPt:alert(1)", "javascript: mixed case"],
+      ["java\tscript:alert(1)", "javascript: with tab control character"],
+      ["java\x00script:alert(1)", "javascript: with null byte"],
+      ["data:text/html,<script>alert(1)</script>", "data: scheme"],
+      ["vbscript:msgbox", "vbscript: scheme"],
+      ["blob:https://example.com/uuid", "blob: scheme"],
+      ["file:///etc/passwd", "file: scheme"],
+      ["mailto:evil@example.com", "mailto: scheme"],
+    ])("rejects %s (%s)", (input) => {
+      expect(sanitizeHrefUrl(input)).toBe("");
+    });
+  });
+
+  describe("rejects invalid URLs", () => {
+    it.each([
+      ["", "empty string"],
+      ["not a url", "random text"],
+      ["://missing-scheme", "missing scheme"],
+    ])("rejects %s (%s)", (input) => {
+      expect(sanitizeHrefUrl(input)).toBe("");
+    });
+  });
+
+  describe("allows safe URLs", () => {
+    it.each([
+      ["https://example.com", "basic HTTPS"],
+      ["https://github.com/getsentry/sentry-mcp", "HTTPS with path"],
+      [
+        "https://example.com/path?query=1&other=2#fragment",
+        "HTTPS with query and fragment",
+      ],
+      ["http://localhost:3000", "HTTP localhost (dev)"],
+      ["http://example.com", "basic HTTP"],
+    ])("allows %s (%s)", (input) => {
+      expect(sanitizeHrefUrl(input)).toBe(input);
+    });
+  });
+
+  describe("handles whitespace and control characters", () => {
+    it("trims leading/trailing whitespace from valid URLs", () => {
+      expect(sanitizeHrefUrl("  https://example.com  ")).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("rejects URLs with embedded control characters", () => {
+      expect(sanitizeHrefUrl("\x01javascript:alert(1)")).toBe("");
+    });
+  });
+});
+
+describe("sanitizeHtml", () => {
+  it("escapes HTML entities", () => {
+    expect(sanitizeHtml('<script>alert("xss")</script>')).toBe(
+      "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;",
+    );
+  });
+
+  it("escapes single quotes", () => {
+    expect(sanitizeHtml("it's")).toBe("it&#039;s");
+  });
+
+  it("escapes ampersands", () => {
+    expect(sanitizeHtml("a&b")).toBe("a&amp;b");
+  });
+});

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.ts
@@ -3,6 +3,23 @@
  */
 
 /**
+ * Sanitizes a URL for safe use in href attributes.
+ * Only allows http: and https: schemes; returns empty string for
+ * dangerous schemes (javascript:, data:, vbscript:, etc.) or invalid URLs.
+ */
+export function sanitizeHrefUrl(url: string): string {
+  try {
+    const parsed = new URL(url.trim());
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return url.trim();
+    }
+    return "";
+  } catch {
+    return "";
+  }
+}
+
+/**
  * Sanitizes HTML content to prevent XSS attacks
  */
 export function sanitizeHtml(unsafe: string): string {


### PR DESCRIPTION
The client_uri, policy_uri, and tos_uri fields render as clickable hrefs only after HTML escaping. Anything `javascript:` contained no HTML characters and was never sanitized. Real world exploitability very low, only Firefox was impacted, but an easy thing to fix. 

Added a sanitizeHrefURL() allow list to only permit http/s: in these URIs, others return an empty string. 