### PR TITLE
fix(events): include user geo in formatted output

### DIFF
--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -242,6 +242,47 @@ describe("EventSchema", () => {
     expect(result.type).toBe("error");
   });
 
+  it("should allow partially populated user geo payloads", () => {
+    const errorEvent = {
+      id: "geo123",
+      title: "Geo Event",
+      message: "geo payload includes nulls",
+      platform: "javascript",
+      type: "error",
+      entries: [
+        {
+          type: "exception",
+          data: {
+            values: [
+              {
+                type: "Error",
+                value: "geo payload includes nulls",
+              },
+            ],
+          },
+        },
+      ],
+      culprit: "app/geo.ts",
+      dateCreated: "2025-01-01T00:00:00Z",
+      tags: [],
+      user: {
+        ip_address: "127.0.0.1",
+        geo: {
+          country_code: "US",
+          city: null,
+          region: "United States",
+        },
+      },
+    };
+
+    const result = EventSchema.parse(errorEvent);
+    expect(result.user?.geo).toEqual({
+      country_code: "US",
+      city: null,
+      region: "United States",
+    });
+  });
+
   it("should parse a regressed performance event (generic type)", () => {
     // This is the actual event structure from a regressed performance issue
     const regressedEvent = {

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -491,6 +491,20 @@ const BaseEventSchema = z.object({
   // This is different from "contexts" (plural) which are structured contexts
   context: z.record(z.string(), z.unknown()).optional(),
   tags: EventTagsSchema.optional(),
+  user: z
+    .object({
+      display_name: z.string().nullable().optional(),
+      email: z.string().nullable().optional(),
+      id: z.string().nullable().optional(),
+      ip: z.string().nullable().optional(),
+      ip_address: z.string().nullable().optional(),
+      name: z.string().nullable().optional(),
+      username: z.string().nullable().optional(),
+      geo: z.record(z.string(), z.string()).nullable().optional(),
+    })
+    .passthrough()
+    .nullable()
+    .optional(),
   // The _meta field contains metadata about fields in the response
   // It's safer to type as unknown since its structure varies
   _meta: z.unknown().optional(),

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -500,7 +500,10 @@ const BaseEventSchema = z.object({
       ip_address: z.string().nullable().optional(),
       name: z.string().nullable().optional(),
       username: z.string().nullable().optional(),
-      geo: z.record(z.string(), z.string()).nullable().optional(),
+      geo: z
+        .record(z.string(), z.union([z.string(), z.null()]))
+        .nullable()
+        .optional(),
     })
     .passthrough()
     .nullable()

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -187,6 +187,11 @@ export function formatEventOutput(
   },
 ) {
   let output = "";
+  const eventUser = (
+    event as Event & {
+      user?: z.infer<typeof EventSchema>["user"];
+    }
+  ).user;
   const eventWithReplayMetadataStripped = options?.replaySummary
     ? stripReplayMetadata(event)
     : event;
@@ -270,6 +275,7 @@ export function formatEventOutput(
     output += formatGenericEventOutput(eventToRender);
   }
 
+  output += formatEventUser(eventUser);
   output += formatTags(eventToRender.tags);
   output += formatContext(eventToRender.context);
   output += formatContexts(eventToRender.contexts);
@@ -1531,6 +1537,48 @@ function formatTags(tags: z.infer<typeof EventSchema>["tags"]) {
   return `### Tags\n\n${tags
     .map((tag) => `**${tag.key}**: ${tag.value}`)
     .join("\n")}\n\n`;
+}
+
+function formatEventUser(user: z.infer<typeof EventSchema>["user"]) {
+  if (!user || Object.keys(user).length === 0) {
+    return "";
+  }
+
+  const userFields = [
+    ["id", user.id],
+    ["email", user.email],
+    ["username", user.username],
+    ["ip", user.ip ?? user.ip_address],
+    ["display_name", user.display_name ?? user.name],
+  ].filter(([, value]) => typeof value === "string" && value.length > 0);
+
+  const userSummary = userFields
+    .map(([key, value]) => `${key}:${value}`)
+    .join(", ");
+  const geoParts = [
+    user.geo?.country_code,
+    user.geo?.city,
+    user.geo?.region,
+    user.geo?.country_name,
+  ].filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  const geoSummary =
+    geoParts.length > 0 ? Array.from(new Set(geoParts)).join(", ") : null;
+
+  if (!userSummary && !geoSummary) {
+    return "";
+  }
+
+  let output = "### User\n\n";
+  if (userSummary) {
+    output += `**user**: ${userSummary}\n`;
+  }
+  if (geoSummary) {
+    output += `**user.geo**: ${geoSummary}\n`;
+  }
+
+  return `${output}\n`;
 }
 
 function formatContext(context: z.infer<typeof EventSchema>["context"]) {

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -34,6 +34,7 @@ import {
   getStatusDisplayName,
 } from "./tool-helpers/seer";
 import { logIssue } from "../telem/logging";
+import { formatUserGeoSummary } from "./user-formatting";
 
 /**
  * Convert Seer fixability score to actionability label.
@@ -209,6 +210,7 @@ export function formatEventOutput(
   // Check if entries exist (may be undefined for unsupported event types)
   if (!eventToRender.entries || !Array.isArray(eventToRender.entries)) {
     // For unsupported event types, just show tags and contexts
+    output += formatEventUser(eventUser);
     output += formatTags(eventToRender.tags);
     output += formatContext(eventToRender.context);
     output += formatContexts(eventToRender.contexts);
@@ -1555,16 +1557,7 @@ function formatEventUser(user: z.infer<typeof EventSchema>["user"]) {
   const userSummary = userFields
     .map(([key, value]) => `${key}:${value}`)
     .join(", ");
-  const geoParts = [
-    user.geo?.country_code,
-    user.geo?.city,
-    user.geo?.region,
-    user.geo?.country_name,
-  ].filter(
-    (value): value is string => typeof value === "string" && value.length > 0,
-  );
-  const geoSummary =
-    geoParts.length > 0 ? Array.from(new Set(geoParts)).join(", ") : null;
+  const geoSummary = formatUserGeoSummary(user.geo);
 
   if (!userSummary && !geoSummary) {
     return "";

--- a/packages/mcp-core/src/internal/user-formatting.ts
+++ b/packages/mcp-core/src/internal/user-formatting.ts
@@ -1,4 +1,6 @@
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 

--- a/packages/mcp-core/src/internal/user-formatting.ts
+++ b/packages/mcp-core/src/internal/user-formatting.ts
@@ -1,0 +1,24 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function formatUserGeoSummary(value: unknown): string | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const parts = [
+    value.country_code,
+    value.city,
+    value.region,
+    value.country_name,
+  ].filter(
+    (part): part is string => typeof part === "string" && part.length > 0,
+  );
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return Array.from(new Set(parts)).join(", ");
+}

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -218,6 +218,11 @@ describe("get_issue_details", () => {
       **Method:** GET
       **URL:** https://mcp.sentry.dev/sse
 
+      ### User
+
+      **user**: ip:2a06:98c0:3600::103
+      **user.geo**: US, United States
+
       ### Tags
 
       **environment**: development
@@ -441,6 +446,11 @@ describe("get_issue_details", () => {
 
       **Method:** GET
       **URL:** https://mcp.sentry.dev/sse
+
+      ### User
+
+      **user**: ip:2a06:98c0:3600::103
+      **user.geo**: US, United States
 
       ### Tags
 
@@ -718,6 +728,11 @@ describe("get_issue_details", () => {
 
       **Method:** GET
       **URL:** https://mcp.sentry.dev/sse
+
+      ### User
+
+      **user**: ip:2a06:98c0:3600::103
+      **user.geo**: US, United States
 
       ### Tags
 
@@ -1535,7 +1550,6 @@ describe("get_issue_details", () => {
       **Please report this**: Open a GitHub issue at https://github.com/getsentry/sentry-mcp/issues/new and include Event ID **ffffffffffffffffffffffffffffffff** and Sentry Event ID **<SENTRY_EVENT_ID>** to help us add support for this event type.
       "
     `);
-    expect(result).toContain("**user.geo**: US, United States");
 
     // Verify we actually got a Sentry Event ID
     expect(sentryEventId).toMatch(/^[a-f0-9]{32}$/);

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -1535,6 +1535,7 @@ describe("get_issue_details", () => {
       **Please report this**: Open a GitHub issue at https://github.com/getsentry/sentry-mcp/issues/new and include Event ID **ffffffffffffffffffffffffffffffff** and Sentry Event ID **<SENTRY_EVENT_ID>** to help us add support for this event type.
       "
     `);
+    expect(result).toContain("**user.geo**: US, United States");
 
     // Verify we actually got a Sentry Event ID
     expect(sentryEventId).toMatch(/^[a-f0-9]{32}$/);

--- a/packages/mcp-core/src/tools/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.test.ts
@@ -387,6 +387,7 @@ describe("get_sentry_resource", () => {
       expect(result).toContain(
         "**Event ID**: 7ca573c0f4814912aaa9bdc77d1a7d51",
       );
+      expect(result).toContain("**user.geo**: US, United States");
     });
 
     it("fetches trace by traceId", async () => {

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -312,6 +312,123 @@ describe("search_events", () => {
     expect(result).not.toContain("**user**:");
   });
 
+  it("should render log user geo on a dedicated line", async () => {
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse("logs", "user logs", [
+        "timestamp",
+        "message",
+        "severity",
+        "user",
+      ]),
+    );
+
+    mswServer.use(
+      http.get("https://sentry.io/api/0/organizations/test-org/events/", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              timestamp: "2024-01-15T10:30:00Z",
+              message: "User log message",
+              severity: "info",
+              user: {
+                id: "user-123",
+                geo: {
+                  country_code: "US",
+                  region: "United States",
+                },
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        naturalLanguageQuery: "logs with user geo",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain("- **user**: id=user-123");
+    expect(result).toContain("- **user.geo**: US, United States");
+    expect(result).not.toContain(
+      "- **user**: id=user-123, geo=US, United States",
+    );
+  });
+
+  it("should render span user geo on a dedicated line", async () => {
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse("spans", "span users", [
+        "span.description",
+        "span.duration",
+        "timestamp",
+        "user",
+      ]),
+    );
+
+    mswServer.use(
+      http.get("https://sentry.io/api/0/organizations/test-org/events/", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: "span1",
+              "span.description": "SELECT * FROM users",
+              "span.duration": 1500,
+              timestamp: "2024-01-15T10:30:00Z",
+              user: {
+                id: "user-123",
+                geo: {
+                  country_code: "US",
+                  region: "United States",
+                },
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        naturalLanguageQuery: "spans with user geo",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain("**user**: id=user-123");
+    expect(result).toContain("**user.geo**: US, United States");
+    expect(result).not.toContain(
+      "**user**: id=user-123, geo=US, United States",
+    );
+  });
+
   it("should handle logs dataset queries", async () => {
     // Mock AI response for logs dataset
     mockGenerateText.mockResolvedValueOnce(

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -258,6 +258,60 @@ describe("search_events", () => {
     expect(result).not.toContain("[object Object]");
   });
 
+  it("should render geo-only users without raw user JSON in error results", async () => {
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse("errors", "issue:PROJ-123", [
+        "title",
+        "timestamp",
+        "user",
+      ]),
+    );
+
+    mswServer.use(
+      http.get("https://sentry.io/api/0/organizations/test-org/events/", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: "error1",
+              title: "Geo-only User Error",
+              timestamp: "2024-01-15T10:30:00Z",
+              user: {
+                geo: {
+                  country_code: "US",
+                  region: "United States",
+                },
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        naturalLanguageQuery: "recent errors with geo-only user data",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain("**user.geo**: US, United States");
+    expect(result).not.toContain('**user**: {"geo"');
+    expect(result).not.toContain("**user**:");
+  });
+
   it("should handle logs dataset queries", async () => {
     // Mock AI response for logs dataset
     mockGenerateText.mockResolvedValueOnce(

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -7,6 +7,31 @@ import {
   isAggregateQuery,
 } from "./utils";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatUserGeoValue(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const parts = [
+    value.country_code,
+    value.city,
+    value.region,
+    value.country_name,
+  ].filter(
+    (part): part is string => typeof part === "string" && part.length > 0,
+  );
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return Array.from(new Set(parts)).join(", ");
+}
+
 /**
  * Format an explanation for how a natural language query was translated
  */
@@ -138,6 +163,13 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
           value !== undefined
         ) {
           output += `**${key}**: ${formatEventValue(value)}\n`;
+
+          if (key === "user" && isRecord(value)) {
+            const geoSummary = formatUserGeoValue(value.geo);
+            if (geoSummary) {
+              output += `**user.geo**: ${geoSummary}\n`;
+            }
+          }
         }
       }
 

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -140,7 +140,10 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
         ) {
           const formattedValue =
             key === "user"
-              ? formatEventValue(value, { includeUserGeo: false })
+              ? formatEventValue(value, {
+                  includeUserGeo: false,
+                  allowGeoOnlyUser: true,
+                })
               : formatEventValue(value);
           output += `**${key}**: ${formattedValue}\n`;
 
@@ -296,7 +299,11 @@ export function formatLogResults(params: FormatEventResultsParams): string {
           value !== null &&
           value !== undefined
         ) {
-          output += `- **${key}**: ${formatEventValue(value)}\n`;
+          const formattedValue =
+            key === "user"
+              ? formatEventValue(value, { allowGeoOnlyUser: true })
+              : formatEventValue(value);
+          output += `- **${key}**: ${formattedValue}\n`;
         }
       }
 
@@ -420,7 +427,11 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
           value !== null &&
           value !== undefined
         ) {
-          output += `**${key}**: ${formatEventValue(value)}\n`;
+          const formattedValue =
+            key === "user"
+              ? formatEventValue(value, { allowGeoOnlyUser: true })
+              : formatEventValue(value);
+          output += `**${key}**: ${formattedValue}\n`;
         }
       }
 

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -1,4 +1,5 @@
 import type { SentryApiService } from "../../api-client";
+import { formatUserGeoSummary } from "../../internal/user-formatting";
 import { logInfo } from "../../telem/logging";
 import {
   type FlexibleEventData,
@@ -6,31 +7,6 @@ import {
   getStringValue,
   isAggregateQuery,
 } from "./utils";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function formatUserGeoValue(value: unknown): string | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const parts = [
-    value.country_code,
-    value.city,
-    value.region,
-    value.country_name,
-  ].filter(
-    (part): part is string => typeof part === "string" && part.length > 0,
-  );
-
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return Array.from(new Set(parts)).join(", ");
-}
 
 /**
  * Format an explanation for how a natural language query was translated
@@ -164,8 +140,10 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
         ) {
           output += `**${key}**: ${formatEventValue(value)}\n`;
 
-          if (key === "user" && isRecord(value)) {
-            const geoSummary = formatUserGeoValue(value.geo);
+          if (key === "user" && typeof value === "object" && value !== null) {
+            const geoSummary = formatUserGeoSummary(
+              (value as Record<string, unknown>).geo,
+            );
             if (geoSummary) {
               output += `**user.geo**: ${geoSummary}\n`;
             }

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -5,6 +5,7 @@ import {
   type FlexibleEventData,
   formatEventValue,
   getStringValue,
+  hasUserSummaryFields,
   isAggregateQuery,
 } from "./utils";
 
@@ -138,23 +139,31 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
           value !== null &&
           value !== undefined
         ) {
-          const formattedValue =
-            key === "user"
-              ? formatEventValue(value, {
-                  includeUserGeo: false,
-                  allowGeoOnlyUser: true,
-                })
-              : formatEventValue(value);
-          output += `**${key}**: ${formattedValue}\n`;
-
           if (key === "user" && typeof value === "object" && value !== null) {
-            const geoSummary = formatUserGeoSummary(
-              (value as Record<string, unknown>).geo,
-            );
+            const userValue = value as Record<string, unknown>;
+            const geoSummary = formatUserGeoSummary(userValue.geo);
+            const hasSummary = hasUserSummaryFields(userValue, {
+              allowId: true,
+            });
+
+            if (hasSummary || !geoSummary) {
+              const formattedValue = hasSummary
+                ? formatEventValue(userValue, {
+                    includeUserGeo: false,
+                    allowGeoOnlyUser: true,
+                    allowIdOnlyUser: true,
+                  })
+                : formatEventValue(userValue);
+              output += `**${key}**: ${formattedValue}\n`;
+            }
+
             if (geoSummary) {
               output += `**user.geo**: ${geoSummary}\n`;
             }
+            continue;
           }
+
+          output += `**${key}**: ${formatEventValue(value)}\n`;
         }
       }
 
@@ -301,7 +310,10 @@ export function formatLogResults(params: FormatEventResultsParams): string {
         ) {
           const formattedValue =
             key === "user"
-              ? formatEventValue(value, { allowGeoOnlyUser: true })
+              ? formatEventValue(value, {
+                  allowGeoOnlyUser: true,
+                  allowIdOnlyUser: true,
+                })
               : formatEventValue(value);
           output += `- **${key}**: ${formattedValue}\n`;
         }
@@ -429,7 +441,10 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
         ) {
           const formattedValue =
             key === "user"
-              ? formatEventValue(value, { allowGeoOnlyUser: true })
+              ? formatEventValue(value, {
+                  allowGeoOnlyUser: true,
+                  allowIdOnlyUser: true,
+                })
               : formatEventValue(value);
           output += `**${key}**: ${formattedValue}\n`;
         }

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -138,7 +138,11 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
           value !== null &&
           value !== undefined
         ) {
-          output += `**${key}**: ${formatEventValue(value)}\n`;
+          const formattedValue =
+            key === "user"
+              ? formatEventValue(value, { includeUserGeo: false })
+              : formatEventValue(value);
+          output += `**${key}**: ${formattedValue}\n`;
 
           if (key === "user" && typeof value === "object" && value !== null) {
             const geoSummary = formatUserGeoSummary(

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -31,6 +31,35 @@ export interface FormatEventResultsParams {
   explanation?: string;
 }
 
+function formatUserFieldLines(
+  value: Record<string, unknown>,
+  options: { prefix?: string } = {},
+): string[] {
+  const prefix = options.prefix ?? "";
+  const geoSummary = formatUserGeoSummary(value.geo);
+  const hasSummary = hasUserSummaryFields(value, {
+    allowId: true,
+  });
+  const lines: string[] = [];
+
+  if (hasSummary || !geoSummary) {
+    const formattedValue = hasSummary
+      ? formatEventValue(value, {
+          includeUserGeo: false,
+          allowGeoOnlyUser: true,
+          allowIdOnlyUser: true,
+        })
+      : formatEventValue(value);
+    lines.push(`${prefix}**user**: ${formattedValue}`);
+  }
+
+  if (geoSummary) {
+    lines.push(`${prefix}**user.geo**: ${geoSummary}`);
+  }
+
+  return lines;
+}
+
 /**
  * Format error event results for display
  */
@@ -140,25 +169,10 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
           value !== undefined
         ) {
           if (key === "user" && typeof value === "object" && value !== null) {
-            const userValue = value as Record<string, unknown>;
-            const geoSummary = formatUserGeoSummary(userValue.geo);
-            const hasSummary = hasUserSummaryFields(userValue, {
-              allowId: true,
-            });
-
-            if (hasSummary || !geoSummary) {
-              const formattedValue = hasSummary
-                ? formatEventValue(userValue, {
-                    includeUserGeo: false,
-                    allowGeoOnlyUser: true,
-                    allowIdOnlyUser: true,
-                  })
-                : formatEventValue(userValue);
-              output += `**${key}**: ${formattedValue}\n`;
-            }
-
-            if (geoSummary) {
-              output += `**user.geo**: ${geoSummary}\n`;
+            for (const line of formatUserFieldLines(
+              value as Record<string, unknown>,
+            )) {
+              output += `${line}\n`;
             }
             continue;
           }
@@ -308,14 +322,17 @@ export function formatLogResults(params: FormatEventResultsParams): string {
           value !== null &&
           value !== undefined
         ) {
-          const formattedValue =
-            key === "user"
-              ? formatEventValue(value, {
-                  allowGeoOnlyUser: true,
-                  allowIdOnlyUser: true,
-                })
-              : formatEventValue(value);
-          output += `- **${key}**: ${formattedValue}\n`;
+          if (key === "user" && typeof value === "object" && value !== null) {
+            for (const line of formatUserFieldLines(
+              value as Record<string, unknown>,
+              { prefix: "- " },
+            )) {
+              output += `${line}\n`;
+            }
+            continue;
+          }
+
+          output += `- **${key}**: ${formatEventValue(value)}\n`;
         }
       }
 
@@ -439,14 +456,16 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
           value !== null &&
           value !== undefined
         ) {
-          const formattedValue =
-            key === "user"
-              ? formatEventValue(value, {
-                  allowGeoOnlyUser: true,
-                  allowIdOnlyUser: true,
-                })
-              : formatEventValue(value);
-          output += `**${key}**: ${formattedValue}\n`;
+          if (key === "user" && typeof value === "object" && value !== null) {
+            for (const line of formatUserFieldLines(
+              value as Record<string, unknown>,
+            )) {
+              output += `${line}\n`;
+            }
+            continue;
+          }
+
+          output += `**${key}**: ${formatEventValue(value)}\n`;
         }
       }
 

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -4,8 +4,8 @@ import { logInfo } from "../../telem/logging";
 import {
   type FlexibleEventData,
   formatEventValue,
+  formatKnownUserValue,
   getStringValue,
-  hasUserSummaryFields,
   isAggregateQuery,
 } from "./utils";
 
@@ -37,20 +37,13 @@ function formatUserFieldLines(
 ): string[] {
   const prefix = options.prefix ?? "";
   const geoSummary = formatUserGeoSummary(value.geo);
-  const hasSummary = hasUserSummaryFields(value, {
-    allowId: true,
-  });
+  const userSummary = formatKnownUserValue(value, { includeGeo: false });
   const lines: string[] = [];
 
-  if (hasSummary || !geoSummary) {
-    const formattedValue = hasSummary
-      ? formatEventValue(value, {
-          includeUserGeo: false,
-          allowGeoOnlyUser: true,
-          allowIdOnlyUser: true,
-        })
-      : formatEventValue(value);
-    lines.push(`${prefix}**user**: ${formattedValue}`);
+  if (userSummary) {
+    lines.push(`${prefix}**user**: ${userSummary}`);
+  } else if (!geoSummary) {
+    lines.push(`${prefix}**user**: ${formatEventValue(value)}`);
   }
 
   if (geoSummary) {

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -103,6 +103,20 @@ describe("formatEventValue", () => {
       expect(formatEventValue(user)).toContain("geo=US, United States");
     });
 
+    it("should omit geo summaries when requested", () => {
+      const user = {
+        id: "3c7631c0121d40e79e2f992ff5cf7671",
+        geo: {
+          country_code: "US",
+          region: "United States",
+        },
+      };
+
+      expect(formatEventValue(user, { includeUserGeo: false })).toBe(
+        "id=3c7631c0121d40e79e2f992ff5cf7671",
+      );
+    });
+
     it("should NOT apply user formatting to objects with only id", () => {
       const obj = { id: "abc", type: "transaction", description: "GET /api" };
       const result = formatEventValue(obj);

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -91,6 +91,18 @@ describe("formatEventValue", () => {
       expect(result).toContain("ip_address=10.0.0.1");
     });
 
+    it("should include geo summaries for user objects", () => {
+      const user = {
+        id: "3c7631c0121d40e79e2f992ff5cf7671",
+        geo: {
+          country_code: "US",
+          region: "United States",
+        },
+      };
+
+      expect(formatEventValue(user)).toContain("geo=US, United States");
+    });
+
     it("should NOT apply user formatting to objects with only id", () => {
       const obj = { id: "abc", type: "transaction", description: "GET /api" };
       const result = formatEventValue(obj);

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { mswServer } from "@sentry/mcp-server-mocks";
-import { fetchCustomAttributes, formatEventValue } from "./utils";
+import {
+  fetchCustomAttributes,
+  formatEventValue,
+  formatKnownUserValue,
+} from "./utils";
 import { SentryApiService } from "../../api-client";
 import * as logging from "../../telem/logging";
 
@@ -91,7 +95,7 @@ describe("formatEventValue", () => {
       expect(result).toContain("ip_address=10.0.0.1");
     });
 
-    it("should include geo summaries for user objects", () => {
+    it("should include geo summaries for known user objects", () => {
       const user = {
         id: "3c7631c0121d40e79e2f992ff5cf7671",
         geo: {
@@ -100,12 +104,12 @@ describe("formatEventValue", () => {
         },
       };
 
-      expect(formatEventValue(user, { allowGeoOnlyUser: true })).toContain(
+      expect(formatKnownUserValue(user, { includeGeo: true })).toContain(
         "geo=US, United States",
       );
     });
 
-    it("should omit geo summaries when requested", () => {
+    it("should omit geo summaries for known user objects when requested", () => {
       const user = {
         id: "3c7631c0121d40e79e2f992ff5cf7671",
         geo: {
@@ -114,12 +118,20 @@ describe("formatEventValue", () => {
         },
       };
 
-      expect(
-        formatEventValue(user, {
-          includeUserGeo: false,
-          allowGeoOnlyUser: true,
-        }),
-      ).toBe("id=3c7631c0121d40e79e2f992ff5cf7671");
+      expect(formatKnownUserValue(user, { includeGeo: false })).toBe(
+        "id=3c7631c0121d40e79e2f992ff5cf7671",
+      );
+    });
+
+    it("should omit summary text for geo-only known users", () => {
+      const user = {
+        geo: {
+          country_code: "US",
+          region: "United States",
+        },
+      };
+
+      expect(formatKnownUserValue(user, { includeGeo: false })).toBeNull();
     });
 
     it("should NOT apply user formatting to objects with only id", () => {

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -100,7 +100,9 @@ describe("formatEventValue", () => {
         },
       };
 
-      expect(formatEventValue(user)).toContain("geo=US, United States");
+      expect(formatEventValue(user, { allowGeoOnlyUser: true })).toContain(
+        "geo=US, United States",
+      );
     });
 
     it("should omit geo summaries when requested", () => {
@@ -112,9 +114,12 @@ describe("formatEventValue", () => {
         },
       };
 
-      expect(formatEventValue(user, { includeUserGeo: false })).toBe(
-        "id=3c7631c0121d40e79e2f992ff5cf7671",
-      );
+      expect(
+        formatEventValue(user, {
+          includeUserGeo: false,
+          allowGeoOnlyUser: true,
+        }),
+      ).toBe("id=3c7631c0121d40e79e2f992ff5cf7671");
     });
 
     it("should NOT apply user formatting to objects with only id", () => {
@@ -124,6 +129,21 @@ describe("formatEventValue", () => {
       expect(result).toContain("type");
       expect(result).toContain("transaction");
       expect(result).toContain("description");
+    });
+
+    it("should NOT apply user formatting to non-user objects with geo", () => {
+      const obj = {
+        method: "GET",
+        path: "/api/0/issues/",
+        geo: {
+          country_code: "US",
+        },
+      };
+
+      const result = formatEventValue(obj);
+      expect(result).toContain('"method":"GET"');
+      expect(result).toContain('"path":"/api/0/issues/"');
+      expect(result).toContain('"country_code":"US"');
     });
 
     it("should format tag-pair objects", () => {

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -70,7 +70,11 @@ const USER_IDENTITY_FIELDS = new Set([
   "display_name",
 ]);
 
-function formatUserSummary(value: Record<string, unknown>): string | null {
+function formatUserSummary(
+  value: Record<string, unknown>,
+  options: { includeGeo?: boolean } = {},
+): string | null {
+  const includeGeo = options.includeGeo ?? true;
   // Require at least one identity field to avoid matching arbitrary objects that just have "id"
   const hasIdentityField =
     USER_FIELDS.some((f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null) ||
@@ -83,7 +87,7 @@ function formatUserSummary(value: Record<string, unknown>): string | null {
     (f) => `${f}=${formatSimpleValue(value[f])}`,
   );
   const geoSummary = formatUserGeoSummary(value.geo);
-  if (geoSummary) {
+  if (includeGeo && geoSummary) {
     parts.push(`geo=${geoSummary}`);
   }
 
@@ -174,6 +178,7 @@ function formatArrayValue(values: unknown[], maxLength: number): string {
 function formatObjectValue(
   value: Record<string, unknown>,
   maxLength: number,
+  options: { includeUserGeo?: boolean } = {},
 ): string {
   // Check tag pair first -- it's more specific than the user summary heuristic
   if (isTagPair(value)) {
@@ -183,7 +188,9 @@ function formatObjectValue(
     );
   }
 
-  const userSummary = formatUserSummary(value);
+  const userSummary = formatUserSummary(value, {
+    includeGeo: options.includeUserGeo,
+  });
   if (userSummary) {
     return truncateString(sanitizeWhitespace(userSummary), maxLength);
   }
@@ -196,7 +203,7 @@ function formatObjectValue(
 
 export function formatEventValue(
   value: unknown,
-  options: { maxLength?: number } = {},
+  options: { maxLength?: number; includeUserGeo?: boolean } = {},
 ): string {
   const maxLength = options.maxLength ?? DEFAULT_MAX_VALUE_LENGTH;
 
@@ -216,7 +223,9 @@ export function formatEventValue(
   }
 
   if (isPlainObject(value)) {
-    return formatObjectValue(value, maxLength);
+    return formatObjectValue(value, maxLength, {
+      includeUserGeo: options.includeUserGeo,
+    });
   }
 
   return truncateString(sanitizeWhitespace(String(value)), maxLength);

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import type { SentryApiService } from "../../api-client";
 import { agentTool } from "../../internal/agents/tools/utils";
-import { formatUserGeoSummary } from "../../internal/user-formatting";
+import {
+  formatUserGeoSummary,
+  isPlainObject,
+} from "../../internal/user-formatting";
 
 // Type for flexible event data that can contain any fields
 export type FlexibleEventData = Record<string, unknown>;
@@ -31,10 +34,6 @@ export function getNumberValue(
 // Helper to check if fields contain aggregate functions
 export function isAggregateQuery(fields: string[]): boolean {
   return fields.some((field) => field.includes("(") && field.includes(")"));
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isPrimitive(

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -70,17 +70,36 @@ const USER_IDENTITY_FIELDS = new Set([
   "display_name",
 ]);
 
+export function hasUserIdentityFields(value: Record<string, unknown>): boolean {
+  return USER_FIELDS.some(
+    (f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null,
+  );
+}
+
+export function hasUserSummaryFields(
+  value: Record<string, unknown>,
+  options: { allowId?: boolean } = {},
+): boolean {
+  return (
+    hasUserIdentityFields(value) ||
+    (options.allowId === true && value.id != null)
+  );
+}
+
 function formatUserSummary(
   value: Record<string, unknown>,
-  options: { includeGeo?: boolean; allowGeoOnly?: boolean } = {},
+  options: {
+    includeGeo?: boolean;
+    allowGeoOnly?: boolean;
+    allowIdOnly?: boolean;
+  } = {},
 ): string | null {
   const includeGeo = options.includeGeo ?? true;
   const allowGeoOnly = options.allowGeoOnly ?? false;
+  const allowIdOnly = options.allowIdOnly ?? false;
   // Require at least one identity field to avoid matching arbitrary objects that just have "id"
-  const hasIdentityField = USER_FIELDS.some(
-    (f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null,
-  );
-  if (!hasIdentityField && !(allowGeoOnly && value.geo != null)) {
+  const hasSummaryField = hasUserSummaryFields(value, { allowId: allowIdOnly });
+  if (!hasSummaryField && !(allowGeoOnly && value.geo != null)) {
     return null;
   }
 
@@ -179,7 +198,11 @@ function formatArrayValue(values: unknown[], maxLength: number): string {
 function formatObjectValue(
   value: Record<string, unknown>,
   maxLength: number,
-  options: { includeUserGeo?: boolean; allowGeoOnlyUser?: boolean } = {},
+  options: {
+    includeUserGeo?: boolean;
+    allowGeoOnlyUser?: boolean;
+    allowIdOnlyUser?: boolean;
+  } = {},
 ): string {
   // Check tag pair first -- it's more specific than the user summary heuristic
   if (isTagPair(value)) {
@@ -192,6 +215,7 @@ function formatObjectValue(
   const userSummary = formatUserSummary(value, {
     includeGeo: options.includeUserGeo,
     allowGeoOnly: options.allowGeoOnlyUser,
+    allowIdOnly: options.allowIdOnlyUser,
   });
   if (userSummary) {
     return truncateString(sanitizeWhitespace(userSummary), maxLength);
@@ -209,6 +233,7 @@ export function formatEventValue(
     maxLength?: number;
     includeUserGeo?: boolean;
     allowGeoOnlyUser?: boolean;
+    allowIdOnlyUser?: boolean;
   } = {},
 ): string {
   const maxLength = options.maxLength ?? DEFAULT_MAX_VALUE_LENGTH;
@@ -232,6 +257,7 @@ export function formatEventValue(
     return formatObjectValue(value, maxLength, {
       includeUserGeo: options.includeUserGeo,
       allowGeoOnlyUser: options.allowGeoOnlyUser,
+      allowIdOnlyUser: options.allowIdOnlyUser,
     });
   }
 

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { SentryApiService } from "../../api-client";
 import { agentTool } from "../../internal/agents/tools/utils";
+import { formatUserGeoSummary } from "../../internal/user-formatting";
 
 // Type for flexible event data that can contain any fields
 export type FlexibleEventData = Record<string, unknown>;
@@ -70,27 +71,6 @@ const USER_IDENTITY_FIELDS = new Set([
   "geo",
 ]);
 
-function formatGeoSummary(value: unknown): string | null {
-  if (!isPlainObject(value)) {
-    return null;
-  }
-
-  const parts = [
-    value.country_code,
-    value.city,
-    value.region,
-    value.country_name,
-  ].filter(
-    (part): part is string => typeof part === "string" && part.length > 0,
-  );
-
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return Array.from(new Set(parts)).join(", ");
-}
-
 function formatUserSummary(value: Record<string, unknown>): string | null {
   // Require at least one identity field to avoid matching arbitrary objects that just have "id"
   const hasIdentityField =
@@ -103,7 +83,7 @@ function formatUserSummary(value: Record<string, unknown>): string | null {
   const parts = USER_FIELDS.filter((f) => value[f] != null).map(
     (f) => `${f}=${formatSimpleValue(value[f])}`,
   );
-  const geoSummary = formatGeoSummary(value.geo);
+  const geoSummary = formatUserGeoSummary(value.geo);
   if (geoSummary) {
     parts.push(`geo=${geoSummary}`);
   }

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -72,14 +72,15 @@ const USER_IDENTITY_FIELDS = new Set([
 
 function formatUserSummary(
   value: Record<string, unknown>,
-  options: { includeGeo?: boolean } = {},
+  options: { includeGeo?: boolean; allowGeoOnly?: boolean } = {},
 ): string | null {
   const includeGeo = options.includeGeo ?? true;
+  const allowGeoOnly = options.allowGeoOnly ?? false;
   // Require at least one identity field to avoid matching arbitrary objects that just have "id"
-  const hasIdentityField =
-    USER_FIELDS.some((f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null) ||
-    value.geo != null;
-  if (!hasIdentityField) {
+  const hasIdentityField = USER_FIELDS.some(
+    (f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null,
+  );
+  if (!hasIdentityField && !(allowGeoOnly && value.geo != null)) {
     return null;
   }
 
@@ -178,7 +179,7 @@ function formatArrayValue(values: unknown[], maxLength: number): string {
 function formatObjectValue(
   value: Record<string, unknown>,
   maxLength: number,
-  options: { includeUserGeo?: boolean } = {},
+  options: { includeUserGeo?: boolean; allowGeoOnlyUser?: boolean } = {},
 ): string {
   // Check tag pair first -- it's more specific than the user summary heuristic
   if (isTagPair(value)) {
@@ -190,6 +191,7 @@ function formatObjectValue(
 
   const userSummary = formatUserSummary(value, {
     includeGeo: options.includeUserGeo,
+    allowGeoOnly: options.allowGeoOnlyUser,
   });
   if (userSummary) {
     return truncateString(sanitizeWhitespace(userSummary), maxLength);
@@ -203,7 +205,11 @@ function formatObjectValue(
 
 export function formatEventValue(
   value: unknown,
-  options: { maxLength?: number; includeUserGeo?: boolean } = {},
+  options: {
+    maxLength?: number;
+    includeUserGeo?: boolean;
+    allowGeoOnlyUser?: boolean;
+  } = {},
 ): string {
   const maxLength = options.maxLength ?? DEFAULT_MAX_VALUE_LENGTH;
 
@@ -225,6 +231,7 @@ export function formatEventValue(
   if (isPlainObject(value)) {
     return formatObjectValue(value, maxLength, {
       includeUserGeo: options.includeUserGeo,
+      allowGeoOnlyUser: options.allowGeoOnlyUser,
     });
   }
 

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -68,7 +68,6 @@ const USER_IDENTITY_FIELDS = new Set([
   "ip_address",
   "name",
   "display_name",
-  "geo",
 ]);
 
 function formatUserSummary(value: Record<string, unknown>): string | null {

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -89,16 +89,14 @@ function formatUserSummary(
   value: Record<string, unknown>,
   options: {
     includeGeo?: boolean;
-    allowGeoOnly?: boolean;
     allowIdOnly?: boolean;
   } = {},
 ): string | null {
   const includeGeo = options.includeGeo ?? true;
-  const allowGeoOnly = options.allowGeoOnly ?? false;
   const allowIdOnly = options.allowIdOnly ?? false;
   // Require at least one identity field to avoid matching arbitrary objects that just have "id"
   const hasSummaryField = hasUserSummaryFields(value, { allowId: allowIdOnly });
-  if (!hasSummaryField && !(allowGeoOnly && value.geo != null)) {
+  if (!hasSummaryField) {
     return null;
   }
 

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -69,7 +69,7 @@ const USER_IDENTITY_FIELDS = new Set([
   "display_name",
 ]);
 
-export function hasUserIdentityFields(value: Record<string, unknown>): boolean {
+function hasUserIdentityFields(value: Record<string, unknown>): boolean {
   return USER_FIELDS.some(
     (f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null,
   );

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -75,7 +75,7 @@ function hasUserIdentityFields(value: Record<string, unknown>): boolean {
   );
 }
 
-export function hasUserSummaryFields(
+function hasUserSummaryFields(
   value: Record<string, unknown>,
   options: { allowId?: boolean } = {},
 ): boolean {
@@ -111,6 +111,16 @@ function formatUserSummary(
   }
 
   return parts.length > 0 ? parts.join(", ") : null;
+}
+
+export function formatKnownUserValue(
+  value: Record<string, unknown>,
+  options: { includeGeo?: boolean } = {},
+): string | null {
+  return formatUserSummary(value, {
+    includeGeo: options.includeGeo,
+    allowIdOnly: true,
+  });
 }
 
 function sanitizeWhitespace(value: string): string {
@@ -197,11 +207,6 @@ function formatArrayValue(values: unknown[], maxLength: number): string {
 function formatObjectValue(
   value: Record<string, unknown>,
   maxLength: number,
-  options: {
-    includeUserGeo?: boolean;
-    allowGeoOnlyUser?: boolean;
-    allowIdOnlyUser?: boolean;
-  } = {},
 ): string {
   // Check tag pair first -- it's more specific than the user summary heuristic
   if (isTagPair(value)) {
@@ -211,11 +216,7 @@ function formatObjectValue(
     );
   }
 
-  const userSummary = formatUserSummary(value, {
-    includeGeo: options.includeUserGeo,
-    allowGeoOnly: options.allowGeoOnlyUser,
-    allowIdOnly: options.allowIdOnlyUser,
-  });
+  const userSummary = formatUserSummary(value);
   if (userSummary) {
     return truncateString(sanitizeWhitespace(userSummary), maxLength);
   }
@@ -230,9 +231,6 @@ export function formatEventValue(
   value: unknown,
   options: {
     maxLength?: number;
-    includeUserGeo?: boolean;
-    allowGeoOnlyUser?: boolean;
-    allowIdOnlyUser?: boolean;
   } = {},
 ): string {
   const maxLength = options.maxLength ?? DEFAULT_MAX_VALUE_LENGTH;
@@ -253,11 +251,7 @@ export function formatEventValue(
   }
 
   if (isPlainObject(value)) {
-    return formatObjectValue(value, maxLength, {
-      includeUserGeo: options.includeUserGeo,
-      allowGeoOnlyUser: options.allowGeoOnlyUser,
-      allowIdOnlyUser: options.allowIdOnlyUser,
-    });
+    return formatObjectValue(value, maxLength);
   }
 
   return truncateString(sanitizeWhitespace(String(value)), maxLength);

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -53,19 +53,49 @@ function isTagPair(value: unknown): value is { key: string; value: unknown } {
   );
 }
 
-const USER_FIELDS = ["id", "email", "username", "ip_address", "name"] as const;
+const USER_FIELDS = [
+  "id",
+  "email",
+  "username",
+  "ip_address",
+  "name",
+  "display_name",
+] as const;
 const USER_IDENTITY_FIELDS = new Set([
   "email",
   "username",
   "ip_address",
   "name",
+  "display_name",
+  "geo",
 ]);
+
+function formatGeoSummary(value: unknown): string | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const parts = [
+    value.country_code,
+    value.city,
+    value.region,
+    value.country_name,
+  ].filter(
+    (part): part is string => typeof part === "string" && part.length > 0,
+  );
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return Array.from(new Set(parts)).join(", ");
+}
 
 function formatUserSummary(value: Record<string, unknown>): string | null {
   // Require at least one identity field to avoid matching arbitrary objects that just have "id"
-  const hasIdentityField = USER_FIELDS.some(
-    (f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null,
-  );
+  const hasIdentityField =
+    USER_FIELDS.some((f) => USER_IDENTITY_FIELDS.has(f) && value[f] != null) ||
+    value.geo != null;
   if (!hasIdentityField) {
     return null;
   }
@@ -73,6 +103,10 @@ function formatUserSummary(value: Record<string, unknown>): string | null {
   const parts = USER_FIELDS.filter((f) => value[f] != null).map(
     (f) => `${f}=${formatSimpleValue(value[f])}`,
   );
+  const geoSummary = formatGeoSummary(value.geo);
+  if (geoSummary) {
+    parts.push(`geo=${geoSummary}`);
+  }
 
   return parts.length > 0 ? parts.join(", ") : null;
 }

--- a/packages/mcp-core/src/tools/search-issue-events.test.ts
+++ b/packages/mcp-core/src/tools/search-issue-events.test.ts
@@ -126,6 +126,49 @@ describe("search_issue_events", () => {
     expect(result).toContain("2025-01-15T10:00:00Z");
   });
 
+  it("should include user geo details in formatted event output", async () => {
+    mockGenerateText.mockResolvedValue(
+      mockAIResponse("", ["id", "timestamp", "title", "user"], "-timestamp"),
+    );
+
+    mswServer.use(
+      http.get("*/api/0/organizations/*/issues/*/events/", () =>
+        HttpResponse.json([
+          {
+            id: "event1",
+            timestamp: "2025-01-15T10:00:00Z",
+            title: "Geo-tagged Error",
+            user: {
+              id: "3c7631c0121d40e79e2f992ff5cf7671",
+              geo: {
+                country_code: "US",
+                region: "United States",
+              },
+            },
+          },
+        ]),
+      ),
+    );
+
+    const result = await searchIssueEvents.handler(
+      {
+        organizationSlug: "test-org",
+        issueId: "MCP-41",
+        naturalLanguageQuery: "events with user details",
+        projectSlug: null,
+        regionUrl: null,
+        limit: 50,
+        includeExplanation: false,
+      },
+      mockContext,
+    );
+
+    expect(result).toContain(
+      "**user**: id=3c7631c0121d40e79e2f992ff5cf7671, geo=US, United States",
+    );
+    expect(result).toContain("**user.geo**: US, United States");
+  });
+
   it("should parse issueUrl and extract organization and issue ID", async () => {
     mockGenerateText.mockResolvedValue(mockAIResponse());
 

--- a/packages/mcp-core/src/tools/search-issue-events.test.ts
+++ b/packages/mcp-core/src/tools/search-issue-events.test.ts
@@ -163,9 +163,7 @@ describe("search_issue_events", () => {
       mockContext,
     );
 
-    expect(result).toContain(
-      "**user**: id=3c7631c0121d40e79e2f992ff5cf7671, geo=US, United States",
-    );
+    expect(result).toContain("**user**: id=3c7631c0121d40e79e2f992ff5cf7671");
     expect(result).toContain("**user.geo**: US, United States");
   });
 

--- a/packages/mcp-core/src/tools/search-issue-events.test.ts
+++ b/packages/mcp-core/src/tools/search-issue-events.test.ts
@@ -167,6 +167,47 @@ describe("search_issue_events", () => {
     expect(result).toContain("**user.geo**: US, United States");
   });
 
+  it("should render geo-only users without duplicating raw user JSON", async () => {
+    mockGenerateText.mockResolvedValue(
+      mockAIResponse("", ["id", "timestamp", "title", "user"], "-timestamp"),
+    );
+
+    mswServer.use(
+      http.get("*/api/0/organizations/*/issues/*/events/", () =>
+        HttpResponse.json([
+          {
+            id: "event1",
+            timestamp: "2025-01-15T10:00:00Z",
+            title: "Geo-only User Error",
+            user: {
+              geo: {
+                country_code: "US",
+                region: "United States",
+              },
+            },
+          },
+        ]),
+      ),
+    );
+
+    const result = await searchIssueEvents.handler(
+      {
+        organizationSlug: "test-org",
+        issueId: "MCP-41",
+        naturalLanguageQuery: "events with geo-only users",
+        projectSlug: null,
+        regionUrl: null,
+        limit: 50,
+        includeExplanation: false,
+      },
+      mockContext,
+    );
+
+    expect(result).not.toContain('**user**: {"geo"');
+    expect(result).not.toContain("**user**:");
+    expect(result).toContain("**user.geo**: US, United States");
+  });
+
   it("should parse issueUrl and extract organization and issue ID", async () => {
     mockGenerateText.mockResolvedValue(mockAIResponse());
 


### PR DESCRIPTION
Include `user.geo` in formatted event output for both `get_sentry_resource` event lookups and `search_issue_events` results. This exposes the same location context already present in the upstream event payload instead of forcing callers back to raw REST API responses.

The change also aligns our event schema with upstream Sentry serialization by accepting nullable `user` and `user.geo` values. That keeps parsing compatible with real events that do not have an attached user while still surfacing geo data when it is present.

I considered handling this only in the formatter layer, but the event parser also needed to understand the upstream payload shape or the fix would remain unsafe for events with `user: null`.

Fixes #893