### PR TITLE
fix(mcp-core): parallelize trace metadata and span data requests

### DIFF
--- a/packages/mcp-core/src/tools/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/get-trace-details.ts
@@ -113,20 +113,22 @@ export default defineTool({
 
       summary = buildProjectScopedTraceSummary(trace, constrainedProjectSlug);
     } else {
-      // Get trace metadata for overview
-      const traceMeta = await apiService.getTraceMeta({
-        organizationSlug: params.organizationSlug,
-        traceId: params.traceId,
-        statsPeriod: "14d", // Fixed stats period
-      });
+      // Fetch trace metadata and span data in parallel (no data dependency)
+      const [traceMeta, traceResult] = await Promise.all([
+        apiService.getTraceMeta({
+          organizationSlug: params.organizationSlug,
+          traceId: params.traceId,
+          statsPeriod: "14d", // Fixed stats period
+        }),
+        apiService.getTrace({
+          organizationSlug: params.organizationSlug,
+          traceId: params.traceId,
+          limit: 10, // Only get top-level spans for overview
+          statsPeriod: "14d", // Fixed stats period
+        }),
+      ]);
 
-      // Get minimal trace data to show key transactions
-      trace = await apiService.getTrace({
-        organizationSlug: params.organizationSlug,
-        traceId: params.traceId,
-        limit: 10, // Only get top-level spans for overview
-        statsPeriod: "14d", // Fixed stats period
-      });
+      trace = traceResult;
 
       summary = {
         spanCount: traceMeta.span_count,


### PR DESCRIPTION
getTraceMeta and getTrace were called sequentially despite having no data dependency, adding unnecessary latency.

https://sentry.sentry.io/issues/7414187622/events/54f0c3f6fab6474ab2f2852a5b3dd3d7/?project=4509062593708032

Fixes MCP-SERVER-FQX