### PR TITLE
fix(agents): Make Azure OpenAI explicit

### DIFF
--- a/docs/embedded-agents.md
+++ b/docs/embedded-agents.md
@@ -175,6 +175,16 @@ export OPENAI_API_KEY=sk-...
 npx @sentry/mcp-server --openai-base-url=https://custom.openai.example.com
 ```
 
+Azure-style deployment URLs such as
+`https://.../openai/deployments/<deployment>` automatically use chat
+completions for compatibility with deployment-based proxies. Generic custom
+OpenAI base URLs continue using the Responses API.
+
+For responses-only models on deployment-style URLs, use the canonical OpenAI
+model name (for example `codex-mini-latest` or `computer-use-preview`). If you
+use an opaque deployment alias instead, Sentry MCP cannot infer the backend
+model capability and will assume chat completions.
+
 ### Model Selection
 
 Override the default model for each provider:

--- a/docs/embedded-agents.md
+++ b/docs/embedded-agents.md
@@ -10,7 +10,7 @@ Sentry MCP uses embedded AI agents for the following tools:
 - `search_issue_events` - Search events within a specific issue
 - `use_sentry` - Unified natural language interface to all Sentry operations
 
-These tools require an LLM provider (OpenAI or Anthropic) to be configured.
+These tools require an LLM provider (OpenAI, Azure OpenAI, or Anthropic) to be configured.
 
 ## Provider Selection
 
@@ -19,7 +19,7 @@ These tools require an LLM provider (OpenAI or Anthropic) to be configured.
 Always set `EMBEDDED_AGENT_PROVIDER` to explicitly specify your LLM provider:
 
 ```bash
-export EMBEDDED_AGENT_PROVIDER=openai   # or 'anthropic'
+export EMBEDDED_AGENT_PROVIDER=openai   # or 'azure-openai' / 'anthropic'
 export OPENAI_API_KEY=sk-...            # corresponding API key
 ```
 
@@ -51,6 +51,14 @@ Set `EMBEDDED_AGENT_PROVIDER` to explicitly choose a provider:
 ```bash
 export EMBEDDED_AGENT_PROVIDER=openai
 export OPENAI_API_KEY=sk-...
+```
+
+Or:
+
+```bash
+export EMBEDDED_AGENT_PROVIDER=azure-openai
+export OPENAI_API_KEY=sk-...
+npx @sentry/mcp-server --openai-base-url=https://example.openai.azure.com/openai/v1/
 ```
 
 Or:
@@ -133,7 +141,7 @@ Always set `EMBEDDED_AGENT_PROVIDER` when multiple API keys might be present:
 ```
 Error: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set.
 Please specify which provider to use by setting the EMBEDDED_AGENT_PROVIDER
-environment variable to 'openai' or 'anthropic'.
+environment variable to 'openai', 'azure-openai', or 'anthropic'.
 ```
 
 **Cause:** Multiple API keys detected without explicit provider selection.
@@ -175,15 +183,20 @@ export OPENAI_API_KEY=sk-...
 npx @sentry/mcp-server --openai-base-url=https://custom.openai.example.com
 ```
 
-Azure-style deployment URLs such as
-`https://.../openai/deployments/<deployment>` automatically use chat
-completions for compatibility with deployment-based proxies. Generic custom
-OpenAI base URLs continue using the Responses API.
+For Azure OpenAI or Azure-compatible deployment proxies, use the dedicated
+provider instead of the generic `openai` mode:
 
-For responses-only models on deployment-style URLs, use the canonical OpenAI
-model name (for example `codex-mini-latest` or `computer-use-preview`). If you
-use an opaque deployment alias instead, Sentry MCP cannot infer the backend
-model capability and will reject the configuration.
+```bash
+export EMBEDDED_AGENT_PROVIDER=azure-openai
+export OPENAI_API_KEY=sk-...
+export OPENAI_API_VERSION=2024-02-15-preview
+
+# Azure v1 endpoint -> Responses API
+npx @sentry/mcp-server --openai-base-url=https://example.openai.azure.com/openai/v1/
+
+# Deployment endpoint -> chat completions
+npx @sentry/mcp-server --openai-base-url=https://example.openai.azure.com/openai/deployments/my-assistant
+```
 
 ### Model Selection
 
@@ -207,7 +220,7 @@ npx @sentry/mcp-server --access-token=... 2>&1 | grep "Using"
 
 Expected output:
 ```
-Using openai for AI-powered search tools (from EMBEDDED_AGENT_PROVIDER).
+Using openai responses API for AI-powered search tools (from EMBEDDED_AGENT_PROVIDER).
 ```
 
 Or:
@@ -252,7 +265,7 @@ npx @sentry/mcp-server --access-token=...
 
 Should output:
 ```
-Using openai for AI-powered search tools (from EMBEDDED_AGENT_PROVIDER).
+Using openai responses API for AI-powered search tools (from EMBEDDED_AGENT_PROVIDER).
 ```
 
 ## Related Documentation

--- a/docs/embedded-agents.md
+++ b/docs/embedded-agents.md
@@ -183,7 +183,7 @@ OpenAI base URLs continue using the Responses API.
 For responses-only models on deployment-style URLs, use the canonical OpenAI
 model name (for example `codex-mini-latest` or `computer-use-preview`). If you
 use an opaque deployment alias instead, Sentry MCP cannot infer the backend
-model capability and will assume chat completions.
+model capability and will reject the configuration.
 
 ### Model Selection
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -37,6 +37,13 @@ When adding a new feature specification:
 
 ## Current Specifications
 
+### embedded-agent-openai-routing
+A spec for splitting generic `openai` from explicit `azure-openai` embedded
+agent behavior so Azure compatibility no longer depends on hidden heuristics.
+
+- **Status**: 📝 Proposed
+- **Key Benefits**: Preserves Azure compatibility, keeps unknown OpenAI-compatible providers predictable, and removes alias-based footguns
+
 ### search-events
 A unified event search tool that uses OpenAI GPT-5 to translate natural language queries into Sentry's search syntax. Replaced the separate `find_errors` and `find_transactions` tools with a single, more powerful interface.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,6 +1,7 @@
 # Feature Specifications
 
-This directory contains detailed specifications for features in the Sentry MCP server. Each feature has its own subdirectory with related design documents, technical specifications, and implementation guides.
+This directory contains detailed specifications for features in the Sentry MCP
+server. Each spec should live in a single Markdown file under `docs/specs/`.
 
 
 ## Purpose
@@ -17,8 +18,8 @@ Feature specifications serve to:
 
 When adding a new feature specification:
 
-1. Create a new directory under `specs/` with a descriptive name
-2. Create a **single, concise README.md file** that covers:
+1. Create a new Markdown file under `specs/` with a descriptive name
+2. Keep the spec in a **single, concise `.md` file** that covers:
    - Problem statement and motivation
    - High-level design approach
    - Interface definitions (with code examples)
@@ -28,7 +29,7 @@ When adding a new feature specification:
 4. Link to the spec from relevant documentation
 
 **Important Guidelines**:
-- Keep specs in a single file (README.md)
+- Keep specs in a single file under `docs/specs/`
 - Focus on WHAT and WHY, not HOW
 - Include code examples for interfaces and usage
 - Document constraints and meta concerns
@@ -37,14 +38,14 @@ When adding a new feature specification:
 
 ## Current Specifications
 
-### embedded-agent-openai-routing
+### [embedded-agent-openai-routing](./embedded-agent-openai-routing.md)
 A spec for splitting generic `openai` from explicit `azure-openai` embedded
 agent behavior so Azure compatibility no longer depends on hidden heuristics.
 
 - **Status**: 📝 Proposed
 - **Key Benefits**: Preserves Azure compatibility, keeps unknown OpenAI-compatible providers predictable, and removes alias-based footguns
 
-### search-events
+### [search-events](./search-events.md)
 A unified event search tool that uses OpenAI GPT-5 to translate natural language queries into Sentry's search syntax. Replaced the separate `find_errors` and `find_transactions` tools with a single, more powerful interface.
 
 - **Status**: ✅ Complete

--- a/docs/specs/embedded-agent-openai-routing.md
+++ b/docs/specs/embedded-agent-openai-routing.md
@@ -84,9 +84,9 @@ the same footguns this change is intended to remove.
 
 This follows the broad pattern used elsewhere:
 
-- Azure’s docs treat Azure as explicit configuration, and their v1 examples use
+- Azure's docs treat Azure as explicit configuration, and their v1 examples use
   deployment names as the `model` value on an Azure endpoint.
-- OpenAI’s official SDK exposes Azure through a distinct `AzureOpenAI` client.
+- OpenAI's official SDK exposes Azure through a distinct `AzureOpenAI` client.
 - Vercel AI SDK exposes Azure through a separate Azure provider instead of
   adding Azure heuristics to the generic OpenAI provider.
 
@@ -258,16 +258,3 @@ Tests should assert request paths, not just selected models.
 
 This introduces one explicit provider choice in exchange for removing hidden
 heuristics.
-
-## Future Work
-
-If Azure support expands beyond URL compatibility, add dedicated Azure flags so
-users do not have to encode Azure details into a generic `openai-base-url`.
-That could include:
-
-- `--azure-openai-endpoint`
-- `--azure-openai-deployment`
-- `--azure-openai-api-version`
-
-That is optional follow-up work. The immediate goal is to make Azure behavior
-explicit without adding a generic routing flag.

--- a/docs/specs/embedded-agent-openai-routing/README.md
+++ b/docs/specs/embedded-agent-openai-routing/README.md
@@ -1,0 +1,273 @@
+# Embedded Agent Azure OpenAI Provider
+
+## Overview
+
+Sentry MCP currently has a generic `openai` embedded-agent provider plus a
+custom `--openai-base-url` override. The AI SDK upgrade changed the default API
+surface toward `responses`, which broke Azure-style deployment URLs and
+corporate proxies that previously worked through chat completions.
+
+The right fix is to stop teaching the generic `openai` provider Azure-specific
+behavior. Generic OpenAI-compatible endpoints are too heterogeneous to route
+reliably from URL shape alone. Instead, Sentry MCP should introduce an explicit
+`azure-openai` provider and keep `openai` intentionally simple.
+
+## Motivation
+
+- Preserve the 0.29.x compatibility path for Azure deployment URLs.
+- Remove model-prefix heuristics such as `gpt-*` or `codex-*`.
+- Avoid adding a generic routing flag like `--openai-api-surface`.
+- Avoid brittle URL-shape inference for unknown OpenAI-compatible providers.
+- Keep Azure compatibility opt-in instead of silently affecting all custom
+  OpenAI endpoints.
+
+## Design
+
+### Provider Split
+
+Supported embedded-agent providers become:
+
+- `openai`
+- `azure-openai`
+- `anthropic`
+
+### `openai` Provider
+
+The generic `openai` provider remains the default OpenAI-family option.
+
+Rules:
+
+- `OPENAI_MODEL` and `--openai-model` are opaque identifiers.
+- `--openai-base-url` is allowed for generic OpenAI-compatible proxies.
+- The generic `openai` provider always uses the Responses API.
+- The generic `openai` provider never switches behavior based on model prefixes.
+- The generic `openai` provider never applies Azure deployment-path special
+  cases.
+
+This keeps unknown providers predictable.
+
+### `azure-openai` Provider
+
+Azure behavior becomes explicit instead of inferred.
+
+Rules:
+
+- `azure-openai` must be selected explicitly via `--agent-provider` or
+  `EMBEDDED_AGENT_PROVIDER`.
+- `OPENAI_MODEL` and `--openai-model` remain opaque deployment identifiers.
+- `--openai-base-url` continues to provide the Azure or Azure-compatible base
+  URL.
+- `OPENAI_API_VERSION` is honored only when `azure-openai` is selected.
+- URL-shape routing is allowed only inside `azure-openai`.
+
+Within `azure-openai`, supported routing is:
+
+- Base URL ending in `/openai/v1` or `/openai/v1/`: use Responses API
+- Base URL ending in `/openai/deployments/<deployment>`:
+  use chat completions
+
+That gives Azure users compatibility without teaching generic OpenAI mode to
+guess.
+
+### Auto-Detection
+
+Auto-detection should remain:
+
+- `anthropic` when only `ANTHROPIC_API_KEY` is present
+- `openai` when only `OPENAI_API_KEY` is present
+
+`azure-openai` should never be auto-detected. It shares the same broad key
+family as `openai`, and inferring Azure mode from a key or URL would recreate
+the same footguns this change is intended to remove.
+
+### Why This Is the Default
+
+This follows the broad pattern used elsewhere:
+
+- Azure’s docs treat Azure as explicit configuration, and their v1 examples use
+  deployment names as the `model` value on an Azure endpoint.
+- OpenAI’s official SDK exposes Azure through a distinct `AzureOpenAI` client.
+- Vercel AI SDK exposes Azure through a separate Azure provider instead of
+  adding Azure heuristics to the generic OpenAI provider.
+
+## Interface
+
+### CLI
+
+No generic routing flag is added.
+
+Add a new supported provider value:
+
+```bash
+--agent-provider <provider>   LLM provider: openai, azure-openai, or anthropic
+```
+
+The existing OpenAI-family flags continue to apply:
+
+```bash
+--openai-base-url <url>
+--openai-model <model>
+```
+
+For Azure-specific API versioning, honor:
+
+```bash
+OPENAI_API_VERSION=<version>
+```
+
+The initial design does not require a dedicated `--openai-api-version` flag,
+though one can be added later if CLI parity becomes important.
+
+### Types
+
+Update:
+
+- `packages/mcp-core/src/internal/agents/types.ts`
+- `packages/mcp-core/src/internal/agents/provider-factory.ts`
+- `packages/mcp-server/src/cli/types.ts`
+- `packages/mcp-server/src/cli/parse.ts`
+- `packages/mcp-server/src/cli/resolve.ts`
+- `packages/mcp-server/src/cli/usage.ts`
+
+Add:
+
+```ts
+type AgentProviderType = "openai" | "azure-openai" | "anthropic";
+```
+
+### Provider Behavior
+
+The provider factory becomes:
+
+- `openai` -> generic OpenAI/OpenAI-compatible provider, Responses API only
+- `azure-openai` -> Azure-aware provider with Azure-only URL-shape routing
+- `anthropic` -> unchanged
+
+Implementation options for `azure-openai`:
+
+- use `@ai-sdk/azure` directly, if we want proper Azure semantics now
+- or keep a minimal dedicated Azure wrapper around the existing OpenAI stack as
+  an intermediate step
+
+The key requirement is conceptual separation, not the specific SDK choice.
+
+## Examples
+
+### Direct OpenAI
+
+```bash
+npx @sentry/mcp-server --access-token=TOKEN
+```
+
+Result: auto-detects `openai` when `OPENAI_API_KEY` is present and uses
+Responses API.
+
+### Generic OpenAI-Compatible Proxy
+
+```bash
+npx @sentry/mcp-server \
+  --access-token=TOKEN \
+  --agent-provider=openai \
+  --openai-base-url=https://proxy.example.com/v1 \
+  --openai-model=my-company-assistant
+```
+
+Result: Responses API. `my-company-assistant` is treated as an opaque model or
+deployment alias.
+
+### Azure-Compatible Deployment Proxy
+
+```bash
+npx @sentry/mcp-server \
+  --access-token=TOKEN \
+  --agent-provider=azure-openai \
+  --openai-base-url=https://proxy.example.com/openai/deployments/my-assistant \
+  --openai-model=my-assistant
+```
+
+Result: chat completions. `my-assistant` is treated as an opaque deployment
+alias.
+
+### Azure v1 Endpoint
+
+```bash
+export OPENAI_API_VERSION=2024-02-15-preview
+
+npx @sentry/mcp-server \
+  --access-token=TOKEN \
+  --agent-provider=azure-openai \
+  --openai-base-url=https://my-resource.openai.azure.com/openai/v1/ \
+  --openai-model=my-assistant
+```
+
+Result: Responses API on Azure v1, with `my-assistant` treated as an opaque
+deployment alias.
+
+## Startup Output
+
+When an OpenAI-family provider is resolved, startup logs should show both the
+provider and API surface. Examples:
+
+- `Using openai responses API (generic OpenAI provider).`
+- `Using azure-openai chat completions API (deployment-style Azure base URL).`
+- `Using azure-openai responses API (Azure v1 base URL).`
+
+This makes the compatibility path explicit.
+
+## Implementation
+
+1. Add `azure-openai` to the allowed embedded-agent provider values.
+2. Keep generic `openai` on the Responses API only.
+3. Add an `azure-openai` provider module.
+4. Honor `OPENAI_API_VERSION` only in the `azure-openai` provider path.
+5. Support Azure-only routing between:
+   - `/openai/v1` -> Responses
+   - `/openai/deployments/<deployment>` -> chat completions
+6. Remove model-prefix routing logic and any canonical-model validation.
+7. Update startup messages to show provider plus selected API surface.
+8. Update docs and examples to steer Azure users toward
+   `--agent-provider=azure-openai`.
+
+## Testing
+
+Add or update tests for:
+
+- parsing and validation of `--agent-provider=azure-openai`
+- explicit `EMBEDDED_AGENT_PROVIDER=azure-openai`
+- generic `openai` staying on Responses API for custom base URLs
+- `azure-openai` using Responses for `/openai/v1`
+- `azure-openai` using chat completions for `/openai/deployments/<deployment>`
+- opaque aliases such as `my-company-assistant`
+- `gpt-*`-prefixed aliases that are not canonical model names
+- `OPENAI_API_VERSION` being ignored outside `azure-openai`
+
+Tests should assert request paths, not just selected models.
+
+## Migration
+
+- Existing direct OpenAI users remain on the generic `openai` provider and stay
+  on Responses API.
+- Existing generic proxy users remain on the generic `openai` provider and stay
+  on Responses API.
+- Azure users move from implicit OpenAI compatibility mode to explicit
+  `azure-openai` mode.
+- The “reject ambiguous deployment aliases” behavior should be removed rather
+  than shipped.
+- Documentation should stop claiming that deployment URLs require canonical
+  OpenAI model names.
+
+This introduces one explicit provider choice in exchange for removing hidden
+heuristics.
+
+## Future Work
+
+If Azure support expands beyond URL compatibility, add dedicated Azure flags so
+users do not have to encode Azure details into a generic `openai-base-url`.
+That could include:
+
+- `--azure-openai-endpoint`
+- `--azure-openai-deployment`
+- `--azure-openai-api-version`
+
+That is optional follow-up work. The immediate goal is to make Azure behavior
+explicit without adding a generic routing flag.

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -41,6 +41,10 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.example.com
 npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://proxy.example.com/v1
 ```
 
+Azure-style deployment URLs such as
+`https://.../openai/deployments/<deployment>` are treated as deployment-based
+chat-completions endpoints for compatibility with Azure and similar proxies.
+
 ### Constraint-Based Tool Exclusion
 
 When a session is scoped to a specific organization or project (tenant-bound context), certain list tools are automatically excluded since they cannot query other resources:

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -39,6 +39,9 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.example.com
 
 # Override OpenAI endpoint for AI-powered tools (stdio only)
 npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://proxy.example.com/v1
+
+# Azure OpenAI / Azure-compatible deployment routing (stdio only)
+npx @sentry/mcp-server@latest --access-token=TOKEN --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
 ```
 
 Azure-style deployment URLs such as

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -44,11 +44,14 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://pro
 npx @sentry/mcp-server@latest --access-token=TOKEN --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
 ```
 
-Azure-style deployment URLs such as
-`https://.../openai/deployments/<deployment>` are treated as deployment-based
-chat-completions endpoints for compatibility with Azure and similar proxies.
-Responses-only models on deployment URLs must use the canonical OpenAI model
-name rather than an opaque deployment alias.
+For Azure OpenAI or Azure-compatible deployment proxies, use the dedicated
+`azure-openai` provider instead of generic `openai` mode:
+
+- `/openai/v1` endpoints use the Responses API
+- `/openai/deployments/<deployment>` endpoints use chat completions
+
+Generic `openai` mode always uses the Responses API and treats `OPENAI_MODEL`
+as an opaque model identifier.
 
 ### Constraint-Based Tool Exclusion
 

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -44,6 +44,8 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://pro
 Azure-style deployment URLs such as
 `https://.../openai/deployments/<deployment>` are treated as deployment-based
 chat-completions endpoints for compatibility with Azure and similar proxies.
+Responses-only models on deployment URLs must use the canonical OpenAI model
+name rather than an opaque deployment alias.
 
 ### Constraint-Based Tool Exclusion
 

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -11,9 +11,7 @@
   "author": "Sentry",
   "description": "Sentry MCP Core - Shared code for MCP transports",
   "homepage": "https://github.com/getsentry/sentry-mcp",
-  "keywords": [
-    "sentry"
-  ],
+  "keywords": ["sentry"],
   "bugs": {
     "url": "https://github.com/getsentry/sentry-mcp/issues"
   },
@@ -21,9 +19,7 @@
     "type": "git",
     "url": "git@github.com:getsentry/sentry-mcp.git"
   },
-  "files": [
-    "./dist/*"
-  ],
+  "files": ["./dist/*"],
   "exports": {
     "./api-client": {
       "types": "./dist/api-client/index.ts",
@@ -112,6 +108,10 @@
     "./internal/agents/openai-provider": {
       "types": "./dist/internal/agents/openai-provider.ts",
       "default": "./dist/internal/agents/openai-provider.js"
+    },
+    "./internal/agents/azure-openai-provider": {
+      "types": "./dist/internal/agents/azure-openai-provider.ts",
+      "default": "./dist/internal/agents/azure-openai-provider.js"
     },
     "./internal/agents/anthropic-provider": {
       "types": "./dist/internal/agents/anthropic-provider.ts",

--- a/packages/mcp-core/src/internal/agents/azure-openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/azure-openai-provider.test.ts
@@ -1,0 +1,157 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { generateText } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfigurationError } from "../../errors";
+import {
+  getAzureOpenAIApiSurface,
+  getAzureOpenAIModel,
+  setAzureOpenAIBaseUrl,
+} from "./azure-openai-provider.js";
+
+describe("azure-openai-provider", () => {
+  const originalModel = process.env.OPENAI_MODEL;
+  const originalApiKey = process.env.OPENAI_API_KEY;
+  const originalApiVersion = process.env.OPENAI_API_VERSION;
+
+  beforeEach(() => {
+    setAzureOpenAIBaseUrl(undefined);
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENAI_MODEL;
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENAI_API_VERSION;
+  });
+
+  afterEach(() => {
+    if (originalModel === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENAI_MODEL;
+    } else {
+      process.env.OPENAI_MODEL = originalModel;
+    }
+
+    if (originalApiKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalApiKey;
+    }
+
+    if (originalApiVersion === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENAI_API_VERSION;
+    } else {
+      process.env.OPENAI_API_VERSION = originalApiVersion;
+    }
+
+    vi.unstubAllGlobals();
+  });
+
+  it("requires an explicit Azure base URL", () => {
+    expect(() => getAzureOpenAIModel()).toThrow(ConfigurationError);
+    expect(() => getAzureOpenAIModel()).toThrow(/requires --openai-base-url/);
+  });
+
+  it("rejects unsupported Azure base URL shapes", () => {
+    setAzureOpenAIBaseUrl("https://proxy.example.com/v1");
+
+    expect(() => getAzureOpenAIApiSurface()).toThrow(ConfigurationError);
+    expect(() => getAzureOpenAIApiSurface()).toThrow(
+      /requires an Azure v1 base URL ending in \/openai\/v1 or a deployment URL/,
+    );
+  });
+
+  it("uses responses API for Azure v1 endpoints", async () => {
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENAI_API_VERSION = "2024-02-15-preview";
+    setAzureOpenAIBaseUrl("https://proxy.example.com/openai/v1/");
+
+    const fetchMock = vi.fn(async (input: Request | URL | string) => {
+      const request =
+        input instanceof Request ? input : new Request(input.toString());
+
+      expect(request.url).toBe("https://proxy.example.com/openai/v1/responses");
+      expect(request.url).not.toContain("api-version=");
+      expect(request.headers.get("api-key")).toBe("test-key");
+
+      return new Response(
+        JSON.stringify({
+          error: {
+            message: "boom",
+            type: "invalid_request_error",
+            param: null,
+            code: "bad_request",
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      generateText({
+        model: getAzureOpenAIModel("my-assistant"),
+        prompt: "hello",
+      }),
+    ).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("uses chat completions for deployment-style Azure endpoints", async () => {
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENAI_API_VERSION = "2024-02-15-preview";
+    setAzureOpenAIBaseUrl(
+      "https://proxy.example.com/openai/deployments/test-model",
+    );
+
+    const fetchMock = vi.fn(async (input: Request | URL | string) => {
+      const request =
+        input instanceof Request ? input : new Request(input.toString());
+
+      expect(request.url).toBe(
+        "https://proxy.example.com/openai/deployments/test-model/chat/completions?api-version=2024-02-15-preview",
+      );
+      expect(request.headers.get("api-key")).toBe("test-key");
+
+      return new Response(
+        JSON.stringify({
+          error: {
+            message: "boom",
+            type: "invalid_request_error",
+            param: null,
+            code: "bad_request",
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      generateText({
+        model: getAzureOpenAIModel("my-company-assistant"),
+        prompt: "hello",
+      }),
+    ).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("treats deployment aliases as opaque model identifiers", () => {
+    setAzureOpenAIBaseUrl("https://proxy.example.com/openai/v1/");
+
+    const model = getAzureOpenAIModel(
+      "my-company-assistant",
+    ) as LanguageModelV3;
+
+    expect(model.modelId).toBe("my-company-assistant");
+  });
+});

--- a/packages/mcp-core/src/internal/agents/azure-openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/azure-openai-provider.test.ts
@@ -64,30 +64,34 @@ describe("azure-openai-provider", () => {
     process.env.OPENAI_API_KEY = "test-key";
     process.env.OPENAI_API_VERSION = "2024-02-15-preview";
     setAzureOpenAIBaseUrl("https://proxy.example.com/openai/v1/");
+    let requestUrl: string | undefined;
+    let apiKeyHeader: string | null | undefined;
 
-    const fetchMock = vi.fn(async (input: Request | URL | string) => {
-      const request =
-        input instanceof Request ? input : new Request(input.toString());
+    const fetchMock = vi.fn(
+      async (input: Request | URL | string, init?: RequestInit) => {
+        const request =
+          input instanceof Request
+            ? new Request(input, init)
+            : new Request(input.toString(), init);
+        requestUrl = request.url;
+        apiKeyHeader = request.headers.get("api-key");
 
-      expect(request.url).toBe("https://proxy.example.com/openai/v1/responses");
-      expect(request.url).not.toContain("api-version=");
-      expect(request.headers.get("api-key")).toBe("test-key");
-
-      return new Response(
-        JSON.stringify({
-          error: {
-            message: "boom",
-            type: "invalid_request_error",
-            param: null,
-            code: "bad_request",
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
           },
-        }),
-        {
-          status: 400,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    });
+        );
+      },
+    );
 
     vi.stubGlobal("fetch", fetchMock);
 
@@ -99,6 +103,9 @@ describe("azure-openai-provider", () => {
     ).rejects.toThrow();
 
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(requestUrl).toBe("https://proxy.example.com/openai/v1/responses");
+    expect(requestUrl).not.toContain("api-version=");
+    expect(apiKeyHeader).toBe("test-key");
   });
 
   it("uses chat completions for deployment-style Azure endpoints", async () => {
@@ -107,31 +114,34 @@ describe("azure-openai-provider", () => {
     setAzureOpenAIBaseUrl(
       "https://proxy.example.com/openai/deployments/test-model",
     );
+    let requestUrl: string | undefined;
+    let apiKeyHeader: string | null | undefined;
 
-    const fetchMock = vi.fn(async (input: Request | URL | string) => {
-      const request =
-        input instanceof Request ? input : new Request(input.toString());
+    const fetchMock = vi.fn(
+      async (input: Request | URL | string, init?: RequestInit) => {
+        const request =
+          input instanceof Request
+            ? new Request(input, init)
+            : new Request(input.toString(), init);
+        requestUrl = request.url;
+        apiKeyHeader = request.headers.get("api-key");
 
-      expect(request.url).toBe(
-        "https://proxy.example.com/openai/deployments/test-model/chat/completions?api-version=2024-02-15-preview",
-      );
-      expect(request.headers.get("api-key")).toBe("test-key");
-
-      return new Response(
-        JSON.stringify({
-          error: {
-            message: "boom",
-            type: "invalid_request_error",
-            param: null,
-            code: "bad_request",
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
           },
-        }),
-        {
-          status: 400,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    });
+        );
+      },
+    );
 
     vi.stubGlobal("fetch", fetchMock);
 
@@ -143,6 +153,10 @@ describe("azure-openai-provider", () => {
     ).rejects.toThrow();
 
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(requestUrl).toBe(
+      "https://proxy.example.com/openai/deployments/test-model/chat/completions?api-version=2024-02-15-preview",
+    );
+    expect(apiKeyHeader).toBe("test-key");
   });
 
   it("treats deployment aliases as opaque model identifiers", () => {

--- a/packages/mcp-core/src/internal/agents/azure-openai-provider.ts
+++ b/packages/mcp-core/src/internal/agents/azure-openai-provider.ts
@@ -1,0 +1,119 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
+import { ConfigurationError } from "../../errors";
+import { USER_AGENT } from "../../version";
+
+const DEFAULT_OPENAI_MODEL = "gpt-5";
+
+let configuredBaseUrl: string | undefined;
+
+export type AzureOpenAIApiSurface = "responses" | "chat-completions";
+
+export function setAzureOpenAIBaseUrl(baseUrl: string | undefined): void {
+  configuredBaseUrl = baseUrl;
+}
+
+function hasAzureDeploymentPath(baseUrl: string): boolean {
+  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
+  return /\/openai\/deployments\/[^/]+$/i.test(pathname);
+}
+
+function hasAzureV1Path(baseUrl: string): boolean {
+  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
+  return /\/openai\/v1$/i.test(pathname);
+}
+
+export function getAzureOpenAIApiSurface(): AzureOpenAIApiSurface {
+  if (!configuredBaseUrl) {
+    throw new ConfigurationError(
+      'Provider "azure-openai" requires --openai-base-url to target an Azure OpenAI endpoint.',
+    );
+  }
+
+  if (hasAzureV1Path(configuredBaseUrl)) {
+    return "responses";
+  }
+
+  if (hasAzureDeploymentPath(configuredBaseUrl)) {
+    return "chat-completions";
+  }
+
+  throw new ConfigurationError(
+    'Provider "azure-openai" requires an Azure v1 base URL ending in /openai/v1 or a deployment URL ending in /openai/deployments/<deployment>.',
+  );
+}
+
+function getAzureOpenAIApiVersion(): string | undefined {
+  const apiVersion = process.env.OPENAI_API_VERSION?.trim();
+  return apiVersion && apiVersion.length > 0 ? apiVersion : undefined;
+}
+
+function createAzureOpenAIFetch(baseUrl: string): typeof fetch {
+  const apiVersion = getAzureOpenAIApiVersion();
+  const shouldAppendApiVersion =
+    apiVersion !== undefined && hasAzureDeploymentPath(baseUrl);
+
+  return async (input, init) => {
+    const requestUrl =
+      input instanceof Request
+        ? new URL(input.url)
+        : new URL(input instanceof URL ? input.href : input.toString());
+
+    if (shouldAppendApiVersion) {
+      requestUrl.searchParams.set("api-version", apiVersion);
+    }
+
+    const headers = new Headers(
+      input instanceof Request ? input.headers : undefined,
+    );
+    if (init?.headers) {
+      for (const [key, value] of new Headers(init.headers).entries()) {
+        headers.set(key, value);
+      }
+    }
+
+    if (process.env.OPENAI_API_KEY) {
+      // Azure API-key auth uses the `api-key` header. Keep the existing
+      // Authorization header as well for proxy compatibility.
+      headers.set("api-key", process.env.OPENAI_API_KEY);
+    }
+
+    if (input instanceof Request) {
+      return fetch(new Request(requestUrl.toString(), input), {
+        ...init,
+        headers,
+      });
+    }
+
+    return fetch(requestUrl.toString(), {
+      ...init,
+      headers,
+    });
+  };
+}
+
+export function getAzureOpenAIModel(model?: string): LanguageModel {
+  if (!configuredBaseUrl) {
+    throw new ConfigurationError(
+      'Provider "azure-openai" requires --openai-base-url to target an Azure OpenAI endpoint.',
+    );
+  }
+
+  const apiSurface = getAzureOpenAIApiSurface();
+  const modelId = model ?? (process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL);
+
+  const factory = createOpenAI({
+    baseURL: configuredBaseUrl,
+    headers: {
+      "User-Agent": USER_AGENT,
+    },
+    name: "azure-openai",
+    fetch: createAzureOpenAIFetch(configuredBaseUrl),
+  });
+
+  if (apiSurface === "chat-completions") {
+    return factory.chat(modelId);
+  }
+
+  return factory(modelId);
+}

--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
@@ -45,7 +45,7 @@ export async function callEmbeddedAgent<
 }): Promise<EmbeddedAgentResult<TOutput>> {
   const capturedToolCalls: ToolCall[] = [];
 
-  // Get the configured provider (OpenAI or Anthropic)
+  // Get the configured provider (OpenAI, Azure OpenAI, or Anthropic)
   const provider = getAgentProvider();
 
   try {

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -1,17 +1,19 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { generateText } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ConfigurationError } from "../../errors";
 import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider.js";
 
 describe("openai-provider", () => {
   const originalModel = process.env.OPENAI_MODEL;
   const originalApiKey = process.env.OPENAI_API_KEY;
+  const originalApiVersion = process.env.OPENAI_API_VERSION;
 
   beforeEach(() => {
     setOpenAIBaseUrl(undefined);
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.OPENAI_MODEL;
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENAI_API_VERSION;
   });
 
   afterEach(() => {
@@ -27,6 +29,13 @@ describe("openai-provider", () => {
       delete process.env.OPENAI_API_KEY;
     } else {
       process.env.OPENAI_API_KEY = originalApiKey;
+    }
+
+    if (originalApiVersion === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENAI_API_VERSION;
+    } else {
+      process.env.OPENAI_API_VERSION = originalApiVersion;
     }
 
     vi.unstubAllGlobals();
@@ -86,18 +95,16 @@ describe("openai-provider", () => {
       expect(fetchMock).toHaveBeenCalledOnce();
     });
 
-    it("uses chat completions for Azure-style deployment base URLs", async () => {
+    it("ignores OPENAI_API_VERSION for generic openai provider requests", async () => {
       process.env.OPENAI_API_KEY = "test-key";
-      setOpenAIBaseUrl(
-        "https://proxy.example.com/openai/deployments/test-model",
-      );
+      process.env.OPENAI_API_VERSION = "2024-02-15-preview";
+      setOpenAIBaseUrl("https://proxy.example.com/v1");
 
       const fetchMock = vi.fn(async (input: Request | URL | string) => {
         const url = input instanceof Request ? input.url : input.toString();
 
-        expect(url).toBe(
-          "https://proxy.example.com/openai/deployments/test-model/chat/completions",
-        );
+        expect(url).toBe("https://proxy.example.com/v1/responses");
+        expect(url).not.toContain("api-version=");
 
         return new Response(
           JSON.stringify({
@@ -119,105 +126,7 @@ describe("openai-provider", () => {
 
       await expect(
         generateText({
-          model: getOpenAIModel(),
-          prompt: "hello",
-        }),
-      ).rejects.toThrow();
-
-      expect(fetchMock).toHaveBeenCalledOnce();
-    });
-
-    it("rejects unrecognized deployment aliases", () => {
-      process.env.OPENAI_API_KEY = "test-key";
-      setOpenAIBaseUrl(
-        "https://proxy.example.com/openai/deployments/test-model",
-      );
-
-      expect(() => getOpenAIModel("my-company-assistant")).toThrow(
-        ConfigurationError,
-      );
-      expect(() => getOpenAIModel("my-company-assistant")).toThrow(
-        /canonical OPENAI_MODEL value/,
-      );
-    });
-
-    it("keeps responses API for responses-only models on deployment base URLs", async () => {
-      process.env.OPENAI_API_KEY = "test-key";
-      setOpenAIBaseUrl(
-        "https://proxy.example.com/openai/deployments/test-model",
-      );
-      const responsesOnlyModels = [
-        "codex-mini-latest",
-        "computer-use-preview",
-        "gpt-5-codex",
-      ];
-
-      const fetchMock = vi.fn(async (input: Request | URL | string) => {
-        const url = input instanceof Request ? input.url : input.toString();
-
-        expect(url).toBe(
-          "https://proxy.example.com/openai/deployments/test-model/responses",
-        );
-
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: "boom",
-              type: "invalid_request_error",
-              param: null,
-              code: "bad_request",
-            },
-          }),
-          {
-            status: 400,
-            headers: { "content-type": "application/json" },
-          },
-        );
-      });
-
-      vi.stubGlobal("fetch", fetchMock);
-
-      for (const modelId of responsesOnlyModels) {
-        await expect(
-          generateText({
-            model: getOpenAIModel(modelId),
-            prompt: "hello",
-          }),
-        ).rejects.toThrow();
-      }
-
-      expect(fetchMock).toHaveBeenCalledTimes(responsesOnlyModels.length);
-    });
-
-    it("uses responses API when custom base URL is not configured", async () => {
-      process.env.OPENAI_API_KEY = "test-key";
-
-      const fetchMock = vi.fn(async (input: Request | URL | string) => {
-        const url = input instanceof Request ? input.url : input.toString();
-
-        expect(url).toBe("https://api.openai.com/v1/responses");
-
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: "boom",
-              type: "invalid_request_error",
-              param: null,
-              code: "bad_request",
-            },
-          }),
-          {
-            status: 400,
-            headers: { "content-type": "application/json" },
-          },
-        );
-      });
-
-      vi.stubGlobal("fetch", fetchMock);
-
-      await expect(
-        generateText({
-          model: getOpenAIModel(),
+          model: getOpenAIModel("my-company-assistant"),
           prompt: "hello",
         }),
       ).rejects.toThrow();

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { generateText } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider.js";
 
 describe("openai-provider", () => {
   const originalModel = process.env.OPENAI_MODEL;
+  const originalApiKey = process.env.OPENAI_API_KEY;
 
   beforeEach(() => {
     setOpenAIBaseUrl(undefined);
@@ -18,6 +20,15 @@ describe("openai-provider", () => {
     } else {
       process.env.OPENAI_MODEL = originalModel;
     }
+
+    if (originalApiKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalApiKey;
+    }
+
+    vi.unstubAllGlobals();
   });
 
   describe("base URL configuration", () => {
@@ -35,6 +46,168 @@ describe("openai-provider", () => {
 
       expect(model).toBeDefined();
       expect(model.modelId).toBe("gpt-5");
+    });
+
+    it("uses responses API for generic custom base URL requests", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      setOpenAIBaseUrl("https://proxy.example.com/v1");
+
+      const fetchMock = vi.fn(async (input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : input.toString();
+
+        expect(url).toBe("https://proxy.example.com/v1/responses");
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        generateText({
+          model: getOpenAIModel(),
+          prompt: "hello",
+        }),
+      ).rejects.toThrow();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it("uses chat completions for Azure-style deployment base URLs", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      setOpenAIBaseUrl(
+        "https://proxy.example.com/openai/deployments/test-model",
+      );
+
+      const fetchMock = vi.fn(async (input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : input.toString();
+
+        expect(url).toBe(
+          "https://proxy.example.com/openai/deployments/test-model/chat/completions",
+        );
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        generateText({
+          model: getOpenAIModel(),
+          prompt: "hello",
+        }),
+      ).rejects.toThrow();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it("keeps responses API for responses-only models on deployment base URLs", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      setOpenAIBaseUrl(
+        "https://proxy.example.com/openai/deployments/test-model",
+      );
+      const responsesOnlyModels = [
+        "codex-mini-latest",
+        "computer-use-preview",
+        "gpt-5.1-codex-max",
+      ];
+
+      const fetchMock = vi.fn(async (input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : input.toString();
+
+        expect(url).toBe(
+          "https://proxy.example.com/openai/deployments/test-model/responses",
+        );
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+
+      for (const modelId of responsesOnlyModels) {
+        await expect(
+          generateText({
+            model: getOpenAIModel(modelId),
+            prompt: "hello",
+          }),
+        ).rejects.toThrow();
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(responsesOnlyModels.length);
+    });
+
+    it("uses responses API when custom base URL is not configured", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+
+      const fetchMock = vi.fn(async (input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : input.toString();
+
+        expect(url).toBe("https://api.openai.com/v1/responses");
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        generateText({
+          model: getOpenAIModel(),
+          prompt: "hello",
+        }),
+      ).rejects.toThrow();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -61,27 +61,32 @@ describe("openai-provider", () => {
     it("uses responses API for generic custom base URL requests", async () => {
       process.env.OPENAI_API_KEY = "test-key";
       setOpenAIBaseUrl("https://proxy.example.com/v1");
+      let requestUrl: string | undefined;
 
-      const fetchMock = vi.fn(async (input: Request | URL | string) => {
-        const url = input instanceof Request ? input.url : input.toString();
+      const fetchMock = vi.fn(
+        async (input: Request | URL | string, init?: RequestInit) => {
+          const request =
+            input instanceof Request
+              ? new Request(input, init)
+              : new Request(input.toString(), init);
+          requestUrl = request.url;
 
-        expect(url).toBe("https://proxy.example.com/v1/responses");
-
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: "boom",
-              type: "invalid_request_error",
-              param: null,
-              code: "bad_request",
+          return new Response(
+            JSON.stringify({
+              error: {
+                message: "boom",
+                type: "invalid_request_error",
+                param: null,
+                code: "bad_request",
+              },
+            }),
+            {
+              status: 400,
+              headers: { "content-type": "application/json" },
             },
-          }),
-          {
-            status: 400,
-            headers: { "content-type": "application/json" },
-          },
-        );
-      });
+          );
+        },
+      );
 
       vi.stubGlobal("fetch", fetchMock);
 
@@ -93,6 +98,7 @@ describe("openai-provider", () => {
       ).rejects.toThrow();
 
       expect(fetchMock).toHaveBeenCalledOnce();
+      expect(requestUrl).toBe("https://proxy.example.com/v1/responses");
     });
 
     it("keeps responses API for deployment-style URLs in generic openai mode", async () => {
@@ -100,29 +106,32 @@ describe("openai-provider", () => {
       setOpenAIBaseUrl(
         "https://proxy.example.com/openai/deployments/test-model",
       );
+      let requestUrl: string | undefined;
 
-      const fetchMock = vi.fn(async (input: Request | URL | string) => {
-        const url = input instanceof Request ? input.url : input.toString();
+      const fetchMock = vi.fn(
+        async (input: Request | URL | string, init?: RequestInit) => {
+          const request =
+            input instanceof Request
+              ? new Request(input, init)
+              : new Request(input.toString(), init);
+          requestUrl = request.url;
 
-        expect(url).toBe(
-          "https://proxy.example.com/openai/deployments/test-model/responses",
-        );
-
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: "boom",
-              type: "invalid_request_error",
-              param: null,
-              code: "bad_request",
+          return new Response(
+            JSON.stringify({
+              error: {
+                message: "boom",
+                type: "invalid_request_error",
+                param: null,
+                code: "bad_request",
+              },
+            }),
+            {
+              status: 400,
+              headers: { "content-type": "application/json" },
             },
-          }),
-          {
-            status: 400,
-            headers: { "content-type": "application/json" },
-          },
-        );
-      });
+          );
+        },
+      );
 
       vi.stubGlobal("fetch", fetchMock);
 
@@ -134,34 +143,41 @@ describe("openai-provider", () => {
       ).rejects.toThrow();
 
       expect(fetchMock).toHaveBeenCalledOnce();
+      expect(requestUrl).toBe(
+        "https://proxy.example.com/openai/deployments/test-model/responses",
+      );
     });
 
     it("ignores OPENAI_API_VERSION for generic openai provider requests", async () => {
       process.env.OPENAI_API_KEY = "test-key";
       process.env.OPENAI_API_VERSION = "2024-02-15-preview";
       setOpenAIBaseUrl("https://proxy.example.com/v1");
+      let requestUrl: string | undefined;
 
-      const fetchMock = vi.fn(async (input: Request | URL | string) => {
-        const url = input instanceof Request ? input.url : input.toString();
+      const fetchMock = vi.fn(
+        async (input: Request | URL | string, init?: RequestInit) => {
+          const request =
+            input instanceof Request
+              ? new Request(input, init)
+              : new Request(input.toString(), init);
+          requestUrl = request.url;
 
-        expect(url).toBe("https://proxy.example.com/v1/responses");
-        expect(url).not.toContain("api-version=");
-
-        return new Response(
-          JSON.stringify({
-            error: {
-              message: "boom",
-              type: "invalid_request_error",
-              param: null,
-              code: "bad_request",
+          return new Response(
+            JSON.stringify({
+              error: {
+                message: "boom",
+                type: "invalid_request_error",
+                param: null,
+                code: "bad_request",
+              },
+            }),
+            {
+              status: 400,
+              headers: { "content-type": "application/json" },
             },
-          }),
-          {
-            status: 400,
-            headers: { "content-type": "application/json" },
-          },
-        );
-      });
+          );
+        },
+      );
 
       vi.stubGlobal("fetch", fetchMock);
 
@@ -173,6 +189,8 @@ describe("openai-provider", () => {
       ).rejects.toThrow();
 
       expect(fetchMock).toHaveBeenCalledOnce();
+      expect(requestUrl).toBe("https://proxy.example.com/v1/responses");
+      expect(requestUrl).not.toContain("api-version=");
     });
   });
 

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -95,6 +95,47 @@ describe("openai-provider", () => {
       expect(fetchMock).toHaveBeenCalledOnce();
     });
 
+    it("keeps responses API for deployment-style URLs in generic openai mode", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      setOpenAIBaseUrl(
+        "https://proxy.example.com/openai/deployments/test-model",
+      );
+
+      const fetchMock = vi.fn(async (input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : input.toString();
+
+        expect(url).toBe(
+          "https://proxy.example.com/openai/deployments/test-model/responses",
+        );
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        generateText({
+          model: getOpenAIModel("my-company-assistant"),
+          prompt: "hello",
+        }),
+      ).rejects.toThrow();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
     it("ignores OPENAI_API_VERSION for generic openai provider requests", async () => {
       process.env.OPENAI_API_KEY = "test-key";
       process.env.OPENAI_API_VERSION = "2024-02-15-preview";

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -150,7 +150,7 @@ describe("openai-provider", () => {
         "codex-mini-latest",
         "computer-use-preview",
         "gpt-5-codex",
-        "gpt-5.1-codex-max",
+        "gpt-5.2-codex",
       ];
 
       const fetchMock = vi.fn(async (input: Request | URL | string) => {

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -150,7 +150,6 @@ describe("openai-provider", () => {
         "codex-mini-latest",
         "computer-use-preview",
         "gpt-5-codex",
-        "gpt-5.2-codex",
       ];
 
       const fetchMock = vi.fn(async (input: Request | URL | string) => {

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { generateText } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfigurationError } from "../../errors";
 import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider.js";
 
 describe("openai-provider", () => {
@@ -126,6 +127,20 @@ describe("openai-provider", () => {
       expect(fetchMock).toHaveBeenCalledOnce();
     });
 
+    it("rejects unrecognized deployment aliases", () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      setOpenAIBaseUrl(
+        "https://proxy.example.com/openai/deployments/test-model",
+      );
+
+      expect(() => getOpenAIModel("my-company-assistant")).toThrow(
+        ConfigurationError,
+      );
+      expect(() => getOpenAIModel("my-company-assistant")).toThrow(
+        /canonical OPENAI_MODEL value/,
+      );
+    });
+
     it("keeps responses API for responses-only models on deployment base URLs", async () => {
       process.env.OPENAI_API_KEY = "test-key";
       setOpenAIBaseUrl(
@@ -134,6 +149,7 @@ describe("openai-provider", () => {
       const responsesOnlyModels = [
         "codex-mini-latest",
         "computer-use-preview",
+        "gpt-5-codex",
         "gpt-5.1-codex-max",
       ];
 

--- a/packages/mcp-core/src/internal/agents/openai-provider.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.ts
@@ -1,6 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
-import { ConfigurationError } from "../../errors";
 import { USER_AGENT } from "../../version";
 
 // Default configuration constants
@@ -15,56 +14,6 @@ let configuredBaseUrl: string | undefined;
  */
 export function setOpenAIBaseUrl(baseUrl: string | undefined): void {
   configuredBaseUrl = baseUrl;
-}
-
-function hasAzureDeploymentPath(baseUrl: string): boolean {
-  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
-  return /\/openai\/deployments\/[^/]+$/i.test(pathname);
-}
-
-function isResponsesOnlyOpenAIModel(modelId: string): boolean {
-  return (
-    modelId.startsWith("codex-") ||
-    modelId.startsWith("computer-use-preview") ||
-    /^gpt-[\d.]+-codex(?:-|$)/.test(modelId)
-  );
-}
-
-function isCanonicalOpenAIModelId(modelId: string): boolean {
-  return (
-    modelId === "chatgpt-4o-latest" ||
-    modelId.startsWith("gpt-") ||
-    modelId.startsWith("o1") ||
-    modelId.startsWith("o3") ||
-    modelId.startsWith("o4") ||
-    modelId.startsWith("codex-") ||
-    modelId.startsWith("computer-use-preview")
-  );
-}
-
-function shouldUseChatCompletionsApi(modelId: string): boolean {
-  if (!configuredBaseUrl) {
-    return false;
-  }
-
-  // Azure-style deployment endpoints and compatible proxies typically expose
-  // chat completions at the deployment URL. Preserve the 0.29.x behavior there
-  // without forcing all custom base URLs or responses-only models off the
-  // Responses API. Opaque deployment aliases are rejected because we cannot
-  // safely infer whether they target a responses-only backend model.
-  if (
-    hasAzureDeploymentPath(configuredBaseUrl) &&
-    !isCanonicalOpenAIModelId(modelId)
-  ) {
-    throw new ConfigurationError(
-      `Deployment-style OpenAI base URLs require a canonical OPENAI_MODEL value. Use the formal OpenAI model name instead of the deployment alias "${modelId}" so the correct API can be selected.`,
-    );
-  }
-
-  return (
-    hasAzureDeploymentPath(configuredBaseUrl) &&
-    !isResponsesOnlyOpenAIModel(modelId)
-  );
 }
 
 /**
@@ -88,7 +37,7 @@ function shouldUseChatCompletionsApi(modelId: string): boolean {
  * provider so generic OpenAI-compatible endpoints keep predictable behavior.
  */
 export function getOpenAIModel(model?: string): LanguageModel {
-  const modelId = model ?? (process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL);
+  const defaultModel = process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL;
 
   const factory = createOpenAI({
     ...(configuredBaseUrl && { baseURL: configuredBaseUrl }),
@@ -97,9 +46,5 @@ export function getOpenAIModel(model?: string): LanguageModel {
     },
   });
 
-  if (shouldUseChatCompletionsApi(modelId)) {
-    return factory.chat(modelId);
-  }
-
-  return factory(modelId);
+  return factory(model ?? defaultModel);
 }

--- a/packages/mcp-core/src/internal/agents/openai-provider.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.ts
@@ -16,6 +16,35 @@ export function setOpenAIBaseUrl(baseUrl: string | undefined): void {
   configuredBaseUrl = baseUrl;
 }
 
+function hasAzureDeploymentPath(baseUrl: string): boolean {
+  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
+  return /\/openai\/deployments\/[^/]+$/i.test(pathname);
+}
+
+function isResponsesOnlyOpenAIModel(modelId: string): boolean {
+  return (
+    modelId === "codex-mini-latest" ||
+    modelId.startsWith("computer-use-preview") ||
+    modelId === "gpt-5-codex" ||
+    modelId.startsWith("gpt-5.1-codex")
+  );
+}
+
+function shouldUseChatCompletionsApi(modelId: string): boolean {
+  if (!configuredBaseUrl) {
+    return false;
+  }
+
+  // Azure-style deployment endpoints and compatible proxies typically expose
+  // chat completions at the deployment URL. Preserve the 0.29.x behavior there
+  // without forcing all custom base URLs or responses-only models off the
+  // Responses API.
+  return (
+    hasAzureDeploymentPath(configuredBaseUrl) &&
+    !isResponsesOnlyOpenAIModel(modelId)
+  );
+}
+
 /**
  * Retrieve an OpenAI language model configured from environment variables and explicit config.
  *
@@ -34,7 +63,7 @@ export function setOpenAIBaseUrl(baseUrl: string | undefined): void {
  * - Other providers: Check their documentation
  */
 export function getOpenAIModel(model?: string): LanguageModel {
-  const defaultModel = process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL;
+  const modelId = model ?? (process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL);
 
   const factory = createOpenAI({
     ...(configuredBaseUrl && { baseURL: configuredBaseUrl }),
@@ -43,5 +72,9 @@ export function getOpenAIModel(model?: string): LanguageModel {
     },
   });
 
-  return factory(model ?? defaultModel);
+  if (shouldUseChatCompletionsApi(modelId)) {
+    return factory.chat(modelId);
+  }
+
+  return factory(modelId);
 }

--- a/packages/mcp-core/src/internal/agents/openai-provider.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
+import { ConfigurationError } from "../../errors";
 import { USER_AGENT } from "../../version";
 
 // Default configuration constants
@@ -23,10 +24,21 @@ function hasAzureDeploymentPath(baseUrl: string): boolean {
 
 function isResponsesOnlyOpenAIModel(modelId: string): boolean {
   return (
-    modelId === "codex-mini-latest" ||
+    modelId.startsWith("codex-") ||
     modelId.startsWith("computer-use-preview") ||
-    modelId === "gpt-5-codex" ||
-    modelId.startsWith("gpt-5.1-codex")
+    /^gpt-[\d.]+-codex(?:-|$)/.test(modelId)
+  );
+}
+
+function isCanonicalOpenAIModelId(modelId: string): boolean {
+  return (
+    modelId === "chatgpt-4o-latest" ||
+    modelId.startsWith("gpt-") ||
+    modelId.startsWith("o1") ||
+    modelId.startsWith("o3") ||
+    modelId.startsWith("o4") ||
+    modelId.startsWith("codex-") ||
+    modelId.startsWith("computer-use-preview")
   );
 }
 
@@ -38,7 +50,17 @@ function shouldUseChatCompletionsApi(modelId: string): boolean {
   // Azure-style deployment endpoints and compatible proxies typically expose
   // chat completions at the deployment URL. Preserve the 0.29.x behavior there
   // without forcing all custom base URLs or responses-only models off the
-  // Responses API.
+  // Responses API. Opaque deployment aliases are rejected because we cannot
+  // safely infer whether they target a responses-only backend model.
+  if (
+    hasAzureDeploymentPath(configuredBaseUrl) &&
+    !isCanonicalOpenAIModelId(modelId)
+  ) {
+    throw new ConfigurationError(
+      `Deployment-style OpenAI base URLs require a canonical OPENAI_MODEL value. Use the formal OpenAI model name instead of the deployment alias "${modelId}" so the correct API can be selected.`,
+    );
+  }
+
   return (
     hasAzureDeploymentPath(configuredBaseUrl) &&
     !isResponsesOnlyOpenAIModel(modelId)

--- a/packages/mcp-core/src/internal/agents/openai-provider.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.ts
@@ -72,7 +72,7 @@ function shouldUseChatCompletionsApi(modelId: string): boolean {
  *
  * Works with:
  * - OpenAI API directly (default)
- * - Any OpenAI-compatible API via custom base URL (Vercel AI Gateway, Azure OpenAI, etc.)
+ * - Generic OpenAI-compatible APIs via custom base URL (Vercel AI Gateway, proxies, etc.)
  *
  * Configuration:
  * - OPENAI_API_KEY: API key for authentication (required)
@@ -83,6 +83,9 @@ function shouldUseChatCompletionsApi(modelId: string): boolean {
  * - Direct OpenAI: "gpt-4o", "gpt-4-turbo", etc.
  * - Vercel AI Gateway: "openai/gpt-4o", "anthropic/claude-sonnet-4.5", etc.
  * - Other providers: Check their documentation
+ *
+ * Azure-specific endpoint routing lives in the dedicated `azure-openai`
+ * provider so generic OpenAI-compatible endpoints keep predictable behavior.
  */
 export function getOpenAIModel(model?: string): LanguageModel {
   const modelId = model ?? (process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL);

--- a/packages/mcp-core/src/internal/agents/provider-factory.test.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.test.ts
@@ -211,4 +211,40 @@ describe("provider-factory", () => {
       expect(provider.type).toBe("openai");
     });
   });
+
+  describe("provider labels", () => {
+    it("labels openai as responses", () => {
+      process.env.OPENAI_API_KEY = "sk-test";
+
+      const provider = getAgentProvider();
+      expect(provider.label).toBe("openai responses API");
+    });
+
+    it("labels anthropic without an API surface suffix", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+
+      const provider = getAgentProvider();
+      expect(provider.label).toBe("anthropic");
+    });
+
+    it("labels azure-openai v1 endpoints as responses", () => {
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.EMBEDDED_AGENT_PROVIDER = "azure-openai";
+      setAzureOpenAIBaseUrl("https://example.openai.azure.com/openai/v1/");
+
+      const provider = getAgentProvider();
+      expect(provider.label).toBe("azure-openai responses API");
+    });
+
+    it("labels azure-openai deployment endpoints as chat completions", () => {
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.EMBEDDED_AGENT_PROVIDER = "azure-openai";
+      setAzureOpenAIBaseUrl(
+        "https://example.openai.azure.com/openai/deployments/my-assistant",
+      );
+
+      const provider = getAgentProvider();
+      expect(provider.label).toBe("azure-openai chat completions API");
+    });
+  });
 });

--- a/packages/mcp-core/src/internal/agents/provider-factory.test.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.test.ts
@@ -4,6 +4,7 @@ import {
   setAgentProvider,
   getResolvedProviderType,
 } from "./provider-factory.js";
+import { setAzureOpenAIBaseUrl } from "./azure-openai-provider.js";
 import { ConfigurationError } from "../../errors.js";
 
 describe("provider-factory", () => {
@@ -14,6 +15,7 @@ describe("provider-factory", () => {
   beforeEach(() => {
     // Reset module state
     setAgentProvider(undefined);
+    setAzureOpenAIBaseUrl(undefined);
     // Clear environment variables
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.ANTHROPIC_API_KEY;
@@ -44,6 +46,7 @@ describe("provider-factory", () => {
       process.env.EMBEDDED_AGENT_PROVIDER = originalProviderEnv;
     }
     setAgentProvider(undefined);
+    setAzureOpenAIBaseUrl(undefined);
   });
 
   describe("single API key auto-detection", () => {
@@ -93,6 +96,16 @@ describe("provider-factory", () => {
       expect(provider.type).toBe("anthropic");
     });
 
+    it("uses azure-openai when both keys present and EMBEDDED_AGENT_PROVIDER=azure-openai", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.EMBEDDED_AGENT_PROVIDER = "azure-openai";
+      setAzureOpenAIBaseUrl("https://example.openai.azure.com/openai/v1/");
+
+      const provider = getAgentProvider();
+      expect(provider.type).toBe("azure-openai");
+    });
+
     it("uses openai when both keys present and setAgentProvider called", () => {
       process.env.ANTHROPIC_API_KEY = "sk-ant-test";
       process.env.OPENAI_API_KEY = "sk-test";
@@ -130,7 +143,9 @@ describe("provider-factory", () => {
       expect(() => getAgentProvider()).toThrow(
         /EMBEDDED_AGENT_PROVIDER environment variable/,
       );
-      expect(() => getAgentProvider()).toThrow(/'openai' or 'anthropic'/);
+      expect(() => getAgentProvider()).toThrow(
+        /'openai', 'azure-openai', or 'anthropic'/,
+      );
     });
 
     it("returns undefined from getResolvedProviderType when both keys present", () => {
@@ -154,6 +169,22 @@ describe("provider-factory", () => {
     it("returns undefined from getResolvedProviderType when explicit provider lacks API key", () => {
       process.env.EMBEDDED_AGENT_PROVIDER = "openai";
       // No OPENAI_API_KEY set
+
+      const providerType = getResolvedProviderType();
+      expect(providerType).toBeUndefined();
+    });
+
+    it("throws ConfigurationError when azure-openai lacks a supported base URL", () => {
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.EMBEDDED_AGENT_PROVIDER = "azure-openai";
+
+      expect(() => getAgentProvider()).toThrow(ConfigurationError);
+      expect(() => getAgentProvider()).toThrow(/requires --openai-base-url/);
+    });
+
+    it("returns undefined from getResolvedProviderType when azure-openai lacks a supported base URL", () => {
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.EMBEDDED_AGENT_PROVIDER = "azure-openai";
 
       const providerType = getResolvedProviderType();
       expect(providerType).toBeUndefined();

--- a/packages/mcp-core/src/internal/agents/provider-factory.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.ts
@@ -1,7 +1,12 @@
-import { ConfigurationError } from "../../errors";
-import { getAnthropicModel, setAnthropicBaseUrl } from "./anthropic-provider";
+import type { EmbeddedAgentProvider, AgentProviderType } from "./types";
+import {
+  getAzureOpenAIApiSurface,
+  getAzureOpenAIModel,
+  setAzureOpenAIBaseUrl,
+} from "./azure-openai-provider";
 import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider";
-import type { AgentProviderType, EmbeddedAgentProvider } from "./types";
+import { getAnthropicModel, setAnthropicBaseUrl } from "./anthropic-provider";
+import { ConfigurationError } from "../../errors";
 
 // Module-level state for explicit provider selection
 let configuredProvider: AgentProviderType | undefined;
@@ -24,6 +29,7 @@ export function setProviderBaseUrls(config: {
   anthropicBaseUrl?: string;
 }): void {
   setOpenAIBaseUrl(config.openaiBaseUrl);
+  setAzureOpenAIBaseUrl(config.openaiBaseUrl);
   setAnthropicBaseUrl(config.anthropicBaseUrl);
 }
 
@@ -45,6 +51,7 @@ function hasApiKeyForProvider(type: AgentProviderType): boolean {
     case "anthropic":
       return Boolean(process.env.ANTHROPIC_API_KEY);
     case "openai":
+    case "azure-openai":
       return Boolean(process.env.OPENAI_API_KEY);
   }
 }
@@ -57,6 +64,7 @@ function getApiKeyName(type: AgentProviderType): string {
     case "anthropic":
       return "ANTHROPIC_API_KEY";
     case "openai":
+    case "azure-openai":
       return "OPENAI_API_KEY";
   }
 }
@@ -86,6 +94,21 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
           },
         }),
       };
+    case "azure-openai":
+      // Validate Azure-only configuration up front so explicit misconfiguration
+      // is surfaced before any tool calls.
+      getAzureOpenAIApiSurface();
+
+      return {
+        type: "azure-openai",
+        getModel: getAzureOpenAIModel,
+        getProviderOptions: () => ({
+          openai: {
+            structuredOutputs: false,
+            strictJsonSchema: false,
+          },
+        }),
+      };
   }
 }
 
@@ -101,7 +124,11 @@ function resolveProviderType(): AgentProviderType | undefined {
 
   // 2. Environment variable
   const envProvider = process.env.EMBEDDED_AGENT_PROVIDER?.toLowerCase();
-  if (envProvider === "openai" || envProvider === "anthropic") {
+  if (
+    envProvider === "openai" ||
+    envProvider === "azure-openai" ||
+    envProvider === "anthropic"
+  ) {
     return envProvider;
   }
 
@@ -141,7 +168,7 @@ export function getAgentProvider(): EmbeddedAgentProvider {
   if (!providerType && detectProviderConflict()) {
     throw new ConfigurationError(
       "Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set. " +
-        "Please specify which provider to use by setting the EMBEDDED_AGENT_PROVIDER environment variable to 'openai' or 'anthropic'.",
+        "Please specify which provider to use by setting the EMBEDDED_AGENT_PROVIDER environment variable to 'openai', 'azure-openai', or 'anthropic'.",
     );
   }
 
@@ -175,8 +202,9 @@ export function hasAgentProvider(): boolean {
  * Returns undefined if no provider is available, API key is missing, or both API keys are present without explicit selection.
  */
 export function getResolvedProviderType(): AgentProviderType | undefined {
-  const providerType = resolveProviderType();
-  return providerType && hasApiKeyForProvider(providerType)
-    ? providerType
-    : undefined;
+  try {
+    return getAgentProvider().type;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/mcp-core/src/internal/agents/provider-factory.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.ts
@@ -1,7 +1,7 @@
-import type { EmbeddedAgentProvider, AgentProviderType } from "./types";
-import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider";
-import { getAnthropicModel, setAnthropicBaseUrl } from "./anthropic-provider";
 import { ConfigurationError } from "../../errors";
+import { getAnthropicModel, setAnthropicBaseUrl } from "./anthropic-provider";
+import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider";
+import type { AgentProviderType, EmbeddedAgentProvider } from "./types";
 
 // Module-level state for explicit provider selection
 let configuredProvider: AgentProviderType | undefined;
@@ -23,8 +23,8 @@ export function setProviderBaseUrls(config: {
   openaiBaseUrl?: string;
   anthropicBaseUrl?: string;
 }): void {
-  if (config.openaiBaseUrl) setOpenAIBaseUrl(config.openaiBaseUrl);
-  if (config.anthropicBaseUrl) setAnthropicBaseUrl(config.anthropicBaseUrl);
+  setOpenAIBaseUrl(config.openaiBaseUrl);
+  setAnthropicBaseUrl(config.anthropicBaseUrl);
 }
 
 /**

--- a/packages/mcp-core/src/internal/agents/provider-factory.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.ts
@@ -77,6 +77,7 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
     case "anthropic":
       return {
         type: "anthropic",
+        label: "anthropic",
         getModel: getAnthropicModel,
         // Anthropic doesn't need the structuredOutputs workaround
         getProviderOptions: () => ({}),
@@ -84,6 +85,7 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
     case "openai":
       return {
         type: "openai",
+        label: "openai responses API",
         getModel: getOpenAIModel,
         // OpenAI requires structuredOutputs: false for optional fields
         // See: https://github.com/getsentry/sentry-mcp/issues/623
@@ -94,13 +96,16 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
           },
         }),
       };
-    case "azure-openai":
+    case "azure-openai": {
       // Validate Azure-only configuration up front so explicit misconfiguration
       // is surfaced before any tool calls.
-      getAzureOpenAIApiSurface();
+      const apiSurface = getAzureOpenAIApiSurface();
 
       return {
         type: "azure-openai",
+        label: `azure-openai ${
+          apiSurface === "chat-completions" ? "chat completions" : "responses"
+        } API`,
         getModel: getAzureOpenAIModel,
         getProviderOptions: () => ({
           openai: {
@@ -109,6 +114,7 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
           },
         }),
       };
+    }
   }
 }
 

--- a/packages/mcp-core/src/internal/agents/types.ts
+++ b/packages/mcp-core/src/internal/agents/types.ts
@@ -8,7 +8,7 @@ export type ProviderOptions = Record<string, Record<string, JSONValue>>;
 /**
  * Supported embedded agent provider types.
  */
-export type AgentProviderType = "openai" | "anthropic";
+export type AgentProviderType = "openai" | "azure-openai" | "anthropic";
 
 /**
  * Interface for embedded agent providers.

--- a/packages/mcp-core/src/internal/agents/types.ts
+++ b/packages/mcp-core/src/internal/agents/types.ts
@@ -18,6 +18,9 @@ export interface EmbeddedAgentProvider {
   /** The provider type identifier */
   readonly type: AgentProviderType;
 
+  /** Human-readable label for startup/status logging */
+  readonly label: string;
+
   /** Get a language model instance, optionally with a model override */
   getModel(modelOverride?: string): LanguageModel;
 

--- a/packages/mcp-server/src/cli/parse.test.ts
+++ b/packages/mcp-server/src/cli/parse.test.ts
@@ -37,6 +37,14 @@ describe("cli/parseArgv", () => {
     expect(parsed.disableSkills).toBe("seer");
   });
 
+  it("parses --agent-provider=azure-openai", () => {
+    const parsed = parseArgv([
+      "--access-token=tok",
+      "--agent-provider=azure-openai",
+    ]);
+    expect(parsed.agentProvider).toBe("azure-openai");
+  });
+
   it("collects unknown args", () => {
     const parsed = parseArgv(["--unknown", "--another=1"]);
     expect(parsed.unknownArgs.length).toBeGreaterThan(0);
@@ -129,5 +137,18 @@ describe("cli/merge", () => {
     const cli = parseArgv(["--access-token=clitok"]);
     const merged = merge(cli, env);
     expect(merged.disableSkills).toBe("seer");
+  });
+
+  it("applies precedence for agentProvider: CLI over env", () => {
+    const env = parseEnv({
+      SENTRY_ACCESS_TOKEN: "envtok",
+      EMBEDDED_AGENT_PROVIDER: "openai",
+    } as any);
+    const cli = parseArgv([
+      "--access-token=clitok",
+      "--agent-provider=azure-openai",
+    ]);
+    const merged = merge(cli, env);
+    expect(merged.agentProvider).toBe("azure-openai");
   });
 });

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -52,6 +52,25 @@ describe("cli/finalize", () => {
     ).toThrow(/OPENAI base URL must use http or https scheme/);
   });
 
+  it("accepts azure-openai as a valid explicit provider", () => {
+    const cfg = finalize({
+      accessToken: "tok",
+      agentProvider: "azure-openai",
+      unknownArgs: [],
+    });
+    expect(cfg.agentProvider).toBe("azure-openai");
+  });
+
+  it("rejects invalid explicit provider values", () => {
+    expect(() =>
+      finalize({
+        accessToken: "tok",
+        agentProvider: "openrouter",
+        unknownArgs: [],
+      }),
+    ).toThrow(/Must be "openai", "azure-openai", or "anthropic"/);
+  });
+
   it("throws on non-https URL", () => {
     expect(() =>
       finalize({ accessToken: "tok", url: "http://bad", unknownArgs: [] }),

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -95,12 +95,17 @@ export function finalize(input: MergedArgs): PartiallyResolvedConfig {
     : undefined;
 
   // Validate agent provider if explicitly set
-  let agentProvider: "openai" | "anthropic" | undefined = undefined;
+  let agentProvider: "openai" | "azure-openai" | "anthropic" | undefined =
+    undefined;
   if (input.agentProvider) {
     const provider = input.agentProvider.toLowerCase();
-    if (provider !== "openai" && provider !== "anthropic") {
+    if (
+      provider !== "openai" &&
+      provider !== "azure-openai" &&
+      provider !== "anthropic"
+    ) {
       throw new Error(
-        `Error: Invalid agent provider "${input.agentProvider}". Must be "openai" or "anthropic".`,
+        `Error: Invalid agent provider "${input.agentProvider}". Must be "openai", "azure-openai", or "anthropic".`,
       );
     }
     agentProvider = provider;

--- a/packages/mcp-server/src/cli/types.ts
+++ b/packages/mcp-server/src/cli/types.ts
@@ -73,7 +73,7 @@ export type PartiallyResolvedConfig = {
   openaiModel?: string;
   anthropicBaseUrl?: string;
   anthropicModel?: string;
-  agentProvider?: "openai" | "anthropic";
+  agentProvider?: "openai" | "azure-openai" | "anthropic";
   /** Skills granted for this session (always populated by finalize()) */
   finalSkills: Set<Skill>;
   organizationSlug?: string;

--- a/packages/mcp-server/src/cli/usage.ts
+++ b/packages/mcp-server/src/cli/usage.ts
@@ -24,7 +24,7 @@ Common optional flags:
   --experimental          Enable forward-looking tool variants and experimental features
 
 Embedded agent configuration:
-  --agent-provider <provider>   LLM provider: openai or anthropic (auto-detects from API keys)
+  --agent-provider <provider>   LLM provider: openai, azure-openai, or anthropic (auto-detects from API keys)
   --openai-base-url <url>       Override OpenAI API base URL
   --openai-model <model>        Override OpenAI model (default: gpt-5)
   --anthropic-base-url <url>    Override Anthropic API base URL
@@ -45,7 +45,7 @@ Environment variables:
   SENTRY_CLIENT_ID        Override OAuth client ID for device code flow
   OPENAI_API_KEY          OpenAI API key for AI-powered search tools
   ANTHROPIC_API_KEY       Anthropic API key for AI-powered search tools
-  EMBEDDED_AGENT_PROVIDER Provider override: openai or anthropic
+  EMBEDDED_AGENT_PROVIDER Provider override: openai, azure-openai, or anthropic
   MCP_DISABLE_SKILLS      Disable specific skills (comma-separated)
 
 Examples:
@@ -54,5 +54,6 @@ Examples:
   ${packageName} --access-token=TOKEN --skills=inspect,triage
   ${packageName} --access-token=TOKEN --host=sentry.example.com
   ${packageName} --access-token=TOKEN --host=sentry.example.com --disable-skills=seer
+  ${packageName} --access-token=TOKEN --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
   ${packageName} --access-token=TOKEN --agent-provider=anthropic`;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -31,7 +31,6 @@ import { resolveAccessToken } from "./auth/resolve-token";
 import { authCommand } from "./cli/commands/auth";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 import { SKILLS } from "@sentry/mcp-core/skills";
-import { getAzureOpenAIApiSurface } from "@sentry/mcp-core/internal/agents/azure-openai-provider";
 import {
   getAgentProvider,
   setAgentProvider,
@@ -242,15 +241,11 @@ async function main() {
     console.warn("");
   } else {
     const providerSource = getProviderSource();
-    const azureApiSurfaceLabel =
-      getAzureOpenAIApiSurface() === "chat-completions"
-        ? "chat completions"
-        : "responses";
     const providerLabel =
       resolvedProvider === "openai"
         ? "openai responses API"
         : resolvedProvider === "azure-openai"
-          ? `azure-openai ${azureApiSurfaceLabel} API`
+          ? "azure-openai API"
           : "anthropic";
     console.warn(
       `Using ${providerLabel} for AI-powered search tools (${providerSource}).`,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -31,6 +31,7 @@ import { resolveAccessToken } from "./auth/resolve-token";
 import { authCommand } from "./cli/commands/auth";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 import { SKILLS } from "@sentry/mcp-core/skills";
+import { getAzureOpenAIApiSurface } from "@sentry/mcp-core/internal/agents/azure-openai-provider";
 import {
   getAgentProvider,
   setAgentProvider,
@@ -48,24 +49,6 @@ function die(message: string): never {
   console.error(message);
   console.error(usageText);
   process.exit(1);
-}
-
-function hasAzureDeploymentPath(baseUrl: string | undefined): boolean {
-  if (!baseUrl) {
-    return false;
-  }
-
-  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
-  return /\/openai\/deployments\/[^/]+$/i.test(pathname);
-}
-
-function hasAzureV1Path(baseUrl: string | undefined): boolean {
-  if (!baseUrl) {
-    return false;
-  }
-
-  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
-  return /\/openai\/v1$/i.test(pathname);
 }
 
 async function main() {
@@ -263,11 +246,7 @@ async function main() {
       resolvedProvider === "openai"
         ? "openai responses API"
         : resolvedProvider === "azure-openai"
-          ? hasAzureDeploymentPath(cfg.openaiBaseUrl)
-            ? "azure-openai chat-completions API"
-            : hasAzureV1Path(cfg.openaiBaseUrl)
-              ? "azure-openai responses API"
-              : "azure-openai"
+          ? `azure-openai ${getAzureOpenAIApiSurface()} API`
           : "anthropic";
     console.warn(
       `Using ${providerLabel} for AI-powered search tools (${providerSource}).`,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -32,6 +32,7 @@ import { authCommand } from "./cli/commands/auth";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 import { SKILLS } from "@sentry/mcp-core/skills";
 import {
+  getAgentProvider,
   setAgentProvider,
   setProviderBaseUrls,
   getResolvedProviderType,
@@ -47,6 +48,24 @@ function die(message: string): never {
   console.error(message);
   console.error(usageText);
   process.exit(1);
+}
+
+function hasAzureDeploymentPath(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
+  return /\/openai\/deployments\/[^/]+$/i.test(pathname);
+}
+
+function hasAzureV1Path(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
+  return /\/openai\/v1$/i.test(pathname);
 }
 
 async function main() {
@@ -91,7 +110,9 @@ async function main() {
 
   // Configure embedded agent provider
   if (cfg.agentProvider) {
-    setAgentProvider(cfg.agentProvider);
+    setAgentProvider(
+      cfg.agentProvider as Parameters<typeof setAgentProvider>[0],
+    );
   }
   setProviderBaseUrls({
     openaiBaseUrl: cfg.openaiBaseUrl,
@@ -131,10 +152,14 @@ async function main() {
     const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
 
     // Check if configured provider's key is missing but other key is present
-    if (configured === "openai" && !hasOpenAI && hasAnthropic) {
+    if (
+      (configured === "openai" || configured === "azure-openai") &&
+      !hasOpenAI &&
+      hasAnthropic
+    ) {
       return {
         mismatch: true,
-        configured: "openai",
+        configured,
         availableKey: "ANTHROPIC_API_KEY",
       };
     }
@@ -159,23 +184,36 @@ async function main() {
   }
 
   // Check for LLM API keys and warn if none available
-  const resolvedProvider = getResolvedProviderType();
+  const resolvedProvider = getResolvedProviderType() as
+    | "openai"
+    | "azure-openai"
+    | "anthropic"
+    | undefined;
 
   if (!resolvedProvider) {
     const mismatchInfo = hasProviderMismatch();
+    let providerConfigError: string | undefined;
+    try {
+      getAgentProvider();
+    } catch (error) {
+      providerConfigError =
+        error instanceof Error ? error.message : String(error);
+    }
+
     if (hasProviderConflict()) {
       console.warn(
         "Warning: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set, but no provider is explicitly configured.",
       );
       console.warn(
-        "Please set EMBEDDED_AGENT_PROVIDER='openai' or 'anthropic' to specify which provider to use.",
+        "Please set EMBEDDED_AGENT_PROVIDER='openai', 'azure-openai', or 'anthropic' to specify which provider to use.",
       );
       console.warn(
         "AI-powered search tools will be unavailable until a provider is selected.",
       );
     } else if (mismatchInfo.mismatch) {
       const expectedKey =
-        mismatchInfo.configured === "openai"
+        mismatchInfo.configured === "openai" ||
+        mismatchInfo.configured === "azure-openai"
           ? "OPENAI_API_KEY"
           : "ANTHROPIC_API_KEY";
       const configuredViaCliFlag = Boolean(cli.agentProvider);
@@ -196,6 +234,14 @@ async function main() {
       console.warn(
         "AI-powered search tools will be unavailable until this is resolved.",
       );
+    } else if (
+      providerConfigError &&
+      !providerConfigError.startsWith("No embedded agent provider configured")
+    ) {
+      console.warn(`Warning: ${providerConfigError}`);
+      console.warn(
+        "AI-powered search tools will be unavailable until this is resolved.",
+      );
     } else {
       console.warn(
         "Warning: No LLM API key found (OPENAI_API_KEY or ANTHROPIC_API_KEY).",
@@ -213,8 +259,18 @@ async function main() {
     console.warn("");
   } else {
     const providerSource = getProviderSource();
+    const providerLabel =
+      resolvedProvider === "openai"
+        ? "openai responses API"
+        : resolvedProvider === "azure-openai"
+          ? hasAzureDeploymentPath(cfg.openaiBaseUrl)
+            ? "azure-openai chat-completions API"
+            : hasAzureV1Path(cfg.openaiBaseUrl)
+              ? "azure-openai responses API"
+              : "azure-openai"
+          : "anthropic";
     console.warn(
-      `Using ${resolvedProvider} for AI-powered search tools (${providerSource}).`,
+      `Using ${providerLabel} for AI-powered search tools (${providerSource}).`,
     );
     // Warn about auto-detection deprecation
     if (providerSource === "auto-detected") {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -242,11 +242,15 @@ async function main() {
     console.warn("");
   } else {
     const providerSource = getProviderSource();
+    const azureApiSurfaceLabel =
+      getAzureOpenAIApiSurface() === "chat-completions"
+        ? "chat completions"
+        : "responses";
     const providerLabel =
       resolvedProvider === "openai"
         ? "openai responses API"
         : resolvedProvider === "azure-openai"
-          ? `azure-openai ${getAzureOpenAIApiSurface()} API`
+          ? `azure-openai ${azureApiSurfaceLabel} API`
           : "anthropic";
     console.warn(
       `Using ${providerLabel} for AI-powered search tools (${providerSource}).`,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -241,12 +241,7 @@ async function main() {
     console.warn("");
   } else {
     const providerSource = getProviderSource();
-    const providerLabel =
-      resolvedProvider === "openai"
-        ? "openai responses API"
-        : resolvedProvider === "azure-openai"
-          ? "azure-openai API"
-          : "anthropic";
+    const providerLabel = getAgentProvider().label;
     console.warn(
       `Using ${providerLabel} for AI-powered search tools (${providerSource}).`,
     );


### PR DESCRIPTION
Make Azure OpenAI an explicit embedded-agent provider instead of teaching the generic `openai` provider to guess from deployment URLs and model prefixes.

Generic `openai` now always uses the Responses API and treats `OPENAI_MODEL` as an opaque identifier, which keeps OpenRouter and other gateways predictable. Azure-specific routing only happens when `EMBEDDED_AGENT_PROVIDER=azure-openai` or `--agent-provider=azure-openai` is set.

In `azure-openai` mode, `/openai/v1` endpoints use Responses and `/openai/deployments/<deployment>` endpoints use chat completions. `OPENAI_API_VERSION` is only applied for Azure deployment URLs, deployment aliases remain valid model identifiers, and startup labeling now comes from the provider abstraction instead of recreating Azure-specific checks in `mcp-server`.

This updates the CLI and docs to describe the explicit provider split, adds a spec for the routing decision, and adds regression coverage for both Azure routing and generic deployment-shaped base URLs.

I considered adding a generic API-surface flag, but that would add more configuration to every OpenAI-compatible setup just to paper over the Azure URL split. Keeping Azure explicit and generic OpenAI boring avoids more routing footguns.

Fixes #847