### PR TITLE
fix(tools): route replay lookups through org regions

### DIFF
--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -45,7 +45,7 @@
       {
         "name": "get_replay_details",
         "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
-        "requiredScopes": ["event:read"]
+        "requiredScopes": ["org:read", "project:read", "event:read"]
       },
       {
         "name": "get_sentry_resource",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -552,12 +552,24 @@
         "replayId": {
           "type": "string",
           "description": "The replay ID. e.g. `7e07485f-12f9-416b-8b14-26260799b51f`"
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
         }
       },
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["org:read", "project:read", "event:read"]
   },
   {
     "name": "get_sentry_resource",

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
-import { mswServer, replayDetailsFixture } from "@sentry/mcp-server-mocks";
+import {
+  mswServer,
+  organizationFixture,
+  replayDetailsFixture,
+} from "@sentry/mcp-server-mocks";
 import getReplayDetails from "./get-replay-details.js";
 import { getServerContext } from "../test-setup.js";
 
@@ -51,7 +55,7 @@ describe("get_replay_details", () => {
 
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        `https://us.sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
         () => HttpResponse.json({ data: replayWithUnresolvedError }),
         { once: true },
       ),
@@ -61,6 +65,7 @@ describe("get_replay_details", () => {
       {
         organizationSlug: "sentry-mcp-evals",
         replayId: replayDetailsFixture.id,
+        regionUrl: "https://us.sentry.io",
       },
       getServerContext(),
     );
@@ -77,7 +82,7 @@ describe("get_replay_details", () => {
 
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${archivedReplay.id}/`,
+        `https://us.sentry.io/api/0/organizations/sentry-mcp-evals/replays/${archivedReplay.id}/`,
         () => HttpResponse.json({ data: archivedReplay }),
         { once: true },
       ),
@@ -87,6 +92,7 @@ describe("get_replay_details", () => {
       {
         organizationSlug: "sentry-mcp-evals",
         replayId: archivedReplay.id,
+        regionUrl: "https://us.sentry.io",
       },
       getServerContext(),
     );
@@ -122,12 +128,12 @@ describe("get_replay_details", () => {
   it("degrades gracefully when segment fetch fails", async () => {
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        `https://us.sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
         () => HttpResponse.json({ data: replayDetailsFixture }),
         { once: true },
       ),
       http.get(
-        `https://sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        `https://us.sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
         () =>
           HttpResponse.json(
             { detail: "Replay recording segment not found." },
@@ -141,6 +147,7 @@ describe("get_replay_details", () => {
       {
         organizationSlug: "sentry-mcp-evals",
         replayId: replayDetailsFixture.id,
+        regionUrl: "https://us.sentry.io",
       },
       getServerContext(),
     );
@@ -181,10 +188,88 @@ describe("get_replay_details", () => {
     );
   });
 
+  it("uses the constrained regionUrl for replay endpoints", async () => {
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        () => HttpResponse.json({ detail: "wrong host" }, { status: 404 }),
+        { once: true },
+      ),
+      http.get(
+        `https://us.sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        () => HttpResponse.json({ data: replayDetailsFixture }),
+        { once: true },
+      ),
+      http.get(
+        `https://us.sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        () => HttpResponse.json([]),
+        { once: true },
+      ),
+    );
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        replayId: replayDetailsFixture.id,
+      },
+      getServerContext({
+        constraints: { regionUrl: "https://us.sentry.io" },
+      }),
+    );
+
+    expect(result).toContain(
+      `# Replay ${replayDetailsFixture.id} in **sentry-mcp-evals**`,
+    );
+  });
+
+  it("resolves the organization region when none is provided", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/",
+        () =>
+          HttpResponse.json({
+            ...organizationFixture,
+            links: {
+              ...organizationFixture.links,
+              regionUrl: "https://us.sentry.io",
+            },
+          }),
+        { once: true },
+      ),
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        () => HttpResponse.json({ detail: "wrong host" }, { status: 404 }),
+        { once: true },
+      ),
+      http.get(
+        `https://us.sentry.io/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
+        () => HttpResponse.json({ data: replayDetailsFixture }),
+        { once: true },
+      ),
+      http.get(
+        `https://us.sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        () => HttpResponse.json([]),
+        { once: true },
+      ),
+    );
+
+    const result = await getReplayDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        replayId: replayDetailsFixture.id,
+      },
+      getServerContext(),
+    );
+
+    expect(result).toContain(
+      `# Replay ${replayDetailsFixture.id} in **sentry-mcp-evals**`,
+    );
+  });
+
   it("does not repeat explicit payload fields in generic replay events", async () => {
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        `https://us.sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
         () =>
           HttpResponse.json([
             [
@@ -213,6 +298,7 @@ describe("get_replay_details", () => {
       {
         organizationSlug: "sentry-mcp-evals",
         replayId: replayDetailsFixture.id,
+        regionUrl: "https://us.sentry.io",
       },
       getServerContext(),
     );
@@ -225,7 +311,7 @@ describe("get_replay_details", () => {
   it("ignores array payloads instead of rendering numeric keys", async () => {
     mswServer.use(
       http.get(
-        `https://sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
+        `https://us.sentry.io/api/0/projects/sentry-mcp-evals/${replayDetailsFixture.project_id}/replays/${replayDetailsFixture.id}/recording-segments/`,
         () =>
           HttpResponse.json([
             [
@@ -247,11 +333,31 @@ describe("get_replay_details", () => {
       {
         organizationSlug: "sentry-mcp-evals",
         replayId: replayDetailsFixture.id,
+        regionUrl: "https://us.sentry.io",
       },
       getServerContext(),
     );
 
     expect(result).not.toContain("- T+0s · `console`");
     expect(result).not.toContain('payload="0=');
+  });
+
+  describe("tool definition", () => {
+    it("requires the replay read scopes used by the backend endpoints", () => {
+      expect(getReplayDetails.requiredScopes).toEqual([
+        "org:read",
+        "project:read",
+        "event:read",
+      ]);
+    });
+
+    it("accepts regionUrl so constrained sessions can inject it", () => {
+      expect(Object.keys(getReplayDetails.inputSchema)).toEqual([
+        "replayUrl",
+        "organizationSlug",
+        "replayId",
+        "regionUrl",
+      ]);
+    });
   });
 });

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -14,6 +14,7 @@ import type { ServerContext } from "../types";
 import {
   ParamOrganizationSlug,
   ParamReplayId,
+  ParamRegionUrl,
   ParamReplayUrl,
 } from "../schema";
 
@@ -45,7 +46,7 @@ const MAX_RELATED_TRACES = 2;
 export default defineTool({
   name: "get_replay_details",
   skills: ["inspect"],
-  requiredScopes: ["event:read"],
+  requiredScopes: ["org:read", "project:read", "event:read"],
   requiredCapabilities: ["replays"],
   description: [
     "Get high-level information about a specific Sentry replay by URL or replay ID.",
@@ -71,6 +72,7 @@ export default defineTool({
     replayUrl: ParamReplayUrl.optional(),
     organizationSlug: ParamOrganizationSlug.optional(),
     replayId: ParamReplayId.optional(),
+    regionUrl: ParamRegionUrl.nullable().optional(),
   },
   annotations: {
     readOnlyHint: true,
@@ -78,7 +80,14 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const resolved = resolveReplayParams(params);
-    const apiService = apiServiceFromContext(context);
+    const regionUrl = await resolveReplayRegionUrl({
+      context,
+      organizationSlug: resolved.organizationSlug,
+      regionUrl: params.regionUrl ?? context.constraints.regionUrl,
+    });
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: regionUrl ?? undefined,
+    });
 
     setTag("organization.slug", resolved.organizationSlug);
     setTag("replay.id", resolved.replayId);
@@ -156,6 +165,31 @@ export function resolveReplayParams(params: {
     organizationSlug: params.organizationSlug,
     replayId: params.replayId,
   };
+}
+
+async function resolveReplayRegionUrl({
+  context,
+  organizationSlug,
+  regionUrl,
+}: {
+  context: ServerContext;
+  organizationSlug: string;
+  regionUrl?: string | null;
+}): Promise<string | null> {
+  if (regionUrl != null) {
+    const trimmedRegionUrl = regionUrl.trim();
+    return trimmedRegionUrl || null;
+  }
+
+  try {
+    const organization = await apiServiceFromContext(context).getOrganization(
+      organizationSlug,
+    );
+    const resolvedRegionUrl = organization.links?.regionUrl?.trim();
+    return resolvedRegionUrl || null;
+  } catch {
+    return null;
+  }
 }
 
 function formatReplayOutput({

--- a/packages/mcp-core/src/tools/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import {
   mswServer,
+  organizationFixture,
   replayDetailsFixture,
   traceMetaFixture,
   traceFixture,
@@ -604,7 +605,21 @@ describe("get_sentry_resource", () => {
     it("accepts replay as explicit resourceType", async () => {
       mswServer.use(
         http.get(
-          "https://sentry.io/api/0/organizations/my-org/replays/something/",
+          "https://sentry.io/api/0/organizations/my-org/",
+          () =>
+            HttpResponse.json({
+              ...organizationFixture,
+              slug: "my-org",
+              links: {
+                ...organizationFixture.links,
+                regionUrl: "https://us.sentry.io",
+                organizationUrl: "https://my-org.sentry.io",
+              },
+            }),
+          { once: true },
+        ),
+        http.get(
+          "https://us.sentry.io/api/0/organizations/my-org/replays/something/",
           () =>
             HttpResponse.json({
               data: {


### PR DESCRIPTION
## Summary
Replay lookups were still calling sentry.io even when an organization's replay APIs lived on a region-silo host. That could break normal OAuth sessions despite having the right auth, because get_replay_details was not consuming the region information that other region-aware inspect tools already use.

### Key Changes
- teach get_replay_details to accept an injected egionUrl
- fall back to resolving organization.links.regionUrl before replay API calls when no region is already present in the session
- add regression coverage for both direct replay lookups and replay dispatch through get_sentry_resource
- regenerate tool and skill definitions so the replay schema and scope metadata stay in sync

### Breaking Changes
- None
