### PR TITLE
fix(stdio): Allow HTTP for self-hosted hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,20 @@ npx @sentry/mcp-server@latest --access-token=sentry-user-token
 
 Need to connect to a self-hosted deployment? Add <code>--host</code> (hostname
 only, e.g. <code>--host=sentry.example.com</code>) when you run the command.
+For isolated internal deployments that only expose plain HTTP, also add
+<code>--insecure-http</code>.
 
 Some features (like Seer) may not be available on self-hosted instances. You can
 disable specific skills to prevent unsupported tools from being exposed:
 
 ```shell
 npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.example.com --disable-skills=seer
+```
+
+For self-hosted instances without TLS:
+
+```shell
+npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.internal:9000 --insecure-http
 ```
 
 #### Environment Variables

--- a/docs/stdio-auth.md
+++ b/docs/stdio-auth.md
@@ -7,6 +7,7 @@ How the stdio transport authenticates with Sentry, including the device code flo
 The stdio transport supports two authentication methods, in order of precedence:
 
 1. **Explicit token** — `--access-token` flag or `SENTRY_ACCESS_TOKEN` env var. Works for all Sentry hosts. This is the only method available for self-hosted instances.
+   For self-hosted deployments that only expose plain HTTP, pair `--access-token` with `--host` and `--insecure-http`.
 
 2. **Device code flow** — OAuth Device Authorization Grant (RFC 8628). Only available for sentry.io (including regional subdomains like `us.sentry.io`). Requires an interactive terminal (TTY). Falls back to cached tokens in non-interactive contexts.
 

--- a/docs/testing-stdio.md
+++ b/docs/testing-stdio.md
@@ -176,6 +176,19 @@ This opens the MCP Inspector at `http://localhost:6274`
 }
 ```
 
+**For self-hosted Sentry on plain HTTP:**
+```json
+{
+  "command": "npx",
+  "args": [
+    "@sentry/mcp-server@latest",
+    "--access-token=YOUR_TOKEN",
+    "--host=sentry.internal:9000",
+    "--insecure-http"
+  ]
+}
+```
+
 4. Click "Connect"
 5. Click "List Tools" to verify connection
 

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -35,6 +35,16 @@ describe("getIssueUrl", () => {
       `"https://localhost:8000/organizations/sentry-mcp/issues/123456"`,
     );
   });
+  it("should support HTTP issue URLs for self-hosted instances when configured", () => {
+    const apiService = new SentryApiService({
+      host: "localhost:8000",
+      protocol: "http",
+    });
+    const result = apiService.getIssueUrl("sentry-mcp", "123456");
+    expect(result).toMatchInlineSnapshot(
+      `"http://localhost:8000/organizations/sentry-mcp/issues/123456"`,
+    );
+  });
   it("should handle regional URLs correctly for SaaS", () => {
     const apiService = new SentryApiService({ host: "us.sentry.io" });
     const result = apiService.getIssueUrl("sentry", "PROJ-THREAD-LEAKS-12");
@@ -622,6 +632,20 @@ describe("host configuration", () => {
     expect(apiService.host).toBe("localhost:8000");
     // @ts-expect-error - accessing private property for testing
     expect(apiService.apiPrefix).toBe("https://localhost:8000/api/0");
+  });
+
+  it("should support opt-in HTTP for self-hosted instances", () => {
+    const apiService = new SentryApiService({
+      host: "sentry.internal:9000",
+      protocol: "http",
+    });
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.host).toBe("sentry.internal:9000");
+    // @ts-expect-error - accessing private property for testing
+    expect(apiService.apiPrefix).toBe("http://sentry.internal:9000/api/0");
+    expect(apiService.getIssueUrl("sentry-mcp", "123456")).toBe(
+      "http://sentry.internal:9000/organizations/sentry-mcp/issues/123456",
+    );
   });
 
   it("should update host and API prefix with setHost", () => {

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -55,6 +55,7 @@ import {
 import { ConfigurationError } from "../errors";
 import { createApiError, ApiNotFoundError, ApiValidationError } from "./errors";
 import { USER_AGENT } from "../version";
+import type { SentryProtocol } from "../types";
 import type {
   AutofixRun,
   AutofixRunState,
@@ -135,7 +136,7 @@ type RequestOptions = {
  * - Enhanced error handling with LLM-friendly messages
  * - URL generation for Sentry resources (issues, traces)
  * - Bearer token authentication
- * - Always uses HTTPS for secure connections
+ * - Uses HTTPS by default, with opt-in HTTP for self-hosted stdio deployments
  *
  * @example Basic Usage
  * ```typescript
@@ -169,12 +170,13 @@ type RequestOptions = {
 export class SentryApiService {
   private accessToken: string | null;
   protected host: string;
+  protected protocol: SentryProtocol;
   protected apiPrefix: string;
 
   /**
    * Creates a new Sentry API service instance.
    *
-   * Always uses HTTPS for secure connections.
+   * Uses HTTPS by default. Stdio may opt into HTTP for self-hosted deployments.
    *
    * @param config Configuration object
    * @param config.accessToken OAuth access token for authentication (optional for some endpoints)
@@ -183,26 +185,29 @@ export class SentryApiService {
   constructor({
     accessToken = null,
     host = "sentry.io",
+    protocol = "https",
   }: {
     accessToken?: string | null;
     host?: string;
+    protocol?: SentryProtocol;
   }) {
     this.accessToken = accessToken;
     this.host = host;
-    this.apiPrefix = `https://${host}/api/0`;
+    this.protocol = protocol;
+    this.apiPrefix = `${protocol}://${host}/api/0`;
   }
 
   /**
    * Updates the host for API requests.
    *
    * Used for multi-region support or switching between Sentry instances.
-   * Always uses HTTPS protocol.
+   * Preserves the configured URL scheme.
    *
    * @param host New hostname to use for API requests
    */
   setHost(host: string) {
     this.host = host;
-    this.apiPrefix = `https://${this.host}/api/0`;
+    this.apiPrefix = `${this.protocol}://${this.host}/api/0`;
   }
 
   /**
@@ -275,7 +280,7 @@ export class SentryApiService {
     { host }: { host?: string } = {},
   ): Promise<Response> {
     const url = host
-      ? `https://${host}/api/0${path}`
+      ? `${this.protocol}://${host}/api/0${path}`
       : `${this.apiPrefix}${path}`;
 
     const headers: Record<string, string> = {
@@ -499,7 +504,7 @@ export class SentryApiService {
    * Generates a Sentry issue URL for browser navigation.
    *
    * Handles both SaaS (subdomain-based) and self-hosted URL formats.
-   * Always uses HTTPS protocol.
+   * Uses the configured protocol.
    *
    * @param organizationSlug Organization identifier
    * @param issueId Issue identifier (short ID or numeric ID)
@@ -515,17 +520,17 @@ export class SentryApiService {
    * ```
    */
   getIssueUrl(organizationSlug: string, issueId: string): string {
-    return getIssueUrlUtil(this.host, organizationSlug, issueId);
+    return getIssueUrlUtil(this.host, organizationSlug, issueId, this.protocol);
   }
 
   /**
    * Generates a Sentry trace URL for performance investigation.
    *
-   * Always uses HTTPS protocol.
+   * Uses the configured protocol.
    *
    * @param organizationSlug Organization identifier
    * @param traceId Trace identifier (hex string)
-   * @returns Full HTTPS URL to the trace in Sentry UI
+   * @returns Full URL to the trace in Sentry UI
    *
    * @example
    * ```typescript
@@ -534,11 +539,16 @@ export class SentryApiService {
    * ```
    */
   getTraceUrl(organizationSlug: string, traceId: string): string {
-    return getTraceUrlUtil(this.host, organizationSlug, traceId);
+    return getTraceUrlUtil(this.host, organizationSlug, traceId, this.protocol);
   }
 
   getReplayUrl(organizationSlug: string, replayId: string): string {
-    return getReplayUrlUtil(this.host, organizationSlug, replayId);
+    return getReplayUrlUtil(
+      this.host,
+      organizationSlug,
+      replayId,
+      this.protocol,
+    );
   }
 
   getProfileUrl(
@@ -551,6 +561,7 @@ export class SentryApiService {
       organizationSlug,
       projectSlug,
       profileId,
+      this.protocol,
     );
   }
 
@@ -568,6 +579,7 @@ export class SentryApiService {
       organizationSlug,
       projectSlug,
       options,
+      this.protocol,
     );
   }
 
@@ -575,7 +587,12 @@ export class SentryApiService {
     organizationSlug: string,
     options: Parameters<typeof getReplaysSearchUrlUtil>[2] = {},
   ): string {
-    return getReplaysSearchUrlUtil(this.host, organizationSlug, options);
+    return getReplaysSearchUrlUtil(
+      this.host,
+      organizationSlug,
+      options,
+      this.protocol,
+    );
   }
 
   // ================================================================================
@@ -667,8 +684,8 @@ export class SentryApiService {
     // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
     const webHost = this.isSaas() ? "sentry.io" : this.host;
     const path = this.isSaas()
-      ? `https://${organizationSlug}.${webHost}/explore/discover/homepage/`
-      : `https://${this.host}/organizations/${organizationSlug}/explore/discover/homepage/`;
+      ? `${this.protocol}://${organizationSlug}.${webHost}/explore/discover/homepage/`
+      : `${this.protocol}://${this.host}/organizations/${organizationSlug}/explore/discover/homepage/`;
 
     return `${path}?${urlParams.toString()}`;
   }
@@ -805,8 +822,8 @@ export class SentryApiService {
     // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
     const webHost = this.isSaas() ? "sentry.io" : this.host;
     const path = this.isSaas()
-      ? `https://${organizationSlug}.${webHost}/explore/${basePath}/`
-      : `https://${this.host}/organizations/${organizationSlug}/explore/${basePath}/`;
+      ? `${this.protocol}://${organizationSlug}.${webHost}/explore/${basePath}/`
+      : `${this.protocol}://${this.host}/organizations/${organizationSlug}/explore/${basePath}/`;
 
     return `${path}?${urlParams.toString()}`;
   }
@@ -857,7 +874,7 @@ export class SentryApiService {
    * @param start Absolute start time (ISO 8601)
    * @param end Absolute end time (ISO 8601)
    * @param eventData Optional event rows used to derive trace metric identity for metrics sample URLs
-   * @returns Full HTTPS URL to the events explorer in Sentry UI
+   * @returns Full URL to the events explorer in Sentry UI
    */
   getEventsExplorerUrl(
     organizationSlug: string,
@@ -890,31 +907,41 @@ export class SentryApiService {
     }
 
     if (isMetricsDataset(dataset)) {
-      return getTraceMetricsExploreUrl(this.host, organizationSlug, {
-        query,
-        projectId,
-        sort,
-        statsPeriod,
-        start,
-        end,
-        aggregateFunctions,
-        groupByFields,
-        traceMetrics: this.extractTraceMetricsFromResults(eventData),
-      });
+      return getTraceMetricsExploreUrl(
+        this.host,
+        organizationSlug,
+        {
+          query,
+          projectId,
+          sort,
+          statsPeriod,
+          start,
+          end,
+          aggregateFunctions,
+          groupByFields,
+          traceMetrics: this.extractTraceMetricsFromResults(eventData),
+        },
+        this.protocol,
+      );
     }
 
     if (isProfilesDataset(dataset)) {
-      return getProfilingExplorerUrl(this.host, organizationSlug, {
-        query,
-        projectId,
-        fields,
-        sort,
-        statsPeriod,
-        start,
-        end,
-        aggregateFunctions,
-        groupByFields,
-      });
+      return getProfilingExplorerUrl(
+        this.host,
+        organizationSlug,
+        {
+          query,
+          projectId,
+          fields,
+          sort,
+          statsPeriod,
+          start,
+          end,
+          aggregateFunctions,
+          groupByFields,
+        },
+        this.protocol,
+      );
     }
 
     // Route to modern EAP API (spans and logs)

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 import {
   getContinuousProfileUrl as getContinuousProfileUrlUtil,
   getIssueUrl as getIssueUrlUtil,
+  getMonitorUrl as getMonitorUrlUtil,
   getProfileUrl as getProfileUrlUtil,
   getProfilingExplorerUrl,
+  getReleaseUrl as getReleaseUrlUtil,
   getReplayUrl as getReplayUrlUtil,
   getReplaysSearchUrl as getReplaysSearchUrlUtil,
   getTraceMetricsExploreUrl,
@@ -591,6 +593,24 @@ export class SentryApiService {
       this.host,
       organizationSlug,
       options,
+      this.protocol,
+    );
+  }
+
+  getMonitorUrl(organizationSlug: string, monitorSlug: string): string {
+    return getMonitorUrlUtil(
+      this.host,
+      organizationSlug,
+      monitorSlug,
+      this.protocol,
+    );
+  }
+
+  getReleaseUrl(organizationSlug: string, releaseVersion: string): string {
+    return getReleaseUrlUtil(
+      this.host,
+      organizationSlug,
+      releaseVersion,
       this.protocol,
     );
   }

--- a/packages/mcp-core/src/internal/tool-helpers/api.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.ts
@@ -11,7 +11,7 @@ import { validateRegionUrl } from "./validate-region-url";
  * Create a Sentry API service from server context with optional region override
  * @param context - Server context containing host and access token
  * @param opts - Options object containing optional regionUrl override
- * @returns Configured SentryApiService instance (always uses HTTPS)
+ * @returns Configured SentryApiService instance using the context's configured protocol
  * @throws {UserInputError} When regionUrl is provided but invalid
  */
 export function apiServiceFromContext(
@@ -29,6 +29,7 @@ export function apiServiceFromContext(
 
   return new SentryApiService({
     host,
+    protocol: context.sentryProtocol,
     accessToken: context.accessToken,
   });
 }

--- a/packages/mcp-core/src/tools/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.test.ts
@@ -318,6 +318,44 @@ describe("get_sentry_resource", () => {
         - **Search issues**: Use \`search_issues\` with query \`release:backend@2024.01.15-abc123\` to find issues in this release"
       `);
     });
+
+    it("uses configured host and protocol for self-hosted monitor URL", async () => {
+      const result = await getSentryResource.handler(
+        {
+          resourceType: undefined,
+          resourceId: undefined,
+          organizationSlug: undefined,
+          url: "http://sentry.internal:9000/organizations/my-org/crons/daily-backup/",
+        },
+        {
+          ...baseContext,
+          sentryHost: "sentry.internal:9000",
+          sentryProtocol: "http",
+        },
+      );
+      expect(result).toContain(
+        "[Open Monitor](http://sentry.internal:9000/organizations/my-org/crons/daily-backup/)",
+      );
+    });
+
+    it("uses configured host and protocol for self-hosted release URL", async () => {
+      const result = await getSentryResource.handler(
+        {
+          resourceType: undefined,
+          resourceId: undefined,
+          organizationSlug: undefined,
+          url: "http://sentry.internal:9000/organizations/my-org/releases/v1.2.3/",
+        },
+        {
+          ...baseContext,
+          sentryHost: "sentry.internal:9000",
+          sentryProtocol: "http",
+        },
+      );
+      expect(result).toContain(
+        "[Open Release](http://sentry.internal:9000/organizations/my-org/releases/v1.2.3/)",
+      );
+    });
   });
 
   // ─── URL mode: error cases ────────────────────────────────────────────────

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -10,7 +10,7 @@ import {
   resolveScopedProjectSlug,
 } from "../internal/url-scope";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
-import { ApiNotFoundError } from "../api-client";
+import { ApiNotFoundError, type SentryApiService } from "../api-client";
 import { enhanceNotFoundError } from "../internal/tool-helpers/enhance-error";
 import { ensureIssueWithinProjectConstraint } from "../internal/tool-helpers/issue";
 import { fetchAndFormatBreadcrumbs } from "../internal/tool-helpers/breadcrumbs";
@@ -288,6 +288,7 @@ function resolveFromParsedUrl(
 
 function generateUnsupportedResourceMessage(
   resolved: ResolvedResourceParams,
+  apiService: SentryApiService,
 ): string {
   const { type, organizationSlug } = resolved;
 
@@ -296,8 +297,11 @@ function generateUnsupportedResourceMessage(
       // Include projectSlug in URL when present
       const monitorPath = resolved.projectSlug
         ? `${resolved.projectSlug}/${resolved.monitorSlug}`
-        : resolved.monitorSlug;
-      const monitorUrl = `https://${organizationSlug}.sentry.io/crons/${monitorPath}/`;
+        : (resolved.monitorSlug ?? "");
+      const monitorUrl = apiService.getMonitorUrl(
+        organizationSlug,
+        monitorPath,
+      );
       return [
         "# Cron Monitor Detected",
         "",
@@ -315,7 +319,10 @@ function generateUnsupportedResourceMessage(
     }
 
     case "release": {
-      const releaseUrl = `https://${organizationSlug}.sentry.io/releases/${resolved.releaseVersion}/`;
+      const releaseUrl = apiService.getReleaseUrl(
+        organizationSlug,
+        resolved.releaseVersion ?? "",
+      );
       return [
         "# Release Detected",
         "",
@@ -400,7 +407,10 @@ export default defineTool({
 
     // Recognized but not yet fully supported types return guidance messages
     if (resolved.type === "monitor" || resolved.type === "release") {
-      return generateUnsupportedResourceMessage(resolved);
+      const apiService = apiServiceFromContext(context, {
+        regionUrl: context.constraints.regionUrl ?? undefined,
+      });
+      return generateUnsupportedResourceMessage(resolved, apiService);
     }
 
     switch (resolved.type) {

--- a/packages/mcp-core/src/tools/list-issues/index.ts
+++ b/packages/mcp-core/src/tools/list-issues/index.ts
@@ -106,6 +106,8 @@ export default defineTool({
       projectSlugOrId: params.projectSlugOrId ?? undefined,
       query: params.query,
       regionUrl: params.regionUrl ?? undefined,
+      host: context.sentryHost,
+      protocol: context.sentryProtocol,
     });
   },
 });

--- a/packages/mcp-core/src/tools/list-issues/list-issues.test.ts
+++ b/packages/mcp-core/src/tools/list-issues/list-issues.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { mswServer } from "@sentry/mcp-server-mocks";
 import listIssues from "./index.js";
 import { getServerContext } from "../../test-setup.js";
 
@@ -87,5 +89,63 @@ describe("list_issues", () => {
 
     // Should still return results (limited to 1)
     expect(result).toContain("# Issues in **sentry-mcp-evals**");
+  });
+
+  it("uses configured host and protocol for self-hosted issue URLs", async () => {
+    mswServer.use(
+      http.get(
+        "http://sentry.internal:9000/api/0/organizations/sentry-mcp-evals/issues/",
+        () =>
+          HttpResponse.json([
+            {
+              id: "1",
+              shortId: "TEST-1",
+              title: "Self-hosted issue",
+              culprit: "test",
+              permalink: "http://sentry.internal:9000/issues/1/",
+              level: "error",
+              status: "unresolved",
+              statusDetails: {},
+              isPublic: false,
+              platform: "javascript",
+              project: { id: "1", name: "test", slug: "test", platform: "" },
+              type: "error",
+              metadata: {},
+              numComments: 0,
+              isBookmarked: false,
+              isSubscribed: false,
+              hasSeen: true,
+              annotations: [],
+              issueType: "error",
+              issueCategory: "error",
+              firstSeen: "2024-01-01T00:00:00Z",
+              lastSeen: "2024-01-01T00:00:00Z",
+              count: "1",
+              userCount: 1,
+              stats: {},
+            },
+          ]),
+      ),
+    );
+
+    const result = await listIssues.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        query: "is:unresolved",
+        projectSlugOrId: null,
+        sort: "date",
+        limit: 10,
+        regionUrl: null,
+      },
+      getServerContext({
+        sentryHost: "sentry.internal:9000",
+        sentryProtocol: "http",
+      }),
+    );
+
+    expect(result).toContain(
+      "http://sentry.internal:9000/organizations/sentry-mcp-evals/issues/TEST-1",
+    );
+    expect(result).not.toContain("https://sentry.io/");
   });
 });

--- a/packages/mcp-core/src/tools/search-issues/formatters.test.ts
+++ b/packages/mcp-core/src/tools/search-issues/formatters.test.ts
@@ -273,5 +273,28 @@ describe("formatIssueResults", () => {
         "
       `);
     });
+
+    it("uses the configured self-hosted host and protocol when regionUrl is absent", () => {
+      const feedbackIssue = createFeedbackIssue({
+        shortId: "PROJ-FB-2",
+        title: "User Feedback: Internal Sentry",
+        issueCategory: "feedback",
+      });
+
+      const result = formatIssueResults({
+        organizationSlug: "test-org",
+        host: "sentry.internal:9000",
+        protocol: "http",
+        issues: [feedbackIssue],
+        naturalLanguageQuery: "show me user feedback",
+      });
+
+      expect(result).toContain(
+        "http://sentry.internal:9000/organizations/test-org/issues/",
+      );
+      expect(result).toContain(
+        "## 1. [PROJ-FB-2](http://sentry.internal:9000/organizations/test-org/issues/PROJ-FB-2)",
+      );
+    });
   });
 });

--- a/packages/mcp-core/src/tools/search-issues/formatters.ts
+++ b/packages/mcp-core/src/tools/search-issues/formatters.ts
@@ -2,6 +2,7 @@ import type { Issue } from "../../api-client";
 import { logInfo } from "../../telem/logging";
 import { getIssueUrl, getIssuesSearchUrl } from "../../utils/url-utils";
 import { getSeerActionabilityLabel } from "../../internal/formatting";
+import type { SentryProtocol } from "../../types";
 
 /**
  * Format an explanation for how a natural language query was translated
@@ -16,6 +17,8 @@ export interface FormatIssueResultsParams {
   projectSlugOrId?: string;
   query?: string | null;
   regionUrl?: string;
+  host?: string;
+  protocol?: SentryProtocol;
   naturalLanguageQuery?: string;
   skipHeader?: boolean;
 }
@@ -30,11 +33,17 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
     projectSlugOrId,
     query,
     regionUrl,
+    host,
+    protocol = "https",
     naturalLanguageQuery,
     skipHeader = false,
   } = params;
 
-  const host = regionUrl ? new URL(regionUrl).host : "sentry.io";
+  const region = regionUrl ? new URL(regionUrl) : null;
+  const resolvedHost = region?.host || host || "sentry.io";
+  const resolvedProtocol =
+    (region?.protocol.replace(":", "") as SentryProtocol | undefined) ||
+    protocol;
 
   let output = "";
 
@@ -71,10 +80,11 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
 
   // Generate search URL for viewing results
   const searchUrl = getIssuesSearchUrl(
-    host,
+    resolvedHost,
     organizationSlug,
     query,
     projectSlugOrId,
+    resolvedProtocol,
   );
 
   // Add view link with emoji and guidance text (like search_events)
@@ -86,7 +96,12 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
   // Format each issue
   issues.forEach((issue, index) => {
     // Generate issue URL using the utility function
-    const issueUrl = getIssueUrl(host, organizationSlug, issue.shortId);
+    const issueUrl = getIssueUrl(
+      resolvedHost,
+      organizationSlug,
+      issue.shortId,
+      resolvedProtocol,
+    );
 
     output += `## ${index + 1}. [${issue.shortId}](${issueUrl})\n\n`;
     output += `**${issue.title}**\n\n`;

--- a/packages/mcp-core/src/tools/search-issues/handler.ts
+++ b/packages/mcp-core/src/tools/search-issues/handler.ts
@@ -160,6 +160,8 @@ export default defineTool({
         projectSlugOrId: params.projectSlugOrId ?? undefined,
         query: translatedQuery.query,
         regionUrl: params.regionUrl ?? undefined,
+        host: context.sentryHost,
+        protocol: context.sentryProtocol,
         naturalLanguageQuery: params.naturalLanguageQuery,
         skipHeader: true,
       });
@@ -171,6 +173,8 @@ export default defineTool({
         projectSlugOrId: params.projectSlugOrId ?? undefined,
         query: translatedQuery.query,
         regionUrl: params.regionUrl ?? undefined,
+        host: context.sentryHost,
+        protocol: context.sentryProtocol,
         naturalLanguageQuery: params.naturalLanguageQuery,
         skipHeader: false,
       });

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -39,9 +39,11 @@ export const CONSTRAINT_PARAMETER_KEYS = new Set<string>([
 ]);
 
 export type TransportType = "stdio" | "http";
+export type SentryProtocol = "http" | "https";
 
 export type ServerContext = {
   sentryHost?: string;
+  sentryProtocol?: SentryProtocol;
   mcpUrl?: string;
   accessToken: string;
   openaiBaseUrl?: string;

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -148,6 +148,18 @@ describe("url-utils", () => {
         "https://sentry.example.com/organizations/myorg/issues/PROJ-123",
       );
     });
+
+    it("should support HTTP for self-hosted issue URLs when requested", () => {
+      const result = getIssueUrl(
+        "sentry.internal:9000",
+        "myorg",
+        "PROJ-123",
+        "http",
+      );
+      expect(result).toBe(
+        "http://sentry.internal:9000/organizations/myorg/issues/PROJ-123",
+      );
+    });
   });
 
   describe("getIssuesSearchUrl", () => {
@@ -179,6 +191,19 @@ describe("url-utils", () => {
       );
       expect(result).toBe(
         "https://sentry.example.com/organizations/myorg/issues/?project=proj1&query=is%3Aunresolved",
+      );
+    });
+
+    it("should support HTTP for self-hosted issue search URLs when requested", () => {
+      const result = getIssuesSearchUrl(
+        "sentry.internal:9000",
+        "myorg",
+        "is:unresolved",
+        "proj1",
+        "http",
+      );
+      expect(result).toBe(
+        "http://sentry.internal:9000/organizations/myorg/issues/?project=proj1&query=is%3Aunresolved",
       );
     });
   });

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -344,6 +344,48 @@ export function getIssueUrl(
 }
 
 /**
+ * Generates a Sentry cron monitor URL.
+ * @param host The Sentry host (may include regional subdomain for API access)
+ * @param organizationSlug Organization identifier
+ * @param monitorSlug Monitor slug, optionally prefixed with project slug (e.g. "my-project/my-monitor")
+ * @returns The complete monitor URL
+ */
+export function getMonitorUrl(
+  host: string,
+  organizationSlug: string,
+  monitorSlug: string,
+  protocol: SentryProtocol = "https",
+): string {
+  return getSentryWebBaseUrl(
+    host,
+    organizationSlug,
+    `/crons/${monitorSlug}/`,
+    protocol,
+  );
+}
+
+/**
+ * Generates a Sentry release URL.
+ * @param host The Sentry host (may include regional subdomain for API access)
+ * @param organizationSlug Organization identifier
+ * @param releaseVersion Release version identifier
+ * @returns The complete release URL
+ */
+export function getReleaseUrl(
+  host: string,
+  organizationSlug: string,
+  releaseVersion: string,
+  protocol: SentryProtocol = "https",
+): string {
+  return getSentryWebBaseUrl(
+    host,
+    organizationSlug,
+    `/releases/${releaseVersion}/`,
+    protocol,
+  );
+}
+
+/**
  * Generates a Sentry issues search URL.
  * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -3,6 +3,7 @@ import {
   isProfilesDataset,
   type EventsDataset,
 } from "./events-datasets";
+import type { SentryProtocol } from "../types";
 
 /**
  * Determines if a Sentry instance is SaaS or self-hosted based on the host.
@@ -61,12 +62,13 @@ function getSentryWebBaseUrl(
   host: string,
   organizationSlug: string,
   path: string,
+  protocol: SentryProtocol = "https",
 ): string {
   const isSaas = isSentryHost(host);
   const webHost = isSaas ? "sentry.io" : host;
   return isSaas
-    ? `https://${organizationSlug}.${webHost}${path}`
-    : `https://${host}/organizations/${organizationSlug}${path}`;
+    ? `${protocol}://${organizationSlug}.${webHost}${path}`
+    : `${protocol}://${host}/organizations/${organizationSlug}${path}`;
 }
 
 function normalizeTraceMetric(
@@ -169,6 +171,7 @@ export function getTraceMetricsExploreUrl(
   host: string,
   organizationSlug: string,
   options: TraceMetricsExplorerUrlOptions,
+  protocol: SentryProtocol = "https",
 ): string {
   const {
     query,
@@ -269,13 +272,14 @@ export function getTraceMetricsExploreUrl(
     }
   }
 
-  return `${getSentryWebBaseUrl(host, organizationSlug, "/explore/metrics/")}?${urlParams.toString()}`;
+  return `${getSentryWebBaseUrl(host, organizationSlug, "/explore/metrics/", protocol)}?${urlParams.toString()}`;
 }
 
 export function getProfilingExplorerUrl(
   host: string,
   organizationSlug: string,
   options: ProfilesExplorerUrlOptions,
+  protocol: SentryProtocol = "https",
 ): string {
   const {
     query,
@@ -315,7 +319,7 @@ export function getProfilingExplorerUrl(
     urlParams.set("statsPeriod", statsPeriod || "24h");
   }
 
-  return `${getSentryWebBaseUrl(host, organizationSlug, "/explore/profiling/")}?${urlParams.toString()}`;
+  return `${getSentryWebBaseUrl(host, organizationSlug, "/explore/profiling/", protocol)}?${urlParams.toString()}`;
 }
 
 /**
@@ -329,8 +333,14 @@ export function getIssueUrl(
   host: string,
   organizationSlug: string,
   issueId: string,
+  protocol: SentryProtocol = "https",
 ): string {
-  return getSentryWebBaseUrl(host, organizationSlug, `/issues/${issueId}`);
+  return getSentryWebBaseUrl(
+    host,
+    organizationSlug,
+    `/issues/${issueId}`,
+    protocol,
+  );
 }
 
 /**
@@ -346,8 +356,9 @@ export function getIssuesSearchUrl(
   organizationSlug: string,
   query?: string | null,
   projectSlugOrId?: string,
+  protocol: SentryProtocol = "https",
 ): string {
-  let url = getSentryWebBaseUrl(host, organizationSlug, "/issues/");
+  let url = getSentryWebBaseUrl(host, organizationSlug, "/issues/", protocol);
 
   const params = new URLSearchParams();
   if (projectSlugOrId) {
@@ -384,11 +395,17 @@ export function getReplaysSearchUrl(
     start?: string | null;
     end?: string | null;
   } = {},
+  protocol: SentryProtocol = "https",
 ): string {
   const { query, projectSlugOrId, environment, sort, statsPeriod, start, end } =
     options;
 
-  let url = getSentryWebBaseUrl(host, organizationSlug, "/explore/replays/");
+  let url = getSentryWebBaseUrl(
+    host,
+    organizationSlug,
+    "/explore/replays/",
+    protocol,
+  );
   const params = new URLSearchParams();
 
   if (projectSlugOrId) {
@@ -434,11 +451,13 @@ export function getTraceUrl(
   host: string,
   organizationSlug: string,
   traceId: string,
+  protocol: SentryProtocol = "https",
 ): string {
   return getSentryWebBaseUrl(
     host,
     organizationSlug,
     `/explore/traces/trace/${traceId}`,
+    protocol,
   );
 }
 
@@ -453,11 +472,13 @@ export function getReplayUrl(
   host: string,
   organizationSlug: string,
   replayId: string,
+  protocol: SentryProtocol = "https",
 ): string {
   return getSentryWebBaseUrl(
     host,
     organizationSlug,
     `/explore/replays/${replayId}/`,
+    protocol,
   );
 }
 
@@ -466,11 +487,13 @@ export function getProfileUrl(
   organizationSlug: string,
   projectSlug: string,
   profileId: string,
+  protocol: SentryProtocol = "https",
 ): string {
   return getSentryWebBaseUrl(
     host,
     organizationSlug,
     `/explore/profiling/profile/${projectSlug}/${profileId}/flamegraph/`,
+    protocol,
   );
 }
 
@@ -483,12 +506,14 @@ export function getContinuousProfileUrl(
     start: string;
     end: string;
   },
+  protocol: SentryProtocol = "https",
 ): string {
   const url = new URL(
     getSentryWebBaseUrl(
       host,
       organizationSlug,
       `/explore/profiling/profile/${projectSlug}/flamegraph/`,
+      protocol,
     ),
   );
   url.searchParams.set("profilerId", options.profilerId);
@@ -515,6 +540,7 @@ export function getEventsExplorerUrl(
   projectSlugOrId?: string,
   fields?: string[],
   explorerOptions?: Omit<TraceMetricsExplorerUrlOptions, "query" | "projectId">,
+  protocol: SentryProtocol = "https",
 ): string {
   if (isMetricsDataset(dataset)) {
     const derivedAggregateFunctions =
@@ -524,13 +550,18 @@ export function getEventsExplorerUrl(
       explorerOptions?.groupByFields ??
       fields?.filter((field) => !field.includes("(") && !field.includes(")"));
 
-    return getTraceMetricsExploreUrl(host, organizationSlug, {
-      ...explorerOptions,
-      query,
-      projectId: projectSlugOrId,
-      aggregateFunctions: derivedAggregateFunctions,
-      groupByFields: derivedGroupByFields,
-    });
+    return getTraceMetricsExploreUrl(
+      host,
+      organizationSlug,
+      {
+        ...explorerOptions,
+        query,
+        projectId: projectSlugOrId,
+        aggregateFunctions: derivedAggregateFunctions,
+        groupByFields: derivedGroupByFields,
+      },
+      protocol,
+    );
   }
 
   if (isProfilesDataset(dataset)) {
@@ -541,20 +572,25 @@ export function getEventsExplorerUrl(
       explorerOptions?.groupByFields ??
       fields?.filter((field) => !field.includes("(") && !field.includes(")"));
 
-    return getProfilingExplorerUrl(host, organizationSlug, {
-      query,
-      projectId: projectSlugOrId,
-      fields,
-      sort: explorerOptions?.sort,
-      statsPeriod: explorerOptions?.statsPeriod,
-      start: explorerOptions?.start,
-      end: explorerOptions?.end,
-      aggregateFunctions: derivedAggregateFunctions,
-      groupByFields: derivedGroupByFields,
-    });
+    return getProfilingExplorerUrl(
+      host,
+      organizationSlug,
+      {
+        query,
+        projectId: projectSlugOrId,
+        fields,
+        sort: explorerOptions?.sort,
+        statsPeriod: explorerOptions?.statsPeriod,
+        start: explorerOptions?.start,
+        end: explorerOptions?.end,
+        aggregateFunctions: derivedAggregateFunctions,
+        groupByFields: derivedGroupByFields,
+      },
+      protocol,
+    );
   }
 
-  let url = getSentryWebBaseUrl(host, organizationSlug, "/explore/");
+  let url = getSentryWebBaseUrl(host, organizationSlug, "/explore/", protocol);
 
   const params = new URLSearchParams();
   params.append("query", query);

--- a/packages/mcp-server/src/cli/parse.test.ts
+++ b/packages/mcp-server/src/cli/parse.test.ts
@@ -6,6 +6,7 @@ describe("cli/parseArgv", () => {
     const parsed = parseArgv([
       "--access-token=tok",
       "--host=sentry.io",
+      "--insecure-http",
       "--url=https://example.com",
       "--mcp-url=https://mcp.example.com",
       "--sentry-dsn=dsn",
@@ -16,6 +17,7 @@ describe("cli/parseArgv", () => {
     ]);
     expect(parsed.accessToken).toBe("tok");
     expect(parsed.host).toBe("sentry.io");
+    expect(parsed.insecureHttp).toBe(true);
     expect(parsed.url).toBe("https://example.com");
     expect(parsed.mcpUrl).toBe("https://mcp.example.com");
     expect(parsed.sentryDsn).toBe("dsn");
@@ -35,6 +37,16 @@ describe("cli/parseArgv", () => {
   it("parses --disable-skills", () => {
     const parsed = parseArgv(["--access-token=tok", "--disable-skills=seer"]);
     expect(parsed.disableSkills).toBe("seer");
+  });
+
+  it("parses --insecure-http", () => {
+    const parsed = parseArgv([
+      "--access-token=tok",
+      "--host=sentry.internal:9000",
+      "--insecure-http",
+    ]);
+    expect(parsed.host).toBe("sentry.internal:9000");
+    expect(parsed.insecureHttp).toBe(true);
   });
 
   it("parses --agent-provider=azure-openai", () => {
@@ -87,6 +99,7 @@ describe("cli/merge", () => {
     const cli = parseArgv([
       "--access-token=clitok",
       "--host=clihost",
+      "--insecure-http",
       "--mcp-url=climcp",
       "--sentry-dsn=clidsn",
       "--openai-base-url=https://api.cli/v1",
@@ -94,6 +107,7 @@ describe("cli/merge", () => {
     const merged = merge(cli, env);
     expect(merged.accessToken).toBe("clitok");
     expect(merged.host).toBe("clihost");
+    expect(merged.insecureHttp).toBe(true);
     expect(merged.mcpUrl).toBe("climcp");
     expect(merged.sentryDsn).toBe("clidsn");
     expect(merged.openaiBaseUrl).toBe("https://api.cli/v1");

--- a/packages/mcp-server/src/cli/parse.ts
+++ b/packages/mcp-server/src/cli/parse.ts
@@ -5,6 +5,7 @@ export function parseArgv(argv: string[]): CliArgs {
   const options = {
     "access-token": { type: "string" as const },
     host: { type: "string" as const },
+    "insecure-http": { type: "boolean" as const },
     url: { type: "string" as const },
     "mcp-url": { type: "string" as const },
     "sentry-dsn": { type: "string" as const },
@@ -53,6 +54,7 @@ export function parseArgv(argv: string[]): CliArgs {
   return {
     accessToken: values["access-token"] as string | undefined,
     host: values.host as string | undefined,
+    insecureHttp: values["insecure-http"] === true,
     url: values.url as string | undefined,
     mcpUrl: values["mcp-url"] as string | undefined,
     sentryDsn: values["sentry-dsn"] as string | undefined,
@@ -100,6 +102,7 @@ export function merge(cli: CliArgs, env: EnvArgs): MergedArgs {
     // If CLI provided url/host, prefer those; else fall back to env
     url: cli.url ?? env.url,
     host: cli.host ?? env.host,
+    insecureHttp: cli.insecureHttp === true,
     mcpUrl: cli.mcpUrl ?? env.mcpUrl,
     sentryDsn: cli.sentryDsn ?? env.sentryDsn,
     openaiBaseUrl: cli.openaiBaseUrl,

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -100,6 +100,20 @@ describe("cli/finalize", () => {
     ).toThrow(/cannot be used with --url or SENTRY_URL/);
   });
 
+  it("surfaces the --insecure-http + --url conflict before URL validation", () => {
+    // Even with a non-HTTPS --url, the --insecure-http conflict should win
+    // so the user gets the actionable guidance rather than the generic
+    // "must be a full HTTPS URL" error.
+    expect(() =>
+      finalize({
+        accessToken: "tok",
+        url: "http://sentry.internal:9000",
+        insecureHttp: true,
+        unknownArgs: [],
+      }),
+    ).toThrow(/cannot be used with --url or SENTRY_URL/);
+  });
+
   it("throws when --insecure-http targets sentry.io", () => {
     expect(() =>
       finalize({

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -29,6 +29,18 @@ describe("cli/finalize", () => {
       unknownArgs: [],
     });
     expect(cfg.sentryHost).toBe("sentry.example.com");
+    expect(cfg.sentryProtocol).toBe("https");
+  });
+
+  it("uses http protocol for self-hosted hosts when --insecure-http is enabled", () => {
+    const cfg = finalize({
+      accessToken: "tok",
+      host: "sentry.internal:9000",
+      insecureHttp: true,
+      unknownArgs: [],
+    });
+    expect(cfg.sentryHost).toBe("sentry.internal:9000");
+    expect(cfg.sentryProtocol).toBe("http");
   });
 
   it("accepts valid OpenAI base URL", () => {
@@ -75,6 +87,28 @@ describe("cli/finalize", () => {
     expect(() =>
       finalize({ accessToken: "tok", url: "http://bad", unknownArgs: [] }),
     ).toThrow(/must be a full HTTPS URL/);
+  });
+
+  it("throws when --insecure-http is used with --url", () => {
+    expect(() =>
+      finalize({
+        accessToken: "tok",
+        url: "https://sentry.example.com",
+        insecureHttp: true,
+        unknownArgs: [],
+      }),
+    ).toThrow(/cannot be used with --url or SENTRY_URL/);
+  });
+
+  it("throws when --insecure-http targets sentry.io", () => {
+    expect(() =>
+      finalize({
+        accessToken: "tok",
+        host: "sentry.io",
+        insecureHttp: true,
+        unknownArgs: [],
+      }),
+    ).toThrow(/only supported for self-hosted Sentry hosts/);
   });
 
   // Skills tests

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -1,5 +1,6 @@
 import { ALL_SKILLS, parseSkills, type Skill } from "@sentry/mcp-core/skills";
 import {
+  isSentryHost,
   validateAndParseSentryUrlThrows,
   validateOpenAiBaseUrlThrows,
   validateSentryHostThrows,
@@ -33,6 +34,20 @@ export function resolveHost(url?: string, host?: string): string {
 
 export function finalize(input: MergedArgs): PartiallyResolvedConfig {
   const sentryHost = resolveHost(input.url, input.host);
+
+  if (input.insecureHttp && input.url) {
+    throw new Error(
+      "Error: --insecure-http cannot be used with --url or SENTRY_URL. Use --host for insecure self-hosted instances.",
+    );
+  }
+
+  if (input.insecureHttp && isSentryHost(sentryHost)) {
+    throw new Error(
+      "Error: --insecure-http is only supported for self-hosted Sentry hosts.",
+    );
+  }
+
+  const sentryProtocol = input.insecureHttp ? "http" : "https";
 
   // Skills resolution
   //
@@ -115,6 +130,7 @@ export function finalize(input: MergedArgs): PartiallyResolvedConfig {
     accessToken: input.accessToken,
     clientId: input.clientId || DEFAULT_SENTRY_CLIENT_ID,
     sentryHost,
+    sentryProtocol,
     mcpUrl: input.mcpUrl,
     sentryDsn: input.sentryDsn,
     openaiBaseUrl: resolvedOpenAiBaseUrl,

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -33,13 +33,13 @@ export function resolveHost(url?: string, host?: string): string {
 }
 
 export function finalize(input: MergedArgs): PartiallyResolvedConfig {
-  const sentryHost = resolveHost(input.url, input.host);
-
   if (input.insecureHttp && input.url) {
     throw new Error(
       "Error: --insecure-http cannot be used with --url or SENTRY_URL. Use --host for insecure self-hosted instances.",
     );
   }
+
+  const sentryHost = resolveHost(input.url, input.host);
 
   if (input.insecureHttp && isSentryHost(sentryHost)) {
     throw new Error(

--- a/packages/mcp-server/src/cli/types.ts
+++ b/packages/mcp-server/src/cli/types.ts
@@ -1,8 +1,10 @@
+import type { SentryProtocol } from "@sentry/mcp-core/types";
 import type { Skill } from "@sentry/mcp-core/skills";
 
 export type CliArgs = {
   accessToken?: string;
   host?: string;
+  insecureHttp?: boolean;
   url?: string;
   mcpUrl?: string;
   sentryDsn?: string;
@@ -39,6 +41,7 @@ export type EnvArgs = {
 export type MergedArgs = {
   accessToken?: string;
   host?: string;
+  insecureHttp?: boolean;
   url?: string;
   mcpUrl?: string;
   sentryDsn?: string;
@@ -67,6 +70,7 @@ export type PartiallyResolvedConfig = {
   accessToken?: string;
   clientId: string;
   sentryHost: string;
+  sentryProtocol: SentryProtocol;
   mcpUrl?: string;
   sentryDsn?: string;
   openaiBaseUrl?: string;

--- a/packages/mcp-server/src/cli/usage.ts
+++ b/packages/mcp-server/src/cli/usage.ts
@@ -4,7 +4,7 @@ export function buildUsage(
   packageName: string,
   allSkills: ReadonlyArray<Skill>,
 ): string {
-  return `Usage: ${packageName} [--access-token=<token>] [--host=<host>]
+  return `Usage: ${packageName} [--access-token=<token>] [--host=<host>] [--insecure-http]
        ${packageName} auth [login|logout|status]
 
 Commands:
@@ -19,6 +19,7 @@ Authentication:
 
 Common optional flags:
   --host <host>           Change Sentry host (self-hosted)
+  --insecure-http         Use http:// for self-hosted --host values
   --sentry-dsn <dsn>      Override DSN used for telemetry reporting
   --agent                 Agent mode: only expose use_sentry tool (for AI agents)
   --experimental          Enable forward-looking tool variants and experimental features
@@ -53,6 +54,7 @@ Examples:
   ${packageName} --access-token=TOKEN
   ${packageName} --access-token=TOKEN --skills=inspect,triage
   ${packageName} --access-token=TOKEN --host=sentry.example.com
+  ${packageName} --access-token=TOKEN --host=sentry.internal:9000 --insecure-http
   ${packageName} --access-token=TOKEN --host=sentry.example.com --disable-skills=seer
   ${packageName} --access-token=TOKEN --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
   ${packageName} --access-token=TOKEN --agent-provider=anthropic`;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -340,6 +340,7 @@ async function main() {
       regionUrl: null,
     },
     sentryHost: cfg.sentryHost,
+    sentryProtocol: cfg.sentryProtocol,
     mcpUrl: cfg.mcpUrl,
     openaiBaseUrl: cfg.openaiBaseUrl,
     agentMode: cli.agent,


### PR DESCRIPTION
Add an opt-in `--insecure-http` flag for stdio clients that need to talk to
self-hosted Sentry deployments on isolated networks without TLS.

Today `--host` still forces HTTPS when we construct API and web URLs, which
breaks plain HTTP self-hosted installs. This threads the resolved protocol
through stdio config, the API client, and shared URL formatters so generated
links and requests match the configured deployment.

The flag stays narrow on purpose: it only works with `--host`, it is rejected
for `--url` and `SENTRY_URL`, and it is rejected for sentry.io hosts. Docs and
regression tests cover the new opt-in path.

Fixes GH-891
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/getsentry/sentry-mcp/pull/908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
