### PR TITLE
feat(mcp): Carry regionUrl on constraints and unify regional routing

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/constraint-utils.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/constraint-utils.test.ts
@@ -294,8 +294,13 @@ describe("verifyConstraintsAccess", () => {
       expect(mockKV.put).toHaveBeenCalledOnce();
     });
 
-    it("does not use cache for org-only verification", async () => {
-      const mockKV = createMockKV({ getResult: cachedData });
+    it("uses cache for org-only verification", async () => {
+      const orgOnlyCached: CachedConstraints = {
+        regionUrl: "https://us.sentry.io",
+        projectCapabilities: null,
+        cachedAt: Date.now(),
+      };
+      const mockKV = createMockKV({ getResult: orgOnlyCached });
       const cache: CacheOptions = {
         kv: mockKV,
         userId: "user-org-only",
@@ -307,10 +312,52 @@ describe("verifyConstraintsAccess", () => {
       );
 
       expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.constraints).toEqual({
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: null,
+          regionUrl: "https://us.sentry.io",
+          projectCapabilities: null,
+        });
+      }
 
-      // Cache should not be checked for org-only verification
-      expect(mockKV.get).not.toHaveBeenCalled();
+      expect(mockKV.get).toHaveBeenCalledOnce();
+      expect(mockKV.get).toHaveBeenCalledWith(
+        "caps:v1:user-org-only:sentry.io:sentry-mcp-evals:__org__",
+        "json",
+      );
       expect(mockKV.put).not.toHaveBeenCalled();
+    });
+
+    it("writes KV cache after org-only verification on miss", async () => {
+      const mockKV = createMockKV({ getResult: null });
+      const cache: CacheOptions = {
+        kv: mockKV,
+        userId: "user-org-cache-write",
+      };
+
+      const result = await verifyConstraintsAccess(
+        { organizationSlug: "sentry-mcp-evals", projectSlug: null },
+        { accessToken: token, sentryHost: host, cache },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(mockKV.get).toHaveBeenCalledOnce();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(mockKV.put).toHaveBeenCalledOnce();
+      expect(mockKV.put).toHaveBeenCalledWith(
+        "caps:v1:user-org-cache-write:sentry.io:sentry-mcp-evals:__org__",
+        expect.any(String),
+        { expirationTtl: 900 },
+      );
+      const parsed = JSON.parse(
+        vi.mocked(mockKV.put).mock.calls[0][1] as string,
+      );
+      expect(parsed).toMatchObject({
+        regionUrl: "https://us.sentry.io",
+        projectCapabilities: null,
+        cachedAt: expect.any(Number),
+      });
     });
   });
 });

--- a/packages/mcp-cloudflare/src/server/lib/constraint-utils.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/constraint-utils.test.ts
@@ -177,7 +177,7 @@ describe("verifyConstraintsAccess", () => {
       // Verify cache was checked
       expect(mockKV.get).toHaveBeenCalledOnce();
       expect(mockKV.get).toHaveBeenCalledWith(
-        "caps:v1:user-123:sentry.io:sentry-mcp-evals:cloudflare-mcp",
+        "caps:v1:user-123:sentry.io:sentry-mcp-evals:project:cloudflare-mcp",
         "json",
       );
 
@@ -222,7 +222,7 @@ describe("verifyConstraintsAccess", () => {
       // Verify cache was written with correct key and TTL
       expect(mockKV.put).toHaveBeenCalledOnce();
       expect(mockKV.put).toHaveBeenCalledWith(
-        "caps:v1:user-456:sentry.io:sentry-mcp-evals:cloudflare-mcp",
+        "caps:v1:user-456:sentry.io:sentry-mcp-evals:project:cloudflare-mcp",
         expect.any(String),
         { expirationTtl: 900 },
       );
@@ -323,10 +323,40 @@ describe("verifyConstraintsAccess", () => {
 
       expect(mockKV.get).toHaveBeenCalledOnce();
       expect(mockKV.get).toHaveBeenCalledWith(
-        "caps:v1:user-org-only:sentry.io:sentry-mcp-evals:__org__",
+        "caps:v1:user-org-only:sentry.io:sentry-mcp-evals:org",
         "json",
       );
       expect(mockKV.put).not.toHaveBeenCalled();
+    });
+
+    it("uses distinct cache keys for org-only and '__org__' project constraints", async () => {
+      const mockKV = createMockKV({ getResult: cachedData });
+      const cache: CacheOptions = {
+        kv: mockKV,
+        userId: "user-sentinel",
+      };
+
+      const orgOnlyResult = await verifyConstraintsAccess(
+        { organizationSlug: "sentry-mcp-evals", projectSlug: null },
+        { accessToken: token, sentryHost: host, cache },
+      );
+      const projectResult = await verifyConstraintsAccess(
+        { organizationSlug: "sentry-mcp-evals", projectSlug: "__org__" },
+        { accessToken: token, sentryHost: host, cache },
+      );
+
+      expect(orgOnlyResult.ok).toBe(true);
+      expect(projectResult.ok).toBe(true);
+      expect(mockKV.get).toHaveBeenNthCalledWith(
+        1,
+        "caps:v1:user-sentinel:sentry.io:sentry-mcp-evals:org",
+        "json",
+      );
+      expect(mockKV.get).toHaveBeenNthCalledWith(
+        2,
+        "caps:v1:user-sentinel:sentry.io:sentry-mcp-evals:project:__org__",
+        "json",
+      );
     });
 
     it("writes KV cache after org-only verification on miss", async () => {
@@ -346,7 +376,7 @@ describe("verifyConstraintsAccess", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       expect(mockKV.put).toHaveBeenCalledOnce();
       expect(mockKV.put).toHaveBeenCalledWith(
-        "caps:v1:user-org-cache-write:sentry.io:sentry-mcp-evals:__org__",
+        "caps:v1:user-org-cache-write:sentry.io:sentry-mcp-evals:org",
         expect.any(String),
         { expirationTtl: 900 },
       );

--- a/packages/mcp-cloudflare/src/server/lib/constraint-utils.ts
+++ b/packages/mcp-cloudflare/src/server/lib/constraint-utils.ts
@@ -29,8 +29,8 @@ export type CacheOptions = {
 
 /**
  * Build a cache key for constraints verification.
- * Format: caps:v1:{userId}:{sentryHost}:{organizationSlug}:{projectKey}
- * projectKey is the project slug, or "__org__" when only the organization is constrained.
+ * Format: caps:v1:{userId}:{sentryHost}:{organizationSlug}:{scopeKey}
+ * scopeKey is "org" for org-only entries or "project:{slug}" for project-scoped entries.
  */
 function buildCacheKey(
   userId: string,
@@ -38,8 +38,11 @@ function buildCacheKey(
   organizationSlug: string,
   projectSlug: string | null | undefined,
 ): string {
-  const projectKey = projectSlug?.trim() || "__org__";
-  return `caps:${CACHE_KEY_VERSION}:${userId}:${sentryHost}:${organizationSlug}:${projectKey}`;
+  const normalizedProjectSlug = projectSlug?.trim();
+  const scopeKey = normalizedProjectSlug
+    ? `project:${normalizedProjectSlug}`
+    : "org";
+  return `caps:${CACHE_KEY_VERSION}:${userId}:${sentryHost}:${organizationSlug}:${scopeKey}`;
 }
 
 /**

--- a/packages/mcp-cloudflare/src/server/lib/constraint-utils.ts
+++ b/packages/mcp-cloudflare/src/server/lib/constraint-utils.ts
@@ -14,7 +14,8 @@ const CACHE_KEY_VERSION = "v1";
  */
 export type CachedConstraints = {
   regionUrl: string | null;
-  projectCapabilities: ProjectCapabilities;
+  /** Populated when a project constraint was verified; null for org-only cache entries. */
+  projectCapabilities: ProjectCapabilities | null;
   cachedAt: number;
 };
 
@@ -28,15 +29,17 @@ export type CacheOptions = {
 
 /**
  * Build a cache key for constraints verification.
- * Format: caps:v1:{userId}:{sentryHost}:{organizationSlug}:{projectSlug}
+ * Format: caps:v1:{userId}:{sentryHost}:{organizationSlug}:{projectKey}
+ * projectKey is the project slug, or "__org__" when only the organization is constrained.
  */
 function buildCacheKey(
   userId: string,
   sentryHost: string,
   organizationSlug: string,
-  projectSlug: string,
+  projectSlug: string | null | undefined,
 ): string {
-  return `caps:${CACHE_KEY_VERSION}:${userId}:${sentryHost}:${organizationSlug}:${projectSlug}`;
+  const projectKey = projectSlug?.trim() || "__org__";
+  return `caps:${CACHE_KEY_VERSION}:${userId}:${sentryHost}:${organizationSlug}:${projectKey}`;
 }
 
 /**
@@ -149,10 +152,10 @@ export async function verifyConstraintsAccess(
     };
   }
 
-  // Check cache if project constraints are requested and cache is available
-  // Cache key includes userId to ensure per-user isolation
+  // Check KV cache when available (org-only and org+project keys).
+  // Cache key includes userId to ensure per-user isolation.
   let cacheKey: string | null = null;
-  if (projectSlug && cache) {
+  if (cache) {
     cacheKey = buildCacheKey(
       cache.userId,
       sentryHost,
@@ -161,12 +164,11 @@ export async function verifyConstraintsAccess(
     );
     const cached = await getCachedConstraints(cache.kv, cacheKey);
     if (cached) {
-      // Cache hit - return cached constraints without API calls
       return {
         ok: true,
         constraints: {
           organizationSlug,
-          projectSlug,
+          projectSlug: projectSlug || null,
           regionUrl: cached.regionUrl,
           projectCapabilities: cached.projectCapabilities,
         },
@@ -254,12 +256,12 @@ export async function verifyConstraintsAccess(
     }
   }
 
-  // Cache successful verification results for project constraints
-  // Fire-and-forget write - don't block response on cache update
-  if (cacheKey && projectCapabilities) {
+  // Cache: org-only after org fetch; org+project only when project verification
+  // succeeded (skip caching on project timeout so the next request can retry).
+  if (cacheKey && (!projectSlug || projectCapabilities !== null)) {
     void setCachedConstraints(cache!.kv, cacheKey, {
       regionUrl: regionUrl || null,
-      projectCapabilities,
+      projectCapabilities: projectSlug ? projectCapabilities : null,
       cachedAt: Date.now(),
     });
   }

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext, RateLimit } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
-import mcpHandler from "./mcp-handler";
+import mcpHandler, { mergeConstraintRegionUrl } from "./mcp-handler";
 
 interface OAuthProps {
   id: string;
@@ -87,6 +87,42 @@ function createTestEnv(): Env {
 describe("MCP Handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("mergeConstraintRegionUrl", () => {
+    it("matches the trimmed token org slug before merging the token region URL", () => {
+      const merged = mergeConstraintRegionUrl(
+        {
+          organizationSlug: "my-org",
+          projectSlug: null,
+          regionUrl: null,
+        },
+        "my-org",
+        " my-org ",
+        " https://de.sentry.io ",
+      );
+
+      expect(merged).toEqual({
+        organizationSlug: "my-org",
+        projectSlug: null,
+        regionUrl: "https://de.sentry.io",
+      });
+    });
+
+    it("does not override a verified region URL", () => {
+      const merged = mergeConstraintRegionUrl(
+        {
+          organizationSlug: "my-org",
+          projectSlug: null,
+          regionUrl: "https://us.sentry.io",
+        },
+        "my-org",
+        "my-org",
+        "https://de.sentry.io",
+      );
+
+      expect(merged.regionUrl).toBe("https://us.sentry.io");
+    });
   });
 
   describe("authentication", () => {

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -251,6 +251,26 @@ describe("MCP Handler", () => {
       expect(await response.text()).toContain("not found");
     });
 
+    it("returns 403 when the token is org-scoped but the MCP URL uses a different organization", async () => {
+      const request = createMcpRequest(
+        "initialize",
+        {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+        { path: "/mcp/other-org" },
+      );
+      const ctx = createMcpContext({
+        constraintOrganizationSlug: "my-org",
+      });
+
+      const response = await mcpHandler.fetch!(request, createTestEnv(), ctx);
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toContain("scoped to an organization");
+    });
+
     it("returns 403 when the token is project-scoped but the MCP URL uses a different project", async () => {
       const request = createMcpRequest(
         "initialize",

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext, RateLimit } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
-import mcpHandler, { mergeConstraintRegionUrl } from "./mcp-handler";
+import mcpHandler from "./mcp-handler";
 
 interface OAuthProps {
   id: string;
@@ -87,42 +87,6 @@ function createTestEnv(): Env {
 describe("MCP Handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe("mergeConstraintRegionUrl", () => {
-    it("matches the trimmed token org slug before merging the token region URL", () => {
-      const merged = mergeConstraintRegionUrl(
-        {
-          organizationSlug: "my-org",
-          projectSlug: null,
-          regionUrl: null,
-        },
-        "my-org",
-        " my-org ",
-        " https://de.sentry.io ",
-      );
-
-      expect(merged).toEqual({
-        organizationSlug: "my-org",
-        projectSlug: null,
-        regionUrl: "https://de.sentry.io",
-      });
-    });
-
-    it("does not override a verified region URL", () => {
-      const merged = mergeConstraintRegionUrl(
-        {
-          organizationSlug: "my-org",
-          projectSlug: null,
-          regionUrl: "https://us.sentry.io",
-        },
-        "my-org",
-        "my-org",
-        "https://de.sentry.io",
-      );
-
-      expect(merged.regionUrl).toBe("https://us.sentry.io");
-    });
   });
 
   describe("authentication", () => {

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -9,6 +9,8 @@ interface OAuthProps {
   accessToken: string;
   refreshToken: string;
   grantedSkills: string[];
+  constraintOrganizationSlug?: string | null;
+  constraintProjectSlug?: string | null;
 }
 
 const DEFAULT_OAUTH_PROPS: OAuthProps = {
@@ -247,6 +249,48 @@ describe("MCP Handler", () => {
 
       expect(response.status).toBe(404);
       expect(await response.text()).toContain("not found");
+    });
+
+    it("returns 403 when the token is project-scoped but the MCP URL uses a different project", async () => {
+      const request = createMcpRequest(
+        "initialize",
+        {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+        { path: "/mcp/my-org/wrong-project" },
+      );
+      const ctx = createMcpContext({
+        constraintOrganizationSlug: "my-org",
+        constraintProjectSlug: "expected-project",
+      });
+
+      const response = await mcpHandler.fetch!(request, createTestEnv(), ctx);
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toContain("scoped to a project");
+    });
+
+    it("returns 403 when the token is project-scoped but the MCP URL omits the project segment", async () => {
+      const request = createMcpRequest(
+        "initialize",
+        {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+        { path: "/mcp/my-org" },
+      );
+      const ctx = createMcpContext({
+        constraintOrganizationSlug: "my-org",
+        constraintProjectSlug: "my-project",
+      });
+
+      const response = await mcpHandler.fetch!(request, createTestEnv(), ctx);
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toContain("scoped to a project");
     });
   });
 

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -220,6 +220,23 @@ const mcpHandler: ExportedHandler<Env> = {
       );
     }
 
+    const tokenOrg = rawProps.constraintOrganizationSlug?.trim() || null;
+    const tokenProject = rawProps.constraintProjectSlug?.trim() || null;
+    if (tokenProject) {
+      if (!tokenOrg || organizationSlug !== tokenOrg) {
+        return new Response(
+          "This token is scoped to a project. Use the MCP URL for the organization you authorized.",
+          { status: 403 },
+        );
+      }
+      if (!projectSlug || projectSlug !== tokenProject) {
+        return new Response(
+          "This token is scoped to a project. Use the MCP URL that includes that project (for example /mcp/<org>/<project>).",
+          { status: 403 },
+        );
+      }
+    }
+
     // Verify user has access to the requested org/project
     // Cache verification results in KV to avoid repeated API calls
     const verification = await verifyConstraintsAccess(

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -240,13 +240,26 @@ const mcpHandler: ExportedHandler<Env> = {
       });
     }
 
+    let constraints = verification.constraints;
+    if (
+      organizationSlug &&
+      !constraints.regionUrl?.trim() &&
+      rawProps.constraintRegionUrl?.trim() &&
+      rawProps.constraintOrganizationSlug === organizationSlug
+    ) {
+      constraints = {
+        ...constraints,
+        regionUrl: rawProps.constraintRegionUrl.trim(),
+      };
+    }
+
     // Build complete ServerContext from OAuth props + verified constraints
     const serverContext: ServerContext = {
       userId,
       clientId,
       accessToken,
       grantedSkills: validSkills,
-      constraints: verification.constraints,
+      constraints,
       sentryHost,
       mcpUrl: env.MCP_URL,
       agentMode: isAgentMode,

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -25,6 +25,30 @@ import {
 import { annotateResponseMetric } from "../metrics";
 import { verifyConstraintsAccess } from "./constraint-utils";
 
+export function mergeConstraintRegionUrl(
+  constraints: ServerContext["constraints"],
+  organizationSlug: string | null,
+  rawConstraintOrganizationSlug: string | null | undefined,
+  rawConstraintRegionUrl: string | null | undefined,
+): ServerContext["constraints"] {
+  const tokenOrganizationSlug = rawConstraintOrganizationSlug?.trim() || null;
+  const tokenRegionUrl = rawConstraintRegionUrl?.trim() || null;
+
+  if (
+    organizationSlug &&
+    !constraints.regionUrl?.trim() &&
+    tokenRegionUrl &&
+    tokenOrganizationSlug === organizationSlug
+  ) {
+    return {
+      ...constraints,
+      regionUrl: tokenRegionUrl,
+    };
+  }
+
+  return constraints;
+}
+
 /**
  * ExecutionContext with OAuth props injected by the OAuth provider.
  */
@@ -258,17 +282,12 @@ const mcpHandler: ExportedHandler<Env> = {
     }
 
     let constraints = verification.constraints;
-    if (
-      organizationSlug &&
-      !constraints.regionUrl?.trim() &&
-      rawProps.constraintRegionUrl?.trim() &&
-      rawProps.constraintOrganizationSlug === organizationSlug
-    ) {
-      constraints = {
-        ...constraints,
-        regionUrl: rawProps.constraintRegionUrl.trim(),
-      };
-    }
+    constraints = mergeConstraintRegionUrl(
+      constraints,
+      organizationSlug,
+      rawProps.constraintOrganizationSlug ?? null,
+      rawProps.constraintRegionUrl ?? null,
+    );
 
     // Build complete ServerContext from OAuth props + verified constraints
     const serverContext: ServerContext = {

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -222,13 +222,13 @@ const mcpHandler: ExportedHandler<Env> = {
 
     const tokenOrg = rawProps.constraintOrganizationSlug?.trim() || null;
     const tokenProject = rawProps.constraintProjectSlug?.trim() || null;
+    if (tokenOrg && organizationSlug !== tokenOrg) {
+      return new Response(
+        "This token is scoped to an organization. Use the MCP URL for the organization you authorized.",
+        { status: 403 },
+      );
+    }
     if (tokenProject) {
-      if (!tokenOrg || organizationSlug !== tokenOrg) {
-        return new Response(
-          "This token is scoped to a project. Use the MCP URL for the organization you authorized.",
-          { status: 403 },
-        );
-      }
       if (!projectSlug || projectSlug !== tokenProject) {
         return new Response(
           "This token is scoped to a project. Use the MCP URL that includes that project (for example /mcp/<org>/<project>).",

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -25,30 +25,6 @@ import {
 import { annotateResponseMetric } from "../metrics";
 import { verifyConstraintsAccess } from "./constraint-utils";
 
-export function mergeConstraintRegionUrl(
-  constraints: ServerContext["constraints"],
-  organizationSlug: string | null,
-  rawConstraintOrganizationSlug: string | null | undefined,
-  rawConstraintRegionUrl: string | null | undefined,
-): ServerContext["constraints"] {
-  const tokenOrganizationSlug = rawConstraintOrganizationSlug?.trim() || null;
-  const tokenRegionUrl = rawConstraintRegionUrl?.trim() || null;
-
-  if (
-    organizationSlug &&
-    !constraints.regionUrl?.trim() &&
-    tokenRegionUrl &&
-    tokenOrganizationSlug === organizationSlug
-  ) {
-    return {
-      ...constraints,
-      regionUrl: tokenRegionUrl,
-    };
-  }
-
-  return constraints;
-}
-
 /**
  * ExecutionContext with OAuth props injected by the OAuth provider.
  */
@@ -281,13 +257,7 @@ const mcpHandler: ExportedHandler<Env> = {
       });
     }
 
-    let constraints = verification.constraints;
-    constraints = mergeConstraintRegionUrl(
-      constraints,
-      organizationSlug,
-      rawProps.constraintOrganizationSlug ?? null,
-      rawProps.constraintRegionUrl ?? null,
-    );
+    const constraints = verification.constraints;
 
     // Build complete ServerContext from OAuth props + verified constraints
     const serverContext: ServerContext = {

--- a/packages/mcp-cloudflare/src/server/oauth/resource-scope.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/resource-scope.ts
@@ -1,0 +1,38 @@
+/**
+ * Parse RFC 8707 `resource` URLs that scope this MCP deployment to an org/project.
+ * Example: https://example.com/mcp/my-org/backend
+ */
+export function parseResourceMcpConstraints(
+  resource: string | null | undefined,
+): { organizationSlug: string; projectSlug: string | null } | null {
+  if (!resource) {
+    return null;
+  }
+
+  try {
+    const { pathname } = new URL(resource);
+    const pathSegments = pathname.split("/").filter(Boolean);
+
+    if (pathSegments[0] !== "mcp") {
+      return null;
+    }
+
+    if (pathSegments.length === 2) {
+      return {
+        organizationSlug: pathSegments[1],
+        projectSlug: null,
+      };
+    }
+
+    if (pathSegments.length === 3) {
+      return {
+        organizationSlug: pathSegments[1],
+        projectSlug: pathSegments[2],
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -14,6 +14,7 @@ import {
 import { SCOPES } from "../../../constants";
 import { signState, type OAuthState } from "../state";
 import { logWarn } from "@sentry/mcp-core/telem/logging";
+import { parseResourceMcpConstraints } from "../resource-scope";
 
 /**
  * Extended AuthRequest that includes skills and resource parameter
@@ -21,42 +22,6 @@ import { logWarn } from "@sentry/mcp-core/telem/logging";
 interface AuthRequestWithSkills extends AuthRequest {
   skills?: unknown;
   resource?: string;
-}
-
-function getApprovalScopeFromResource(resource: string | null | undefined): {
-  organizationSlug: string;
-  projectSlug: string | null;
-} | null {
-  if (!resource) {
-    return null;
-  }
-
-  try {
-    const { pathname } = new URL(resource);
-    const pathSegments = pathname.split("/").filter(Boolean);
-
-    if (pathSegments[0] !== "mcp") {
-      return null;
-    }
-
-    if (pathSegments.length === 2) {
-      return {
-        organizationSlug: pathSegments[1],
-        projectSlug: null,
-      };
-    }
-
-    if (pathSegments.length === 3) {
-      return {
-        organizationSlug: pathSegments[1],
-        projectSlug: pathSegments[2],
-      };
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
 }
 
 async function redirectToUpstream(
@@ -154,7 +119,7 @@ export default new Hono<{ Bindings: Env }>()
       ...oauthReqInfoWithoutResource,
       ...(resourceParam ? { resource: resourceParam } : {}),
     };
-    const approvalScope = getApprovalScopeFromResource(resourceParam);
+    const approvalScope = parseResourceMcpConstraints(resourceParam);
 
     // XXX(dcramer): we want to confirm permissions on each time
     // so you can always choose new ones

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -266,6 +266,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
 
   let constraintOrganizationSlug: string | null = null;
   let constraintRegionUrl: string | null = null;
+  let constraintProjectSlug: string | null = null;
   const resource = (oauthReqInfo as AuthRequestWithSkills).resource;
   const resourceScope = parseResourceMcpConstraints(
     typeof resource === "string" ? resource : undefined,
@@ -279,6 +280,9 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       const org = await api.getOrganization(resourceScope.organizationSlug);
       constraintOrganizationSlug = resourceScope.organizationSlug;
       constraintRegionUrl = org.links?.regionUrl?.trim() || null;
+      if (resourceScope.projectSlug) {
+        constraintProjectSlug = resourceScope.projectSlug;
+      }
     } catch {
       // Fail-open: MCP requests still run verifyConstraintsAccess
     }
@@ -314,6 +318,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
 
       constraintOrganizationSlug,
       constraintRegionUrl,
+      constraintProjectSlug,
 
       // Note: sentryHost and mcpUrl come from env, not OAuth props
     } as WorkerProps,

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -12,6 +12,8 @@ import {
 import { verifyAndParseState, type OAuthState } from "../state";
 import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
 import { parseSkills, getScopesForSkills } from "@sentry/mcp-core/skills";
+import { SentryApiService } from "@sentry/mcp-core/api-client";
+import { parseResourceMcpConstraints } from "../resource-scope";
 
 /**
  * Extended AuthRequest that includes skills and resource parameter
@@ -262,6 +264,26 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // Convert valid skills Set to array for OAuth props
   const grantedSkills = Array.from(validSkills);
 
+  let constraintOrganizationSlug: string | null = null;
+  let constraintRegionUrl: string | null = null;
+  const resource = (oauthReqInfo as AuthRequestWithSkills).resource;
+  const resourceScope = parseResourceMcpConstraints(
+    typeof resource === "string" ? resource : undefined,
+  );
+  if (resourceScope?.organizationSlug) {
+    try {
+      const api = new SentryApiService({
+        accessToken: payload.access_token,
+        host: c.env.SENTRY_HOST || "sentry.io",
+      });
+      const org = await api.getOrganization(resourceScope.organizationSlug);
+      constraintOrganizationSlug = resourceScope.organizationSlug;
+      constraintRegionUrl = org.links?.regionUrl?.trim() || null;
+    } catch {
+      // Fail-open: MCP requests still run verifyConstraintsAccess
+    }
+  }
+
   // Return back to the MCP client a new token
   const accessTokenExpiresAt = getUpstreamTokenExpiryTimestamp(payload);
   const userLabel = getUpstreamUserLabel(payload);
@@ -290,7 +312,9 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       grantedScopes: Array.from(grantedScopes),
       grantedSkills, // Primary authorization method
 
-      // Note: constraints are NOT included here - they're extracted per-request from URL
+      constraintOrganizationSlug,
+      constraintRegionUrl,
+
       // Note: sentryHost and mcpUrl come from env, not OAuth props
     } as WorkerProps,
   });

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -12,7 +12,6 @@ import {
 import { verifyAndParseState, type OAuthState } from "../state";
 import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
 import { parseSkills, getScopesForSkills } from "@sentry/mcp-core/skills";
-import { SentryApiService } from "@sentry/mcp-core/api-client";
 import { parseResourceMcpConstraints } from "../resource-scope";
 
 /**
@@ -264,29 +263,12 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // Convert valid skills Set to array for OAuth props
   const grantedSkills = Array.from(validSkills);
 
-  let constraintOrganizationSlug: string | null = null;
-  let constraintRegionUrl: string | null = null;
-  let constraintProjectSlug: string | null = null;
   const resource = (oauthReqInfo as AuthRequestWithSkills).resource;
   const resourceScope = parseResourceMcpConstraints(
     typeof resource === "string" ? resource : undefined,
   );
-  if (resourceScope?.organizationSlug) {
-    try {
-      const api = new SentryApiService({
-        accessToken: payload.access_token,
-        host: c.env.SENTRY_HOST || "sentry.io",
-      });
-      const org = await api.getOrganization(resourceScope.organizationSlug);
-      constraintOrganizationSlug = resourceScope.organizationSlug;
-      constraintRegionUrl = org.links?.regionUrl?.trim() || null;
-      if (resourceScope.projectSlug) {
-        constraintProjectSlug = resourceScope.projectSlug;
-      }
-    } catch {
-      // Fail-open: MCP requests still run verifyConstraintsAccess
-    }
-  }
+  const constraintOrganizationSlug = resourceScope?.organizationSlug ?? null;
+  const constraintProjectSlug = resourceScope?.projectSlug ?? null;
 
   // Return back to the MCP client a new token
   const accessTokenExpiresAt = getUpstreamTokenExpiryTimestamp(payload);
@@ -317,7 +299,6 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       grantedSkills, // Primary authorization method
 
       constraintOrganizationSlug,
-      constraintRegionUrl,
       constraintProjectSlug,
 
       // Note: sentryHost and mcpUrl come from env, not OAuth props

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -37,6 +37,11 @@ export type WorkerProps = {
    */
   constraintOrganizationSlug?: string | null;
   constraintRegionUrl?: string | null;
+  /**
+   * When the `resource` URL included a project segment (`/mcp/:org/:project`),
+   * the MCP handler requires the request path to use that same org and project.
+   */
+  constraintProjectSlug?: string | null;
 
   // Note: full URL constraints are still extracted per-request from the MCP path
   // Note: sentryHost and mcpUrl come from env, not OAuth props

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -30,7 +30,15 @@ export type WorkerProps = {
   /** Primary authorization method - array of skill strings */
   grantedSkills?: string[];
 
-  // Note: constraints are NOT included - they're extracted per-request from URL
+  /**
+   * When the OAuth `resource` parameter scoped the grant to `/mcp/:org` (or
+   * `/mcp/:org/:project`), we resolve `links.regionUrl` once at token grant so
+   * MCP requests can merge it into URL constraints without agents passing `regionUrl`.
+   */
+  constraintOrganizationSlug?: string | null;
+  constraintRegionUrl?: string | null;
+
+  // Note: full URL constraints are still extracted per-request from the MCP path
   // Note: sentryHost and mcpUrl come from env, not OAuth props
 };
 

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -32,11 +32,10 @@ export type WorkerProps = {
 
   /**
    * When the OAuth `resource` parameter scoped the grant to `/mcp/:org` (or
-   * `/mcp/:org/:project`), we resolve `links.regionUrl` once at token grant so
-   * MCP requests can merge it into URL constraints without agents passing `regionUrl`.
+   * `/mcp/:org/:project`), persist those path constraints on the token. The
+   * regional API host is resolved later from cached verification or lazy lookup.
    */
   constraintOrganizationSlug?: string | null;
-  constraintRegionUrl?: string | null;
   /**
    * When the `resource` URL included a project segment (`/mcp/:org/:project`),
    * the MCP handler requires the request path to use that same org and project.

--- a/packages/mcp-core/src/internal/constraint-helpers.test.ts
+++ b/packages/mcp-core/src/internal/constraint-helpers.test.ts
@@ -123,6 +123,24 @@ describe("Constraint Helpers", () => {
       // regionUrl not in schema, so it shouldn't be filtered
       expect(keys).toEqual(["organizationSlug"]);
     });
+
+    it("filters regionUrl when it is a resolved non-empty string on constraints", () => {
+      const constraints = {
+        organizationSlug: "my-org",
+        projectSlug: null,
+        regionUrl: "https://us.sentry.io",
+      };
+      const schema = {
+        organizationSlug: z.string(),
+        regionUrl: z.string().nullable(),
+        query: z.string().optional(),
+      };
+      const keys = getConstraintKeysToFilter(constraints, schema);
+      expect(keys).toEqual(
+        expect.arrayContaining(["organizationSlug", "regionUrl"]),
+      );
+      expect(keys).toHaveLength(2);
+    });
   });
 
   describe("getConstraintParametersToInject", () => {
@@ -217,6 +235,22 @@ describe("Constraint Helpers", () => {
       // regionUrl not in schema, so it shouldn't be injected
       expect(params).toEqual({
         organizationSlug: "my-org",
+      });
+    });
+
+    it("injects regionUrl when present on constraints and the tool declares it", () => {
+      const constraints = {
+        organizationSlug: "my-org",
+        projectSlug: null,
+        regionUrl: "https://us.sentry.io",
+      };
+      const schema = {
+        organizationSlug: z.string(),
+        regionUrl: z.string().nullable(),
+      };
+      expect(getConstraintParametersToInject(constraints, schema)).toEqual({
+        organizationSlug: "my-org",
+        regionUrl: "https://us.sentry.io",
       });
     });
   });

--- a/packages/mcp-core/src/internal/constraint-helpers.ts
+++ b/packages/mcp-core/src/internal/constraint-helpers.ts
@@ -3,6 +3,10 @@
  *
  * These functions handle the logic for filtering tool schemas and injecting
  * constraint parameters, including support for parameter aliases (e.g., projectSlug → projectSlugOrId).
+ *
+ * Non-empty string `constraints.regionUrl` (from org resolution on the host transport
+ * or OAuth) is filtered and re-injected like other string constraints so clients cannot
+ * override the regional API host for an org-scoped session.
  */
 import type { Constraints } from "../types";
 import type { z } from "zod";

--- a/packages/mcp-core/src/internal/tool-helpers/resolve-region-url.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/resolve-region-url.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerContext } from "../../types";
+import { resolveRegionUrlForOrganization } from "./resolve-region-url";
+
+const { getOrganization } = vi.hoisted(() => ({
+  getOrganization: vi.fn(),
+}));
+
+vi.mock("./api", () => ({
+  apiServiceFromContext: vi.fn(() => ({
+    getOrganization,
+  })),
+}));
+
+function createContext(
+  constraints: ServerContext["constraints"] = {},
+): ServerContext {
+  return {
+    accessToken: "test-access-token",
+    constraints,
+  };
+}
+
+describe("resolveRegionUrlForOrganization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an explicit regionUrl without fetching the organization", async () => {
+    const result = await resolveRegionUrlForOrganization({
+      context: createContext(),
+      organizationSlug: "my-org",
+      regionUrl: " https://de.sentry.io ",
+    });
+
+    expect(result).toBe("https://de.sentry.io");
+    expect(getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns the scoped regionUrl from context without fetching the organization", async () => {
+    const result = await resolveRegionUrlForOrganization({
+      context: createContext({
+        organizationSlug: "my-org",
+        regionUrl: " https://us.sentry.io ",
+      }),
+      organizationSlug: "my-org",
+      regionUrl: null,
+    });
+
+    expect(result).toBe("https://us.sentry.io");
+    expect(getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("caches fetched region URLs per context", async () => {
+    getOrganization.mockResolvedValue({
+      links: {
+        regionUrl: " https://us.sentry.io ",
+      },
+    });
+
+    const context = createContext();
+
+    const first = await resolveRegionUrlForOrganization({
+      context,
+      organizationSlug: "my-org",
+      regionUrl: null,
+    });
+    const second = await resolveRegionUrlForOrganization({
+      context,
+      organizationSlug: "my-org",
+      regionUrl: null,
+    });
+
+    expect(first).toBe("https://us.sentry.io");
+    expect(second).toBe("https://us.sentry.io");
+    expect(getOrganization).toHaveBeenCalledOnce();
+    expect(getOrganization).toHaveBeenCalledWith("my-org");
+  });
+
+  it("caches empty region URLs after a successful organization lookup", async () => {
+    getOrganization.mockResolvedValue({
+      links: {
+        regionUrl: "",
+      },
+    });
+
+    const context = createContext();
+
+    const first = await resolveRegionUrlForOrganization({
+      context,
+      organizationSlug: "self-hosted-org",
+      regionUrl: null,
+    });
+    const second = await resolveRegionUrlForOrganization({
+      context,
+      organizationSlug: "self-hosted-org",
+      regionUrl: null,
+    });
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(getOrganization).toHaveBeenCalledOnce();
+    expect(getOrganization).toHaveBeenCalledWith("self-hosted-org");
+  });
+});

--- a/packages/mcp-core/src/internal/tool-helpers/resolve-region-url.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/resolve-region-url.ts
@@ -1,12 +1,24 @@
 import { apiServiceFromContext } from "./api";
 import type { ServerContext } from "../../types";
 
+const regionUrlCache = new WeakMap<ServerContext, Map<string, string | null>>();
+
+function getRegionUrlCache(context: ServerContext): Map<string, string | null> {
+  let cache = regionUrlCache.get(context);
+
+  if (!cache) {
+    cache = new Map<string, string | null>();
+    regionUrlCache.set(context, cache);
+  }
+
+  return cache;
+}
+
 /**
  * Resolves which regional Sentry API host to use for organization-scoped calls.
- * Uses the explicit `regionUrl` argument when set; otherwise fetches the
- * organization on the control-plane host. Hosted MCP and stdio hydrate
- * `constraints.regionUrl` from org metadata so it can be auto-injected like
- * `organizationSlug` when the session is org-scoped.
+ * Uses the explicit `regionUrl` argument when set; otherwise prefers the
+ * scoped value already present on `context.constraints`, then lazily fetches
+ * and caches the org metadata for repeated lookups within the same context.
  */
 export async function resolveRegionUrlForOrganization({
   context,
@@ -17,15 +29,31 @@ export async function resolveRegionUrlForOrganization({
   organizationSlug: string;
   regionUrl?: string | null;
 }): Promise<string | null> {
-  if (regionUrl != null) {
+  if (typeof regionUrl === "string") {
     const trimmed = regionUrl.trim();
     return trimmed || null;
   }
 
+  if (context.constraints.organizationSlug === organizationSlug) {
+    const scopedRegionUrl = context.constraints.regionUrl?.trim();
+    if (scopedRegionUrl) {
+      return scopedRegionUrl;
+    }
+  }
+
+  const normalizedOrganizationSlug = organizationSlug.trim();
+  const cache = getRegionUrlCache(context);
+  if (cache.has(normalizedOrganizationSlug)) {
+    return cache.get(normalizedOrganizationSlug) ?? null;
+  }
+
   try {
-    const organization =
-      await apiServiceFromContext(context).getOrganization(organizationSlug);
-    return organization.links?.regionUrl?.trim() || null;
+    const organization = await apiServiceFromContext(context).getOrganization(
+      normalizedOrganizationSlug,
+    );
+    const resolvedRegionUrl = organization.links?.regionUrl?.trim() || null;
+    cache.set(normalizedOrganizationSlug, resolvedRegionUrl);
+    return resolvedRegionUrl;
   } catch {
     return null;
   }

--- a/packages/mcp-core/src/internal/tool-helpers/resolve-region-url.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/resolve-region-url.ts
@@ -1,0 +1,32 @@
+import { apiServiceFromContext } from "./api";
+import type { ServerContext } from "../../types";
+
+/**
+ * Resolves which regional Sentry API host to use for organization-scoped calls.
+ * Uses the explicit `regionUrl` argument when set; otherwise fetches the
+ * organization on the control-plane host. Hosted MCP and stdio hydrate
+ * `constraints.regionUrl` from org metadata so it can be auto-injected like
+ * `organizationSlug` when the session is org-scoped.
+ */
+export async function resolveRegionUrlForOrganization({
+  context,
+  organizationSlug,
+  regionUrl,
+}: {
+  context: ServerContext;
+  organizationSlug: string;
+  regionUrl?: string | null;
+}): Promise<string | null> {
+  if (regionUrl != null) {
+    const trimmed = regionUrl.trim();
+    return trimmed || null;
+  }
+
+  try {
+    const organization =
+      await apiServiceFromContext(context).getOrganization(organizationSlug);
+    return organization.links?.regionUrl?.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -342,6 +342,8 @@ function configureServer({
             tool.inputSchema,
           );
 
+          // Constraints override raw tool arguments. String constraint fields are
+          // also removed from tool schemas and re-injected (see getConstraintKeysToFilter).
           const paramsWithConstraints = {
             ...params,
             ...applicableConstraints,

--- a/packages/mcp-core/src/tools/get-profile-details.ts
+++ b/packages/mcp-core/src/tools/get-profile-details.ts
@@ -2,6 +2,7 @@ import { setTag } from "@sentry/core";
 import { z } from "zod";
 import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
+import { resolveRegionUrlForOrganization } from "../internal/tool-helpers/resolve-region-url";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../schema";
@@ -271,10 +272,6 @@ export default defineTool({
   annotations: { readOnlyHint: true, openWorldHint: false },
 
   async handler(params, context: ServerContext) {
-    const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl ?? undefined,
-    });
-
     const resolved = resolveProfileDetailsParams({
       profileUrl: params.profileUrl,
       organizationSlug: params.organizationSlug,
@@ -283,6 +280,16 @@ export default defineTool({
       profilerId: params.profilerId,
       start: params.start,
       end: params.end,
+    });
+
+    const regionUrl = await resolveRegionUrlForOrganization({
+      context,
+      organizationSlug: resolved.organizationSlug,
+      regionUrl: params.regionUrl,
+    });
+
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: regionUrl ?? undefined,
     });
 
     setTag("organization.slug", resolved.organizationSlug);

--- a/packages/mcp-core/src/tools/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/get-replay-details.ts
@@ -8,6 +8,7 @@ import type {
 } from "../api-client";
 import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
+import { resolveRegionUrlForOrganization } from "../internal/tool-helpers/resolve-region-url";
 import { parseSentryUrl } from "../internal/url-helpers";
 import { resolveScopedOrganizationSlug } from "../internal/url-scope";
 import { UserInputError } from "../errors";
@@ -81,10 +82,10 @@ export default defineTool({
   },
   async handler(params, context: ServerContext) {
     const resolved = resolveReplayParams(params);
-    const regionUrl = await resolveReplayRegionUrl({
+    const regionUrl = await resolveRegionUrlForOrganization({
       context,
       organizationSlug: resolved.organizationSlug,
-      regionUrl: params.regionUrl ?? context.constraints.regionUrl,
+      regionUrl: params.regionUrl,
     });
     const apiService = apiServiceFromContext(context, {
       regionUrl: regionUrl ?? undefined,
@@ -176,30 +177,6 @@ export function resolveReplayParams(params: {
     organizationSlug: params.organizationSlug,
     replayId: params.replayId,
   };
-}
-
-async function resolveReplayRegionUrl({
-  context,
-  organizationSlug,
-  regionUrl,
-}: {
-  context: ServerContext;
-  organizationSlug: string;
-  regionUrl?: string | null;
-}): Promise<string | null> {
-  if (regionUrl != null) {
-    const trimmedRegionUrl = regionUrl.trim();
-    return trimmedRegionUrl || null;
-  }
-
-  try {
-    const organization =
-      await apiServiceFromContext(context).getOrganization(organizationSlug);
-    const resolvedRegionUrl = organization.links?.regionUrl?.trim();
-    return resolvedRegionUrl || null;
-  } catch {
-    return null;
-  }
 }
 
 async function assertReplayWithinProjectConstraint({

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -409,7 +409,7 @@ export default defineTool({
           {
             organizationSlug: resolved.organizationSlug,
             issueId: resolved.issueId,
-            regionUrl: null,
+            regionUrl: context.constraints.regionUrl ?? null,
           },
           context,
         );
@@ -420,7 +420,7 @@ export default defineTool({
             organizationSlug: resolved.organizationSlug,
             issueId: resolved.issueId,
             eventId: resolved.eventId,
-            regionUrl: null,
+            regionUrl: context.constraints.regionUrl ?? null,
           },
           context,
         );
@@ -430,13 +430,15 @@ export default defineTool({
           {
             organizationSlug: resolved.organizationSlug,
             traceId: resolved.traceId!,
-            regionUrl: null,
+            regionUrl: context.constraints.regionUrl ?? null,
           },
           context,
         );
 
       case "breadcrumbs": {
-        const apiService = apiServiceFromContext(context);
+        const apiService = apiServiceFromContext(context, {
+          regionUrl: context.constraints.regionUrl ?? undefined,
+        });
         try {
           await ensureIssueWithinProjectConstraint({
             apiService,
@@ -466,6 +468,7 @@ export default defineTool({
             replayUrl: params.url,
             organizationSlug: resolved.organizationSlug,
             replayId: resolved.replayId,
+            regionUrl: context.constraints.regionUrl ?? undefined,
           },
           context,
         );
@@ -480,7 +483,7 @@ export default defineTool({
             profilerId: resolved.profilerId,
             start: resolved.start,
             end: resolved.end,
-            regionUrl: null,
+            regionUrl: context.constraints.regionUrl ?? null,
             focusOnUserCode: true,
           },
           context,

--- a/packages/mcp-core/src/tools/get-trace-details.test.ts
+++ b/packages/mcp-core/src/tools/get-trace-details.test.ts
@@ -9,6 +9,22 @@ import {
 } from "@sentry/mcp-server-mocks";
 import getTraceDetails from "./get-trace-details.js";
 
+/** Register the same handler on sentry.io and us.sentry.io (org fixture resolves region). */
+function httpGetRegional(
+  sentryIoUrl: string,
+  resolver: Parameters<typeof http.get>[1],
+  options?: Parameters<typeof http.get>[2],
+) {
+  const usUrl = sentryIoUrl.replace(
+    /^https:\/\/sentry\.io\b/,
+    "https://us.sentry.io",
+  );
+  return [
+    http.get(sentryIoUrl, resolver, options),
+    http.get(usUrl, resolver, options),
+  ];
+}
+
 describe("get_trace_details", () => {
   it("serializes with valid trace ID", async () => {
     const result = await getTraceDetails.handler(
@@ -141,7 +157,7 @@ describe("get_trace_details", () => {
     const traceId = "a4d1aae7216b47ff8117cf4e09ce9d0a";
 
     mswServer.use(
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/projects/sentry-mcp-evals/frontend/",
         () =>
           HttpResponse.json({
@@ -151,7 +167,7 @@ describe("get_trace_details", () => {
           }),
         { once: true },
       ),
-      http.get(
+      ...httpGetRegional(
         `https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/${traceId}/`,
         ({ request }) => {
           const url = new URL(request.url);
@@ -187,7 +203,7 @@ describe("get_trace_details", () => {
 
   it("handles empty trace response", async () => {
     mswServer.use(
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
         () => {
           return HttpResponse.json({
@@ -200,7 +216,7 @@ describe("get_trace_details", () => {
           });
         },
       ),
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/a4d1aae7216b47ff8117cf4e09ce9d0a/",
         () => {
           return HttpResponse.json([]);
@@ -232,7 +248,7 @@ describe("get_trace_details", () => {
 
   it("handles API error gracefully", async () => {
     mswServer.use(
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
         () => {
           return new HttpResponse(
@@ -300,13 +316,13 @@ describe("get_trace_details", () => {
 
   it("handles trace meta with null transaction.event_id values", async () => {
     mswServer.use(
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/a4d1aae7216b47ff8117cf4e09ce9d0a/",
         () => {
           return HttpResponse.json(traceMetaWithNullsFixture);
         },
       ),
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/a4d1aae7216b47ff8117cf4e09ce9d0a/",
         () => {
           return HttpResponse.json(traceFixture);
@@ -342,7 +358,7 @@ describe("get_trace_details", () => {
 
   it("handles mixed span/issue arrays in trace responses", async () => {
     mswServer.use(
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/b4d1aae7216b47ff8117cf4e09ce9d0b/",
         () => {
           return HttpResponse.json({
@@ -355,7 +371,7 @@ describe("get_trace_details", () => {
           });
         },
       ),
-      http.get(
+      ...httpGetRegional(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/b4d1aae7216b47ff8117cf4e09ce9d0b/",
         () => {
           return HttpResponse.json(traceMixedFixture);

--- a/packages/mcp-core/src/tools/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/get-trace-details.ts
@@ -1,6 +1,7 @@
 import { setTag } from "@sentry/core";
 import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
+import { resolveRegionUrlForOrganization } from "../internal/tool-helpers/resolve-region-url";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
 import { ParamOrganizationSlug, ParamRegionUrl, ParamTraceId } from "../schema";
@@ -71,8 +72,14 @@ export default defineTool({
       );
     }
 
+    const regionUrl = await resolveRegionUrlForOrganization({
+      context,
+      organizationSlug: params.organizationSlug,
+      regionUrl: params.regionUrl,
+    });
+
     const apiService = apiServiceFromContext(context, {
-      regionUrl: params.regionUrl ?? undefined,
+      regionUrl: regionUrl ?? undefined,
     });
 
     setTag("organization.slug", params.organizationSlug);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -21,6 +21,7 @@
  */
 
 import { buildServer } from "@sentry/mcp-core/server";
+import { SentryApiService } from "@sentry/mcp-core/api-client";
 import { startStdio } from "./transports/stdio";
 import * as Sentry from "@sentry/node";
 import { LIB_VERSION } from "@sentry/mcp-core/version";
@@ -89,6 +90,21 @@ async function main() {
   const cfg = await resolveAccessToken(partialCfg).catch((err) => {
     die(err instanceof Error ? err.message : String(err));
   });
+
+  let constraintRegionUrl: string | null = null;
+  const orgSlugForRegion = cfg.organizationSlug?.trim();
+  if (orgSlugForRegion && cfg.accessToken) {
+    try {
+      const api = new SentryApiService({
+        host: cfg.sentryHost,
+        accessToken: cfg.accessToken,
+      });
+      const org = await api.getOrganization(orgSlugForRegion);
+      constraintRegionUrl = org.links?.regionUrl?.trim() || null;
+    } catch {
+      // Leave null; unconstrained regionUrl stays on tool schemas when applicable.
+    }
+  }
 
   // Configure embedded agent provider
   if (cfg.agentProvider) {
@@ -337,6 +353,7 @@ async function main() {
     constraints: {
       organizationSlug: cfg.organizationSlug ?? null,
       projectSlug: cfg.projectSlug ?? null,
+      regionUrl: constraintRegionUrl,
     },
     sentryHost: cfg.sentryHost,
     mcpUrl: cfg.mcpUrl,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -21,7 +21,6 @@
  */
 
 import { buildServer } from "@sentry/mcp-core/server";
-import { SentryApiService } from "@sentry/mcp-core/api-client";
 import { startStdio } from "./transports/stdio";
 import * as Sentry from "@sentry/node";
 import { LIB_VERSION } from "@sentry/mcp-core/version";
@@ -90,21 +89,6 @@ async function main() {
   const cfg = await resolveAccessToken(partialCfg).catch((err) => {
     die(err instanceof Error ? err.message : String(err));
   });
-
-  let constraintRegionUrl: string | null = null;
-  const orgSlugForRegion = cfg.organizationSlug?.trim();
-  if (orgSlugForRegion && cfg.accessToken) {
-    try {
-      const api = new SentryApiService({
-        host: cfg.sentryHost,
-        accessToken: cfg.accessToken,
-      });
-      const org = await api.getOrganization(orgSlugForRegion);
-      constraintRegionUrl = org.links?.regionUrl?.trim() || null;
-    } catch {
-      // Leave null; unconstrained regionUrl stays on tool schemas when applicable.
-    }
-  }
 
   // Configure embedded agent provider
   if (cfg.agentProvider) {
@@ -353,7 +337,7 @@ async function main() {
     constraints: {
       organizationSlug: cfg.organizationSlug ?? null,
       projectSlug: cfg.projectSlug ?? null,
-      regionUrl: constraintRegionUrl,
+      regionUrl: null,
     },
     sentryHost: cfg.sentryHost,
     mcpUrl: cfg.mcpUrl,


### PR DESCRIPTION
Resolve and carry `regionUrl` on MCP session constraints so it is filtered from tool schemas and auto-injected like `organizationSlug` when it is a non-empty string. Hosted verification already loads `links.regionUrl` from the org API; OAuth can also persist `constraintRegionUrl` when the grant resource scopes `/mcp/:org`, and the worker merges that into URL constraints when the request path org matches the token scope (defense-in-depth when cache or verification paths differ).

Stdio now performs a one-time `getOrganization` when both an org slug and access token are configured, so CLI org-scoped sessions populate `constraints.regionUrl` the same way.

Trace, profile, and replay detail tools share `resolveRegionUrlForOrganization`; `get_sentry_resource` forwards `constraints.regionUrl` into composed handlers because those calls bypass MCP parameter merge. Constraint helpers gain documentation and tests for `regionUrl` as a string constraint.

OAuth `resource` URL parsing is extracted to `resource-scope.ts` for reuse in authorize and callback. Cloudflare constraint verification caching is adjusted for org-only keys alongside existing project-scoped entries.

Reviewers should sanity-check the OAuth merge conditions in `mcp-handler.ts` and KV cache semantics in `constraint-utils.ts` for multi-tenant isolation.