### PR TITLE
fix(events): use correct severity value `warn` in logs query example

### DIFF
--- a/packages/mcp-core/src/tools/search-events/config.ts
+++ b/packages/mcp-core/src/tools/search-events/config.ts
@@ -345,7 +345,7 @@ export const DATASET_FIELDS = {
   logs: {
     // Log-specific fields
     message: "Log message",
-    severity: "Log severity level",
+    severity: "Log severity level (trace, debug, info, warn, error, fatal)",
     severity_number: "Numeric severity level",
     "sentry.item_id": "Sentry item ID",
     "sentry.observed_timestamp_nanos": "Observed timestamp in nanoseconds",
@@ -582,7 +582,7 @@ export const DATASET_EXAMPLES: Record<
     {
       description: "warning logs about memory",
       output: {
-        query: 'severity:warning AND message:"*memory*"',
+        query: 'severity:warn AND message:"*memory*"',
         fields: ["timestamp", "message", "severity", "trace"],
         sort: "-timestamp",
       },


### PR DESCRIPTION
## Summary

The `DATASET_EXAMPLES` for the logs dataset teaches the LLM query translator to use `severity:warning`, but Sentry's structured logs spec defines the level as `warn`. This causes `search_events` queries filtering by warn severity to match no logs, even though the data is there — aggregations grouping by severity correctly show `warn` entries.

### Key Changes
- Fixed the example query in `DATASET_EXAMPLES` from `severity:warning` to `severity:warn`
- Added valid severity values (`trace`, `debug`, `info`, `warn`, `error`, `fatal`) to the `severity` field description so the LLM knows the correct enum

### Validation
- `pnpm run tsc && pnpm run lint && pnpm run test` — all pass
- Confirmed the bug by querying logs via the MCP: `severity:warning` filter returns no results, while `count() GROUP BY severity` shows thousands of `warn` entries
- Sentry's own docs use `severity:warn` in search examples, and the [SDK telemetry spec](https://develop.sentry.dev/sdk/telemetry/logs/) defines the level as `warn`