### PR TITLE
feat(stdio): Add device code flow authentication for sentry.io

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ sentry-mcp/
 - docs/quality-checks.md — Pre-commit checklist
 - docs/pr-management.md — Commit/PR guidelines
 - docs/security.md — Authentication patterns
+- docs/stdio-auth.md — Device code flow, token caching, client ID architecture
 - docs/embedded-agents.md — LLM provider configuration for AI-powered tools
 - docs/releases/stdio.md — npm package release
 - docs/releases/cloudflare.md — Cloudflare deployment

--- a/docs/stdio-auth.md
+++ b/docs/stdio-auth.md
@@ -1,0 +1,140 @@
+# Stdio Authentication
+
+How the stdio transport authenticates with Sentry, including the device code flow, token caching, and the relationship between the bundled client ID and the Cloudflare OAuth app.
+
+## Authentication Methods
+
+The stdio transport supports two authentication methods, in order of precedence:
+
+1. **Explicit token** — `--access-token` flag or `SENTRY_ACCESS_TOKEN` env var. Works for all Sentry hosts. This is the only method available for self-hosted instances.
+
+2. **Device code flow** — OAuth Device Authorization Grant (RFC 8628). Only available for sentry.io (including regional subdomains like `us.sentry.io`). Requires an interactive terminal (TTY). Falls back to cached tokens in non-interactive contexts.
+
+## Device Code Flow
+
+When no token is provided and the host is sentry.io, the CLI initiates the device code flow:
+
+```
+CLI                          Sentry (sentry.io)
+ │                                │
+ │  POST /oauth/device/code/      │
+ │  (client_id, scope)            │
+ │──────────────────────────────>│
+ │                                │
+ │  device_code, user_code,       │
+ │  verification_uri_complete     │
+ │<──────────────────────────────│
+ │                                │
+ │  Display code to user          │
+ │  Open browser to verify URL    │
+ │                                │
+ │  POST /oauth/token/            │  (poll every N seconds)
+ │  (device_code, client_id)      │
+ │──────────────────────────────>│
+ │                                │
+ │  authorization_pending         │  (user hasn't authorized yet)
+ │<──────────────────────────────│
+ │                                │
+ │  ... poll again ...            │
+ │                                │
+ │  access_token, refresh_token   │  (user authorized)
+ │<──────────────────────────────│
+ │                                │
+ │  Cache token to disk           │
+ │  Start MCP server              │
+```
+
+### OAuth Endpoints
+
+All OAuth requests target `sentry.io` directly (via `OAUTH_HOST` constant), regardless of regional subdomain configuration. The device code and token endpoints live on the main domain only.
+
+### Scopes
+
+The device code flow requests the same scopes as the Cloudflare OAuth app:
+
+```
+org:read project:write team:write event:write
+```
+
+These are defined once in `packages/mcp-core/src/scopes.ts` and shared by both transports.
+
+## Client ID
+
+A bundled `DEFAULT_SENTRY_CLIENT_ID` ships in `packages/mcp-server/src/auth/constants.ts`. This is a public OAuth application registered on sentry.io specifically for the stdio device code flow. It has no client secret — device code flow doesn't use one.
+
+The Cloudflare deployment uses a separate OAuth application (configured via `SENTRY_CLIENT_ID` + `SENTRY_CLIENT_SECRET` env vars) because it uses the authorization code grant which requires a secret.
+
+Both transports use the `SENTRY_CLIENT_ID` env var name for overriding, but they're separate deployments with separate values:
+
+| Transport | Default client ID | Grant type | Client secret |
+|-----------|------------------|------------|---------------|
+| stdio | Bundled in `auth/constants.ts` | Device code (RFC 8628) | None (public client) |
+| Cloudflare | `SENTRY_CLIENT_ID` env var | Authorization code | `SENTRY_CLIENT_SECRET` env var |
+
+## Token Cache
+
+Tokens are cached at `~/.sentry/mcp.json` to avoid re-authentication on every server start.
+
+### File Format
+
+```json
+{
+  "sentry.io:client-id-here": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "expires_at": "2026-04-25T...",
+    "sentry_host": "sentry.io",
+    "client_id": "...",
+    "user_email": "user@example.com",
+    "scope": "org:read project:write team:write event:write"
+  }
+}
+```
+
+Cache entries are keyed by `{host}:{clientId}` so different hosts or client IDs don't collide.
+
+### Security
+
+- File permissions: `0o600` (owner read/write only)
+- Directory permissions: `0o700`
+- Writes are atomic (temp file + rename)
+- Tokens are treated as expired 5 minutes before actual expiry
+
+### Override
+
+Set `SENTRY_MCP_AUTH_CACHE` to override the cache file path (primarily for testing).
+
+## Non-Interactive Contexts
+
+When stderr is not a TTY (CI, piped stdio, MCP inspector), the device code flow is not started — it would hang waiting for a human. Instead:
+
+1. If a cached token exists, it's used silently.
+2. If no cached token exists, the process exits with an error directing the user to run `sentry-mcp auth login` interactively first.
+
+## Auth CLI Commands
+
+The CLI exposes auth management as subcommands:
+
+```bash
+sentry-mcp auth login          # Force device code flow (always re-authenticates)
+sentry-mcp auth logout         # Clear cached token
+sentry-mcp auth status         # Show current auth state
+```
+
+These commands support `--host` and `--url` flags with the same precedence as the main server: `--url` beats `--host`, CLI beats env vars.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `packages/mcp-server/src/auth/constants.ts` | Bundled client ID, OAuth endpoints, scopes |
+| `packages/mcp-server/src/auth/device-code-flow.ts` | RFC 8628 implementation (request, poll, browser open) |
+| `packages/mcp-server/src/auth/token-cache.ts` | Persistent token storage at `~/.sentry/mcp.json` |
+| `packages/mcp-server/src/auth/resolve-token.ts` | Orchestration: cache check → TTY check → device code flow |
+| `packages/mcp-server/src/auth/types.ts` | Zod schemas for API responses, `CachedToken` type |
+| `packages/mcp-server/src/cli/commands/auth.ts` | `auth login/logout/status` subcommands |
+| `packages/mcp-core/src/scopes.ts` | Shared OAuth scope definitions |
+
+## Token Refresh
+
+Not implemented. Sentry access tokens last 30 days. When a cached token expires, it's cleared and a new device code flow is triggered. This matches the Cloudflare transport's approach (see `packages/mcp-cloudflare/src/server/oauth/helpers.ts`).

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "biome lint",
     "lint:fix": "biome lint --fix",
     "inspector": "pnpx @modelcontextprotocol/inspector@latest",
+    "inspector:stdio": "pnpx @modelcontextprotocol/inspector@latest -- tsx packages/mcp-server/src/index.ts",
     "measure-tokens": "pnpm run --filter ./packages/mcp-core measure-tokens",
     "prepare": "simple-git-hooks",
     "cli": "pnpm run --filter ./packages/mcp-test-client start",

--- a/packages/mcp-cloudflare/src/constants.ts
+++ b/packages/mcp-cloudflare/src/constants.ts
@@ -1,10 +1,4 @@
-// https://docs.sentry.io/api/permissions/
-export const SCOPES = {
-  "org:read": "Read organization data",
-  "project:write": "Write project data",
-  "team:write": "Write team data",
-  "event:write": "Write event data",
-};
+export { SCOPES } from "@sentry/mcp-core/scopes";
 
 export const NPM_PACKAGE_NAME = "@sentry/mcp-server";
 

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -11,9 +11,7 @@
   "author": "Sentry",
   "description": "Sentry MCP Core - Shared code for MCP transports",
   "homepage": "https://github.com/getsentry/sentry-mcp",
-  "keywords": [
-    "sentry"
-  ],
+  "keywords": ["sentry"],
   "bugs": {
     "url": "https://github.com/getsentry/sentry-mcp/issues"
   },
@@ -21,9 +19,7 @@
     "type": "git",
     "url": "git@github.com:getsentry/sentry-mcp.git"
   },
-  "files": [
-    "./dist/*"
-  ],
+  "files": ["./dist/*"],
   "exports": {
     "./api-client": {
       "types": "./dist/api-client/index.ts",
@@ -128,6 +124,10 @@
     "./utils/url-utils": {
       "types": "./dist/utils/url-utils.ts",
       "default": "./dist/utils/url-utils.js"
+    },
+    "./scopes": {
+      "types": "./dist/scopes.ts",
+      "default": "./dist/scopes.js"
     }
   },
   "scripts": {

--- a/packages/mcp-core/src/scopes.ts
+++ b/packages/mcp-core/src/scopes.ts
@@ -1,0 +1,7 @@
+// https://docs.sentry.io/api/permissions/
+export const SCOPES = {
+  "org:read": "Read organization data",
+  "project:write": "Write project data",
+  "team:write": "Write team data",
+  "event:write": "Write event data",
+};

--- a/packages/mcp-server/src/auth/constants.ts
+++ b/packages/mcp-server/src/auth/constants.ts
@@ -1,25 +1,16 @@
 import { SCOPES } from "@sentry/mcp-core/scopes";
 
-/**
- * Bundled OAuth client ID for sentry.io device code flow.
- * Override via SENTRY_CLIENT_ID environment variable.
- */
+/** Override via SENTRY_CLIENT_ID environment variable. */
 export const DEFAULT_SENTRY_CLIENT_ID =
   "0acbeba7d07d58076dd7dbde8cea2fed8ab525ce3713bda604988009ab35d765";
 
-/** Device code request endpoint. */
 export const DEVICE_CODE_ENDPOINT = "/oauth/device/code/";
-
-/** Token exchange endpoint. */
 export const TOKEN_ENDPOINT = "/oauth/token/";
-
-/** OAuth scopes requested during device code flow (same as cloudflare OAuth). */
 export const DEVICE_CODE_SCOPES = Object.keys(SCOPES).join(" ");
 
 /** Interval increment on slow_down response (RFC 8628). */
 export const SLOW_DOWN_INCREMENT_SEC = 5;
 
-/** Device code flow is only supported for sentry.io. */
 export function isSentryIo(host: string): boolean {
   return host === "sentry.io";
 }

--- a/packages/mcp-server/src/auth/constants.ts
+++ b/packages/mcp-server/src/auth/constants.ts
@@ -1,0 +1,25 @@
+import { SCOPES } from "@sentry/mcp-core/scopes";
+
+/**
+ * Bundled OAuth client ID for sentry.io device code flow.
+ * Override via SENTRY_CLIENT_ID environment variable.
+ */
+export const DEFAULT_SENTRY_CLIENT_ID =
+  "0acbeba7d07d58076dd7dbde8cea2fed8ab525ce3713bda604988009ab35d765";
+
+/** Device code request endpoint. */
+export const DEVICE_CODE_ENDPOINT = "/oauth/device/code/";
+
+/** Token exchange endpoint. */
+export const TOKEN_ENDPOINT = "/oauth/token/";
+
+/** OAuth scopes requested during device code flow (same as cloudflare OAuth). */
+export const DEVICE_CODE_SCOPES = Object.keys(SCOPES).join(" ");
+
+/** Interval increment on slow_down response (RFC 8628). */
+export const SLOW_DOWN_INCREMENT_SEC = 5;
+
+/** Device code flow is only supported for sentry.io. */
+export function isSentryIo(host: string): boolean {
+  return host === "sentry.io";
+}

--- a/packages/mcp-server/src/auth/constants.ts
+++ b/packages/mcp-server/src/auth/constants.ts
@@ -1,7 +1,13 @@
 import { SCOPES } from "@sentry/mcp-core/scopes";
 import { isSentryHost } from "@sentry/mcp-core/utils/url-utils";
 
-/** Override via SENTRY_CLIENT_ID environment variable. */
+/**
+ * Public OAuth app registered on sentry.io for the stdio device code flow.
+ * No client secret — device code grant is a public client flow.
+ * The Cloudflare transport uses a separate OAuth app with a secret.
+ * Override via SENTRY_CLIENT_ID environment variable.
+ * See docs/stdio-auth.md for the full credential architecture.
+ */
 export const DEFAULT_SENTRY_CLIENT_ID =
   "0acbeba7d07d58076dd7dbde8cea2fed8ab525ce3713bda604988009ab35d765";
 

--- a/packages/mcp-server/src/auth/constants.ts
+++ b/packages/mcp-server/src/auth/constants.ts
@@ -1,4 +1,5 @@
 import { SCOPES } from "@sentry/mcp-core/scopes";
+import { isSentryHost } from "@sentry/mcp-core/utils/url-utils";
 
 /** Override via SENTRY_CLIENT_ID environment variable. */
 export const DEFAULT_SENTRY_CLIENT_ID =
@@ -11,6 +12,14 @@ export const DEVICE_CODE_SCOPES = Object.keys(SCOPES).join(" ");
 /** Interval increment on slow_down response (RFC 8628). */
 export const SLOW_DOWN_INCREMENT_SEC = 5;
 
-export function isSentryIo(host: string): boolean {
-  return host === "sentry.io";
-}
+/**
+ * Whether device code auth is available for this host.
+ * Supports sentry.io and regional subdomains (us.sentry.io, eu.sentry.io).
+ */
+export { isSentryHost as isSentryIo };
+
+/**
+ * OAuth endpoints live on sentry.io regardless of regional host.
+ * Always use this as the host for device code and token requests.
+ */
+export const OAUTH_HOST = "sentry.io";

--- a/packages/mcp-server/src/auth/device-code-flow.test.ts
+++ b/packages/mcp-server/src/auth/device-code-flow.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  requestDeviceCode,
+  pollForToken,
+  DeviceCodeError,
+} from "./device-code-flow";
+
+const mockDeviceCodeResponse = {
+  device_code: "test-device-code",
+  user_code: "ABCD-1234",
+  verification_uri: "https://sentry.io/oauth/device",
+  verification_uri_complete:
+    "https://sentry.io/oauth/device?user_code=ABCD-1234",
+  interval: 1,
+  expires_in: 600,
+};
+
+const mockTokenResponse = {
+  access_token: "sntrys_test_access_token",
+  refresh_token: "sntrys_test_refresh_token",
+  token_type: "bearer",
+  expires_in: 2592000,
+  expires_at: new Date(Date.now() + 2592000 * 1000).toISOString(),
+  user: {
+    email: "test@example.com",
+    id: "12345",
+    name: "Test User",
+  },
+  scope: "org:read project:write team:write event:write",
+};
+
+describe("requestDeviceCode", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends correct request and parses response", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(mockDeviceCodeResponse), { status: 200 }),
+    );
+
+    const result = await requestDeviceCode(
+      "test-client-id",
+      "sentry.io",
+      "org:read",
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://sentry.io/oauth/device/code/",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      }),
+    );
+    expect(result.device_code).toBe("test-device-code");
+    expect(result.user_code).toBe("ABCD-1234");
+  });
+
+  it("throws on non-ok response", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("Bad Request", { status: 400 }),
+    );
+
+    await expect(requestDeviceCode("bad-client", "sentry.io")).rejects.toThrow(
+      DeviceCodeError,
+    );
+  });
+});
+
+describe("pollForToken", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns token on immediate success", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(mockTokenResponse), { status: 200 }),
+    );
+
+    const result = await pollForToken({
+      deviceCode: "test-device-code",
+      clientId: "test-client-id",
+      host: "sentry.io",
+      interval: 0.01, // Fast polling for tests
+      expiresIn: 10,
+    });
+
+    expect(result.access_token).toBe("sntrys_test_access_token");
+    expect(result.user.email).toBe("test@example.com");
+  });
+
+  it("retries on authorization_pending", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "authorization_pending" }), {
+          status: 400,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTokenResponse), { status: 200 }),
+      );
+
+    const result = await pollForToken({
+      deviceCode: "test-device-code",
+      clientId: "test-client-id",
+      host: "sentry.io",
+      interval: 0.01,
+      expiresIn: 10,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.access_token).toBe("sntrys_test_access_token");
+  });
+
+  it("throws on access_denied", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "access_denied" }), { status: 400 }),
+    );
+
+    await expect(
+      pollForToken({
+        deviceCode: "test-device-code",
+        clientId: "test-client-id",
+        host: "sentry.io",
+        interval: 0.01,
+        expiresIn: 10,
+      }),
+    ).rejects.toThrow(/Authorization was denied/);
+  });
+
+  it("throws on expired_token", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "expired_token" }), { status: 400 }),
+    );
+
+    await expect(
+      pollForToken({
+        deviceCode: "test-device-code",
+        clientId: "test-client-id",
+        host: "sentry.io",
+        interval: 0.01,
+        expiresIn: 10,
+      }),
+    ).rejects.toThrow(/expired/);
+  });
+
+  it("increases interval on slow_down", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "slow_down" }), { status: 400 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockTokenResponse), { status: 200 }),
+      );
+
+    const promise = pollForToken({
+      deviceCode: "test-device-code",
+      clientId: "test-client-id",
+      host: "sentry.io",
+      interval: 1,
+      expiresIn: 30,
+    });
+
+    // First poll after 1s interval
+    await vi.advanceTimersByTimeAsync(1000);
+    // After slow_down, interval becomes 1 + 5 = 6s
+    await vi.advanceTimersByTimeAsync(6000);
+
+    const result = await promise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.access_token).toBe("sntrys_test_access_token");
+    vi.useRealTimers();
+  });
+});

--- a/packages/mcp-server/src/auth/device-code-flow.ts
+++ b/packages/mcp-server/src/auth/device-code-flow.ts
@@ -160,9 +160,9 @@ function openBrowser(url: string): void {
     } else if (platform === "win32") {
       exec(`start "" ${JSON.stringify(url)}`);
     } else if (isWSL()) {
-      // WSL: cmd.exe needs ^& escaping for unquoted ampersands.
-      // Pass URL without shell quoting so cmd.exe sees it directly.
-      exec(`cmd.exe /c start "" "${url.replace(/&/g, "^&")}"`);
+      // WSL: invoke cmd.exe to open the default browser.
+      // URL is double-quoted so & is safe without escaping.
+      exec(`cmd.exe /c start "" "${url}"`);
     } else {
       exec(`xdg-open ${JSON.stringify(url)}`);
     }

--- a/packages/mcp-server/src/auth/device-code-flow.ts
+++ b/packages/mcp-server/src/auth/device-code-flow.ts
@@ -1,0 +1,207 @@
+import { exec } from "node:child_process";
+import * as fs from "node:fs";
+import { LIB_VERSION } from "@sentry/mcp-core/version";
+import {
+  DEVICE_CODE_ENDPOINT,
+  DEVICE_CODE_SCOPES,
+  SLOW_DOWN_INCREMENT_SEC,
+  TOKEN_ENDPOINT,
+} from "./constants";
+import {
+  DeviceCodeResponseSchema,
+  DeviceCodeErrorSchema,
+  TokenResponseSchema,
+  type DeviceCodeResponse,
+  type TokenResponse,
+} from "./types";
+
+const USER_AGENT = `sentry-mcp-server/${LIB_VERSION}`;
+
+export class DeviceCodeError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "DeviceCodeError";
+  }
+}
+
+export async function requestDeviceCode(
+  clientId: string,
+  host: string,
+  scopes: string = DEVICE_CODE_SCOPES,
+): Promise<DeviceCodeResponse> {
+  const url = `https://${host}${DEVICE_CODE_ENDPOINT}`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": USER_AGENT,
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      scope: scopes,
+    }).toString(),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new DeviceCodeError(
+      `Failed to request device code (HTTP ${resp.status}): ${text}`,
+    );
+  }
+
+  const body = await resp.json();
+  return DeviceCodeResponseSchema.parse(body);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function pollForToken({
+  deviceCode,
+  clientId,
+  host,
+  interval,
+  expiresIn,
+}: {
+  deviceCode: string;
+  clientId: string;
+  host: string;
+  interval: number;
+  expiresIn: number;
+}): Promise<TokenResponse> {
+  const url = `https://${host}${TOKEN_ENDPOINT}`;
+  const deadline = Date.now() + expiresIn * 1000;
+  let pollInterval = interval;
+
+  while (Date.now() < deadline) {
+    await sleep(pollInterval * 1000);
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": USER_AGENT,
+      },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        device_code: deviceCode,
+        client_id: clientId,
+      }).toString(),
+    });
+
+    if (resp.ok) {
+      const body = await resp.json();
+      return TokenResponseSchema.parse(body);
+    }
+
+    // Parse error response
+    const errorBody = await resp.json().catch(() => null);
+    const parsed = DeviceCodeErrorSchema.safeParse(errorBody);
+    const errorCode = parsed.success ? parsed.data.error : undefined;
+
+    switch (errorCode) {
+      case "authorization_pending":
+        // Keep polling at current interval
+        continue;
+      case "slow_down":
+        pollInterval += SLOW_DOWN_INCREMENT_SEC;
+        continue;
+      case "access_denied":
+        throw new DeviceCodeError(
+          "Authorization was denied. Please try again or provide --access-token.",
+          errorCode,
+        );
+      case "expired_token":
+        throw new DeviceCodeError(
+          "Device code expired before authorization was completed.",
+          errorCode,
+        );
+      default:
+        throw new DeviceCodeError(
+          `Unexpected error during device code polling: ${errorCode ?? resp.statusText}`,
+          errorCode,
+        );
+    }
+  }
+
+  throw new DeviceCodeError(
+    "Device code expired before authorization was completed.",
+    "expired_token",
+  );
+}
+
+/**
+ * Write directly to stderr, bypassing console.warn which may be
+ * intercepted by the MCP transport layer.
+ */
+function stderr(msg: string): void {
+  process.stderr.write(`${msg}\n`);
+}
+
+function isWSL(): boolean {
+  try {
+    return fs
+      .readFileSync("/proc/version", "utf-8")
+      .toLowerCase()
+      .includes("microsoft");
+  } catch {
+    return false;
+  }
+}
+
+function openBrowser(url: string): void {
+  try {
+    const { platform } = process;
+    if (platform === "darwin") {
+      exec(`open ${JSON.stringify(url)}`);
+    } else if (platform === "win32") {
+      exec(`start "" ${JSON.stringify(url)}`);
+    } else if (isWSL()) {
+      // WSL: cmd.exe needs ^& escaping for unquoted ampersands.
+      // Pass URL without shell quoting so cmd.exe sees it directly.
+      exec(`cmd.exe /c start "" "${url.replace(/&/g, "^&")}"`);
+    } else {
+      exec(`xdg-open ${JSON.stringify(url)}`);
+    }
+  } catch {
+    // Best-effort — ignore errors (headless, etc.)
+  }
+}
+
+export function displayDeviceCode(response: DeviceCodeResponse): void {
+  stderr("");
+  stderr(`To authorize, visit: ${response.verification_uri_complete}`);
+  stderr(`  and enter code: ${response.user_code}`);
+  stderr("");
+  stderr("Waiting for authorization...");
+
+  openBrowser(response.verification_uri_complete);
+}
+
+export async function authenticate({
+  clientId,
+  host,
+}: {
+  clientId: string;
+  host: string;
+}): Promise<TokenResponse> {
+  stderr("No access token provided. Starting device authorization...");
+
+  const deviceCodeResponse = await requestDeviceCode(clientId, host);
+  displayDeviceCode(deviceCodeResponse);
+
+  const tokenResponse = await pollForToken({
+    deviceCode: deviceCodeResponse.device_code,
+    clientId,
+    host,
+    interval: deviceCodeResponse.interval,
+    expiresIn: deviceCodeResponse.expires_in,
+  });
+
+  stderr(`Successfully authenticated as ${tokenResponse.user.email}`);
+  return tokenResponse;
+}

--- a/packages/mcp-server/src/auth/device-code-flow.ts
+++ b/packages/mcp-server/src/auth/device-code-flow.ts
@@ -161,8 +161,7 @@ function openBrowser(url: string): void {
       exec(`start "" ${JSON.stringify(url)}`);
     } else if (isWSL()) {
       // WSL: invoke cmd.exe to open the default browser.
-      // URL is double-quoted so & is safe without escaping.
-      exec(`cmd.exe /c start "" "${url}"`);
+      exec(`cmd.exe /c start "" ${JSON.stringify(url)}`);
     } else {
       exec(`xdg-open ${JSON.stringify(url)}`);
     }

--- a/packages/mcp-server/src/auth/device-code-flow.ts
+++ b/packages/mcp-server/src/auth/device-code-flow.ts
@@ -42,7 +42,7 @@ export async function requestDeviceCode(
     body: new URLSearchParams({
       client_id: clientId,
       scope: scopes,
-    }).toString(),
+    }),
   });
 
   if (!resp.ok) {
@@ -90,7 +90,7 @@ export async function pollForToken({
         grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         device_code: deviceCode,
         client_id: clientId,
-      }).toString(),
+      }),
     });
 
     if (resp.ok) {
@@ -98,7 +98,6 @@ export async function pollForToken({
       return TokenResponseSchema.parse(body);
     }
 
-    // Parse error response
     const errorBody = await resp.json().catch(() => null);
     const parsed = DeviceCodeErrorSchema.safeParse(errorBody);
     const errorCode = parsed.success ? parsed.data.error : undefined;

--- a/packages/mcp-server/src/auth/resolve-token.test.ts
+++ b/packages/mcp-server/src/auth/resolve-token.test.ts
@@ -116,4 +116,32 @@ describe("resolveAccessToken", () => {
       host: "sentry.io",
     });
   });
+
+  it("accepts regional sentry.io subdomains", async () => {
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const { authenticate } = await import("./device-code-flow");
+    vi.mocked(authenticate).mockResolvedValueOnce({
+      access_token: "regional-token",
+      refresh_token: "refresh",
+      token_type: "bearer",
+      expires_in: 2592000,
+      expires_at: new Date(Date.now() + 2592000000).toISOString(),
+      user: { email: "test@example.com", id: "1", name: "Test" },
+      scope: "org:read",
+    });
+
+    const cfg = makePartialConfig({ sentryHost: "us.sentry.io" });
+    const result = await resolveAccessToken(cfg);
+    expect(result.accessToken).toBe("regional-token");
+    // OAuth endpoints always use sentry.io, not the regional subdomain
+    expect(authenticate).toHaveBeenCalledWith({
+      clientId: "test-client-id",
+      host: "sentry.io",
+    });
+  });
 });

--- a/packages/mcp-server/src/auth/resolve-token.test.ts
+++ b/packages/mcp-server/src/auth/resolve-token.test.ts
@@ -5,9 +5,6 @@ import type { PartiallyResolvedConfig } from "../cli/types";
 // Mock the auth modules so we never make real network calls or touch disk
 vi.mock("./device-code-flow", () => ({
   authenticate: vi.fn(),
-  DeviceCodeError: class DeviceCodeError extends Error {
-    code?: string;
-  },
 }));
 
 vi.mock("./token-cache", () => ({

--- a/packages/mcp-server/src/auth/resolve-token.test.ts
+++ b/packages/mcp-server/src/auth/resolve-token.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolveAccessToken } from "./resolve-token";
+import type { PartiallyResolvedConfig } from "../cli/types";
+
+// Mock the auth modules so we never make real network calls or touch disk
+vi.mock("./device-code-flow", () => ({
+  authenticate: vi.fn(),
+  DeviceCodeError: class DeviceCodeError extends Error {
+    code?: string;
+  },
+}));
+
+vi.mock("./token-cache", () => ({
+  readCachedToken: vi.fn().mockResolvedValue(null),
+  writeCachedToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makePartialConfig(
+  overrides: Partial<PartiallyResolvedConfig> = {},
+): PartiallyResolvedConfig {
+  return {
+    clientId: "test-client-id",
+    sentryHost: "sentry.io",
+    finalSkills: new Set(),
+    ...overrides,
+  };
+}
+
+describe("resolveAccessToken", () => {
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    originalIsTTY = process.stderr.isTTY;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("returns immediately when accessToken is provided", async () => {
+    const cfg = makePartialConfig({ accessToken: "existing-token" });
+    const result = await resolveAccessToken(cfg);
+    expect(result.accessToken).toBe("existing-token");
+  });
+
+  it("throws for non-sentry.io hosts without a token", async () => {
+    const cfg = makePartialConfig({
+      sentryHost: "sentry.example.com",
+    });
+    await expect(resolveAccessToken(cfg)).rejects.toThrow(
+      /only supported for sentry.io/,
+    );
+  });
+
+  it("throws in non-TTY context when no token and no cache", async () => {
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const cfg = makePartialConfig();
+    await expect(resolveAccessToken(cfg)).rejects.toThrow(
+      /Run `sentry-mcp auth login` interactively first/,
+    );
+  });
+
+  it("uses cached token in non-TTY context", async () => {
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { readCachedToken } = await import("./token-cache");
+    vi.mocked(readCachedToken).mockResolvedValueOnce({
+      access_token: "cached-token",
+      refresh_token: "refresh",
+      expires_at: new Date(Date.now() + 86400000).toISOString(),
+      sentry_host: "sentry.io",
+      client_id: "test-client-id",
+      user_email: "test@example.com",
+      scope: "org:read",
+    });
+
+    const cfg = makePartialConfig();
+    const result = await resolveAccessToken(cfg);
+    expect(result.accessToken).toBe("cached-token");
+  });
+
+  it("triggers device code flow in TTY context when no cache", async () => {
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const { authenticate } = await import("./device-code-flow");
+    vi.mocked(authenticate).mockResolvedValueOnce({
+      access_token: "new-token",
+      refresh_token: "refresh",
+      token_type: "bearer",
+      expires_in: 2592000,
+      expires_at: new Date(Date.now() + 2592000000).toISOString(),
+      user: { email: "test@example.com", id: "1", name: "Test" },
+      scope: "org:read",
+    });
+
+    const cfg = makePartialConfig();
+    const result = await resolveAccessToken(cfg);
+    expect(result.accessToken).toBe("new-token");
+    expect(authenticate).toHaveBeenCalledWith({
+      clientId: "test-client-id",
+      host: "sentry.io",
+    });
+  });
+});

--- a/packages/mcp-server/src/auth/resolve-token.ts
+++ b/packages/mcp-server/src/auth/resolve-token.ts
@@ -1,5 +1,5 @@
 import type { PartiallyResolvedConfig, ResolvedConfig } from "../cli/types";
-import { isSentryIo } from "./constants";
+import { isSentryIo, OAUTH_HOST } from "./constants";
 import { authenticate } from "./device-code-flow";
 import { readCachedToken, writeCachedToken } from "./token-cache";
 import { toCachedToken } from "./types";
@@ -58,7 +58,7 @@ export async function resolveAccessToken(
     );
   }
 
-  const tokenResponse = await authenticate({ clientId, host: sentryHost });
+  const tokenResponse = await authenticate({ clientId, host: OAUTH_HOST });
 
   try {
     await writeCachedToken(toCachedToken(tokenResponse, sentryHost, clientId));

--- a/packages/mcp-server/src/auth/resolve-token.ts
+++ b/packages/mcp-server/src/auth/resolve-token.ts
@@ -1,0 +1,65 @@
+import type { PartiallyResolvedConfig, ResolvedConfig } from "../cli/types";
+import { isSentryIo } from "./constants";
+import { authenticate, DeviceCodeError } from "./device-code-flow";
+import { readCachedToken, writeCachedToken } from "./token-cache";
+import { toCachedToken } from "./types";
+
+/**
+ * Resolves the access token for the session.
+ *
+ * If an access token is already provided, returns immediately.
+ * If the host is sentry.io, attempts to use a cached token or
+ * initiates the device code flow.
+ * For non-sentry.io hosts, throws an error requiring --access-token.
+ */
+export async function resolveAccessToken(
+  partial: PartiallyResolvedConfig,
+): Promise<ResolvedConfig> {
+  if (partial.accessToken) {
+    return { ...partial, accessToken: partial.accessToken };
+  }
+
+  if (!isSentryIo(partial.sentryHost)) {
+    throw new Error(
+      "Error: No access token was provided. Device code authentication is only supported for sentry.io.\n" +
+        "Pass one with `--access-token` or via `SENTRY_ACCESS_TOKEN`.",
+    );
+  }
+
+  const { clientId, sentryHost } = partial;
+
+  // Try cached token first
+  try {
+    const cached = await readCachedToken(sentryHost, clientId);
+    if (cached) {
+      process.stderr.write(
+        `Using cached authentication for ${cached.user_email}\n`,
+      );
+      return { ...partial, accessToken: cached.access_token };
+    }
+  } catch {
+    // Cache read failure is non-fatal — fall through to device code flow
+  }
+
+  // Run device code flow
+  try {
+    const tokenResponse = await authenticate({ clientId, host: sentryHost });
+
+    try {
+      await writeCachedToken(
+        toCachedToken(tokenResponse, sentryHost, clientId),
+      );
+    } catch {
+      process.stderr.write("Warning: Could not cache authentication token.\n");
+    }
+
+    return { ...partial, accessToken: tokenResponse.access_token };
+  } catch (err) {
+    if (err instanceof DeviceCodeError) {
+      throw new Error(err.message);
+    }
+    throw new Error(
+      `Device code authentication failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/packages/mcp-server/src/auth/resolve-token.ts
+++ b/packages/mcp-server/src/auth/resolve-token.ts
@@ -9,7 +9,7 @@ import { toCachedToken } from "./types";
  *
  * If an access token is already provided, returns immediately.
  * If the host is sentry.io, attempts to use a cached token or
- * initiates the device code flow.
+ * initiates the device code flow (only when stderr is a TTY).
  * For non-sentry.io hosts, throws an error requiring --access-token.
  */
 export async function resolveAccessToken(
@@ -28,7 +28,7 @@ export async function resolveAccessToken(
 
   const { clientId, sentryHost } = partial;
 
-  // Try cached token first
+  // Try cached token first (works in both interactive and non-interactive contexts)
   try {
     const cached = await readCachedToken(sentryHost, clientId);
     if (cached) {
@@ -41,7 +41,17 @@ export async function resolveAccessToken(
     // Cache read failure is non-fatal — fall through to device code flow
   }
 
-  // Run device code flow
+  // Device code flow requires a human to visit a URL and authorize.
+  // In non-interactive contexts (CI, piped stdio), fail immediately
+  // instead of hanging on the polling loop until expiry.
+  if (!process.stderr.isTTY) {
+    throw new Error(
+      "Error: No access token was provided.\n" +
+        "Run `sentry-mcp auth login` interactively first, or pass `--access-token` / `SENTRY_ACCESS_TOKEN`.",
+    );
+  }
+
+  // Run device code flow (interactive only)
   try {
     const tokenResponse = await authenticate({ clientId, host: sentryHost });
 

--- a/packages/mcp-server/src/auth/resolve-token.ts
+++ b/packages/mcp-server/src/auth/resolve-token.ts
@@ -1,8 +1,15 @@
 import type { PartiallyResolvedConfig, ResolvedConfig } from "../cli/types";
 import { isSentryIo } from "./constants";
-import { authenticate, DeviceCodeError } from "./device-code-flow";
+import { authenticate } from "./device-code-flow";
 import { readCachedToken, writeCachedToken } from "./token-cache";
 import { toCachedToken } from "./types";
+
+function withToken(
+  partial: PartiallyResolvedConfig,
+  accessToken: string,
+): ResolvedConfig {
+  return { ...partial, accessToken };
+}
 
 /**
  * Resolves the access token for the session.
@@ -16,7 +23,7 @@ export async function resolveAccessToken(
   partial: PartiallyResolvedConfig,
 ): Promise<ResolvedConfig> {
   if (partial.accessToken) {
-    return { ...partial, accessToken: partial.accessToken };
+    return withToken(partial, partial.accessToken);
   }
 
   if (!isSentryIo(partial.sentryHost)) {
@@ -35,10 +42,10 @@ export async function resolveAccessToken(
       process.stderr.write(
         `Using cached authentication for ${cached.user_email}\n`,
       );
-      return { ...partial, accessToken: cached.access_token };
+      return withToken(partial, cached.access_token);
     }
   } catch {
-    // Cache read failure is non-fatal — fall through to device code flow
+    // Cache read failure is non-fatal
   }
 
   // Device code flow requires a human to visit a URL and authorize.
@@ -51,25 +58,13 @@ export async function resolveAccessToken(
     );
   }
 
-  // Run device code flow (interactive only)
+  const tokenResponse = await authenticate({ clientId, host: sentryHost });
+
   try {
-    const tokenResponse = await authenticate({ clientId, host: sentryHost });
-
-    try {
-      await writeCachedToken(
-        toCachedToken(tokenResponse, sentryHost, clientId),
-      );
-    } catch {
-      process.stderr.write("Warning: Could not cache authentication token.\n");
-    }
-
-    return { ...partial, accessToken: tokenResponse.access_token };
-  } catch (err) {
-    if (err instanceof DeviceCodeError) {
-      throw new Error(err.message);
-    }
-    throw new Error(
-      `Device code authentication failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    await writeCachedToken(toCachedToken(tokenResponse, sentryHost, clientId));
+  } catch {
+    process.stderr.write("Warning: Could not cache authentication token.\n");
   }
+
+  return withToken(partial, tokenResponse.access_token);
 }

--- a/packages/mcp-server/src/auth/token-cache.test.ts
+++ b/packages/mcp-server/src/auth/token-cache.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  readCachedToken,
+  writeCachedToken,
+  clearCachedToken,
+} from "./token-cache";
+import type { CachedToken } from "./types";
+
+let tmpDir: string;
+
+function makeCachedToken(overrides: Partial<CachedToken> = {}): CachedToken {
+  return {
+    access_token: "sntrys_test_token",
+    refresh_token: "sntrys_refresh_token",
+    expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    sentry_host: "sentry.io",
+    client_id: "test-client-id",
+    user_email: "user@example.com",
+    scope: "org:read project:write team:write event:write",
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-auth-test-"));
+  process.env.SENTRY_MCP_AUTH_CACHE = path.join(tmpDir, "mcp.json");
+});
+
+afterEach(async () => {
+  process.env.SENTRY_MCP_AUTH_CACHE = undefined;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("token-cache", () => {
+  it("returns null when no cache file exists", async () => {
+    const result = await readCachedToken("sentry.io", "test-client-id");
+    expect(result).toBeNull();
+  });
+
+  it("writes and reads a token", async () => {
+    const token = makeCachedToken();
+    await writeCachedToken(token);
+
+    const result = await readCachedToken("sentry.io", "test-client-id");
+    expect(result).toEqual(token);
+  });
+
+  it("returns null for a different host/clientId pair", async () => {
+    await writeCachedToken(makeCachedToken());
+
+    const result = await readCachedToken("other.sentry.io", "test-client-id");
+    expect(result).toBeNull();
+  });
+
+  it("returns null and clears expired tokens", async () => {
+    const expired = makeCachedToken({
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    });
+    await writeCachedToken(expired);
+
+    const result = await readCachedToken("sentry.io", "test-client-id");
+    expect(result).toBeNull();
+
+    // Verify it was cleared from the file
+    const raw = await fs.readFile(process.env.SENTRY_MCP_AUTH_CACHE!, "utf-8");
+    const data = JSON.parse(raw);
+    expect(data["sentry.io:test-client-id"]).toBeUndefined();
+  });
+
+  it("returns null for tokens expiring within safety window", async () => {
+    const almostExpired = makeCachedToken({
+      // Expires in 2 minutes (within 5-minute safety window)
+      expires_at: new Date(Date.now() + 2 * 60 * 1000).toISOString(),
+    });
+    await writeCachedToken(almostExpired);
+
+    const result = await readCachedToken("sentry.io", "test-client-id");
+    expect(result).toBeNull();
+  });
+
+  it("clears a specific token", async () => {
+    await writeCachedToken(makeCachedToken());
+    await writeCachedToken(
+      makeCachedToken({
+        sentry_host: "other.sentry.io",
+        client_id: "other-id",
+      }),
+    );
+
+    await clearCachedToken("sentry.io", "test-client-id");
+
+    const cleared = await readCachedToken("sentry.io", "test-client-id");
+    expect(cleared).toBeNull();
+
+    // Other entry should still exist
+    const other = await readCachedToken("other.sentry.io", "other-id");
+    expect(other).not.toBeNull();
+  });
+
+  it("handles corrupted cache file gracefully", async () => {
+    await fs.writeFile(process.env.SENTRY_MCP_AUTH_CACHE!, "not-json", "utf-8");
+
+    const result = await readCachedToken("sentry.io", "test-client-id");
+    expect(result).toBeNull();
+  });
+
+  it("sets restrictive file permissions", async () => {
+    await writeCachedToken(makeCachedToken());
+
+    const stat = await fs.stat(process.env.SENTRY_MCP_AUTH_CACHE!);
+    // 0o600 = owner read/write only (on Unix-like systems)
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});

--- a/packages/mcp-server/src/auth/token-cache.ts
+++ b/packages/mcp-server/src/auth/token-cache.ts
@@ -1,0 +1,83 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { CachedToken } from "./types";
+
+/** Safety window: treat tokens as expired 5 minutes before actual expiry. */
+const EXPIRY_SAFETY_MS = 5 * 60 * 1000;
+
+function getCacheFilePath(): string {
+  if (process.env.SENTRY_MCP_AUTH_CACHE) {
+    return process.env.SENTRY_MCP_AUTH_CACHE;
+  }
+  return path.join(os.homedir(), ".sentry", "mcp.json");
+}
+
+function cacheKey(host: string, clientId: string): string {
+  return `${host}:${clientId}`;
+}
+
+type CacheFile = Record<string, CachedToken>;
+
+async function readCacheFile(): Promise<CacheFile> {
+  try {
+    const raw = await fs.readFile(getCacheFilePath(), "utf-8");
+    return JSON.parse(raw) as CacheFile;
+  } catch {
+    return {};
+  }
+}
+
+async function writeCacheFile(data: CacheFile): Promise<void> {
+  const filePath = getCacheFilePath();
+  const dir = path.dirname(filePath);
+
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+  // Atomic write: write to temp file then rename
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  await fs.writeFile(tmpPath, JSON.stringify(data, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fs.rename(tmpPath, filePath);
+}
+
+export async function readCachedToken(
+  host: string,
+  clientId: string,
+): Promise<CachedToken | null> {
+  const data = await readCacheFile();
+  const entry = data[cacheKey(host, clientId)];
+  if (!entry) return null;
+
+  const expiresAt = new Date(entry.expires_at).getTime();
+  if (
+    !Number.isFinite(expiresAt) ||
+    expiresAt - Date.now() <= EXPIRY_SAFETY_MS
+  ) {
+    // Token expired or about to expire — clear it
+    await clearCachedToken(host, clientId);
+    return null;
+  }
+
+  return entry;
+}
+
+export async function writeCachedToken(token: CachedToken): Promise<void> {
+  const data = await readCacheFile();
+  data[cacheKey(token.sentry_host, token.client_id)] = token;
+  await writeCacheFile(data);
+}
+
+export async function clearCachedToken(
+  host: string,
+  clientId: string,
+): Promise<void> {
+  const data = await readCacheFile();
+  const key = cacheKey(host, clientId);
+  if (key in data) {
+    delete data[key];
+    await writeCacheFile(data);
+  }
+}

--- a/packages/mcp-server/src/auth/token-cache.ts
+++ b/packages/mcp-server/src/auth/token-cache.ts
@@ -48,7 +48,8 @@ export async function readCachedToken(
   clientId: string,
 ): Promise<CachedToken | null> {
   const data = await readCacheFile();
-  const entry = data[cacheKey(host, clientId)];
+  const key = cacheKey(host, clientId);
+  const entry = data[key];
   if (!entry) return null;
 
   const expiresAt = new Date(entry.expires_at).getTime();
@@ -56,8 +57,8 @@ export async function readCachedToken(
     !Number.isFinite(expiresAt) ||
     expiresAt - Date.now() <= EXPIRY_SAFETY_MS
   ) {
-    // Token expired or about to expire — clear it
-    await clearCachedToken(host, clientId);
+    delete data[key];
+    await writeCacheFile(data);
     return null;
   }
 

--- a/packages/mcp-server/src/auth/token-cache.ts
+++ b/packages/mcp-server/src/auth/token-cache.ts
@@ -1,3 +1,8 @@
+/**
+ * Persistent token cache for device code auth.
+ * Tokens are stored at ~/.sentry/mcp.json, keyed by {host}:{clientId}.
+ * See docs/stdio-auth.md for cache format and security details.
+ */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/packages/mcp-server/src/auth/types.ts
+++ b/packages/mcp-server/src/auth/types.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+/**
+ * Response from Sentry's device code endpoint (POST /oauth/device/code/).
+ * See: https://docs.sentry.io/api/auth/#device-authorization-flow
+ */
+export const DeviceCodeResponseSchema = z.object({
+  device_code: z.string(),
+  user_code: z.string(),
+  verification_uri: z.string().url(),
+  verification_uri_complete: z.string().url(),
+  interval: z.number().int().positive(),
+  expires_in: z.number().int().positive(),
+});
+
+export type DeviceCodeResponse = z.infer<typeof DeviceCodeResponseSchema>;
+
+/**
+ * Error response during device code token polling.
+ */
+export const DeviceCodeErrorSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+});
+
+/**
+ * Successful token response from Sentry's token endpoint.
+ * Mirrors the shape used by the cloudflare OAuth callback.
+ */
+export const TokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  token_type: z.string(),
+  expires_in: z.number(),
+  expires_at: z.string().datetime(),
+  user: z.object({
+    email: z.string().email(),
+    id: z.string(),
+    name: z.string().nullable(),
+  }),
+  scope: z.string(),
+});
+
+export type TokenResponse = z.infer<typeof TokenResponseSchema>;
+
+/**
+ * Shape of a cached token entry stored on disk.
+ */
+export type CachedToken = {
+  access_token: string;
+  refresh_token: string;
+  expires_at: string;
+  sentry_host: string;
+  client_id: string;
+  user_email: string;
+  scope: string;
+};
+
+export function toCachedToken(
+  tokenResponse: TokenResponse,
+  sentryHost: string,
+  clientId: string,
+): CachedToken {
+  return {
+    access_token: tokenResponse.access_token,
+    refresh_token: tokenResponse.refresh_token,
+    expires_at: tokenResponse.expires_at,
+    sentry_host: sentryHost,
+    client_id: clientId,
+    user_email: tokenResponse.user.email,
+    scope: tokenResponse.scope,
+  };
+}

--- a/packages/mcp-server/src/cli/commands/auth.test.ts
+++ b/packages/mcp-server/src/cli/commands/auth.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseFlag } from "./auth";
+
+describe("parseFlag", () => {
+  it("parses --flag=value form", () => {
+    expect(parseFlag(["--host=sentry.example.com"], "host")).toBe(
+      "sentry.example.com",
+    );
+  });
+
+  it("parses --flag value form", () => {
+    expect(parseFlag(["--host", "sentry.example.com"], "host")).toBe(
+      "sentry.example.com",
+    );
+  });
+
+  it("returns undefined when flag is absent", () => {
+    expect(parseFlag(["--other=foo"], "host")).toBeUndefined();
+  });
+
+  it("returns undefined when --flag is last arg with no value", () => {
+    expect(parseFlag(["--host"], "host")).toBeUndefined();
+  });
+
+  it("prefers first occurrence", () => {
+    expect(parseFlag(["--host=first", "--host=second"], "host")).toBe("first");
+  });
+
+  it("works with --url flag", () => {
+    expect(parseFlag(["--url", "https://sentry.example.com"], "url")).toBe(
+      "https://sentry.example.com",
+    );
+  });
+
+  it("does not match partial flag names", () => {
+    expect(parseFlag(["--hostname=foo"], "host")).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/cli/commands/auth.ts
+++ b/packages/mcp-server/src/cli/commands/auth.ts
@@ -1,5 +1,9 @@
 import { parseEnv } from "../parse";
-import { DEFAULT_SENTRY_CLIENT_ID, isSentryIo } from "../../auth/constants";
+import {
+  DEFAULT_SENTRY_CLIENT_ID,
+  isSentryIo,
+  OAUTH_HOST,
+} from "../../auth/constants";
 import { authenticate } from "../../auth/device-code-flow";
 import {
   readCachedToken,
@@ -33,19 +37,17 @@ export function parseFlag(argv: string[], name: string): string | undefined {
 function resolveAuthContext(argv: string[]): AuthContext {
   const env = parseEnv(process.env);
 
+  // Match the precedence of the server's merge() + finalize() path:
+  // merged url (CLI --url ?? env SENTRY_URL) beats merged host (CLI --host ?? env SENTRY_HOST)
+  const url = parseFlag(argv, "url") ?? env.url;
+  const host = parseFlag(argv, "host") ?? env.host;
+
   let sentryHost = "sentry.io";
-  const urlFlag = parseFlag(argv, "url");
-  const hostFlag = parseFlag(argv, "host");
-  if (urlFlag) {
-    sentryHost = validateAndParseSentryUrlThrows(urlFlag);
-  } else if (hostFlag) {
-    validateSentryHostThrows(hostFlag);
-    sentryHost = hostFlag;
-  } else if (env.url) {
-    sentryHost = validateAndParseSentryUrlThrows(env.url);
-  } else if (env.host) {
-    validateSentryHostThrows(env.host);
-    sentryHost = env.host;
+  if (url) {
+    sentryHost = validateAndParseSentryUrlThrows(url);
+  } else if (host) {
+    validateSentryHostThrows(host);
+    sentryHost = host;
   }
 
   return { sentryHost, clientId: env.clientId || DEFAULT_SENTRY_CLIENT_ID };
@@ -62,7 +64,7 @@ async function login(argv: string[]): Promise<void> {
   }
 
   try {
-    const tokenResponse = await authenticate({ clientId, host: sentryHost });
+    const tokenResponse = await authenticate({ clientId, host: OAUTH_HOST });
     await writeCachedToken(toCachedToken(tokenResponse, sentryHost, clientId));
   } catch (err) {
     console.error(

--- a/packages/mcp-server/src/cli/commands/auth.ts
+++ b/packages/mcp-server/src/cli/commands/auth.ts
@@ -1,4 +1,5 @@
 import { parseEnv } from "../parse";
+import { resolveHost } from "../resolve";
 import {
   DEFAULT_SENTRY_CLIENT_ID,
   isSentryIo,
@@ -11,10 +12,6 @@ import {
   clearCachedToken,
 } from "../../auth/token-cache";
 import { toCachedToken } from "../../auth/types";
-import {
-  validateAndParseSentryUrlThrows,
-  validateSentryHostThrows,
-} from "@sentry/mcp-core/utils/url-utils";
 
 type AuthContext = {
   sentryHost: string;
@@ -41,14 +38,7 @@ function resolveAuthContext(argv: string[]): AuthContext {
   // merged url (CLI --url ?? env SENTRY_URL) beats merged host (CLI --host ?? env SENTRY_HOST)
   const url = parseFlag(argv, "url") ?? env.url;
   const host = parseFlag(argv, "host") ?? env.host;
-
-  let sentryHost = "sentry.io";
-  if (url) {
-    sentryHost = validateAndParseSentryUrlThrows(url);
-  } else if (host) {
-    validateSentryHostThrows(host);
-    sentryHost = host;
-  }
+  const sentryHost = resolveHost(url, host);
 
   return { sentryHost, clientId: env.clientId || DEFAULT_SENTRY_CLIENT_ID };
 }

--- a/packages/mcp-server/src/cli/commands/auth.ts
+++ b/packages/mcp-server/src/cli/commands/auth.ts
@@ -1,0 +1,113 @@
+import { parseEnv } from "../parse";
+import { DEFAULT_SENTRY_CLIENT_ID, isSentryIo } from "../../auth/constants";
+import { authenticate, DeviceCodeError } from "../../auth/device-code-flow";
+import {
+  readCachedToken,
+  writeCachedToken,
+  clearCachedToken,
+} from "../../auth/token-cache";
+import { toCachedToken } from "../../auth/types";
+import {
+  validateAndParseSentryUrlThrows,
+  validateSentryHostThrows,
+} from "@sentry/mcp-core/utils/url-utils";
+
+type AuthContext = {
+  sentryHost: string;
+  clientId: string;
+};
+
+function resolveAuthContext(argv: string[]): AuthContext {
+  const env = parseEnv(process.env);
+
+  let sentryHost = "sentry.io";
+  for (const arg of argv) {
+    if (arg.startsWith("--host=")) {
+      const host = arg.slice("--host=".length);
+      validateSentryHostThrows(host);
+      sentryHost = host;
+    } else if (arg.startsWith("--url=")) {
+      sentryHost = validateAndParseSentryUrlThrows(arg.slice("--url=".length));
+    }
+  }
+  if (sentryHost === "sentry.io") {
+    if (env.url) {
+      sentryHost = validateAndParseSentryUrlThrows(env.url);
+    } else if (env.host) {
+      validateSentryHostThrows(env.host);
+      sentryHost = env.host;
+    }
+  }
+
+  return { sentryHost, clientId: env.clientId || DEFAULT_SENTRY_CLIENT_ID };
+}
+
+async function login(argv: string[]): Promise<void> {
+  const { sentryHost, clientId } = resolveAuthContext(argv);
+
+  if (!isSentryIo(sentryHost)) {
+    console.error(
+      "Error: Device code authentication is only supported for sentry.io.",
+    );
+    process.exit(1);
+  }
+
+  try {
+    const tokenResponse = await authenticate({ clientId, host: sentryHost });
+    await writeCachedToken(toCachedToken(tokenResponse, sentryHost, clientId));
+  } catch (err) {
+    if (err instanceof DeviceCodeError) {
+      console.error(err.message);
+    } else {
+      console.error(
+        `Authentication failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    process.exit(1);
+  }
+}
+
+async function logout(argv: string[]): Promise<void> {
+  const { sentryHost, clientId } = resolveAuthContext(argv);
+
+  const cached = await readCachedToken(sentryHost, clientId);
+  if (cached) {
+    await clearCachedToken(sentryHost, clientId);
+    console.log(`Logged out (removed cached token for ${cached.user_email}).`);
+  } else {
+    console.log("No cached authentication found.");
+  }
+}
+
+async function status(argv: string[]): Promise<void> {
+  const { sentryHost, clientId } = resolveAuthContext(argv);
+
+  const cached = await readCachedToken(sentryHost, clientId);
+  if (cached) {
+    const expiresAt = new Date(cached.expires_at);
+    console.log(`Authenticated as ${cached.user_email}`);
+    console.log(`  Host:    ${cached.sentry_host}`);
+    console.log(`  Scopes:  ${cached.scope}`);
+    console.log(`  Expires: ${expiresAt.toLocaleString()}`);
+  } else {
+    console.log("Not authenticated. Run `sentry-mcp auth login` to sign in.");
+  }
+}
+
+export async function authCommand(argv: string[]): Promise<void> {
+  const sub = argv[0] ?? "login";
+  const rest = argv.slice(1);
+
+  switch (sub) {
+    case "login":
+      return login(rest);
+    case "logout":
+      return logout(rest);
+    case "status":
+      return status(rest);
+    default:
+      console.error(`Unknown auth command: ${sub}`);
+      console.error("Available: auth login, auth logout, auth status");
+      process.exit(1);
+  }
+}

--- a/packages/mcp-server/src/cli/commands/auth.ts
+++ b/packages/mcp-server/src/cli/commands/auth.ts
@@ -1,6 +1,6 @@
 import { parseEnv } from "../parse";
 import { DEFAULT_SENTRY_CLIENT_ID, isSentryIo } from "../../auth/constants";
-import { authenticate, DeviceCodeError } from "../../auth/device-code-flow";
+import { authenticate } from "../../auth/device-code-flow";
 import {
   readCachedToken,
   writeCachedToken,
@@ -20,11 +20,9 @@ type AuthContext = {
 export function parseFlag(argv: string[], name: string): string | undefined {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    // --flag=value
     if (arg.startsWith(`--${name}=`)) {
       return arg.slice(`--${name}=`.length);
     }
-    // --flag value
     if (arg === `--${name}` && i + 1 < argv.length) {
       return argv[i + 1];
     }
@@ -36,8 +34,8 @@ function resolveAuthContext(argv: string[]): AuthContext {
   const env = parseEnv(process.env);
 
   let sentryHost = "sentry.io";
-  const hostFlag = parseFlag(argv, "host");
   const urlFlag = parseFlag(argv, "url");
+  const hostFlag = parseFlag(argv, "host");
   if (urlFlag) {
     sentryHost = validateAndParseSentryUrlThrows(urlFlag);
   } else if (hostFlag) {
@@ -67,13 +65,9 @@ async function login(argv: string[]): Promise<void> {
     const tokenResponse = await authenticate({ clientId, host: sentryHost });
     await writeCachedToken(toCachedToken(tokenResponse, sentryHost, clientId));
   } catch (err) {
-    if (err instanceof DeviceCodeError) {
-      console.error(err.message);
-    } else {
-      console.error(
-        `Authentication failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    console.error(
+      err instanceof Error ? err.message : `Authentication failed: ${err}`,
+    );
     process.exit(1);
   }
 }

--- a/packages/mcp-server/src/cli/commands/auth.ts
+++ b/packages/mcp-server/src/cli/commands/auth.ts
@@ -17,26 +17,37 @@ type AuthContext = {
   clientId: string;
 };
 
+function parseFlag(argv: string[], name: string): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    // --flag=value
+    if (arg.startsWith(`--${name}=`)) {
+      return arg.slice(`--${name}=`.length);
+    }
+    // --flag value
+    if (arg === `--${name}` && i + 1 < argv.length) {
+      return argv[i + 1];
+    }
+  }
+  return undefined;
+}
+
 function resolveAuthContext(argv: string[]): AuthContext {
   const env = parseEnv(process.env);
 
   let sentryHost = "sentry.io";
-  for (const arg of argv) {
-    if (arg.startsWith("--host=")) {
-      const host = arg.slice("--host=".length);
-      validateSentryHostThrows(host);
-      sentryHost = host;
-    } else if (arg.startsWith("--url=")) {
-      sentryHost = validateAndParseSentryUrlThrows(arg.slice("--url=".length));
-    }
-  }
-  if (sentryHost === "sentry.io") {
-    if (env.url) {
-      sentryHost = validateAndParseSentryUrlThrows(env.url);
-    } else if (env.host) {
-      validateSentryHostThrows(env.host);
-      sentryHost = env.host;
-    }
+  const hostFlag = parseFlag(argv, "host");
+  const urlFlag = parseFlag(argv, "url");
+  if (urlFlag) {
+    sentryHost = validateAndParseSentryUrlThrows(urlFlag);
+  } else if (hostFlag) {
+    validateSentryHostThrows(hostFlag);
+    sentryHost = hostFlag;
+  } else if (env.url) {
+    sentryHost = validateAndParseSentryUrlThrows(env.url);
+  } else if (env.host) {
+    validateSentryHostThrows(env.host);
+    sentryHost = env.host;
   }
 
   return { sentryHost, clientId: env.clientId || DEFAULT_SENTRY_CLIENT_ID };

--- a/packages/mcp-server/src/cli/commands/auth.ts
+++ b/packages/mcp-server/src/cli/commands/auth.ts
@@ -17,7 +17,7 @@ type AuthContext = {
   clientId: string;
 };
 
-function parseFlag(argv: string[], name: string): string | undefined {
+export function parseFlag(argv: string[], name: string): string | undefined {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     // --flag=value

--- a/packages/mcp-server/src/cli/parse.ts
+++ b/packages/mcp-server/src/cli/parse.ts
@@ -87,6 +87,7 @@ export function parseEnv(env: NodeJS.ProcessEnv): EnvArgs {
   if (env.ANTHROPIC_MODEL) fromEnv.anthropicModel = env.ANTHROPIC_MODEL;
   if (env.EMBEDDED_AGENT_PROVIDER)
     fromEnv.agentProvider = env.EMBEDDED_AGENT_PROVIDER;
+  if (env.SENTRY_CLIENT_ID) fromEnv.clientId = env.SENTRY_CLIENT_ID;
   if (env.MCP_SKILLS) fromEnv.skills = env.MCP_SKILLS;
   if (env.MCP_DISABLE_SKILLS) fromEnv.disableSkills = env.MCP_DISABLE_SKILLS;
   return fromEnv;
@@ -106,6 +107,7 @@ export function merge(cli: CliArgs, env: EnvArgs): MergedArgs {
     anthropicBaseUrl: cli.anthropicBaseUrl,
     anthropicModel: cli.anthropicModel ?? env.anthropicModel,
     agentProvider: cli.agentProvider ?? env.agentProvider,
+    clientId: cli.clientId ?? env.clientId,
     // Skills precedence: CLI skills override env
     skills: cli.skills ?? env.skills,
     disableSkills: cli.disableSkills ?? env.disableSkills,

--- a/packages/mcp-server/src/cli/parse.ts
+++ b/packages/mcp-server/src/cli/parse.ts
@@ -107,7 +107,7 @@ export function merge(cli: CliArgs, env: EnvArgs): MergedArgs {
     anthropicBaseUrl: cli.anthropicBaseUrl,
     anthropicModel: cli.anthropicModel ?? env.anthropicModel,
     agentProvider: cli.agentProvider ?? env.agentProvider,
-    clientId: cli.clientId ?? env.clientId,
+    clientId: env.clientId,
     // Skills precedence: CLI skills override env
     skills: cli.skills ?? env.skills,
     disableSkills: cli.disableSkills ?? env.disableSkills,

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -2,10 +2,24 @@ import { describe, it, expect } from "vitest";
 import { finalize } from "./resolve";
 
 describe("cli/finalize", () => {
-  it("throws on missing access token", () => {
-    expect(() => finalize({ unknownArgs: [] } as any)).toThrow(
-      /No access token was provided/,
-    );
+  it("returns undefined accessToken when none provided", () => {
+    const cfg = finalize({ unknownArgs: [] } as any);
+    expect(cfg.accessToken).toBeUndefined();
+  });
+
+  it("uses DEFAULT_SENTRY_CLIENT_ID when no clientId provided", () => {
+    const cfg = finalize({ accessToken: "tok", unknownArgs: [] });
+    expect(cfg.clientId).toBeDefined();
+    expect(typeof cfg.clientId).toBe("string");
+  });
+
+  it("uses provided clientId over default", () => {
+    const cfg = finalize({
+      accessToken: "tok",
+      clientId: "custom-client-id",
+      unknownArgs: [],
+    });
+    expect(cfg.clientId).toBe("custom-client-id");
   });
 
   it("normalizes host from URL", () => {

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -4,7 +4,8 @@ import {
   validateOpenAiBaseUrlThrows,
   validateSentryHostThrows,
 } from "@sentry/mcp-core/utils/url-utils";
-import type { MergedArgs, ResolvedConfig } from "./types";
+import { DEFAULT_SENTRY_CLIENT_ID } from "../auth/constants";
+import type { MergedArgs, PartiallyResolvedConfig } from "./types";
 
 export function formatInvalidSkills(
   invalid: string[],
@@ -14,14 +15,7 @@ export function formatInvalidSkills(
   return `Error: ${prefix}: ${invalid.join(", ")}\nAvailable skills: ${ALL_SKILLS.join(", ")}`;
 }
 
-export function finalize(input: MergedArgs): ResolvedConfig {
-  // Access token required
-  if (!input.accessToken) {
-    throw new Error(
-      "Error: No access token was provided. Pass one with `--access-token` or via `SENTRY_ACCESS_TOKEN`.",
-    );
-  }
-
+export function finalize(input: MergedArgs): PartiallyResolvedConfig {
   // Determine host from url/host with validation
   let sentryHost = "sentry.io";
   if (input.url) {
@@ -105,6 +99,7 @@ export function finalize(input: MergedArgs): ResolvedConfig {
 
   return {
     accessToken: input.accessToken,
+    clientId: input.clientId || DEFAULT_SENTRY_CLIENT_ID,
     sentryHost,
     mcpUrl: input.mcpUrl,
     sentryDsn: input.sentryDsn,

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -15,15 +15,24 @@ export function formatInvalidSkills(
   return `Error: ${prefix}: ${invalid.join(", ")}\nAvailable skills: ${ALL_SKILLS.join(", ")}`;
 }
 
-export function finalize(input: MergedArgs): PartiallyResolvedConfig {
-  // Determine host from url/host with validation
-  let sentryHost = "sentry.io";
-  if (input.url) {
-    sentryHost = validateAndParseSentryUrlThrows(input.url);
-  } else if (input.host) {
-    validateSentryHostThrows(input.host);
-    sentryHost = input.host;
+/**
+ * Resolves the Sentry host from url/host inputs with validation.
+ * Used by both the server flow (finalize) and auth commands (resolveAuthContext)
+ * to ensure cache keys always match.
+ */
+export function resolveHost(url?: string, host?: string): string {
+  if (url) {
+    return validateAndParseSentryUrlThrows(url);
   }
+  if (host) {
+    validateSentryHostThrows(host);
+    return host;
+  }
+  return "sentry.io";
+}
+
+export function finalize(input: MergedArgs): PartiallyResolvedConfig {
+  const sentryHost = resolveHost(input.url, input.host);
 
   // Skills resolution
   //

--- a/packages/mcp-server/src/cli/types.ts
+++ b/packages/mcp-server/src/cli/types.ts
@@ -11,7 +11,6 @@ export type CliArgs = {
   anthropicBaseUrl?: string;
   anthropicModel?: string;
   agentProvider?: string;
-  clientId?: string;
   skills?: string;
   disableSkills?: string;
   agent?: boolean;
@@ -48,7 +47,7 @@ export type MergedArgs = {
   anthropicBaseUrl?: string;
   anthropicModel?: string;
   agentProvider?: string;
-  clientId?: string;
+  clientId?: string; // env-only, carried from EnvArgs
   skills?: string;
   disableSkills?: string;
   agent?: boolean;

--- a/packages/mcp-server/src/cli/types.ts
+++ b/packages/mcp-server/src/cli/types.ts
@@ -11,6 +11,7 @@ export type CliArgs = {
   anthropicBaseUrl?: string;
   anthropicModel?: string;
   agentProvider?: string;
+  clientId?: string;
   skills?: string;
   disableSkills?: string;
   agent?: boolean;
@@ -31,6 +32,7 @@ export type EnvArgs = {
   openaiModel?: string;
   anthropicModel?: string;
   agentProvider?: string;
+  clientId?: string;
   skills?: string;
   disableSkills?: string;
 };
@@ -46,6 +48,7 @@ export type MergedArgs = {
   anthropicBaseUrl?: string;
   anthropicModel?: string;
   agentProvider?: string;
+  clientId?: string;
   skills?: string;
   disableSkills?: string;
   agent?: boolean;
@@ -57,8 +60,13 @@ export type MergedArgs = {
   unknownArgs: string[];
 };
 
-export type ResolvedConfig = {
-  accessToken: string;
+/**
+ * Partially resolved config — accessToken may not yet be available
+ * (will be resolved via device code flow or cache).
+ */
+export type PartiallyResolvedConfig = {
+  accessToken?: string;
+  clientId: string;
   sentryHost: string;
   mcpUrl?: string;
   sentryDsn?: string;
@@ -71,4 +79,8 @@ export type ResolvedConfig = {
   finalSkills: Set<Skill>;
   organizationSlug?: string;
   projectSlug?: string;
+};
+
+export type ResolvedConfig = Omit<PartiallyResolvedConfig, "accessToken"> & {
+  accessToken: string;
 };

--- a/packages/mcp-server/src/cli/usage.ts
+++ b/packages/mcp-server/src/cli/usage.ts
@@ -4,10 +4,18 @@ export function buildUsage(
   packageName: string,
   allSkills: ReadonlyArray<Skill>,
 ): string {
-  return `Usage: ${packageName} --access-token=<token> [--host=<host>]
+  return `Usage: ${packageName} [--access-token=<token>] [--host=<host>]
+       ${packageName} auth [login|logout|status]
 
-Required:
+Commands:
+  auth login              Authenticate via device code flow (sentry.io only)
+  auth logout             Clear cached authentication
+  auth status             Show current authentication state
+
+Authentication:
   --access-token <token>  Sentry User Auth Token with API access
+                          Optional for sentry.io (device code flow is used if omitted)
+                          Required for self-hosted instances
 
 Common optional flags:
   --host <host>           Change Sentry host (self-hosted)
@@ -34,12 +42,14 @@ All skills: ${allSkills.join(", ")}
 
 Environment variables:
   SENTRY_ACCESS_TOKEN     Sentry auth token (alternative to --access-token)
+  SENTRY_CLIENT_ID        Override OAuth client ID for device code flow
   OPENAI_API_KEY          OpenAI API key for AI-powered search tools
   ANTHROPIC_API_KEY       Anthropic API key for AI-powered search tools
   EMBEDDED_AGENT_PROVIDER Provider override: openai or anthropic
   MCP_DISABLE_SKILLS      Disable specific skills (comma-separated)
 
 Examples:
+  ${packageName}                                        # device code auth (sentry.io only)
   ${packageName} --access-token=TOKEN
   ${packageName} --access-token=TOKEN --skills=inspect,triage
   ${packageName} --access-token=TOKEN --host=sentry.example.com

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -329,7 +329,7 @@ async function main() {
   startStdio(server, context).catch(async (err) => {
     console.error("Server error:", err);
     Sentry.captureException(err);
-    await Sentry.flush(5000);
+    await Sentry.flush(SENTRY_TIMEOUT);
     process.exit(1);
   });
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,13 +4,19 @@
  * Main CLI entry point for the Sentry MCP server.
  *
  * Handles command-line argument parsing, environment configuration, Sentry
- * initialization, and starts the MCP server with stdio transport. Requires
- * a Sentry access token and optionally accepts host and DSN configuration.
+ * initialization, and starts the MCP server with stdio transport. Supports
+ * device code authentication for sentry.io when no access token is provided.
+ *
+ * Subcommands:
+ *   auth [login]   — Force device code authentication
+ *   auth logout    — Clear cached authentication
+ *   auth status    — Show current authentication state
  *
  * @example CLI Usage
  * ```bash
  * npx @sentry/mcp-server --access-token=TOKEN --host=sentry.io
- * npx @sentry/mcp-server --access-token=TOKEN --url=https://sentry.example.com
+ * npx @sentry/mcp-server auth login
+ * npx @sentry/mcp-server auth logout
  * ```
  */
 
@@ -21,6 +27,8 @@ import { LIB_VERSION } from "@sentry/mcp-core/version";
 import { buildUsage } from "./cli/usage";
 import { parseArgv, parseEnv, merge } from "./cli/parse";
 import { finalize } from "./cli/resolve";
+import { resolveAccessToken } from "./auth/resolve-token";
+import { authCommand } from "./cli/commands/auth";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 import { SKILLS } from "@sentry/mcp-core/skills";
 import {
@@ -40,267 +48,293 @@ function die(message: string): never {
   console.error(usageText);
   process.exit(1);
 }
-const cli = parseArgv(process.argv.slice(2));
-if (cli.help) {
-  console.log(usageText);
-  process.exit(0);
-}
-if (cli.version) {
-  console.log(`${packageName} ${LIB_VERSION}`);
-  process.exit(0);
-}
-if (cli.unknownArgs.length > 0) {
-  console.error("Error: Invalid argument(s):", cli.unknownArgs.join(", "));
-  console.error(usageText);
-  process.exit(1);
-}
 
-const env = parseEnv(process.env);
-const cfg = (() => {
-  try {
-    return finalize(merge(cli, env));
-  } catch (err) {
+async function main() {
+  const rawArgs = process.argv.slice(2);
+
+  // Handle subcommands before normal server parsing
+  if (rawArgs[0] === "auth") {
+    await authCommand(rawArgs.slice(1));
+    return;
+  }
+
+  const cli = parseArgv(rawArgs);
+  if (cli.help) {
+    console.log(usageText);
+    process.exit(0);
+  }
+  if (cli.version) {
+    console.log(`${packageName} ${LIB_VERSION}`);
+    process.exit(0);
+  }
+  if (cli.unknownArgs.length > 0) {
+    console.error("Error: Invalid argument(s):", cli.unknownArgs.join(", "));
+    console.error(usageText);
+    process.exit(1);
+  }
+
+  const env = parseEnv(process.env);
+  const partialCfg = (() => {
+    try {
+      return finalize(merge(cli, env));
+    } catch (err) {
+      die(err instanceof Error ? err.message : String(err));
+    }
+  })();
+
+  // Resolve access token before starting the transport.
+  // For sentry.io without a token, this blocks on device code flow —
+  // the client won't connect until the user has authenticated.
+  const cfg = await resolveAccessToken(partialCfg).catch((err) => {
     die(err instanceof Error ? err.message : String(err));
+  });
+
+  // Configure embedded agent provider
+  if (cfg.agentProvider) {
+    setAgentProvider(cfg.agentProvider);
   }
-})();
-
-// Configure embedded agent provider
-if (cfg.agentProvider) {
-  setAgentProvider(cfg.agentProvider);
-}
-setProviderBaseUrls({
-  openaiBaseUrl: cfg.openaiBaseUrl,
-  anthropicBaseUrl: cfg.anthropicBaseUrl,
-});
-if (cfg.openaiModel) {
-  process.env.OPENAI_MODEL = cfg.openaiModel;
-}
-if (cfg.anthropicModel) {
-  process.env.ANTHROPIC_MODEL = cfg.anthropicModel;
-}
-
-// Helper functions for provider status messages
-function hasProviderConflict(): boolean {
-  const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
-  const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
-  const hasExplicitProvider =
-    cfg.agentProvider || process.env.EMBEDDED_AGENT_PROVIDER;
-  return hasAnthropic && hasOpenAI && !hasExplicitProvider;
-}
-
-function getConfiguredProvider(): string | undefined {
-  return (
-    cfg.agentProvider || process.env.EMBEDDED_AGENT_PROVIDER?.toLowerCase()
-  );
-}
-
-function hasProviderMismatch(): {
-  mismatch: boolean;
-  configured?: string;
-  availableKey?: string;
-} {
-  const configured = getConfiguredProvider();
-  if (!configured) return { mismatch: false };
-
-  const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
-  const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
-
-  // Check if configured provider's key is missing but other key is present
-  if (configured === "openai" && !hasOpenAI && hasAnthropic) {
-    return {
-      mismatch: true,
-      configured: "openai",
-      availableKey: "ANTHROPIC_API_KEY",
-    };
+  setProviderBaseUrls({
+    openaiBaseUrl: cfg.openaiBaseUrl,
+    anthropicBaseUrl: cfg.anthropicBaseUrl,
+  });
+  if (cfg.openaiModel) {
+    process.env.OPENAI_MODEL = cfg.openaiModel;
   }
-  if (configured === "anthropic" && !hasAnthropic && hasOpenAI) {
-    return {
-      mismatch: true,
-      configured: "anthropic",
-      availableKey: "OPENAI_API_KEY",
-    };
+  if (cfg.anthropicModel) {
+    process.env.ANTHROPIC_MODEL = cfg.anthropicModel;
   }
 
-  return { mismatch: false };
-}
+  // Helper functions for provider status messages
+  function hasProviderConflict(): boolean {
+    const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
+    const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
+    const hasExplicitProvider =
+      cfg.agentProvider || process.env.EMBEDDED_AGENT_PROVIDER;
+    return hasAnthropic && hasOpenAI && !hasExplicitProvider;
+  }
 
-function getProviderSource(): string {
-  // Check CLI flag first (cli.agentProvider is only set by --agent-provider flag)
-  if (cli.agentProvider) return "explicitly configured";
-  // Then check env var (process.env takes precedence over cfg since cfg merges both)
-  if (process.env.EMBEDDED_AGENT_PROVIDER)
-    return "from EMBEDDED_AGENT_PROVIDER";
-  return "auto-detected";
-}
+  function getConfiguredProvider(): string | undefined {
+    return (
+      cfg.agentProvider || process.env.EMBEDDED_AGENT_PROVIDER?.toLowerCase()
+    );
+  }
 
-// Check for LLM API keys and warn if none available
-const resolvedProvider = getResolvedProviderType();
+  function hasProviderMismatch(): {
+    mismatch: boolean;
+    configured?: string;
+    availableKey?: string;
+  } {
+    const configured = getConfiguredProvider();
+    if (!configured) return { mismatch: false };
 
-if (!resolvedProvider) {
-  const mismatchInfo = hasProviderMismatch();
-  if (hasProviderConflict()) {
-    console.warn(
-      "Warning: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set, but no provider is explicitly configured.",
-    );
-    console.warn(
-      "Please set EMBEDDED_AGENT_PROVIDER='openai' or 'anthropic' to specify which provider to use.",
-    );
-    console.warn(
-      "AI-powered search tools will be unavailable until a provider is selected.",
-    );
-  } else if (mismatchInfo.mismatch) {
-    const expectedKey =
-      mismatchInfo.configured === "openai"
-        ? "OPENAI_API_KEY"
-        : "ANTHROPIC_API_KEY";
-    const configuredViaCliFlag = Boolean(cli.agentProvider);
-    const providerSetting = configuredViaCliFlag
-      ? `--agent-provider=${mismatchInfo.configured}`
-      : `EMBEDDED_AGENT_PROVIDER='${mismatchInfo.configured}'`;
-    const changeProviderHint = configuredViaCliFlag
-      ? "Change --agent-provider to match your available API key"
-      : "Change EMBEDDED_AGENT_PROVIDER to match your available API key";
-    console.warn(`Warning: ${providerSetting} but ${expectedKey} is not set.`);
-    console.warn(`Found ${mismatchInfo.availableKey} instead. Either:`);
-    console.warn(
-      `  - Set ${expectedKey} to use the ${mismatchInfo.configured} provider, or`,
-    );
-    console.warn(`  - ${changeProviderHint}`);
-    console.warn(
-      "AI-powered search tools will be unavailable until this is resolved.",
-    );
+    const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
+    const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
+
+    // Check if configured provider's key is missing but other key is present
+    if (configured === "openai" && !hasOpenAI && hasAnthropic) {
+      return {
+        mismatch: true,
+        configured: "openai",
+        availableKey: "ANTHROPIC_API_KEY",
+      };
+    }
+    if (configured === "anthropic" && !hasAnthropic && hasOpenAI) {
+      return {
+        mismatch: true,
+        configured: "anthropic",
+        availableKey: "OPENAI_API_KEY",
+      };
+    }
+
+    return { mismatch: false };
+  }
+
+  function getProviderSource(): string {
+    // Check CLI flag first (cli.agentProvider is only set by --agent-provider flag)
+    if (cli.agentProvider) return "explicitly configured";
+    // Then check env var (process.env takes precedence over cfg since cfg merges both)
+    if (process.env.EMBEDDED_AGENT_PROVIDER)
+      return "from EMBEDDED_AGENT_PROVIDER";
+    return "auto-detected";
+  }
+
+  // Check for LLM API keys and warn if none available
+  const resolvedProvider = getResolvedProviderType();
+
+  if (!resolvedProvider) {
+    const mismatchInfo = hasProviderMismatch();
+    if (hasProviderConflict()) {
+      console.warn(
+        "Warning: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set, but no provider is explicitly configured.",
+      );
+      console.warn(
+        "Please set EMBEDDED_AGENT_PROVIDER='openai' or 'anthropic' to specify which provider to use.",
+      );
+      console.warn(
+        "AI-powered search tools will be unavailable until a provider is selected.",
+      );
+    } else if (mismatchInfo.mismatch) {
+      const expectedKey =
+        mismatchInfo.configured === "openai"
+          ? "OPENAI_API_KEY"
+          : "ANTHROPIC_API_KEY";
+      const configuredViaCliFlag = Boolean(cli.agentProvider);
+      const providerSetting = configuredViaCliFlag
+        ? `--agent-provider=${mismatchInfo.configured}`
+        : `EMBEDDED_AGENT_PROVIDER='${mismatchInfo.configured}'`;
+      const changeProviderHint = configuredViaCliFlag
+        ? "Change --agent-provider to match your available API key"
+        : "Change EMBEDDED_AGENT_PROVIDER to match your available API key";
+      console.warn(
+        `Warning: ${providerSetting} but ${expectedKey} is not set.`,
+      );
+      console.warn(`Found ${mismatchInfo.availableKey} instead. Either:`);
+      console.warn(
+        `  - Set ${expectedKey} to use the ${mismatchInfo.configured} provider, or`,
+      );
+      console.warn(`  - ${changeProviderHint}`);
+      console.warn(
+        "AI-powered search tools will be unavailable until this is resolved.",
+      );
+    } else {
+      console.warn(
+        "Warning: No LLM API key found (OPENAI_API_KEY or ANTHROPIC_API_KEY).",
+      );
+      console.warn(
+        "The following AI-powered search tools will be unavailable:",
+      );
+      console.warn(
+        "  - search_events, search_issues, search_issue_events, use_sentry",
+      );
+      console.warn(
+        "Use list_issues and list_events for direct Sentry query syntax instead.",
+      );
+    }
+    console.warn("");
   } else {
+    const providerSource = getProviderSource();
     console.warn(
-      "Warning: No LLM API key found (OPENAI_API_KEY or ANTHROPIC_API_KEY).",
+      `Using ${resolvedProvider} for AI-powered search tools (${providerSource}).`,
     );
-    console.warn("The following AI-powered search tools will be unavailable:");
-    console.warn(
-      "  - search_events, search_issues, search_issue_events, use_sentry",
-    );
-    console.warn(
-      "Use list_issues and list_events for direct Sentry query syntax instead.",
-    );
+    // Warn about auto-detection deprecation
+    if (providerSource === "auto-detected") {
+      console.warn(
+        "Deprecation warning: Auto-detection of LLM provider is deprecated.",
+      );
+      console.warn(
+        `Please set EMBEDDED_AGENT_PROVIDER='${resolvedProvider}' explicitly.`,
+      );
+      console.warn("Auto-detection will be removed in a future release.");
+    }
+    console.warn("");
   }
-  console.warn("");
-} else {
-  const providerSource = getProviderSource();
-  console.warn(
-    `Using ${resolvedProvider} for AI-powered search tools (${providerSource}).`,
-  );
-  // Warn about auto-detection deprecation
-  if (providerSource === "auto-detected") {
-    console.warn(
-      "Deprecation warning: Auto-detection of LLM provider is deprecated.",
-    );
-    console.warn(
-      `Please set EMBEDDED_AGENT_PROVIDER='${resolvedProvider}' explicitly.`,
-    );
-    console.warn("Auto-detection will be removed in a future release.");
-  }
-  console.warn("");
-}
 
-Sentry.init({
-  dsn: cfg.sentryDsn,
-  sendDefaultPii: true,
-  tracesSampleRate: 1,
-  beforeSend: sentryBeforeSend,
-  initialScope: {
-    tags: {
-      "mcp.server_version": LIB_VERSION,
-      "mcp.transport": "stdio",
-      "mcp.agent_mode": cli.agent ? "true" : "false",
-      "mcp.experimental_mode": cli.experimental ? "true" : "false",
-      "sentry.host": cfg.sentryHost,
-      "mcp.mcp-url": cfg.mcpUrl,
+  Sentry.init({
+    dsn: cfg.sentryDsn,
+    sendDefaultPii: true,
+    tracesSampleRate: 1,
+    beforeSend: sentryBeforeSend,
+    initialScope: {
+      tags: {
+        "mcp.server_version": LIB_VERSION,
+        "mcp.transport": "stdio",
+        "mcp.agent_mode": cli.agent ? "true" : "false",
+        "mcp.experimental_mode": cli.experimental ? "true" : "false",
+        "sentry.host": cfg.sentryHost,
+        "mcp.mcp-url": cfg.mcpUrl,
+      },
     },
-  },
-  release: process.env.SENTRY_RELEASE,
-  integrations: [
-    Sentry.consoleLoggingIntegration(),
-    Sentry.zodErrorsIntegration(),
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
-  ],
-  environment:
-    process.env.SENTRY_ENVIRONMENT ??
-    (process.env.NODE_ENV !== "production" ? "development" : "production"),
-});
+    release: process.env.SENTRY_RELEASE,
+    integrations: [
+      Sentry.consoleLoggingIntegration(),
+      Sentry.zodErrorsIntegration(),
+      Sentry.vercelAIIntegration({
+        recordInputs: true,
+        recordOutputs: true,
+      }),
+    ],
+    environment:
+      process.env.SENTRY_ENVIRONMENT ??
+      (process.env.NODE_ENV !== "production" ? "development" : "production"),
+  });
 
-// Log agent mode status
-if (cli.agent) {
-  console.warn("Agent mode enabled: Only use_sentry tool is available.");
-  console.warn(
-    "The use_sentry tool provides access to all Sentry operations through natural language.",
-  );
-  console.warn("");
+  // Log agent mode status
+  if (cli.agent) {
+    console.warn("Agent mode enabled: Only use_sentry tool is available.");
+    console.warn(
+      "The use_sentry tool provides access to all Sentry operations through natural language.",
+    );
+    console.warn("");
+  }
+
+  // Log experimental mode status
+  if (cli.experimental) {
+    console.warn(
+      "Experimental mode enabled: Forward-looking tool variants and experimental features are available.",
+    );
+    console.warn("");
+  }
+
+  const SENTRY_TIMEOUT = 5000; // 5 seconds
+
+  // Graceful shutdown handlers
+  async function shutdown(signal: string) {
+    console.error(`${signal} received, shutting down...`);
+    await Sentry.flush(SENTRY_TIMEOUT);
+    process.exit(0);
+  }
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  // Uncaught error handlers
+  process.on("uncaughtException", async (error) => {
+    console.error("Uncaught exception:", error);
+    Sentry.captureException(error);
+    await Sentry.flush(SENTRY_TIMEOUT);
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", async (reason) => {
+    console.error("Unhandled rejection:", reason);
+    Sentry.captureException(reason);
+    await Sentry.flush(SENTRY_TIMEOUT);
+    process.exit(1);
+  });
+
+  const context = {
+    accessToken: cfg.accessToken,
+    grantedSkills: cfg.finalSkills,
+    constraints: {
+      organizationSlug: cfg.organizationSlug ?? null,
+      projectSlug: cfg.projectSlug ?? null,
+    },
+    sentryHost: cfg.sentryHost,
+    mcpUrl: cfg.mcpUrl,
+    openaiBaseUrl: cfg.openaiBaseUrl,
+    agentMode: cli.agent,
+    experimentalMode: cli.experimental,
+    transport: "stdio" as const,
+  };
+
+  // Build server with context to filter tools based on granted skills
+  // Use agentMode when --agent flag is set (only exposes use_sentry tool)
+  // Use experimentalMode when --experimental flag is set (enables forward-looking variants)
+  const server = buildServer({
+    context,
+    agentMode: cli.agent,
+    experimentalMode: cli.experimental,
+  });
+
+  startStdio(server, context).catch(async (err) => {
+    console.error("Server error:", err);
+    Sentry.captureException(err);
+    await Sentry.flush(5000);
+    process.exit(1);
+  });
 }
 
-// Log experimental mode status
-if (cli.experimental) {
-  console.warn(
-    "Experimental mode enabled: Forward-looking tool variants and experimental features are available.",
-  );
-  console.warn("");
-}
-
-const SENTRY_TIMEOUT = 5000; // 5 seconds
-
-// Graceful shutdown handlers
-async function shutdown(signal: string) {
-  console.error(`${signal} received, shutting down...`);
-  await Sentry.flush(SENTRY_TIMEOUT);
-  process.exit(0);
-}
-
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));
-
-// Uncaught error handlers
-process.on("uncaughtException", async (error) => {
-  console.error("Uncaught exception:", error);
-  Sentry.captureException(error);
-  await Sentry.flush(SENTRY_TIMEOUT);
-  process.exit(1);
-});
-
-process.on("unhandledRejection", async (reason) => {
-  console.error("Unhandled rejection:", reason);
-  Sentry.captureException(reason);
-  await Sentry.flush(SENTRY_TIMEOUT);
-  process.exit(1);
-});
-
-// Build context once for server configuration and runtime
-const context = {
-  accessToken: cfg.accessToken,
-  grantedSkills: cfg.finalSkills,
-  constraints: {
-    organizationSlug: cfg.organizationSlug ?? null,
-    projectSlug: cfg.projectSlug ?? null,
-  },
-  sentryHost: cfg.sentryHost,
-  mcpUrl: cfg.mcpUrl,
-  openaiBaseUrl: cfg.openaiBaseUrl,
-  agentMode: cli.agent,
-  experimentalMode: cli.experimental,
-  transport: "stdio" as const,
-};
-
-// Build server with context to filter tools based on granted skills
-// Use agentMode when --agent flag is set (only exposes use_sentry tool)
-// Use experimentalMode when --experimental flag is set (enables forward-looking variants)
-const server = buildServer({
-  context,
-  agentMode: cli.agent,
-  experimentalMode: cli.experimental,
-});
-
-startStdio(server, context).catch(async (err) => {
-  console.error("Server error:", err);
-  Sentry.captureException(err);
-  await Sentry.flush(SENTRY_TIMEOUT);
+main().catch((err) => {
+  console.error("Fatal error:", err);
   process.exit(1);
 });


### PR DESCRIPTION
Add OAuth Device Code Flow (RFC 8628) to the stdio transport so users on sentry.io can authenticate without manually provisioning an access token. When no `--access-token` or `SENTRY_ACCESS_TOKEN` is provided, the CLI initiates device code auth — displaying a verification URL, opening the browser, and polling until the user authorizes. The resulting token is cached at `~/.sentry/mcp.json` for reuse across sessions.

A bundled `SENTRY_CLIENT_ID` ships with the package for sentry.io. The same env var can override it (Cloudflare uses its own value). Device code auth is disabled for non-sentry.io hosts, which still require an explicit access token.

Also adds CLI subcommands for explicit auth management:
- `sentry-mcp auth login` — force re-authentication
- `sentry-mcp auth logout` — clear cached token
- `sentry-mcp auth status` — show current auth state

Moves `SCOPES` from `mcp-cloudflare` to `mcp-core` so both transports share the canonical scope definitions. The cloudflare package re-exports from core, so all existing imports are unchanged.