### PR TITLE
perf(mcp-core): parallelize numeric profile detail lookups

### DIFF
--- a/packages/mcp-core/src/tools/get-profile-details.test.ts
+++ b/packages/mcp-core/src/tools/get-profile-details.test.ts
@@ -89,6 +89,42 @@ describe("get_profile_details", () => {
       expect(result).toContain("cursor.execute");
     });
 
+    it("fetches a transaction profile from a numeric project ID", async () => {
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/projects/sentry-mcp-evals/12345/",
+          () =>
+            HttpResponse.json({ id: 12345, slug: "backend", name: "Backend" }),
+          { once: true },
+        ),
+        http.get(
+          "https://us.sentry.io/api/0/projects/sentry-mcp-evals/12345/",
+          () =>
+            HttpResponse.json({ id: 12345, slug: "backend", name: "Backend" }),
+          { once: true },
+        ),
+      );
+
+      const result = await getProfileDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlugOrId: 12345,
+          profileId: transactionProfileV1Fixture.profile_id,
+          regionUrl: null,
+          focusOnUserCode: true,
+        },
+        baseContext,
+      );
+
+      expect(result).toContain(
+        `# Profile ${transactionProfileV1Fixture.profile_id}`,
+      );
+      expect(result).toContain("**Project**: backend");
+      expect(result).toContain(
+        `https://sentry-mcp-evals.sentry.io/explore/profiling/profile/backend/${transactionProfileV1Fixture.profile_id}/flamegraph/`,
+      );
+    });
+
     it("fetches and formats a continuous profile chunk", async () => {
       mswServer.use(
         http.get(

--- a/packages/mcp-core/src/tools/get-profile-details.ts
+++ b/packages/mcp-core/src/tools/get-profile-details.ts
@@ -295,20 +295,38 @@ export default defineTool({
     setTag("organization.slug", resolved.organizationSlug);
 
     if (resolved.mode === "transaction") {
-      const { projectSlug } = await resolveProjectContext(
-        apiService,
-        resolved.organizationSlug,
-        resolved.projectSlugOrId,
-      );
-
       setTag("profile.id", resolved.profileId);
-      setTag("project.slug", projectSlug);
+      const isNumericProjectInput =
+        typeof resolved.projectSlugOrId === "number" ||
+        isNumericId(String(resolved.projectSlugOrId));
+      let projectSlug: string;
+      let profile: Awaited<ReturnType<typeof apiService.getTransactionProfile>>;
 
-      const profile = await apiService.getTransactionProfile({
-        organizationSlug: resolved.organizationSlug,
-        projectSlugOrId: resolved.projectSlugOrId,
-        profileId: resolved.profileId,
-      });
+      if (isNumericProjectInput) {
+        const [project, fetchedProfile] = await Promise.all([
+          apiService.getProject({
+            organizationSlug: resolved.organizationSlug,
+            projectSlugOrId: String(resolved.projectSlugOrId),
+          }),
+          apiService.getTransactionProfile({
+            organizationSlug: resolved.organizationSlug,
+            projectSlugOrId: resolved.projectSlugOrId,
+            profileId: resolved.profileId,
+          }),
+        ]);
+
+        projectSlug = project.slug;
+        profile = fetchedProfile;
+      } else {
+        projectSlug = String(resolved.projectSlugOrId);
+        profile = await apiService.getTransactionProfile({
+          organizationSlug: resolved.organizationSlug,
+          projectSlugOrId: resolved.projectSlugOrId,
+          profileId: resolved.profileId,
+        });
+      }
+
+      setTag("project.slug", projectSlug);
 
       const profileUrl =
         params.profileUrl ??


### PR DESCRIPTION
Fetch the project metadata and transaction profile in parallel when `get_profile_details` receives a numeric project ID.

That path always needs both requests because the transaction profile response does not include the project slug we use to build the profile URL in the tool output. Parallelizing those two calls trims the extra round trip without changing the slug-based path or the continuous-profile path.

I considered doing the same in `get_trace_details` and `get_replay_details`, but those paths still depend on earlier response data or early constraint checks. Keeping this PR to the unconditional numeric-project branch avoids speculative fetches and keeps the latency win narrowly scoped.

This also adds coverage for the numeric project ID transaction-profile path.