### PR TITLE
fix(oauth): Preserve scoped MCP resources

### DIFF
--- a/docs/cloudflare/oauth-architecture.md
+++ b/docs/cloudflare/oauth-architecture.md
@@ -348,21 +348,18 @@ The MCP worker exposes:
 - `/.well-known/oauth-authorization-server` - MCP OAuth server metadata
 - `/.well-known/oauth-protected-resource/mcp...` - Path-specific protected resource metadata per RFC 9728
 - `/.well-known/oauth-authorization-server/mcp...` - Compatibility metadata for clients that probe path-scoped RFC 8414 discovery from the MCP resource URL
-- `/.well-known/openid-configuration/mcp...` - Compatibility metadata for clients that probe path-scoped OIDC discovery from the MCP resource URL
 
 The worker only serves path-specific protected-resource metadata for `/mcp...`
 resources. Each metadata document preserves the exact `/mcp` path and any query
 parameters so the advertised `resource` value matches the protected resource
 identifier used for discovery.
 
-The path-scoped RFC 8414 and OIDC discovery endpoints are compatibility shims.
-They are not the canonical MCP discovery flow. Instead, they exist for clients
-that infer discovery URLs directly from the `/mcp/...` endpoint path. To remain
-valid RFC 8414 / OIDC discovery documents, each scoped metadata response uses
-that probed `/mcp/...` URL as its `issuer`, while still returning a shared
-authorization endpoint pre-populated with the RFC 8707 `resource` parameter for
-the exact protected resource. This keeps constrained OAuth flows aligned with
-the protected resource even when a client skips RFC 9728 discovery.
+The path-scoped RFC 8414 discovery endpoint is a compatibility shim. It is not
+the canonical MCP discovery flow. Instead, it exists for clients that infer the
+RFC 8414 URL directly from the `/mcp/...` endpoint path. The compatibility
+response keeps the exact protected-resource query string in the RFC 8707
+`resource` parameter, while emitting a query-free `issuer` so the document
+remains valid RFC 8414 metadata.
 
 When a constrained OAuth request includes `resource=/mcp/{org}` or
 `resource=/mcp/{org}/{project}`, the approval page surfaces that scope to the

--- a/docs/cloudflare/oauth-architecture.md
+++ b/docs/cloudflare/oauth-architecture.md
@@ -347,11 +347,26 @@ The MCP worker exposes:
 
 - `/.well-known/oauth-authorization-server` - MCP OAuth server metadata
 - `/.well-known/oauth-protected-resource/mcp...` - Path-specific protected resource metadata per RFC 9728
+- `/.well-known/oauth-authorization-server/mcp...` - Compatibility metadata for clients that probe path-scoped RFC 8414 discovery from the MCP resource URL
+- `/.well-known/openid-configuration/mcp...` - Compatibility metadata for clients that probe path-scoped OIDC discovery from the MCP resource URL
 
 The worker only serves path-specific protected-resource metadata for `/mcp...`
 resources. Each metadata document preserves the exact `/mcp` path and any query
 parameters so the advertised `resource` value matches the protected resource
 identifier used for discovery.
+
+The path-scoped RFC 8414 and OIDC discovery endpoints are compatibility shims.
+They are not the canonical MCP discovery flow. Instead, they exist for clients
+that infer discovery URLs directly from the `/mcp/...` endpoint path. To remain
+valid RFC 8414 / OIDC discovery documents, each scoped metadata response uses
+that probed `/mcp/...` URL as its `issuer`, while still returning a shared
+authorization endpoint pre-populated with the RFC 8707 `resource` parameter for
+the exact protected resource. This keeps constrained OAuth flows aligned with
+the protected resource even when a client skips RFC 9728 discovery.
+
+When a constrained OAuth request includes `resource=/mcp/{org}` or
+`resource=/mcp/{org}/{project}`, the approval page surfaces that scope to the
+user as a "Session scope" banner before permissions are granted.
 
 Note: These describe the MCP OAuth server, not Sentry's OAuth endpoints.
 

--- a/docs/testing-remote.md
+++ b/docs/testing-remote.md
@@ -222,6 +222,10 @@ pnpm -w run cli --mcp-host=http://localhost:5173/mcp/sentry "find_projects()"
 pnpm -w run cli --mcp-host=http://localhost:5173/mcp/sentry "find_projects(organizationSlug='other-org')"
 ```
 
+**Verify OAuth consent shows the constraint:**
+- Start a fresh OAuth flow against a constrained MCP URL such as `http://localhost:5173/mcp/sentry` or `http://localhost:5173/mcp/sentry/javascript`
+- On the approval page, confirm the "Session scope" banner matches the constrained organization or project before approving
+
 **Note:** When testing with constraints, some tools are automatically filtered:
 - With org constraint: `find_organizations` is not available (18 tools instead of 19)
 - With org + project constraints: both `find_organizations` and `find_projects` are not available (17 tools instead of 19)

--- a/packages/mcp-cloudflare/src/server/app.test.ts
+++ b/packages/mcp-cloudflare/src/server/app.test.ts
@@ -256,12 +256,10 @@ describe("app", () => {
         code_challenge_methods_supported: ["plain", "S256"],
       });
     });
-  });
 
-  describe("GET /.well-known/openid-configuration/mcp", () => {
-    it("should mirror scoped OAuth metadata for clients that probe the OIDC path", async () => {
+    it("should keep query flags in resource while emitting a query-free issuer", async () => {
       const res = await app.request(
-        "https://mcp.sentry.dev/.well-known/openid-configuration/mcp/sentry",
+        "https://mcp.sentry.dev/.well-known/oauth-authorization-server/mcp/sentry/mcp-server?experimental=1",
         { headers: TEST_HEADERS },
       );
 
@@ -269,9 +267,9 @@ describe("app", () => {
 
       const json = await res.json();
       expect(json.authorization_endpoint).toBe(
-        "https://mcp.sentry.dev/oauth/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp%2Fsentry",
+        "https://mcp.sentry.dev/oauth/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp%2Fsentry%2Fmcp-server%3Fexperimental%3D1",
       );
-      expect(json.issuer).toBe("https://mcp.sentry.dev/mcp/sentry");
+      expect(json.issuer).toBe("https://mcp.sentry.dev/mcp/sentry/mcp-server");
     });
   });
 });

--- a/packages/mcp-cloudflare/src/server/app.test.ts
+++ b/packages/mcp-cloudflare/src/server/app.test.ts
@@ -221,4 +221,57 @@ describe("app", () => {
       });
     });
   });
+
+  describe("GET /.well-known/oauth-authorization-server/mcp", () => {
+    it("should return scoped OAuth metadata with a resource-aware authorization endpoint", async () => {
+      const res = await app.request(
+        "https://mcp.sentry.dev/.well-known/oauth-authorization-server/mcp/sentry/mcp-server",
+        { headers: TEST_HEADERS },
+      );
+
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json).toEqual({
+        issuer: "https://mcp.sentry.dev/mcp/sentry/mcp-server",
+        authorization_endpoint:
+          "https://mcp.sentry.dev/oauth/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp%2Fsentry%2Fmcp-server",
+        token_endpoint: "https://mcp.sentry.dev/oauth/token",
+        registration_endpoint: "https://mcp.sentry.dev/oauth/register",
+        scopes_supported: [
+          "org:read",
+          "project:write",
+          "team:write",
+          "event:write",
+        ],
+        response_types_supported: ["code"],
+        response_modes_supported: ["query"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: [
+          "client_secret_basic",
+          "client_secret_post",
+          "none",
+        ],
+        revocation_endpoint: "https://mcp.sentry.dev/oauth/token",
+        code_challenge_methods_supported: ["plain", "S256"],
+      });
+    });
+  });
+
+  describe("GET /.well-known/openid-configuration/mcp", () => {
+    it("should mirror scoped OAuth metadata for clients that probe the OIDC path", async () => {
+      const res = await app.request(
+        "https://mcp.sentry.dev/.well-known/openid-configuration/mcp/sentry",
+        { headers: TEST_HEADERS },
+      );
+
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json.authorization_endpoint).toBe(
+        "https://mcp.sentry.dev/oauth/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp%2Fsentry",
+      );
+      expect(json.issuer).toBe("https://mcp.sentry.dev/mcp/sentry");
+    });
+  });
 });

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -13,6 +13,7 @@ import { createRequestLogger } from "./logging";
 import mcpRoutes from "./routes/mcp";
 import { getClientIp } from "./utils/client-ip";
 import { createProtectedResourceMetadataResponse } from "./protected-resource-metadata";
+import { createScopedAuthorizationServerMetadataResponse } from "./authorization-server-metadata";
 
 /** Derive the base URL (origin) from the current request. */
 function getBaseUrl(c: Context): string {
@@ -171,6 +172,20 @@ const app = new Hono<{
   .get(
     "/.well-known/oauth-protected-resource/mcp/*",
     handleOAuthProtectedResourceMetadata,
+  )
+  // Compatibility shim for clients that probe path-scoped RFC 8414 / OIDC
+  // discovery endpoints instead of RFC 9728 protected resource metadata.
+  .get("/.well-known/oauth-authorization-server/mcp", (c) =>
+    createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
+  )
+  .get("/.well-known/oauth-authorization-server/mcp/*", (c) =>
+    createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
+  )
+  .get("/.well-known/openid-configuration/mcp", (c) =>
+    createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
+  )
+  .get("/.well-known/openid-configuration/mcp/*", (c) =>
+    createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
   )
   .route("/oauth", sentryOauth)
   .route("/api/auth", chatOauth)

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -173,18 +173,12 @@ const app = new Hono<{
     "/.well-known/oauth-protected-resource/mcp/*",
     handleOAuthProtectedResourceMetadata,
   )
-  // Compatibility shim for clients that probe path-scoped RFC 8414 / OIDC
-  // discovery endpoints instead of RFC 9728 protected resource metadata.
+  // Compatibility shim for clients that probe path-scoped RFC 8414 discovery
+  // endpoints instead of RFC 9728 protected resource metadata.
   .get("/.well-known/oauth-authorization-server/mcp", (c) =>
     createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
   )
   .get("/.well-known/oauth-authorization-server/mcp/*", (c) =>
-    createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
-  )
-  .get("/.well-known/openid-configuration/mcp", (c) =>
-    createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
-  )
-  .get("/.well-known/openid-configuration/mcp/*", (c) =>
     createScopedAuthorizationServerMetadataResponse(new URL(c.req.url)),
   )
   .route("/oauth", sentryOauth)

--- a/packages/mcp-cloudflare/src/server/authorization-server-metadata.ts
+++ b/packages/mcp-cloudflare/src/server/authorization-server-metadata.ts
@@ -1,0 +1,69 @@
+import { SCOPES } from "../constants";
+
+const OAUTH_METADATA_PREFIX = "/.well-known/oauth-authorization-server";
+const OIDC_METADATA_PREFIX = "/.well-known/openid-configuration";
+
+// RFC 8414 defines authorization server metadata at the root
+// `/.well-known/oauth-authorization-server` endpoint. RFC 9728 defines
+// path-specific protected resource metadata at
+// `/.well-known/oauth-protected-resource/...`.
+//
+// Some MCP clients currently probe path-scoped RFC 8414 and OIDC discovery URLs
+// instead of RFC 9728 protected resource metadata. For those clients, we return a
+// compatibility document whose authorization endpoint is pre-populated with the
+// RFC 8707 `resource` parameter for the scoped `/mcp/...` URL.
+
+function getResourceSuffix(requestUrl: URL, prefix: string): string {
+  const resourcePath = requestUrl.pathname.replace(prefix, "");
+  return `${resourcePath}${requestUrl.search}`;
+}
+
+function createAuthorizationEndpoint(
+  resourceUrl: string,
+  origin: string,
+): string {
+  const authorizationEndpoint = new URL("/oauth/authorize", origin);
+  // RFC 8707: carry the protected resource identifier into the authorization
+  // request so the consent page and downstream grant are bound to the same
+  // `/mcp/...` resource the client is trying to access.
+  authorizationEndpoint.searchParams.set("resource", resourceUrl);
+  return authorizationEndpoint.href;
+}
+
+export function createScopedAuthorizationServerMetadataResponse(
+  requestUrl: URL,
+): Response {
+  const prefix = requestUrl.pathname.startsWith(OIDC_METADATA_PREFIX)
+    ? OIDC_METADATA_PREFIX
+    : OAUTH_METADATA_PREFIX;
+  const resourceSuffix = getResourceSuffix(requestUrl, prefix);
+  const resourceUrl = `${requestUrl.origin}${resourceSuffix}`;
+
+  const metadata = {
+    // RFC 8414 §3 requires the issuer in the metadata document to match the
+    // issuer identifier used to derive the well-known URL. For this
+    // compatibility response, that identifier is the probed `/mcp/...` URL.
+    issuer: resourceUrl,
+    authorization_endpoint: createAuthorizationEndpoint(
+      resourceUrl,
+      requestUrl.origin,
+    ),
+    token_endpoint: new URL("/oauth/token", requestUrl.origin).href,
+    registration_endpoint: new URL("/oauth/register", requestUrl.origin).href,
+    scopes_supported: Object.keys(SCOPES),
+    response_types_supported: ["code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: [
+      "client_secret_basic",
+      "client_secret_post",
+      "none",
+    ],
+    revocation_endpoint: new URL("/oauth/token", requestUrl.origin).href,
+    code_challenge_methods_supported: ["plain", "S256"],
+  };
+
+  return new Response(JSON.stringify(metadata), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/packages/mcp-cloudflare/src/server/authorization-server-metadata.ts
+++ b/packages/mcp-cloudflare/src/server/authorization-server-metadata.ts
@@ -1,21 +1,23 @@
 import { SCOPES } from "../constants";
 
 const OAUTH_METADATA_PREFIX = "/.well-known/oauth-authorization-server";
-const OIDC_METADATA_PREFIX = "/.well-known/openid-configuration";
 
 // RFC 8414 defines authorization server metadata at the root
 // `/.well-known/oauth-authorization-server` endpoint. RFC 9728 defines
 // path-specific protected resource metadata at
 // `/.well-known/oauth-protected-resource/...`.
 //
-// Some MCP clients currently probe path-scoped RFC 8414 and OIDC discovery URLs
-// instead of RFC 9728 protected resource metadata. For those clients, we return a
-// compatibility document whose authorization endpoint is pre-populated with the
-// RFC 8707 `resource` parameter for the scoped `/mcp/...` URL.
+// Some MCP clients currently probe path-scoped RFC 8414 discovery URLs instead
+// of RFC 9728 protected resource metadata. For those clients, we return a
+// compatibility document whose authorization endpoint is pre-populated with
+// the RFC 8707 `resource` parameter for the scoped `/mcp/...` URL.
 
-function getResourceSuffix(requestUrl: URL, prefix: string): string {
-  const resourcePath = requestUrl.pathname.replace(prefix, "");
-  return `${resourcePath}${requestUrl.search}`;
+function getResourcePath(requestUrl: URL): string {
+  return requestUrl.pathname.replace(OAUTH_METADATA_PREFIX, "");
+}
+
+function getResourceUrl(requestUrl: URL, resourcePath: string): string {
+  return `${requestUrl.origin}${resourcePath}${requestUrl.search}`;
 }
 
 function createAuthorizationEndpoint(
@@ -33,17 +35,14 @@ function createAuthorizationEndpoint(
 export function createScopedAuthorizationServerMetadataResponse(
   requestUrl: URL,
 ): Response {
-  const prefix = requestUrl.pathname.startsWith(OIDC_METADATA_PREFIX)
-    ? OIDC_METADATA_PREFIX
-    : OAUTH_METADATA_PREFIX;
-  const resourceSuffix = getResourceSuffix(requestUrl, prefix);
-  const resourceUrl = `${requestUrl.origin}${resourceSuffix}`;
+  const resourcePath = getResourcePath(requestUrl);
+  const resourceUrl = getResourceUrl(requestUrl, resourcePath);
 
   const metadata = {
     // RFC 8414 §3 requires the issuer in the metadata document to match the
-    // issuer identifier used to derive the well-known URL. For this
-    // compatibility response, that identifier is the probed `/mcp/...` URL.
-    issuer: resourceUrl,
+    // issuer identifier used to derive the well-known URL. That identifier
+    // can include a path, but RFC 8414 §2 forbids query components.
+    issuer: `${requestUrl.origin}${resourcePath}`,
     authorization_endpoint: createAuthorizationEndpoint(
       resourceUrl,
       requestUrl.origin,

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
@@ -61,6 +61,49 @@ describe("approval-dialog", () => {
       // Should not contain any script tags (JavaScript-free implementation)
       expect(html).not.toContain("<script>");
     });
+
+    it("should render organization scope summary when provided", async () => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Sentry MCP" },
+          scope: { organizationSlug: "sentry", projectSlug: null },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+
+      const html = await response.text();
+
+      expect(html).toContain("Session scope");
+      expect(html).toContain("This session will be limited to the");
+      expect(html).toContain(">sentry</strong> organization");
+      expect(html).toContain(
+        "The permissions below apply only within this scope.",
+      );
+    });
+
+    it("should render project scope summary when provided", async () => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Sentry MCP" },
+          scope: {
+            organizationSlug: "sentry",
+            projectSlug: "javascript",
+          },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+
+      const html = await response.text();
+
+      expect(html).toContain(">javascript</strong> project");
+      expect(html).toContain(">sentry</strong> organization");
+    });
   });
 
   describe("CSRF protection with HMAC-signed state", () => {

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -193,6 +193,13 @@ export interface ApprovalDialogOptions {
     description?: string;
   };
   /**
+   * Optional organization/project constraints applied to this session.
+   */
+  scope?: {
+    organizationSlug: string;
+    projectSlug: string | null;
+  } | null;
+  /**
    * Arbitrary state data to pass through the approval flow
    * Will be encoded in the form and returned when approval is complete
    */
@@ -268,7 +275,7 @@ export async function renderApprovalDialog(
   request: Request,
   options: ApprovalDialogOptions,
 ): Promise<Response> {
-  const { client, server, state, cookieSecret } = options;
+  const { client, server, scope, state, cookieSecret } = options;
 
   // Use static skill definitions bundled at build time
   const skills: SkillDefinition[] = skillDefinitions as SkillDefinition[];
@@ -329,6 +336,20 @@ export async function renderApprovalDialog(
       `;
     })
     .join("");
+
+  const scopeHtml = scope
+    ? `
+      <section class="scope-banner" role="note" aria-label="Session scope">
+        <div class="scope-label">Session scope</div>
+        <p class="scope-message">${
+          scope.projectSlug
+            ? `This session will be limited to the <strong class="scope-token">${sanitizeHtml(scope.projectSlug)}</strong> project in the <strong class="scope-token">${sanitizeHtml(scope.organizationSlug)}</strong> organization.`
+            : `This session will be limited to the <strong class="scope-token">${sanitizeHtml(scope.organizationSlug)}</strong> organization.`
+        }</p>
+        <p class="scope-help">The permissions below apply only within this scope.</p>
+      </section>
+    `
+    : "";
 
   // Generate HTML for the approval dialog
   const htmlContent = `
@@ -441,6 +462,57 @@ export async function renderApprovalDialog(
             text-align: center;
             color: var(--text-primary);
             line-height: 1.4;
+          }
+
+          .scope-banner {
+            margin: 0 0 var(--space-xl) 0;
+            padding: var(--space-lg);
+            border-radius: var(--radius-md);
+            border: 1px solid rgba(171, 99, 232, 0.28);
+            background:
+              linear-gradient(180deg, rgba(171, 99, 232, 0.10), rgba(171, 99, 232, 0.03)),
+              rgba(255, 255, 255, 0.02);
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+          }
+
+          .scope-label {
+            display: inline-flex;
+            align-items: center;
+            margin-bottom: var(--space-sm);
+            padding: 0.2rem 0.6rem;
+            border-radius: 999px;
+            background: rgba(171, 99, 232, 0.14);
+            color: var(--purple-light);
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+          }
+
+          .scope-message {
+            margin: 0 0 var(--space-sm) 0;
+            color: var(--text-primary);
+            font-size: 1rem;
+            line-height: 1.6;
+          }
+
+          .scope-help {
+            margin: 0;
+            color: var(--text-secondary);
+            font-size: 0.9375rem;
+          }
+
+          .scope-token {
+            display: inline-block;
+            padding: 0.0625rem 0.45rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            color: var(--text-primary);
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.95em;
+            font-weight: 700;
+            white-space: nowrap;
           }
 
           .policy-links {
@@ -716,6 +788,8 @@ export async function renderApprovalDialog(
           <main class="card">
 
             <p class="alert"><strong>${clientUri ? `<a href="${clientUri}" target="_blank" rel="noopener noreferrer">${clientName}</a>` : clientName}</strong> is requesting access to Sentry</p>
+
+            ${scopeHtml}
 
             <form method="post" action="${new URL(request.url).pathname}" aria-label="Authorization form">
               <input type="hidden" name="state" value="${encodedState}">

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -253,6 +253,7 @@ describe("oauth authorize routes", () => {
         expect(response.status).toBe(200);
         const html = await response.text();
         expect(html).toContain("<form");
+        expect(html).not.toContain("Session scope");
       });
 
       it("should allow request with valid resource parameter", async () => {
@@ -276,6 +277,8 @@ describe("oauth authorize routes", () => {
 
         // Should proceed normally
         expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).not.toContain("Session scope");
       });
 
       it("should reject request with origin-only resource parameter", async () => {
@@ -348,6 +351,8 @@ describe("oauth authorize routes", () => {
         const response = await app.fetch(request, testEnv as Env);
 
         expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).not.toContain("Session scope");
       });
 
       it("should allow request with organization-scoped resource parameter", async () => {
@@ -370,6 +375,8 @@ describe("oauth authorize routes", () => {
         const response = await app.fetch(request, testEnv as Env);
 
         expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain(">test-org</strong> organization");
       });
 
       it("should allow request with project-scoped resource parameter", async () => {
@@ -395,6 +402,9 @@ describe("oauth authorize routes", () => {
         const response = await app.fetch(request, testEnv as Env);
 
         expect(response.status).toBe(200);
+        const html = await response.text();
+        expect(html).toContain(">test-project</strong> project");
+        expect(html).toContain(">test-org</strong> organization");
       });
 
       it("should reject request with invalid resource hostname", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -23,6 +23,42 @@ interface AuthRequestWithSkills extends AuthRequest {
   resource?: string;
 }
 
+function getApprovalScopeFromResource(resource: string | null | undefined): {
+  organizationSlug: string;
+  projectSlug: string | null;
+} | null {
+  if (!resource) {
+    return null;
+  }
+
+  try {
+    const { pathname } = new URL(resource);
+    const pathSegments = pathname.split("/").filter(Boolean);
+
+    if (pathSegments[0] !== "mcp") {
+      return null;
+    }
+
+    if (pathSegments.length === 2) {
+      return {
+        organizationSlug: pathSegments[1],
+        projectSlug: null,
+      };
+    }
+
+    if (pathSegments.length === 3) {
+      return {
+        organizationSlug: pathSegments[1],
+        projectSlug: pathSegments[2],
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 async function redirectToUpstream(
   env: Env,
   request: Request,
@@ -118,6 +154,7 @@ export default new Hono<{ Bindings: Env }>()
       ...oauthReqInfoWithoutResource,
       ...(resourceParam ? { resource: resourceParam } : {}),
     };
+    const approvalScope = getApprovalScopeFromResource(resourceParam);
 
     // XXX(dcramer): we want to confirm permissions on each time
     // so you can always choose new ones
@@ -141,6 +178,7 @@ export default new Hono<{ Bindings: Env }>()
       server: {
         name: "Sentry MCP",
       },
+      scope: approvalScope,
       state: { oauthReqInfo: oauthReqInfoWithResource },
       cookieSecret: c.env.COOKIE_SECRET,
     });

--- a/packages/mcp-cloudflare/src/server/sentry.config.test.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import getSentryConfig from "./sentry.config";
+import type { Env } from "./types";
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    NODE_ENV: "development",
+    ASSETS: {} as Fetcher,
+    OAUTH_KV: {} as KVNamespace,
+    MCP_CACHE: {} as KVNamespace,
+    COOKIE_SECRET: "test-secret",
+    SENTRY_CLIENT_ID: "test-client-id",
+    SENTRY_CLIENT_SECRET: "test-client-secret",
+    SENTRY_DSN: "https://public@example.ingest.sentry.io/1",
+    SENTRY_HOST: "sentry.io",
+    OPENAI_API_KEY: "test-openai-key",
+    OAUTH_PROVIDER: {} as Env["OAUTH_PROVIDER"],
+    AI: {} as Ai,
+    ...overrides,
+  };
+}
+
+describe("getSentryConfig", () => {
+  it("uses Cloudflare version metadata as the release when available", () => {
+    const config = getSentryConfig(
+      createEnv({
+        CF_VERSION_METADATA: {
+          id: "worker-version-123",
+          tag: "current",
+        } as Env["CF_VERSION_METADATA"],
+      }),
+    );
+
+    expect(config.release).toBe("worker-version-123");
+  });
+
+  it("omits the release when Cloudflare version metadata is missing", () => {
+    const config = getSentryConfig(createEnv());
+
+    expect(config.release).toBeUndefined();
+  });
+});

--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -6,7 +6,7 @@ import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 type SentryConfig = ReturnType<Parameters<typeof Sentry.withSentry>[0]>;
 
 export default function getSentryConfig(env: Env): SentryConfig {
-  const { id: versionId } = env.CF_VERSION_METADATA;
+  const versionId = env.CF_VERSION_METADATA?.id;
 
   return {
     dsn: env.SENTRY_DSN,
@@ -19,7 +19,7 @@ export default function getSentryConfig(env: Env): SentryConfig {
         "sentry.host": env.SENTRY_HOST,
       },
     },
-    release: versionId,
+    ...(versionId ? { release: versionId } : {}),
     environment:
       env.SENTRY_ENVIRONMENT ??
       (process.env.NODE_ENV !== "production" ? "development" : "production"),

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -49,7 +49,7 @@ export interface Env {
   MCP_URL?: string;
   OAUTH_PROVIDER: OAuthHelpers;
   AI: Ai;
-  CF_VERSION_METADATA: WorkerVersionMetadata;
+  CF_VERSION_METADATA?: WorkerVersionMetadata;
   CHAT_RATE_LIMITER?: RateLimit;
   SEARCH_RATE_LIMITER?: RateLimit;
   MCP_IP_RATE_LIMITER?: RateLimit;

--- a/packages/mcp-test-client/src/auth/oauth.test.ts
+++ b/packages/mcp-test-client/src/auth/oauth.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import open from "open";
+import { OAuthClient } from "./oauth.js";
+
+vi.mock("open", () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("OAuthClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("includes the protected resource in the authorization request", async () => {
+    const client = new OAuthClient({
+      mcpHost: "https://mcp.sentry.dev/mcp/sentry/javascript",
+    });
+
+    vi.spyOn(client as never, "getOrRegisterClientId").mockResolvedValue(
+      "client-123",
+    );
+    vi.spyOn(client as never, "startCallbackServer").mockResolvedValue({
+      waitForCallback: async () => ({
+        code: "auth-code",
+        state: "oauth-state",
+      }),
+    });
+    vi.spyOn(client as never, "generateState").mockReturnValue("oauth-state");
+    vi.spyOn(client as never, "generatePKCE").mockReturnValue({
+      verifier: "verifier",
+      challenge: "challenge",
+    });
+    vi.spyOn(client as never, "exchangeCodeForToken").mockResolvedValue({
+      access_token: "access-token",
+      token_type: "Bearer",
+    });
+    vi.spyOn(
+      (client as never).configManager,
+      "setAccessToken",
+    ).mockResolvedValue(undefined);
+
+    await client.authenticate();
+
+    expect(open).toHaveBeenCalledTimes(1);
+    const authUrl = new URL(vi.mocked(open).mock.calls[0][0]);
+    expect(authUrl.origin).toBe("https://mcp.sentry.dev");
+    expect(authUrl.pathname).toBe("/oauth/authorize");
+    expect(authUrl.searchParams.get("resource")).toBe(
+      "https://mcp.sentry.dev/mcp/sentry/javascript",
+    );
+  });
+});

--- a/packages/mcp-test-client/src/auth/oauth.ts
+++ b/packages/mcp-test-client/src/auth/oauth.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_OAUTH_SCOPES,
 } from "../constants.js";
 import { logInfo, logSuccess, logToolResult, logError } from "../logger.js";
+import {
+  resolveAuthorizationServerUrl,
+  resolveProtectedResourceUrl,
+} from "../mcp-url.js";
 import { ConfigManager } from "./config.js";
 
 export interface OAuthConfig {
@@ -49,6 +53,19 @@ export class OAuthClient {
     this.configManager = new ConfigManager();
   }
 
+  private getProtectedResourceUrl(): URL {
+    return resolveProtectedResourceUrl(this.config.mcpHost);
+  }
+
+  private getAuthorizationServerUrl(pathname: string): string {
+    return new URL(pathname, resolveAuthorizationServerUrl(this.config.mcpHost))
+      .href;
+  }
+
+  private getConfigKey(): string {
+    return this.getProtectedResourceUrl().href;
+  }
+
   /**
    * Generate PKCE code verifier and challenge
    */
@@ -69,7 +86,7 @@ export class OAuthClient {
    * Register the client with the OAuth server using Dynamic Client Registration
    */
   private async registerClient(): Promise<string> {
-    const registrationUrl = `${this.config.mcpHost}/oauth/register`;
+    const registrationUrl = this.getAuthorizationServerUrl("/oauth/register");
 
     const registrationData = {
       client_name: "Sentry MCP CLI",
@@ -219,7 +236,7 @@ export class OAuthClient {
     codeVerifier: string;
     clientId: string;
   }): Promise<TokenResponse> {
-    const tokenUrl = `${this.config.mcpHost}/oauth/token`;
+    const tokenUrl = this.getAuthorizationServerUrl("/oauth/token");
 
     const body = new URLSearchParams({
       grant_type: "authorization_code",
@@ -251,10 +268,10 @@ export class OAuthClient {
    * Get or register OAuth client ID for the MCP host
    */
   private async getOrRegisterClientId(): Promise<string> {
+    const configKey = this.getConfigKey();
+
     // Check if we already have a registered client for this host
-    let clientId = await this.configManager.getOAuthClientId(
-      this.config.mcpHost,
-    );
+    let clientId = await this.configManager.getOAuthClientId(configKey);
 
     if (clientId) {
       return clientId;
@@ -266,7 +283,7 @@ export class OAuthClient {
       clientId = await this.registerClient();
 
       // Store the client ID for future use
-      await this.configManager.setOAuthClientId(this.config.mcpHost, clientId);
+      await this.configManager.setOAuthClientId(configKey, clientId);
 
       logSuccess("Client registered and saved");
       logToolResult(clientId);
@@ -282,10 +299,10 @@ export class OAuthClient {
    * Get cached access token or perform OAuth flow
    */
   async getAccessToken(): Promise<string> {
+    const configKey = this.getConfigKey();
+
     // Check for cached token first
-    const cachedToken = await this.configManager.getAccessToken(
-      this.config.mcpHost,
-    );
+    const cachedToken = await this.configManager.getAccessToken(configKey);
     if (cachedToken) {
       logInfo("Authenticated with Sentry", "using stored token");
       return cachedToken;
@@ -299,6 +316,8 @@ export class OAuthClient {
    * Perform the OAuth flow
    */
   async authenticate(): Promise<string> {
+    const configKey = this.getConfigKey();
+
     // Get or register client ID
     const clientId = await this.getOrRegisterClientId();
 
@@ -310,7 +329,7 @@ export class OAuthClient {
     const state = this.generateState();
 
     // Build authorization URL
-    const authUrl = new URL(`${this.config.mcpHost}/oauth/authorize`);
+    const authUrl = new URL(this.getAuthorizationServerUrl("/oauth/authorize"));
     authUrl.searchParams.set("client_id", clientId);
     authUrl.searchParams.set("redirect_uri", OAUTH_REDIRECT_URI);
     authUrl.searchParams.set("response_type", "code");
@@ -318,6 +337,9 @@ export class OAuthClient {
     authUrl.searchParams.set("state", state);
     authUrl.searchParams.set("code_challenge", challenge);
     authUrl.searchParams.set("code_challenge_method", "S256");
+    // RFC 8707: send the exact `/mcp/...` protected resource the client wants
+    // to use so authorization is scoped to that resource from the start.
+    authUrl.searchParams.set("resource", this.getProtectedResourceUrl().href);
 
     logInfo("Authenticating with Sentry - opening browser");
     console.log(
@@ -352,7 +374,7 @@ export class OAuthClient {
 
         // Cache the access token
         await this.configManager.setAccessToken(
-          this.config.mcpHost,
+          configKey,
           tokenResponse.access_token,
           tokenResponse.expires_in,
         );

--- a/packages/mcp-test-client/src/mcp-test-client-remote.ts
+++ b/packages/mcp-test-client/src/mcp-test-client-remote.ts
@@ -7,7 +7,10 @@ import { logError, logSuccess } from "./logger.js";
 import type { MCPConnection, RemoteMCPConfig } from "./types.js";
 import { randomUUID } from "node:crypto";
 import { LIB_VERSION } from "./version.js";
-import { resolveProtectedResourceUrl } from "./mcp-url.js";
+import {
+  applyProtectedResourceFlags,
+  resolveProtectedResourceUrl,
+} from "./mcp-url.js";
 
 export async function connectToRemoteMCPServer(
   config: RemoteMCPConfig,
@@ -29,19 +32,13 @@ export async function connectToRemoteMCPServer(
           const mcpUrl = resolveProtectedResourceUrl(
             config.mcpHost || DEFAULT_MCP_URL,
           );
+          applyProtectedResourceFlags(mcpUrl, config);
 
           // Remove custom attributes - let SDK handle standard attributes
           let accessToken = config.accessToken;
 
           // If no access token provided, we need to authenticate
           if (!accessToken) {
-            if (config.useAgentEndpoint) {
-              mcpUrl.searchParams.set("agent", "1");
-            }
-            if (config.useExperimental) {
-              mcpUrl.searchParams.set("experimental", "1");
-            }
-
             await startSpan(
               {
                 name: "mcp.auth/oauth",
@@ -66,14 +63,6 @@ export async function connectToRemoteMCPServer(
           }
 
           // Create HTTP streaming client with authentication
-          // Use ?agent=1 query param for agent mode, otherwise standard endpoint
-          // Use ?experimental=1 to enable experimental tools
-          if (config.useAgentEndpoint) {
-            mcpUrl.searchParams.set("agent", "1");
-          }
-          if (config.useExperimental) {
-            mcpUrl.searchParams.set("experimental", "1");
-          }
           const httpTransport = new StreamableHTTPClientTransport(mcpUrl, {
             requestInit: {
               headers: {

--- a/packages/mcp-test-client/src/mcp-test-client-remote.ts
+++ b/packages/mcp-test-client/src/mcp-test-client-remote.ts
@@ -7,6 +7,7 @@ import { logError, logSuccess } from "./logger.js";
 import type { MCPConnection, RemoteMCPConfig } from "./types.js";
 import { randomUUID } from "node:crypto";
 import { LIB_VERSION } from "./version.js";
+import { resolveProtectedResourceUrl } from "./mcp-url.js";
 
 export async function connectToRemoteMCPServer(
   config: RemoteMCPConfig,
@@ -25,13 +26,22 @@ export async function connectToRemoteMCPServer(
       },
       async (span) => {
         try {
-          const mcpHost = config.mcpHost || DEFAULT_MCP_URL;
+          const mcpUrl = resolveProtectedResourceUrl(
+            config.mcpHost || DEFAULT_MCP_URL,
+          );
 
           // Remove custom attributes - let SDK handle standard attributes
           let accessToken = config.accessToken;
 
           // If no access token provided, we need to authenticate
           if (!accessToken) {
+            if (config.useAgentEndpoint) {
+              mcpUrl.searchParams.set("agent", "1");
+            }
+            if (config.useExperimental) {
+              mcpUrl.searchParams.set("experimental", "1");
+            }
+
             await startSpan(
               {
                 name: "mcp.auth/oauth",
@@ -39,7 +49,7 @@ export async function connectToRemoteMCPServer(
               async (authSpan) => {
                 try {
                   const oauthClient = new OAuthClient({
-                    mcpHost: mcpHost,
+                    mcpHost: mcpUrl.href,
                   });
                   accessToken = await oauthClient.getAccessToken();
                   authSpan.setStatus({ code: 1 });
@@ -56,9 +66,8 @@ export async function connectToRemoteMCPServer(
           }
 
           // Create HTTP streaming client with authentication
-          // Use ?agent=1 query param for agent mode, otherwise standard /mcp
+          // Use ?agent=1 query param for agent mode, otherwise standard endpoint
           // Use ?experimental=1 to enable experimental tools
-          const mcpUrl = new URL(`${mcpHost}/mcp`);
           if (config.useAgentEndpoint) {
             mcpUrl.searchParams.set("agent", "1");
           }
@@ -90,7 +99,7 @@ export async function connectToRemoteMCPServer(
           span.setStatus({ code: 1 });
 
           logSuccess(
-            `Connected to MCP server (${mcpHost})`,
+            `Connected to MCP server (${mcpUrl})`,
             `${tools.size} tools available`,
           );
 

--- a/packages/mcp-test-client/src/mcp-url.test.ts
+++ b/packages/mcp-test-client/src/mcp-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyProtectedResourceFlags,
   resolveAuthorizationServerUrl,
   resolveProtectedResourceUrl,
 } from "./mcp-url.js";
@@ -25,5 +26,20 @@ describe("mcp-url helpers", () => {
         "https://mcp.sentry.dev/mcp/sentry/javascript",
       ).href,
     ).toBe("https://mcp.sentry.dev/");
+  });
+
+  it("applies agent and experimental flags without dropping existing query params", () => {
+    const protectedResourceUrl = resolveProtectedResourceUrl(
+      "https://mcp.sentry.dev/mcp/sentry/javascript?foo=bar",
+    );
+
+    expect(
+      applyProtectedResourceFlags(protectedResourceUrl, {
+        useAgentEndpoint: true,
+        useExperimental: true,
+      }).href,
+    ).toBe(
+      "https://mcp.sentry.dev/mcp/sentry/javascript?foo=bar&agent=1&experimental=1",
+    );
   });
 });

--- a/packages/mcp-test-client/src/mcp-url.test.ts
+++ b/packages/mcp-test-client/src/mcp-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAuthorizationServerUrl,
+  resolveProtectedResourceUrl,
+} from "./mcp-url.js";
+
+describe("mcp-url helpers", () => {
+  it("normalizes an origin-only MCP host to /mcp", () => {
+    expect(resolveProtectedResourceUrl("https://mcp.sentry.dev").href).toBe(
+      "https://mcp.sentry.dev/mcp",
+    );
+  });
+
+  it("preserves a scoped protected resource path", () => {
+    expect(
+      resolveProtectedResourceUrl(
+        "https://mcp.sentry.dev/mcp/sentry/javascript?experimental=1",
+      ).href,
+    ).toBe("https://mcp.sentry.dev/mcp/sentry/javascript?experimental=1");
+  });
+
+  it("derives the authorization server from a scoped resource", () => {
+    expect(
+      resolveAuthorizationServerUrl(
+        "https://mcp.sentry.dev/mcp/sentry/javascript",
+      ).href,
+    ).toBe("https://mcp.sentry.dev/");
+  });
+});

--- a/packages/mcp-test-client/src/mcp-url.ts
+++ b/packages/mcp-test-client/src/mcp-url.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_MCP_URL } from "./constants.js";
+
+/**
+ * Normalize the configured MCP value into the exact protected resource URL.
+ *
+ * This is the resource identifier used for RFC 9728 protected resource
+ * metadata and for the RFC 8707 `resource` authorization request parameter.
+ *
+ * Examples:
+ * - `https://mcp.sentry.dev` -> `https://mcp.sentry.dev/mcp`
+ * - `https://mcp.sentry.dev/mcp/sentry` -> unchanged
+ */
+export function resolveProtectedResourceUrl(mcpHost?: string): URL {
+  const protectedResourceUrl = new URL(mcpHost || DEFAULT_MCP_URL);
+
+  if (
+    protectedResourceUrl.pathname === "/" ||
+    protectedResourceUrl.pathname === ""
+  ) {
+    protectedResourceUrl.pathname = "/mcp";
+  }
+
+  return protectedResourceUrl;
+}
+
+/**
+ * Get the OAuth server base URL for a protected resource.
+ */
+export function resolveAuthorizationServerUrl(mcpHost?: string): URL {
+  const protectedResourceUrl = resolveProtectedResourceUrl(mcpHost);
+  return new URL(protectedResourceUrl.origin);
+}

--- a/packages/mcp-test-client/src/mcp-url.ts
+++ b/packages/mcp-test-client/src/mcp-url.ts
@@ -30,3 +30,24 @@ export function resolveAuthorizationServerUrl(mcpHost?: string): URL {
   const protectedResourceUrl = resolveProtectedResourceUrl(mcpHost);
   return new URL(protectedResourceUrl.origin);
 }
+
+/**
+ * Apply optional MCP endpoint flags to the protected resource URL.
+ */
+export function applyProtectedResourceFlags(
+  protectedResourceUrl: URL,
+  options: {
+    useAgentEndpoint?: boolean;
+    useExperimental?: boolean;
+  },
+): URL {
+  if (options.useAgentEndpoint) {
+    protectedResourceUrl.searchParams.set("agent", "1");
+  }
+
+  if (options.useExperimental) {
+    protectedResourceUrl.searchParams.set("experimental", "1");
+  }
+
+  return protectedResourceUrl;
+}

--- a/packages/smoke-tests/src/smoke.test.ts
+++ b/packages/smoke-tests/src/smoke.test.ts
@@ -373,6 +373,30 @@ describeIfPreviewUrl(
       expect(allowMethods).toContain("GET");
     });
 
+    it("should serve scoped OAuth metadata with a resource-aware authorization endpoint", async () => {
+      const { response, data } = await safeFetch(
+        `${PREVIEW_URL}/.well-known/oauth-authorization-server/mcp/sentry/mcp-server`,
+        {
+          headers: {
+            Origin: "http://localhost:6274",
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+      expect(data).toHaveProperty("issuer");
+      expect(data.issuer).toBe(`${PREVIEW_URL}/mcp/sentry/mcp-server`);
+      expect(data).toHaveProperty("authorization_endpoint");
+
+      const authorizationEndpoint = new URL(data.authorization_endpoint);
+      expect(authorizationEndpoint.pathname).toBe("/oauth/authorize");
+      expect(authorizationEndpoint.searchParams.get("resource")).toBe(
+        `${PREVIEW_URL}/mcp/sentry/mcp-server`,
+      );
+    });
+
     it("should respond quickly (under 2 seconds)", async () => {
       const start = Date.now();
       const { response } = await safeFetch(PREVIEW_URL);


### PR DESCRIPTION
Preserve constrained \/mcp\/... resources throughout OAuth discovery and consent.

This surfaces organization and project scope on the approval page, fixes the remote test client to send the RFC 8707 `resource` parameter, and adds scoped discovery metadata for clients that probe path-derived RFC 8414 or OIDC endpoints before starting auth.

The scoped RFC 8414 and OIDC metadata is documented as a compatibility path rather than the canonical MCP flow. It uses the probed \/mcp\/... URL as the metadata issuer so strict issuer validation remains consistent, while the shared authorization endpoint stays pre-populated with the exact protected resource.

This also makes local Cloudflare development tolerate missing `CF_VERSION_METADATA`, and adds focused Cloudflare, test-client, and smoke-test coverage around the new behavior.