### PR TITLE
meta(config): Align MCP server metadata

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,6 @@
 [mcp_servers.sentry]
 url = "https://mcp.sentry.dev/mcp/sentry/mcp-server?experimental=1"
+
+[mcp_servers.sentry-dev]
+url = "http://localhost:5173/mcp/sentry/mcp-server?experimental=1"
+

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,11 +1,9 @@
 {
   "mcpServers": {
     "sentry": {
-      "type": "http",
       "url": "https://mcp.sentry.dev/mcp/sentry/mcp-server?experimental=1"
     },
     "sentry-dev": {
-      "type": "http",
       "url": "http://localhost:5173/mcp/sentry/mcp-server?experimental=1"
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,13 +6,7 @@
     },
     "sentry-dev": {
       "type": "http",
-      "url": "http://localhost:5173/mcp/sentry/mcp-server"
-    },
-    "sentry-spotlight": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@spotlightjs/spotlight", "--stdio-mcp"],
-      "env": {}
+      "url": "http://localhost:5173/mcp/sentry/mcp-server?experimental=1"
     }
   }
 }

--- a/agents.toml
+++ b/agents.toml
@@ -35,3 +35,11 @@ source = "getsentry/skills"
 [[skills]]
 name = "iterate-pr"
 source = "getsentry/skills"
+
+[[mcp]]
+name = "sentry"
+url = "https://mcp.sentry.dev/mcp/sentry/mcp-server?experimental=1"
+
+[[mcp]]
+name = "sentry-dev"
+url = "http://localhost:5173/mcp/sentry/mcp-server?experimental=1"


### PR DESCRIPTION
Align local assistant MCP configuration across Codex, Cursor, and agents.toml.

These files all point at the same Sentry MCP endpoints, but they had drifted in a few ways: the local development URL was inconsistent, the shared config did not include both Sentry endpoints everywhere, and `.mcp.json` still carried an unused Spotlight entry. This brings those definitions back into sync so local assistant behavior matches across clients.

I considered leaving each client config to diverge where their formats differ, but the actual endpoint definitions should stay aligned even if the surrounding file shape is tool-specific.