### PR TITLE
feat: add replay summaries to issue details

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -35,6 +35,7 @@ import {
   FlamegraphSchema,
   ProfileChunkResponseSchema,
   ReplayDetailsSchema,
+  ReplayIdsByResourceSchema,
   ReplayRecordingSegmentsSchema,
 } from "./schema";
 import { ConfigurationError } from "../errors";
@@ -1893,6 +1894,36 @@ export class SentryApiService {
       opts,
     );
     return z.object({ data: ReplayDetailsSchema }).parse(body).data;
+  }
+
+  async listReplayIdsForIssue(
+    {
+      organizationSlug,
+      issueId,
+      dataSource,
+    }: {
+      organizationSlug: string;
+      issueId: string | number;
+      dataSource: "discover" | "search_issues";
+    },
+    opts?: RequestOptions,
+  ): Promise<string[]> {
+    const normalizedIssueId = String(issueId);
+    const queryParams = new URLSearchParams();
+    queryParams.set("returnIds", "true");
+    queryParams.set("query", `issue.id:[${normalizedIssueId}]`);
+    queryParams.set("data_source", dataSource);
+    queryParams.set("statsPeriod", "90d");
+    queryParams.append("project", "-1");
+
+    const body = await this.requestJSON(
+      `/organizations/${organizationSlug}/replay-count/?${queryParams.toString()}`,
+      undefined,
+      opts,
+    );
+
+    const replayIdsByResource = ReplayIdsByResourceSchema.parse(body);
+    return replayIdsByResource[normalizedIssueId] ?? [];
   }
 
   async getReplayRecordingSegments(

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -198,6 +198,11 @@ export const ReplayDetailsSchema = z
 
 export const ReplayRecordingSegmentsSchema = z.array(z.array(z.unknown()));
 
+export const ReplayIdsByResourceSchema = z.record(
+  z.string(),
+  z.array(z.string()),
+);
+
 export const ClientKeySchema = z
   .object({
     id: z.union([z.string(), z.number()]),

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -179,31 +179,51 @@ export function formatEventOutput(
   event: Event,
   options?: {
     performanceTrace?: Trace;
+    replaySummary?: {
+      apiService: SentryApiService;
+      organizationSlug: string;
+      relatedReplayIds?: string[];
+    };
   },
 ) {
   let output = "";
+  const eventWithReplayMetadataStripped = options?.replaySummary
+    ? stripReplayMetadata(event)
+    : event;
+  const eventToRender = eventWithReplayMetadataStripped;
+
+  if (options?.replaySummary) {
+    output += formatIssueReplayOutput({
+      apiService: options.replaySummary.apiService,
+      organizationSlug: options.replaySummary.organizationSlug,
+      event,
+      relatedReplayIds: options.replaySummary.relatedReplayIds,
+    });
+  }
 
   // Check if entries exist (may be undefined for unsupported event types)
-  if (!event.entries || !Array.isArray(event.entries)) {
+  if (!eventToRender.entries || !Array.isArray(eventToRender.entries)) {
     // For unsupported event types, just show tags and contexts
-    output += formatTags(event.tags);
-    output += formatContext(event.context);
-    output += formatContexts(event.contexts);
+    output += formatTags(eventToRender.tags);
+    output += formatContext(eventToRender.context);
+    output += formatContexts(eventToRender.contexts);
     return output;
   }
 
   // Look for the primary error information
-  const messageEntry = event.entries.find((e) => e.type === "message");
-  const exceptionEntry = event.entries.find((e) => e.type === "exception");
-  const threadsEntry = event.entries.find((e) => e.type === "threads");
-  const requestEntry = event.entries.find((e) => e.type === "request");
-  const spansEntry = event.entries.find((e) => e.type === "spans");
-  const cspEntry = event.entries.find((e) => e.type === "csp");
+  const messageEntry = eventToRender.entries.find((e) => e.type === "message");
+  const exceptionEntry = eventToRender.entries.find(
+    (e) => e.type === "exception",
+  );
+  const threadsEntry = eventToRender.entries.find((e) => e.type === "threads");
+  const requestEntry = eventToRender.entries.find((e) => e.type === "request");
+  const spansEntry = eventToRender.entries.find((e) => e.type === "spans");
+  const cspEntry = eventToRender.entries.find((e) => e.type === "csp");
 
   // Error message (if present)
   if (messageEntry) {
     output += formatMessageInterfaceOutput(
-      event,
+      eventToRender,
       messageEntry.data as z.infer<typeof MessageEntrySchema>,
     );
   }
@@ -211,12 +231,12 @@ export function formatEventOutput(
   // Stack trace (from exception or threads)
   if (exceptionEntry) {
     output += formatExceptionInterfaceOutput(
-      event,
+      eventToRender,
       exceptionEntry.data as z.infer<typeof ErrorEntrySchema>,
     );
   } else if (threadsEntry) {
     output += formatThreadsInterfaceOutput(
-      event,
+      eventToRender,
       threadsEntry.data as z.infer<typeof ThreadsEntrySchema>,
     );
   }
@@ -224,31 +244,35 @@ export function formatEventOutput(
   // Request info (if HTTP error)
   if (requestEntry) {
     output += formatRequestInterfaceOutput(
-      event,
+      eventToRender,
       requestEntry.data as z.infer<typeof RequestEntrySchema>,
     );
   }
 
   // CSP violation details
   if (cspEntry) {
-    output += formatCspInterfaceOutput(event, cspEntry.data);
+    output += formatCspInterfaceOutput(eventToRender, cspEntry.data);
   }
 
   // Performance issue details (N+1 queries, etc.)
   // Pass spans data for additional context even if we have evidence
-  if (event.type === "transaction") {
-    output += formatPerformanceIssueOutput(event, spansEntry?.data, options);
+  if (eventToRender.type === "transaction") {
+    output += formatPerformanceIssueOutput(
+      eventToRender,
+      spansEntry?.data,
+      options,
+    );
   }
 
   // Generic events (performance regressions, metric-based issues)
   // These have occurrence data with evidenceDisplay that needs formatting
-  if (event.type === "generic") {
-    output += formatGenericEventOutput(event);
+  if (eventToRender.type === "generic") {
+    output += formatGenericEventOutput(eventToRender);
   }
 
-  output += formatTags(event.tags);
-  output += formatContext(event.context);
-  output += formatContexts(event.contexts);
+  output += formatTags(eventToRender.tags);
+  output += formatContext(eventToRender.context);
+  output += formatContexts(eventToRender.contexts);
   return output;
 }
 
@@ -1684,6 +1708,7 @@ export function formatIssueOutput({
   autofixState,
   performanceTrace,
   externalIssues,
+  relatedReplayIds,
   experimentalMode,
 }: {
   organizationSlug: string;
@@ -1693,6 +1718,7 @@ export function formatIssueOutput({
   autofixState?: AutofixRunState;
   performanceTrace?: Trace;
   externalIssues?: ExternalIssueList;
+  relatedReplayIds?: string[];
   experimentalMode?: boolean;
 }) {
   let output = `# Issue ${issue.shortId} in **${organizationSlug}**\n\n`;
@@ -1829,7 +1855,14 @@ export function formatIssueOutput({
     output += `**Message**:\n${event.message}\n`;
   }
   output += "\n";
-  output += formatEventOutput(event, { performanceTrace });
+  output += formatEventOutput(event, {
+    performanceTrace,
+    replaySummary: {
+      apiService,
+      organizationSlug,
+      relatedReplayIds,
+    },
+  });
 
   // Add Seer context if available
   if (autofixState) {
@@ -1854,4 +1887,157 @@ export function formatIssueOutput({
     output += `- To see the trail of events leading up to this error, use \`get_sentry_resource(url='${apiService.getIssueUrl(organizationSlug, issue.shortId)}', resourceType='breadcrumbs')\`\n`;
   }
   return output;
+}
+
+const MAX_DISPLAY_REPLAYS = 5;
+
+function formatIssueReplayOutput({
+  apiService,
+  organizationSlug,
+  event,
+  relatedReplayIds,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  event: Event;
+  relatedReplayIds?: string[];
+}): string {
+  const attachedReplayId = getReplayIdFromEvent(event);
+  const normalizedRelatedReplayIds = dedupeReplayIds(relatedReplayIds ?? []);
+  const additionalRelatedReplayIds = normalizedRelatedReplayIds.filter(
+    (replayId) => replayId !== attachedReplayId,
+  );
+
+  if (!attachedReplayId && normalizedRelatedReplayIds.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = ["## Session Replay", ""];
+
+  if (attachedReplayId) {
+    lines.push(
+      `**Attached Replay**: ${apiService.getReplayUrl(organizationSlug, attachedReplayId)}`,
+    );
+  }
+
+  if (normalizedRelatedReplayIds.length > 0) {
+    lines.push(
+      `**Related Replay Count**: ${normalizedRelatedReplayIds.length}`,
+    );
+  }
+
+  if (additionalRelatedReplayIds.length > 0) {
+    const displayedReplayIds = additionalRelatedReplayIds.slice(
+      0,
+      MAX_DISPLAY_REPLAYS,
+    );
+
+    lines.push("");
+    lines.push(
+      attachedReplayId ? "### Other Related Replays" : "### Related Replays",
+    );
+    lines.push("");
+
+    for (const replayId of displayedReplayIds) {
+      lines.push(`- ${apiService.getReplayUrl(organizationSlug, replayId)}`);
+    }
+
+    const remainingReplayCount =
+      additionalRelatedReplayIds.length - displayedReplayIds.length;
+    if (remainingReplayCount > 0) {
+      lines.push(
+        `- ... and ${remainingReplayCount} more replay${remainingReplayCount === 1 ? "" : "s"}`,
+      );
+    }
+  }
+
+  const exampleReplayId =
+    attachedReplayId ?? normalizedRelatedReplayIds.at(0) ?? null;
+  if (exampleReplayId) {
+    lines.push("");
+    lines.push(
+      `Use \`get_replay_details(organizationSlug='${organizationSlug}', replayId='${exampleReplayId}')\` to inspect a replay in detail.`,
+    );
+  }
+
+  return `${lines.join("\n")}\n\n`;
+}
+
+function getReplayIdFromEvent(event: Event): string | null {
+  const replayContext = event.contexts?.replay as
+    | Record<string, unknown>
+    | undefined;
+  const replayContextId =
+    typeof replayContext?.replay_id === "string"
+      ? replayContext.replay_id
+      : null;
+  const replayTagId =
+    event.tags?.find((tag) => tag.key === "replayId" || tag.key === "replay.id")
+      ?.value ?? null;
+
+  return normalizeReplayId(replayContextId ?? replayTagId);
+}
+
+function dedupeReplayIds(replayIds: string[]): string[] {
+  const normalizedReplayIds: string[] = [];
+  const seenReplayIds = new Set<string>();
+
+  for (const replayId of replayIds) {
+    const normalizedReplayId = normalizeReplayId(replayId);
+    if (!normalizedReplayId || seenReplayIds.has(normalizedReplayId)) {
+      continue;
+    }
+    seenReplayIds.add(normalizedReplayId);
+    normalizedReplayIds.push(normalizedReplayId);
+  }
+
+  return normalizedReplayIds;
+}
+
+function normalizeReplayId(replayId: string | null | undefined): string | null {
+  if (typeof replayId !== "string") {
+    return null;
+  }
+
+  const trimmedReplayId = replayId.trim();
+  if (!trimmedReplayId) {
+    return null;
+  }
+
+  return trimmedReplayId.replace(/-/g, "");
+}
+
+function stripReplayMetadata(event: Event): Event {
+  const tags = event.tags?.filter(
+    (tag) => tag.key !== "replay.id" && tag.key !== "replayId",
+  );
+  const replayContext = event.contexts?.replay;
+
+  if (!replayContext) {
+    return { ...event, tags };
+  }
+
+  const nextReplayContext = Object.fromEntries(
+    Object.entries(replayContext).filter(([key]) => key !== "replay_id"),
+  );
+  const nonTypeReplayKeys = Object.keys(nextReplayContext).filter(
+    (key) => key !== "type",
+  );
+  const contexts =
+    nonTypeReplayKeys.length === 0
+      ? Object.fromEntries(
+          Object.entries(event.contexts ?? {}).filter(
+            ([key]) => key !== "replay",
+          ),
+        )
+      : {
+          ...event.contexts,
+          replay: nextReplayContext,
+        };
+
+  return {
+    ...event,
+    tags,
+    contexts,
+  };
 }

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -495,5 +495,42 @@ describe("buildServer", () => {
         expect(toolNames).not.toContain("get_issue_details");
       }
     });
+
+    it("removes constrained organizationSlug from get_replay_details schema", () => {
+      const server = buildServer({
+        context: {
+          ...baseContext,
+          constraints: {
+            organizationSlug: "bound-org",
+            projectSlug: null,
+          },
+        },
+      });
+
+      const replayTool = (
+        server as unknown as {
+          _registeredTools?: Record<
+            string,
+            {
+              inputSchema?: {
+                shape?: Record<string, unknown>;
+                _def?: { shape?: () => Record<string, unknown> };
+              };
+            }
+          >;
+        }
+      )._registeredTools?.get_replay_details;
+      const inputSchema = replayTool?.inputSchema;
+      const shape =
+        typeof inputSchema?.shape === "object"
+          ? inputSchema.shape
+          : (inputSchema?._def?.shape?.() ?? {});
+
+      expect(Object.keys(shape).sort()).toEqual([
+        "regionUrl",
+        "replayId",
+        "replayUrl",
+      ]);
+    });
   });
 });

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -314,6 +314,74 @@ describe("get_issue_details", () => {
     expect(result).toContain("**Assigned To**: Platform Team (Team)");
   });
 
+  it("includes attached and related replays when available", async () => {
+    const attachedReplayId = "7e07485f12f9416b8b1426260799b51f";
+    const attachedReplayIdWithDashes = "7e07485f-12f9-416b-8b14-26260799b51f";
+    const relatedReplayId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const event = createDefaultEvent();
+    event.tags.push({
+      key: "replayId",
+      value: attachedReplayIdWithDashes,
+    });
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () => HttpResponse.json(event),
+        { once: true },
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/replay-count/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("returnIds")).toBe("true");
+          expect(url.searchParams.get("query")).toBe("issue.id:[6507376925]");
+          expect(url.searchParams.get("data_source")).toBe("discover");
+          expect(url.searchParams.get("statsPeriod")).toBe("90d");
+          expect(url.searchParams.get("project")).toBe("-1");
+
+          return HttpResponse.json({
+            "6507376925": [attachedReplayId, relatedReplayId, attachedReplayId],
+          });
+        },
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    if (typeof result !== "string") {
+      throw new Error("Expected string result");
+    }
+
+    const replaySection = result
+      .slice(result.indexOf("## Session Replay"), result.indexOf("### Error"))
+      .trim();
+
+    expect(replaySection).toMatchInlineSnapshot(`
+      "## Session Replay
+
+      **Attached Replay**: https://sentry-mcp-evals.sentry.io/replays/7e07485f12f9416b8b1426260799b51f/
+      **Related Replay Count**: 2
+
+      ### Other Related Replays
+
+      - https://sentry-mcp-evals.sentry.io/replays/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/
+
+      Use \`get_replay_details(organizationSlug='sentry-mcp-evals', replayId='7e07485f12f9416b8b1426260799b51f')\` to inspect a replay in detail."
+    `);
+    expect(result).not.toContain("**replayId**:");
+  });
+
   it("serializes with issueUrl", async () => {
     const result = await getIssueDetails.handler(
       {

--- a/packages/mcp-core/src/tools/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.ts
@@ -17,6 +17,7 @@ import type {
   TransactionEvent,
   Trace,
   ExternalIssueList,
+  Issue,
 } from "../api-client/types";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
@@ -117,39 +118,41 @@ export default defineTool({
         issue = found;
       }
       // For this call, we might want to provide context if it fails
-      const [{ event, performanceTrace }, { autofixState, externalIssues }] =
-        await Promise.all([
-          apiService
-            .getEventForIssue({
-              organizationSlug: orgSlug,
-              issueId: issue.shortId,
-              eventId,
-            })
-            // Optionally enhance 404 errors with parameter context
-            .catch((error) => {
-              if (error instanceof ApiNotFoundError) {
-                throw enhanceNotFoundError(error, {
-                  organizationSlug: orgSlug,
-                  issueId: issue.shortId,
-                  eventId,
-                });
-              }
-              throw error;
-            })
-            .then(async (event) => ({
-              event,
-              performanceTrace: await maybeFetchPerformanceTrace({
-                apiService,
-                organizationSlug: orgSlug,
-                event,
-              }),
-            })),
-          fetchIssueEnrichmentData({
-            apiService,
+      const [
+        { event, performanceTrace },
+        { autofixState, externalIssues, relatedReplayIds },
+      ] = await Promise.all([
+        apiService
+          .getEventForIssue({
             organizationSlug: orgSlug,
             issueId: issue.shortId,
-          }),
-        ]);
+            eventId,
+          })
+          // Optionally enhance 404 errors with parameter context
+          .catch((error) => {
+            if (error instanceof ApiNotFoundError) {
+              throw enhanceNotFoundError(error, {
+                organizationSlug: orgSlug,
+                issueId: issue.shortId,
+                eventId,
+              });
+            }
+            throw error;
+          })
+          .then(async (event) => ({
+            event,
+            performanceTrace: await maybeFetchPerformanceTrace({
+              apiService,
+              organizationSlug: orgSlug,
+              event,
+            }),
+          })),
+        fetchIssueEnrichmentData({
+          apiService,
+          organizationSlug: orgSlug,
+          issue,
+        }),
+      ]);
 
       return formatIssueOutput({
         organizationSlug: orgSlug,
@@ -159,6 +162,7 @@ export default defineTool({
         autofixState,
         performanceTrace,
         externalIssues,
+        relatedReplayIds,
         experimentalMode: context.experimentalMode,
       });
     }
@@ -202,27 +206,29 @@ export default defineTool({
       throw error;
     }
 
-    const [{ event, performanceTrace }, { autofixState, externalIssues }] =
-      await Promise.all([
-        apiService
-          .getLatestEventForIssue({
-            organizationSlug: orgSlug,
-            issueId: issue.shortId,
-          })
-          .then(async (event) => ({
-            event,
-            performanceTrace: await maybeFetchPerformanceTrace({
-              apiService,
-              organizationSlug: orgSlug,
-              event,
-            }),
-          })),
-        fetchIssueEnrichmentData({
-          apiService,
+    const [
+      { event, performanceTrace },
+      { autofixState, externalIssues, relatedReplayIds },
+    ] = await Promise.all([
+      apiService
+        .getLatestEventForIssue({
           organizationSlug: orgSlug,
           issueId: issue.shortId,
-        }),
-      ]);
+        })
+        .then(async (event) => ({
+          event,
+          performanceTrace: await maybeFetchPerformanceTrace({
+            apiService,
+            organizationSlug: orgSlug,
+            event,
+          }),
+        })),
+      fetchIssueEnrichmentData({
+        apiService,
+        organizationSlug: orgSlug,
+        issue,
+      }),
+    ]);
 
     return formatIssueOutput({
       organizationSlug: orgSlug,
@@ -232,6 +238,7 @@ export default defineTool({
       autofixState,
       performanceTrace,
       externalIssues,
+      relatedReplayIds,
       experimentalMode: context.experimentalMode,
     });
   },
@@ -245,25 +252,34 @@ export default defineTool({
 async function fetchIssueEnrichmentData({
   apiService,
   organizationSlug,
-  issueId,
+  issue,
 }: {
   apiService: SentryApiService;
   organizationSlug: string;
-  issueId: string;
+  issue: Issue;
 }): Promise<{
   autofixState: AutofixRunState | undefined;
   externalIssues: ExternalIssueList | undefined;
+  relatedReplayIds: string[] | undefined;
 }> {
-  const [autofixState, externalIssues] = await Promise.all([
+  const issueId = String(issue.id);
+  const [autofixState, externalIssues, relatedReplayIds] = await Promise.all([
     apiService
-      .getAutofixState({ organizationSlug, issueId })
+      .getAutofixState({ organizationSlug, issueId: issue.shortId })
       .catch(() => undefined),
     apiService
-      .getIssueExternalLinks({ organizationSlug, issueId })
+      .getIssueExternalLinks({ organizationSlug, issueId: issue.shortId })
+      .catch(() => undefined),
+    apiService
+      .listReplayIdsForIssue({
+        organizationSlug,
+        issueId,
+        dataSource: getReplayDataSource(issue),
+      })
       .catch(() => undefined),
   ]);
 
-  return { autofixState, externalIssues };
+  return { autofixState, externalIssues, relatedReplayIds };
 }
 
 async function maybeFetchPerformanceTrace({
@@ -315,4 +331,10 @@ function shouldFetchTraceForEvent(event: Event): { traceId: string } | null {
   }
 
   return { traceId };
+}
+
+function getReplayDataSource(issue: Issue): "discover" | "search_issues" {
+  return issue.issueCategory === "error" || issue.type === "error"
+    ? "discover"
+    : "search_issues";
 }

--- a/packages/mcp-core/src/tools/get-replay-details.test.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.test.ts
@@ -5,7 +5,7 @@ import {
   organizationFixture,
   replayDetailsFixture,
 } from "@sentry/mcp-server-mocks";
-import getReplayDetails from "./get-replay-details.js";
+import getReplayDetails, { resolveReplayParams } from "./get-replay-details.js";
 import { getServerContext } from "../test-setup.js";
 
 describe("get_replay_details", () => {
@@ -186,6 +186,18 @@ describe("get_replay_details", () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[UserInputError: Provide either \`replayUrl\` or both \`organizationSlug\` and \`replayId\`.]`,
     );
+  });
+
+  it("prefers explicit organizationSlug over replayUrl org when both are provided", () => {
+    expect(
+      resolveReplayParams({
+        replayUrl: `https://url-org.sentry.io/replays/${replayDetailsFixture.id}/`,
+        organizationSlug: "constrained-org",
+      }),
+    ).toEqual({
+      organizationSlug: "constrained-org",
+      replayId: replayDetailsFixture.id,
+    });
   });
 
   it("uses the constrained regionUrl for replay endpoints", async () => {

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -150,7 +150,9 @@ export function resolveReplayParams(params: {
       );
     }
     return {
-      organizationSlug: parsed.organizationSlug,
+      // Prefer an explicit or injected organization constraint when available,
+      // while still validating and extracting the replay ID from the URL.
+      organizationSlug: params.organizationSlug ?? parsed.organizationSlug,
       replayId: parsed.replayId,
     };
   }
@@ -182,9 +184,8 @@ async function resolveReplayRegionUrl({
   }
 
   try {
-    const organization = await apiServiceFromContext(context).getOrganization(
-      organizationSlug,
-    );
+    const organization =
+      await apiServiceFromContext(context).getOrganization(organizationSlug);
     const resolvedRegionUrl = organization.links?.regionUrl?.trim();
     return resolvedRegionUrl || null;
   } catch {

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -533,6 +533,11 @@ export const restHandlers = buildHandlers([
   },
   {
     method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/replay-count/",
+    fetch: () => HttpResponse.json({}),
+  },
+  {
+    method: "get",
     path: `/api/0/organizations/sentry-mcp-evals/replays/${replayDetailsFixture.id}/`,
     fetch: () => HttpResponse.json({ data: replayDetailsFixture }),
   },


### PR DESCRIPTION
This updates issue-details replay handling to behave like the embedded trace summary path, while also fixing replay resolution when organization context is bound above the tool layer.

- add related replay lookup for issues and render attached and related replay summaries through the shared event formatting path
- strip duplicate raw replay metadata from tags and contexts when the replay summary is present
- prefer the injected or explicit organizationSlug over the replay URL org in get_replay_details
- add regression coverage for replay summaries, constrained replay tool schemas, and replay URL org resolution

Issue details now surface replay context in a first-class way, including an attached replay, related replays, and a follow-up get_replay_details hint. Bound-organization sessions also stop falling through to the replay URL org and 403ing on the first lookup.