### PR TITLE
ref: Improve Cloudflare OAuth failure diagnostics

### DIFF
--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -343,6 +343,37 @@ describe("oauth callback routes", () => {
       expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
     });
 
+    it("treats unknown callback errors as system failures", async () => {
+      logIssue.mockReturnValue("oauth-event-id");
+
+      const testEnv = createTestEnv();
+      const oauthApp = createTestApp();
+      const client = await createClient(testEnv);
+      const cookie = await approveClient(oauthApp, testEnv, client.clientId);
+      const state = await createSignedCallbackState(client.clientId);
+
+      const response = await callCallback(oauthApp, testEnv, {
+        state,
+        cookie,
+        error: "provider_broke_it",
+      });
+
+      const body = await response.text();
+      expect(response.status).toBe(502);
+      expect(body).toContain(
+        "There was an internal error authenticating your account. Please try again shortly.",
+      );
+      expect(body).toContain("Event ID:</strong> <code>oauth-event-id</code>");
+      expect(logIssue).toHaveBeenCalledWith(
+        "[oauth] Upstream authorization callback error",
+        expect.objectContaining({
+          loggerScope: ["cloudflare", "oauth", "callback"],
+        }),
+      );
+      expect(logWarn).not.toHaveBeenCalled();
+      expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
+    });
+
     it("renders a safe error page when the callback is missing a code", async () => {
       const testEnv = createTestEnv();
       const oauthApp = createTestApp();

--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -10,14 +10,19 @@ import type { Env } from "../types";
 import oauthRoute from "./index";
 import { signState, type OAuthState } from "./state";
 
-const { exchangeCodeForAccessToken } = vi.hoisted(() => ({
-  exchangeCodeForAccessToken: vi.fn(),
-}));
+const { exchangeCodeForAccessToken, logError, logIssue, logWarn } = vi.hoisted(
+  () => ({
+    exchangeCodeForAccessToken: vi.fn(),
+    logError: vi.fn(),
+    logIssue: vi.fn(),
+    logWarn: vi.fn(),
+  }),
+);
 
 vi.mock("@sentry/mcp-core/telem/logging", () => ({
-  logError: vi.fn(),
-  logWarn: vi.fn(),
-  logIssue: vi.fn(),
+  logError,
+  logWarn,
+  logIssue,
 }));
 
 vi.mock("./helpers", async (importOriginal) => {
@@ -220,6 +225,9 @@ async function parseSseJson<T>(response: Response): Promise<T> {
 describe("oauth callback routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    logError.mockReturnValue(undefined);
+    logIssue.mockReturnValue(undefined);
+    logWarn.mockReturnValue(undefined);
     exchangeCodeForAccessToken.mockResolvedValue([
       {
         access_token: "sentry-access-token",
@@ -266,6 +274,43 @@ describe("oauth callback routes", () => {
       expect(response.status).toBe(400);
       expect(body).toContain("OAuth Error:</strong> access_denied");
       expect(body).toContain("Authorization was denied");
+      expect(body).not.toContain("Event ID:");
+      expect(logWarn).toHaveBeenCalledWith(
+        "[oauth] Upstream authorization callback error",
+        expect.objectContaining({
+          loggerScope: ["cloudflare", "oauth", "callback"],
+        }),
+      );
+      expect(logIssue).not.toHaveBeenCalled();
+      expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
+    });
+
+    it("renders an event ID for upstream system oauth errors", async () => {
+      logIssue.mockReturnValue("oauth-event-id");
+
+      const testEnv = createTestEnv();
+      const oauthApp = createTestApp();
+      const client = await createClient(testEnv);
+      const cookie = await approveClient(oauthApp, testEnv, client.clientId);
+      const state = await createSignedCallbackState(client.clientId);
+
+      const response = await callCallback(oauthApp, testEnv, {
+        state,
+        cookie,
+        error: "server_error",
+      });
+
+      const body = await response.text();
+      expect(response.status).toBe(502);
+      expect(body).toContain("Sentry OAuth encountered an internal error");
+      expect(body).toContain("Event ID:</strong> <code>oauth-event-id</code>");
+      expect(logIssue).toHaveBeenCalledWith(
+        "[oauth] Upstream authorization callback error",
+        expect.objectContaining({
+          loggerScope: ["cloudflare", "oauth", "callback"],
+        }),
+      );
+      expect(logWarn).not.toHaveBeenCalled();
       expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
     });
 

--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -314,6 +314,39 @@ describe("oauth callback routes", () => {
       expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
     });
 
+    it("treats invalid_request callback errors as system failures", async () => {
+      logIssue.mockReturnValue("oauth-invalid-request-event-id");
+
+      const testEnv = createTestEnv();
+      const oauthApp = createTestApp();
+      const client = await createClient(testEnv);
+      const cookie = await approveClient(oauthApp, testEnv, client.clientId);
+      const state = await createSignedCallbackState(client.clientId);
+
+      const response = await callCallback(oauthApp, testEnv, {
+        state,
+        cookie,
+        error: "invalid_request",
+      });
+
+      const body = await response.text();
+      expect(response.status).toBe(502);
+      expect(body).toContain(
+        "The authorization request was rejected. Please try again.",
+      );
+      expect(body).toContain(
+        "Event ID:</strong> <code>oauth-invalid-request-event-id</code>",
+      );
+      expect(logIssue).toHaveBeenCalledWith(
+        "[oauth] Upstream authorization callback error",
+        expect.objectContaining({
+          loggerScope: ["cloudflare", "oauth", "callback"],
+        }),
+      );
+      expect(logWarn).not.toHaveBeenCalled();
+      expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
+    });
+
     it("renders a safe error page when the callback is missing a code", async () => {
       const testEnv = createTestEnv();
       const oauthApp = createTestApp();

--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -314,9 +314,7 @@ describe("oauth callback routes", () => {
       expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
     });
 
-    it("treats invalid_request callback errors as system failures", async () => {
-      logIssue.mockReturnValue("oauth-invalid-request-event-id");
-
+    it("treats invalid_request callback errors as user-correctable", async () => {
       const testEnv = createTestEnv();
       const oauthApp = createTestApp();
       const client = await createClient(testEnv);
@@ -330,20 +328,18 @@ describe("oauth callback routes", () => {
       });
 
       const body = await response.text();
-      expect(response.status).toBe(502);
+      expect(response.status).toBe(400);
       expect(body).toContain(
         "The authorization request was rejected. Please try again.",
       );
-      expect(body).toContain(
-        "Event ID:</strong> <code>oauth-invalid-request-event-id</code>",
-      );
-      expect(logIssue).toHaveBeenCalledWith(
+      expect(body).not.toContain("Event ID:");
+      expect(logWarn).toHaveBeenCalledWith(
         "[oauth] Upstream authorization callback error",
         expect.objectContaining({
           loggerScope: ["cloudflare", "oauth", "callback"],
         }),
       );
-      expect(logWarn).not.toHaveBeenCalled();
+      expect(logIssue).not.toHaveBeenCalled();
       expect(exchangeCodeForAccessToken).not.toHaveBeenCalled();
     });
 

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -445,6 +445,17 @@ describe("getOAuthCallbackFailureDetails", () => {
       shouldLogIssue: false,
     });
   });
+
+  it("treats unknown callback errors as system failures", () => {
+    expect(
+      getOAuthCallbackFailureDetails({ oauthError: "provider_broke_it" }),
+    ).toEqual({
+      message:
+        "There was an internal error authenticating your account. Please try again shortly.",
+      status: 502,
+      shouldLogIssue: true,
+    });
+  });
 });
 
 describe("getTokenExchangeFailureDetails", () => {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -1,8 +1,19 @@
 import type { TokenExchangeCallbackOptions } from "@cloudflare/workers-oauth-provider";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkerProps } from "../types";
+const { logIssue, logWarn } = vi.hoisted(() => ({
+  logIssue: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+vi.mock("@sentry/mcp-core/telem/logging", () => ({
+  logIssue,
+  logWarn,
+}));
+
 import {
   createResourceValidationError,
+  exchangeCodeForAccessToken,
   tokenExchangeCallback,
   validateResourceParameter,
 } from "./helpers";
@@ -38,6 +49,10 @@ const TEST_ENV = { SENTRY_HOST: "sentry.io" };
 describe("tokenExchangeCallback", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    logIssue.mockReset();
+    logWarn.mockReset();
+    logIssue.mockReturnValue(undefined);
+    logWarn.mockReturnValue(undefined);
   });
 
   it("should return undefined for non-refresh_token grant types", async () => {
@@ -246,6 +261,95 @@ describe("tokenExchangeCallback", () => {
       }),
     });
     expect(globalThis.fetch).toHaveBeenCalled();
+  });
+});
+
+describe("exchangeCodeForAccessToken", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    logIssue.mockReset();
+    logWarn.mockReset();
+    logIssue.mockReturnValue(undefined);
+    logWarn.mockReturnValue(undefined);
+  });
+
+  it("returns a specific invalid_grant message without an event ID", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Authorization code expired",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const [payload, response] = await exchangeCodeForAccessToken({
+      client_id: "test-client-id",
+      client_secret: "test-client-secret",
+      code: "expired-code",
+      upstream_url: "https://sentry.io/oauth/token",
+      redirect_uri: "https://mcp.sentry.dev/oauth/callback",
+    });
+
+    expect(payload).toBeNull();
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(400);
+
+    const body = await response!.text();
+    expect(body).toContain(
+      "The authorization code was invalid or expired. Please try connecting your account again.",
+    );
+    expect(body).toContain("OAuth Error:</strong> invalid_grant");
+    expect(body).not.toContain("Event ID:");
+    expect(logWarn).toHaveBeenCalledWith(
+      "[oauth] Failed to exchange code for access token",
+      expect.objectContaining({
+        loggerScope: ["cloudflare", "oauth", "callback"],
+      }),
+    );
+    expect(logIssue).not.toHaveBeenCalled();
+  });
+
+  it("returns an event ID for upstream token exchange system failures", async () => {
+    logIssue.mockReturnValue("oauth-token-event-id");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("upstream unavailable", {
+        status: 503,
+        statusText: "Service Unavailable",
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+
+    const [payload, response] = await exchangeCodeForAccessToken({
+      client_id: "test-client-id",
+      client_secret: "test-client-secret",
+      code: "test-code",
+      upstream_url: "https://sentry.io/oauth/token",
+      redirect_uri: "https://mcp.sentry.dev/oauth/callback",
+    });
+
+    expect(payload).toBeNull();
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(502);
+
+    const body = await response!.text();
+    expect(body).toContain(
+      "There was an internal error authenticating your account. Please try again shortly.",
+    );
+    expect(body).toContain(
+      "Event ID:</strong> <code>oauth-token-event-id</code>",
+    );
+    expect(logIssue).toHaveBeenCalledWith(
+      "[oauth] Failed to exchange code for access token",
+      expect.objectContaining({
+        loggerScope: ["cloudflare", "oauth", "callback"],
+      }),
+    );
+    expect(logWarn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -458,8 +458,8 @@ describe("getTokenExchangeFailureDetails", () => {
     });
   });
 
-  it("treats unknown upstream http failures as system failures", () => {
-    expect(getTokenExchangeFailureDetails({ upstreamStatus: 403 })).toEqual({
+  it("treats unknown token exchange failures as system failures", () => {
+    expect(getTokenExchangeFailureDetails({})).toEqual({
       message:
         "There was an internal error authenticating your account. Please try again shortly.",
       status: 502,

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -14,7 +14,8 @@ vi.mock("@sentry/mcp-core/telem/logging", () => ({
 import {
   createResourceValidationError,
   exchangeCodeForAccessToken,
-  getOAuthFailureDetails,
+  getOAuthCallbackFailureDetails,
+  getTokenExchangeFailureDetails,
   tokenExchangeCallback,
   validateResourceParameter,
 } from "./helpers";
@@ -315,6 +316,48 @@ describe("exchangeCodeForAccessToken", () => {
     expect(logIssue).not.toHaveBeenCalled();
   });
 
+  it("treats invalid_grant without an upstream description as a system failure", async () => {
+    logIssue.mockReturnValue("oauth-invalid-grant-event-id");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const [payload, response] = await exchangeCodeForAccessToken({
+      client_id: "test-client-id",
+      client_secret: "test-client-secret",
+      code: "test-code",
+      upstream_url: "https://sentry.io/oauth/token",
+      redirect_uri: "https://mcp.sentry.dev/oauth/callback",
+    });
+
+    expect(payload).toBeNull();
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(502);
+
+    const body = await response!.text();
+    expect(body).toContain(
+      "The authorization code could not be validated. Please try again.",
+    );
+    expect(body).toContain(
+      "Event ID:</strong> <code>oauth-invalid-grant-event-id</code>",
+    );
+    expect(logIssue).toHaveBeenCalledWith(
+      "[oauth] Failed to exchange code for access token",
+      expect.objectContaining({
+        loggerScope: ["cloudflare", "oauth", "callback"],
+      }),
+    );
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
   it("returns an event ID for upstream token exchange system failures", async () => {
     logIssue.mockReturnValue("oauth-token-event-id");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -392,9 +435,23 @@ describe("exchangeCodeForAccessToken", () => {
   });
 });
 
-describe("getOAuthFailureDetails", () => {
+describe("getOAuthCallbackFailureDetails", () => {
+  it("treats invalid_request as a user-correctable callback failure", () => {
+    expect(
+      getOAuthCallbackFailureDetails({ oauthError: "invalid_request" }),
+    ).toEqual({
+      message: "The authorization request was rejected. Please try again.",
+      status: 400,
+      shouldLogIssue: false,
+    });
+  });
+});
+
+describe("getTokenExchangeFailureDetails", () => {
   it("treats invalid_scope as a system failure", () => {
-    expect(getOAuthFailureDetails({ oauthError: "invalid_scope" })).toEqual({
+    expect(
+      getTokenExchangeFailureDetails({ oauthError: "invalid_scope" }),
+    ).toEqual({
       message: "The requested permissions were invalid. Please try again.",
       status: 502,
       shouldLogIssue: true,
@@ -402,9 +459,34 @@ describe("getOAuthFailureDetails", () => {
   });
 
   it("treats unknown upstream http failures as system failures", () => {
-    expect(getOAuthFailureDetails({ upstreamStatus: 403 })).toEqual({
+    expect(getTokenExchangeFailureDetails({ upstreamStatus: 403 })).toEqual({
       message:
         "There was an internal error authenticating your account. Please try again shortly.",
+      status: 502,
+      shouldLogIssue: true,
+    });
+  });
+
+  it("only treats invalid_grant as retryable when the description says the code expired", () => {
+    expect(
+      getTokenExchangeFailureDetails({
+        oauthError: "invalid_grant",
+        errorDescription: "Authorization code expired",
+      }),
+    ).toEqual({
+      message:
+        "The authorization code was invalid or expired. Please try connecting your account again.",
+      status: 400,
+      shouldLogIssue: false,
+    });
+
+    expect(
+      getTokenExchangeFailureDetails({
+        oauthError: "invalid_grant",
+      }),
+    ).toEqual({
+      message:
+        "The authorization code could not be validated. Please try again.",
       status: 502,
       shouldLogIssue: true,
     });

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -14,6 +14,7 @@ vi.mock("@sentry/mcp-core/telem/logging", () => ({
 import {
   createResourceValidationError,
   exchangeCodeForAccessToken,
+  getOAuthFailureDetails,
   tokenExchangeCallback,
   validateResourceParameter,
 } from "./helpers";
@@ -350,6 +351,63 @@ describe("exchangeCodeForAccessToken", () => {
       }),
     );
     expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns an event ID for unknown upstream http failures", async () => {
+    logIssue.mockReturnValue("oauth-forbidden-event-id");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<title>403</title>403 Forbidden", {
+        status: 403,
+        statusText: "Forbidden",
+        headers: { "Content-Type": "text/html; charset=UTF-8" },
+      }),
+    );
+
+    const [payload, response] = await exchangeCodeForAccessToken({
+      client_id: "test-client-id",
+      client_secret: "test-client-secret",
+      code: "test-code",
+      upstream_url: "https://sentry.io/oauth/token",
+      redirect_uri: "https://mcp.sentry.dev/oauth/callback",
+    });
+
+    expect(payload).toBeNull();
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(502);
+
+    const body = await response!.text();
+    expect(body).toContain(
+      "There was an internal error authenticating your account. Please try again shortly.",
+    );
+    expect(body).toContain(
+      "Event ID:</strong> <code>oauth-forbidden-event-id</code>",
+    );
+    expect(logIssue).toHaveBeenCalledWith(
+      "[oauth] Failed to exchange code for access token",
+      expect.objectContaining({
+        loggerScope: ["cloudflare", "oauth", "callback"],
+      }),
+    );
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+});
+
+describe("getOAuthFailureDetails", () => {
+  it("treats invalid_scope as a system failure", () => {
+    expect(getOAuthFailureDetails({ oauthError: "invalid_scope" })).toEqual({
+      message: "The requested permissions were invalid. Please try again.",
+      status: 502,
+      shouldLogIssue: true,
+    });
+  });
+
+  it("treats unknown upstream http failures as system failures", () => {
+    expect(getOAuthFailureDetails({ upstreamStatus: 403 })).toEqual({
+      message:
+        "There was an internal error authenticating your account. Please try again shortly.",
+      status: 502,
+      shouldLogIssue: true,
+    });
   });
 });
 

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -37,6 +37,12 @@ export function getOAuthFailureDetails({
   status: number;
   shouldLogIssue: boolean;
 } {
+  const systemFailure = (message: string, status = 502) => ({
+    message,
+    status,
+    shouldLogIssue: true,
+  });
+
   switch (oauthError) {
     case "access_denied":
       return {
@@ -46,25 +52,18 @@ export function getOAuthFailureDetails({
         shouldLogIssue: false,
       };
     case "temporarily_unavailable":
-      return {
-        message:
-          "Sentry OAuth is temporarily unavailable. Please try again shortly.",
-        status: 503,
-        shouldLogIssue: true,
-      };
+      return systemFailure(
+        "Sentry OAuth is temporarily unavailable. Please try again shortly.",
+        503,
+      );
     case "server_error":
-      return {
-        message:
-          "Sentry OAuth encountered an internal error. Please try again.",
-        status: 502,
-        shouldLogIssue: true,
-      };
+      return systemFailure(
+        "Sentry OAuth encountered an internal error. Please try again.",
+      );
     case "invalid_request":
-      return {
-        message: "The authorization request was rejected. Please try again.",
-        status: 400,
-        shouldLogIssue: false,
-      };
+      return systemFailure(
+        "The authorization request was rejected. Please try again.",
+      );
     case "invalid_grant":
       return {
         message:
@@ -73,36 +72,34 @@ export function getOAuthFailureDetails({
         shouldLogIssue: false,
       };
     case "invalid_scope":
-      return {
-        message: "The requested permissions were invalid. Please try again.",
-        status: 400,
-        shouldLogIssue: false,
-      };
+      return systemFailure(
+        "The requested permissions were invalid. Please try again.",
+      );
     case "invalid_client":
     case "unauthorized_client":
     case "unsupported_grant_type":
-      return {
-        message:
-          "There was an internal configuration issue completing authentication. Please try again later.",
-        status: 500,
-        shouldLogIssue: true,
-      };
+      return systemFailure(
+        "There was an internal configuration issue completing authentication. Please try again later.",
+        500,
+      );
     default:
-      if (typeof upstreamStatus === "number" && upstreamStatus >= 500) {
-        return {
-          message:
+      if (typeof upstreamStatus === "number") {
+        if (upstreamStatus >= 500) {
+          return systemFailure(
             "There was an internal error authenticating your account. Please try again shortly.",
-          status: 502,
-          shouldLogIssue: true,
-        };
+          );
+        }
+
+        // Any upstream HTTP failure outside explicit user-correctable OAuth errors
+        // points to our configuration, the upstream service, or edge protection.
+        return systemFailure(
+          "There was an internal error authenticating your account. Please try again shortly.",
+        );
       }
 
-      return {
-        message:
-          "There was an issue authenticating your account. Please try again.",
-        status: 400,
-        shouldLogIssue: false,
-      };
+      return systemFailure(
+        "There was an internal error authenticating your account. Please try again shortly.",
+      );
   }
 }
 

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -22,10 +22,6 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
-export function createOAuthErrorMessage(oauthError?: string): string {
-  return getOAuthCallbackFailureDetails({ oauthError }).message;
-}
-
 type OAuthFailureDetails = {
   message: string;
   status: number;
@@ -115,7 +111,7 @@ export function getOAuthCallbackFailureDetails({
 
 export function getTokenExchangeFailureDetails({
   oauthError,
-  upstreamStatus,
+  upstreamStatus: _upstreamStatus,
   errorDescription,
 }: {
   oauthError?: string;
@@ -162,20 +158,6 @@ export function getTokenExchangeFailureDetails({
         500,
       );
     default:
-      if (typeof upstreamStatus === "number") {
-        if (upstreamStatus >= 500) {
-          return systemFailure(
-            "There was an internal error authenticating your account. Please try again shortly.",
-          );
-        }
-
-        // Any upstream HTTP failure outside explicit user-correctable OAuth errors
-        // points to our configuration, the upstream service, or edge protection.
-        return systemFailure(
-          "There was an internal error authenticating your account. Please try again shortly.",
-        );
-      }
-
       return systemFailure(
         "There was an internal error authenticating your account. Please try again shortly.",
       );

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -111,11 +111,9 @@ export function getOAuthCallbackFailureDetails({
 
 export function getTokenExchangeFailureDetails({
   oauthError,
-  upstreamStatus: _upstreamStatus,
   errorDescription,
 }: {
   oauthError?: string;
-  upstreamStatus?: number;
   errorDescription?: string;
 }): OAuthFailureDetails {
   switch (oauthError) {
@@ -359,7 +357,6 @@ export async function exchangeCodeForAccessToken({
     const upstreamError = parseUpstreamOAuthError(responseText, contentType);
     const failure = getTokenExchangeFailureDetails({
       oauthError: upstreamError.error,
-      upstreamStatus: resp.status,
       errorDescription: upstreamError.errorDescription,
     });
     const logOptions = {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -8,7 +8,7 @@ import {
   ApiRateLimitError,
   SentryApiService,
 } from "@sentry/mcp-core/api-client";
-import { logError, logIssue } from "@sentry/mcp-core/telem/logging";
+import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
 import { TokenResponseSchema } from "./constants";
 import type { WorkerProps } from "../types";
 import * as Sentry from "@sentry/cloudflare";
@@ -23,17 +23,86 @@ function escapeHtml(value: string): string {
 }
 
 export function createOAuthErrorMessage(oauthError?: string): string {
+  return getOAuthFailureDetails({ oauthError }).message;
+}
+
+export function getOAuthFailureDetails({
+  oauthError,
+  upstreamStatus,
+}: {
+  oauthError?: string;
+  upstreamStatus?: number;
+}): {
+  message: string;
+  status: number;
+  shouldLogIssue: boolean;
+} {
   switch (oauthError) {
     case "access_denied":
-      return "Authorization was denied. Please try again if you want to continue connecting your account.";
+      return {
+        message:
+          "Authorization was denied. Please try again if you want to continue connecting your account.",
+        status: 400,
+        shouldLogIssue: false,
+      };
     case "temporarily_unavailable":
-      return "Sentry OAuth is temporarily unavailable. Please try again shortly.";
+      return {
+        message:
+          "Sentry OAuth is temporarily unavailable. Please try again shortly.",
+        status: 503,
+        shouldLogIssue: true,
+      };
     case "server_error":
-      return "Sentry OAuth encountered an internal error. Please try again.";
+      return {
+        message:
+          "Sentry OAuth encountered an internal error. Please try again.",
+        status: 502,
+        shouldLogIssue: true,
+      };
     case "invalid_request":
-      return "The authorization request was rejected. Please try again.";
+      return {
+        message: "The authorization request was rejected. Please try again.",
+        status: 400,
+        shouldLogIssue: false,
+      };
+    case "invalid_grant":
+      return {
+        message:
+          "The authorization code was invalid or expired. Please try connecting your account again.",
+        status: 400,
+        shouldLogIssue: false,
+      };
+    case "invalid_scope":
+      return {
+        message: "The requested permissions were invalid. Please try again.",
+        status: 400,
+        shouldLogIssue: false,
+      };
+    case "invalid_client":
+    case "unauthorized_client":
+    case "unsupported_grant_type":
+      return {
+        message:
+          "There was an internal configuration issue completing authentication. Please try again later.",
+        status: 500,
+        shouldLogIssue: true,
+      };
     default:
-      return "There was an issue authenticating your account. Please try again.";
+      if (typeof upstreamStatus === "number" && upstreamStatus >= 500) {
+        return {
+          message:
+            "There was an internal error authenticating your account. Please try again shortly.",
+          status: 502,
+          shouldLogIssue: true,
+        };
+      }
+
+      return {
+        message:
+          "There was an issue authenticating your account. Please try again.",
+        status: 400,
+        shouldLogIssue: false,
+      };
   }
 }
 
@@ -42,15 +111,22 @@ export function createOAuthFailureResponse({
   message,
   status,
   oauthError,
+  eventId,
 }: {
   title?: string;
   message: string;
   status: number;
   oauthError?: string;
+  eventId?: string;
 }): Response {
-  const details = oauthError
-    ? `<p><strong>OAuth Error:</strong> ${escapeHtml(oauthError)}</p>`
-    : "";
+  const details = [
+    oauthError
+      ? `<p><strong>OAuth Error:</strong> ${escapeHtml(oauthError)}</p>`
+      : "",
+    eventId
+      ? `<p><strong>Event ID:</strong> <code>${escapeHtml(eventId)}</code></p>`
+      : "",
+  ].join("");
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -80,6 +156,10 @@ export function createOAuthFailureResponse({
       }
       p {
         line-height: 1.6;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.95em;
       }
       .details {
         margin-top: 24px;
@@ -181,7 +261,7 @@ export async function exchangeCodeForAccessToken({
   redirect_uri?: string;
 }): Promise<[z.infer<typeof TokenResponseSchema>, null] | [null, Response]> {
   if (!code) {
-    logError("[oauth] Missing code in token exchange", {
+    logWarn("[oauth] Missing code in token exchange", {
       contexts: {
         oauth: {
           client_id,
@@ -219,7 +299,11 @@ export async function exchangeCodeForAccessToken({
     const responseText = await resp.text();
     const contentType = resp.headers.get("Content-Type");
     const upstreamError = parseUpstreamOAuthError(responseText, contentType);
-    logError("[oauth] Failed to exchange code for access token", {
+    const failure = getOAuthFailureDetails({
+      oauthError: upstreamError.error,
+      upstreamStatus: resp.status,
+    });
+    const logOptions = {
       contexts: {
         oauth: {
           client_id,
@@ -236,13 +320,23 @@ export async function exchangeCodeForAccessToken({
         responseBodyPreview: responseText.slice(0, 1000),
       },
       loggerScope: ["cloudflare", "oauth", "callback"],
-    });
+    } as const;
+    let eventId: string | undefined;
+    if (failure.shouldLogIssue) {
+      eventId = logIssue(
+        "[oauth] Failed to exchange code for access token",
+        logOptions,
+      );
+    } else {
+      logWarn("[oauth] Failed to exchange code for access token", logOptions);
+    }
     return [
       null,
       createOAuthFailureResponse({
-        message: createOAuthErrorMessage(upstreamError.error),
-        status: 400,
+        message: failure.message,
+        status: failure.status,
         oauthError: upstreamError.error,
+        eventId,
       }),
     ] as const;
   }
@@ -252,7 +346,7 @@ export async function exchangeCodeForAccessToken({
     const output = TokenResponseSchema.parse(body);
     return [output, null];
   } catch (e) {
-    logError(
+    const eventId = logIssue(
       new Error("Failed to parse token response", {
         cause: e,
       }),
@@ -269,8 +363,9 @@ export async function exchangeCodeForAccessToken({
       null,
       createOAuthFailureResponse({
         message:
-          "There was an issue authenticating your account and retrieving an access token. Please try again.",
+          "There was an internal error authenticating your account and retrieving an access token. Please try again.",
         status: 500,
+        eventId,
       }),
     ] as const;
   }

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -103,8 +103,8 @@ export function getOAuthCallbackFailureDetails({
         500,
       );
     default:
-      return userFailure(
-        "There was an issue authenticating your account. Please try again.",
+      return systemFailure(
+        "There was an internal error authenticating your account. Please try again shortly.",
       );
   }
 }

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -23,34 +23,110 @@ function escapeHtml(value: string): string {
 }
 
 export function createOAuthErrorMessage(oauthError?: string): string {
-  return getOAuthFailureDetails({ oauthError }).message;
+  return getOAuthCallbackFailureDetails({ oauthError }).message;
 }
 
-export function getOAuthFailureDetails({
-  oauthError,
-  upstreamStatus,
-}: {
-  oauthError?: string;
-  upstreamStatus?: number;
-}): {
+type OAuthFailureDetails = {
   message: string;
   status: number;
   shouldLogIssue: boolean;
-} {
-  const systemFailure = (message: string, status = 502) => ({
-    message,
-    status,
-    shouldLogIssue: true,
-  });
+};
 
+const userFailure = (message: string, status = 400): OAuthFailureDetails => ({
+  message,
+  status,
+  shouldLogIssue: false,
+});
+
+const systemFailure = (message: string, status = 502): OAuthFailureDetails => ({
+  message,
+  status,
+  shouldLogIssue: true,
+});
+
+function isRetryableInvalidGrant(errorDescription?: string): boolean {
+  if (!errorDescription) {
+    return false;
+  }
+
+  const normalized = errorDescription.toLowerCase();
+  const userRetryablePatterns = [
+    "expired",
+    "already used",
+    "already been used",
+    "invalid or expired",
+    "authorization code expired",
+  ];
+  const systemMismatchPatterns = [
+    "redirect_uri",
+    "client_id",
+    "pkce",
+    "code verifier",
+    "code_verifier",
+    "mismatch",
+  ];
+
+  return (
+    userRetryablePatterns.some((pattern) => normalized.includes(pattern)) &&
+    !systemMismatchPatterns.some((pattern) => normalized.includes(pattern))
+  );
+}
+
+export function getOAuthCallbackFailureDetails({
+  oauthError,
+}: {
+  oauthError?: string;
+}): OAuthFailureDetails {
   switch (oauthError) {
     case "access_denied":
-      return {
-        message:
-          "Authorization was denied. Please try again if you want to continue connecting your account.",
-        status: 400,
-        shouldLogIssue: false,
-      };
+      return userFailure(
+        "Authorization was denied. Please try again if you want to continue connecting your account.",
+      );
+    case "invalid_request":
+      return userFailure(
+        "The authorization request was rejected. Please try again.",
+      );
+    case "temporarily_unavailable":
+      return systemFailure(
+        "Sentry OAuth is temporarily unavailable. Please try again shortly.",
+        503,
+      );
+    case "server_error":
+      return systemFailure(
+        "Sentry OAuth encountered an internal error. Please try again.",
+      );
+    case "invalid_scope":
+      return systemFailure(
+        "The requested permissions were invalid. Please try again.",
+      );
+    case "invalid_client":
+    case "unauthorized_client":
+    case "unsupported_response_type":
+      return systemFailure(
+        "There was an internal configuration issue completing authentication. Please try again later.",
+        500,
+      );
+    default:
+      return userFailure(
+        "There was an issue authenticating your account. Please try again.",
+      );
+  }
+}
+
+export function getTokenExchangeFailureDetails({
+  oauthError,
+  upstreamStatus,
+  errorDescription,
+}: {
+  oauthError?: string;
+  upstreamStatus?: number;
+  errorDescription?: string;
+}): OAuthFailureDetails {
+  switch (oauthError) {
+    case "access_denied":
+      return userFailure(
+        "Authorization was denied. Please try again if you want to continue connecting your account.",
+      );
     case "temporarily_unavailable":
       return systemFailure(
         "Sentry OAuth is temporarily unavailable. Please try again shortly.",
@@ -65,12 +141,15 @@ export function getOAuthFailureDetails({
         "The authorization request was rejected. Please try again.",
       );
     case "invalid_grant":
-      return {
-        message:
+      if (isRetryableInvalidGrant(errorDescription)) {
+        return userFailure(
           "The authorization code was invalid or expired. Please try connecting your account again.",
-        status: 400,
-        shouldLogIssue: false,
-      };
+        );
+      }
+
+      return systemFailure(
+        "The authorization code could not be validated. Please try again.",
+      );
     case "invalid_scope":
       return systemFailure(
         "The requested permissions were invalid. Please try again.",
@@ -296,9 +375,10 @@ export async function exchangeCodeForAccessToken({
     const responseText = await resp.text();
     const contentType = resp.headers.get("Content-Type");
     const upstreamError = parseUpstreamOAuthError(responseText, contentType);
-    const failure = getOAuthFailureDetails({
+    const failure = getTokenExchangeFailureDetails({
       oauthError: upstreamError.error,
       upstreamStatus: resp.status,
+      errorDescription: upstreamError.errorDescription,
     });
     const logOptions = {
       contexts: {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -6,7 +6,7 @@ import { SENTRY_TOKEN_URL } from "../constants";
 import {
   createOAuthFailureResponse,
   exchangeCodeForAccessToken,
-  getOAuthFailureDetails,
+  getOAuthCallbackFailureDetails,
   validateResourceParameter,
 } from "../helpers";
 import { verifyAndParseState, type OAuthState } from "../state";
@@ -91,7 +91,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
 
   const oauthError = c.req.query("error") ?? undefined;
   if (oauthError) {
-    const failure = getOAuthFailureDetails({ oauthError });
+    const failure = getOAuthCallbackFailureDetails({ oauthError });
     const logMessage = "[oauth] Upstream authorization callback error";
     const logOptions = {
       contexts: {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -4,13 +4,13 @@ import { clientIdAlreadyApproved } from "../../lib/approval-dialog";
 import type { Env, WorkerProps } from "../../types";
 import { SENTRY_TOKEN_URL } from "../constants";
 import {
-  createOAuthErrorMessage,
   createOAuthFailureResponse,
   exchangeCodeForAccessToken,
+  getOAuthFailureDetails,
   validateResourceParameter,
 } from "../helpers";
 import { verifyAndParseState, type OAuthState } from "../state";
-import { logError, logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
+import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
 import { parseSkills, getScopesForSkills } from "@sentry/mcp-core/skills";
 
 /**
@@ -91,7 +91,9 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
 
   const oauthError = c.req.query("error") ?? undefined;
   if (oauthError) {
-    logIssue("[oauth] Upstream authorization callback error", {
+    const failure = getOAuthFailureDetails({ oauthError });
+    const logMessage = "[oauth] Upstream authorization callback error";
+    const logOptions = {
       contexts: {
         oauth: {
           clientId: oauthReqInfo.clientId,
@@ -103,17 +105,24 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
         queryKeys: Array.from(new URL(c.req.url).searchParams.keys()),
       },
       loggerScope: ["cloudflare", "oauth", "callback"],
-    });
+    } as const;
+    let eventId: string | undefined;
+    if (failure.shouldLogIssue) {
+      eventId = logIssue(logMessage, logOptions);
+    } else {
+      logWarn(logMessage, logOptions);
+    }
 
     return createOAuthFailureResponse({
-      message: createOAuthErrorMessage(oauthError),
-      status: 400,
+      message: failure.message,
+      status: failure.status,
       oauthError,
+      eventId,
     });
   }
 
   if (!c.req.query("code")) {
-    logError("[oauth] Callback reached without code or upstream error", {
+    logWarn("[oauth] Callback reached without code or upstream error", {
       contexts: {
         oauth: {
           clientId: oauthReqInfo.clientId,
@@ -163,20 +172,24 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       return c.text("Authorization failed: Invalid redirect URL", 400);
     }
   } catch (lookupErr) {
-    logError("Failed to validate client redirect URI on callback", {
-      contexts: {
-        oauth: {
-          clientId: oauthReqInfo.clientId,
-          redirectUri: oauthReqInfo.redirectUri,
+    const eventId = logIssue(
+      "Failed to validate client redirect URI on callback",
+      {
+        contexts: {
+          oauth: {
+            clientId: oauthReqInfo.clientId,
+            redirectUri: oauthReqInfo.redirectUri,
+          },
         },
+        extra: { error: String(lookupErr) },
+        loggerScope: ["cloudflare", "oauth", "callback"],
       },
-      extra: { error: String(lookupErr) },
-      loggerScope: ["cloudflare", "oauth", "callback"],
-    });
+    );
     return createOAuthFailureResponse({
       message:
         "There was an internal error validating the callback redirect URL.",
       status: 500,
+      eventId,
     });
   }
 


### PR DESCRIPTION
## Summary
Improve Cloudflare OAuth failure diagnostics so unexpected callback and token-exchange failures surface a Sentry event ID instead of collapsing into an unactionable generic error page.

### Key Changes
- classify OAuth failures centrally so expected denials and invalid grants stay user-correctable while unexpected failures create Sentry issues
- thread event IDs through the shared OAuth failure page for upstream callback errors, token-exchange failures, and redirect validation failures
- tighten token-exchange copy for known OAuth errors such as `invalid_grant`
- add regression tests for both the `/oauth/callback` route and the token-exchange helper

## Why
Sentry logs for the Cloudflare auth flow showed that the same generic failure page was masking several different upstream token-exchange failure modes, including `invalid_grant`, HTML `403`, HTML `500`, and `504` responses. Only some branches created issues, and none of the HTML pages exposed a support code.

This change improves the operator path when upstream OAuth fails and avoids creating issue noise for expected user-driven failures such as `access_denied`.

## Validation
- `pnpm --filter @sentry/mcp-cloudflare test -- src/server/oauth/callback.test.ts src/server/oauth/helpers.test.ts`
- `pnpm --filter @sentry/mcp-cloudflare tsc`
