### PR TITLE
fix(api): align schemas and fixtures with upstream sentry

### DIFF
--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -1,17 +1,26 @@
-import { describe, expect, it } from "vitest";
 import {
+  autofixStateExplorerFixture,
+  issueNullCulpritFixture,
   profileChunkFixture,
+  tagsFixture,
+  transactionProfileV1MissingFunctionFixture,
   transactionProfileV1Fixture,
 } from "@sentry/mcp-server-mocks";
+import { describe, expect, it } from "vitest";
 import {
+  AutofixRunSchema,
+  AutofixRunStateSchema,
   ClientKeySchema,
   EventSchema,
   FlamegraphSchema,
   IssueSchema,
+  IssueTagValuesSchema,
   ProfileChunkSampleSchema,
   ProfileChunkSchema,
+  ProfileFrameSchema,
   ReleaseSchema,
   ReplayDetailsSchema,
+  TagSchema,
   TransactionProfileSampleSchema,
   TransactionProfileSchema,
 } from "./schema";
@@ -245,6 +254,11 @@ describe("IssueSchema", () => {
     const result = IssueSchema.parse(issue);
     expect(result.firstSeen).toBeNull();
     expect(result.lastSeen).toBeNull();
+  });
+
+  it("should handle issues with null culprit", () => {
+    const result = IssueSchema.parse(issueNullCulpritFixture);
+    expect(result.culprit).toBeNull();
   });
 });
 
@@ -580,6 +594,83 @@ describe("ReleaseSchema", () => {
   });
 });
 
+describe("TagSchema", () => {
+  it("normalizes upstream tag counts when only uniqueValues is present", () => {
+    const tag = TagSchema.parse(tagsFixture[0]);
+
+    expect(tag).toEqual({
+      key: "transaction",
+      name: "Transaction",
+      totalValues: 1080,
+    });
+  });
+});
+
+describe("AutofixRunSchema", () => {
+  it("accepts the numeric run_id returned by the autofix POST endpoint", () => {
+    const run = AutofixRunSchema.parse({ run_id: 123 });
+
+    expect(run.run_id).toBe(123);
+  });
+});
+
+describe("AutofixRunStateSchema", () => {
+  it("accepts explorer-style autofix state without legacy steps", () => {
+    const state = AutofixRunStateSchema.parse(autofixStateExplorerFixture);
+
+    expect(state.autofix?.steps).toEqual([]);
+    expect(state.autofix?.blocks).toEqual([
+      {
+        type: "root_cause",
+        title: "Investigate failing request",
+        status: "COMPLETED",
+      },
+      {
+        type: "solution",
+        title: "Draft fix plan",
+        status: "IN_PROGRESS",
+      },
+    ]);
+  });
+});
+
+describe("IssueTagValuesSchema", () => {
+  it("normalizes aggregate counts and missing topValues from upstream tag details", () => {
+    const tagValues = IssueTagValuesSchema.parse({
+      key: "release",
+      name: "Release",
+      uniqueValues: 3,
+    });
+
+    expect(tagValues).toEqual({
+      key: "release",
+      name: "Release",
+      totalValues: 3,
+      topValues: [],
+    });
+  });
+
+  it("normalizes nullable tag value counts to zero", () => {
+    const tagValues = IssueTagValuesSchema.parse({
+      key: "user",
+      name: "User",
+      totalValues: 1,
+      topValues: [
+        {
+          key: "user",
+          name: null,
+          value: null,
+          count: null,
+          firstSeen: null,
+          lastSeen: null,
+        },
+      ],
+    });
+
+    expect(tagValues.topValues[0]?.count).toBe(0);
+  });
+});
+
 describe("FlamegraphSchema", () => {
   it("fills optional profiling fields that Sentry omits or returns as null", () => {
     const flamegraph = FlamegraphSchema.parse({
@@ -689,6 +780,22 @@ describe("TransactionProfileSampleSchema", () => {
   });
 });
 
+describe("ProfileFrameSchema", () => {
+  it("accepts sampled profile frames without a function name", () => {
+    // Sentry's sampled profile frame contract treats function as optional:
+    // static/app/types/profiling.d.ts defines `function?: string`, and the
+    // profile processing pipeline falls back when it is missing.
+    const frame = ProfileFrameSchema.parse({
+      filename: "main.py",
+      in_app: true,
+      lineno: 42,
+    });
+
+    expect(frame.function).toBeUndefined();
+    expect(frame.in_app).toBe(true);
+  });
+});
+
 describe("profile fixtures", () => {
   it("parses the V1 transaction profile fixture through TransactionProfileSchema", () => {
     // transaction-profile-v1.json mirrors what vroom emits for legacy/V1
@@ -759,5 +866,13 @@ describe("TransactionProfileSchema", () => {
     expect(profile.transaction?.active_thread_id).toBe("1");
     expect(profile.profile.samples[0]?.thread_id).toBe("1");
     expect(profile.profile.samples[0]?.elapsed_since_start_ns).toBe(0);
+  });
+
+  it("accepts V1 transaction profiles when some frames omit function", () => {
+    const parsed = TransactionProfileSchema.parse(
+      structuredClone(transactionProfileV1MissingFunctionFixture),
+    );
+
+    expect(parsed.profile.frames[0]?.function).toBeUndefined();
   });
 });

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -133,6 +133,14 @@ const ReplayTagsSchema = z.preprocess(
   z.record(z.string(), z.array(z.string())),
 );
 
+/**
+ * Replay responses are normalized in getsentry/sentry before they hit this API.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/replays/post_process.py` (`ReplayDetailsResponse`)
+ * - `src/sentry/replays/endpoints/organization_replay_index.py`
+ * - `src/sentry/replays/endpoints/organization_replay_details.py`
+ */
 export const ReplayDetailsSchema = z
   .object({
     activity: z.number().nullable().optional(),
@@ -247,6 +255,15 @@ const ReleaseCommitAuthorSchema = z
   })
   .passthrough();
 
+/**
+ * Local subset of both organization-wide and project-scoped release payloads.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/api/endpoints/organization_releases.py`
+ * - `src/sentry/releases/endpoints/project_releases.py`
+ * - `src/sentry/api/serializers/models/release.py`
+ * - `src/sentry/api/serializers/rest_framework/release.py`
+ */
 export const ReleaseSchema = z.object({
   id: z.union([z.string(), z.number()]),
   version: z.string(),
@@ -279,11 +296,27 @@ export const ReleaseSchema = z.object({
 
 export const ReleaseListSchema = z.array(ReleaseSchema);
 
-export const TagSchema = z.object({
-  key: z.string(),
-  name: z.string(),
-  totalValues: z.number(),
-});
+/**
+ * Organization tag lists are backed by `TagKeySerializerResponse`, which only
+ * guarantees `key` and `name`. Count fields are backend-dependent and may come
+ * back as `uniqueValues`, `totalValues`, or neither.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/tagstore/types.py` (`TagKeySerializerResponse`)
+ * - `src/sentry/api/endpoints/organization_tags.py`
+ */
+export const TagSchema = z
+  .object({
+    key: z.string(),
+    name: z.string(),
+    totalValues: z.number().nullable().optional(),
+    uniqueValues: z.number().nullable().optional(),
+  })
+  .transform((tag) => ({
+    key: tag.key,
+    name: tag.name,
+    totalValues: tag.totalValues ?? tag.uniqueValues ?? 0,
+  }));
 
 export const TagListSchema = z.array(TagSchema);
 
@@ -301,6 +334,16 @@ export const AssignedToSchema = z.union([
     .passthrough(), // Allow additional fields we might not know about
 ]);
 
+/**
+ * Local subset shared by issue list and issue details payloads.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/api/serializers/models/group.py` (`BaseGroupSerializerResponse`)
+ * - `src/sentry/api/serializers/models/group_stream.py` (`StreamGroupSerializerResponse`)
+ * - `src/sentry/issues/endpoints/group_details.py`
+ *
+ * In particular, `culprit` is nullable upstream.
+ */
 export const IssueSchema = z
   .object({
     id: z.union([z.string(), z.number()]),
@@ -315,7 +358,7 @@ export const IssueSchema = z
     platform: z.string().nullable().optional(),
     status: z.string(),
     substatus: z.string().nullable().optional(),
-    culprit: z.string(),
+    culprit: z.string().nullable(),
     type: z.union([
       z.literal("error"),
       z.literal("transaction"),
@@ -691,9 +734,16 @@ export const SpansSearchResponseSchema = EventsResponseSchema.extend({
   ),
 });
 
+/**
+ * The Seer autofix POST endpoint currently returns a simple numeric `run_id`.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/seer/endpoints/group_ai_autofix.py`
+ * - `src/sentry/seer/autofix/types.py` (`AutofixPostResponse`)
+ */
 export const AutofixRunSchema = z
   .object({
-    run_id: z.union([z.string(), z.number()]),
+    run_id: z.number(),
   })
   .passthrough();
 
@@ -790,14 +840,35 @@ export const AutofixRunStepSchema = z.union([
   AutofixRunStepBaseSchema.passthrough(),
 ]);
 
+/**
+ * The Seer autofix GET endpoint is explicitly experimental and currently has
+ * two materially different payload shapes:
+ * - legacy `get_autofix_state(...).dict()` responses with `request` and `steps`
+ * - explorer responses with `blocks`, `pending_user_input`, and coding-agent
+ *   metadata but no `steps`
+ *
+ * We normalize missing `steps` to `[]` so existing formatting code keeps
+ * working even if the server returns the explorer shape.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/seer/endpoints/group_ai_autofix.py`
+ * - `src/sentry/seer/autofix/types.py` (`AutofixStateResponse`)
+ */
 export const AutofixRunStateSchema = z.object({
   autofix: z
     .object({
       run_id: z.number(),
-      request: z.unknown(),
-      updated_at: z.string(),
+      request: z.unknown().optional(),
+      updated_at: z.string().nullable().optional(),
       status: AutofixStatusSchema,
-      steps: z.array(AutofixRunStepSchema),
+      steps: z.preprocess(
+        (value) => value ?? [],
+        z.array(AutofixRunStepSchema),
+      ),
+      blocks: z.array(z.unknown()).optional(),
+      pending_user_input: z.unknown().nullable().optional(),
+      repo_pr_states: z.record(z.string(), z.unknown()).optional(),
+      coding_agents: z.record(z.string(), z.unknown()).optional(),
     })
     .passthrough()
     .nullable(),
@@ -825,7 +896,10 @@ export const IssueTagValueSchema = z.object({
   key: z.string().nullable().optional(),
   name: z.string().nullable().optional(),
   value: z.string().nullable(),
-  count: z.number(),
+  count: z
+    .number()
+    .nullable()
+    .transform((value) => value ?? 0),
   lastSeen: z.string().datetime().nullable().optional(),
   firstSeen: z.string().datetime().nullable().optional(),
 });
@@ -835,13 +909,26 @@ export const IssueTagValueSchema = z.object({
  *
  * Contains aggregate counts of unique tag values for an issue,
  * useful for understanding the distribution of tags like URL, browser, etc.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/tagstore/types.py` (`TagKeySerializerResponse`,
+ *   `TagValueSerializerResponse`)
+ * - `src/sentry/issues/endpoints/group_tagkey_details.py`
  */
-export const IssueTagValuesSchema = z.object({
-  key: z.string(),
-  name: z.string(),
-  totalValues: z.number(),
-  topValues: z.array(IssueTagValueSchema),
-});
+export const IssueTagValuesSchema = z
+  .object({
+    key: z.string(),
+    name: z.string(),
+    totalValues: z.number().nullable().optional(),
+    uniqueValues: z.number().nullable().optional(),
+    topValues: z.array(IssueTagValueSchema).nullable().optional(),
+  })
+  .transform((tagValues) => ({
+    key: tagValues.key,
+    name: tagValues.name,
+    totalValues: tagValues.totalValues ?? tagValues.uniqueValues ?? 0,
+    topValues: tagValues.topValues ?? [],
+  }));
 
 /**
  * Schema for external issue link (e.g., Jira, GitHub Issues).
@@ -864,6 +951,9 @@ export const ExternalIssueListSchema = z.array(ExternalIssueSchema);
  *
  * Contains high-level statistics about a trace including span counts,
  * transaction breakdown, and operation type distribution.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/api/endpoints/organization_trace_meta.py`
  */
 export const TraceMetaSchema = z.object({
   logs: z.number(),
@@ -950,6 +1040,10 @@ export const TraceIssueSchema = z
  * and standalone issue objects. The Sentry API's query_trace_data
  * function returns a mixed list of SerializedSpan and SerializedIssue
  * objects when there are errors not directly associated with spans.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/api/endpoints/organization_trace.py`
+ * - `src/sentry/snuba/trace.py` (`SerializedSpan`, `SerializedIssue`)
  */
 export const TraceSchema = z.array(
   z.union([TraceSpanSchema, TraceIssueSchema]),
@@ -1070,11 +1164,20 @@ export const FlamegraphSchema = z
  * Similar to FlamegraphFrameSchema but uses different field names
  * (function instead of name, in_app instead of is_application).
  * Many fields are optional as the API may not include them for all frames.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `static/app/types/profiling.d.ts` (`SentrySampledProfileFrame`)
+ * - `static/app/utils/profiling/profile/utils.tsx`
+ * - `src/sentry/profiles/task.py`
+ *
+ * In particular, `function` must remain optional here. Sentry's frontend
+ * import path already falls back with `frame.function ?? "unknown"`, and the
+ * profile processing pipeline uses `frame.get("function", "")`.
  */
 export const ProfileFrameSchema = z
   .object({
     filename: z.string().nullable().optional(),
-    function: z.string(),
+    function: z.string().nullable().optional(),
     in_app: z.boolean(),
     lineno: z.number().nullable().optional(),
     colno: z.number().nullable().optional(),
@@ -1106,6 +1209,9 @@ const ProfileThreadMetadataSchema = z.record(
  * transactions. Each sample carries an absolute (or relative-to-chunk) wall
  * clock `timestamp` in seconds and a string `thread_id` matching
  * `thread_metadata` keys.
+ *
+ * Upstream type reference in getsentry/sentry:
+ * - `static/app/types/profiling.d.ts` (`SentrySampledProfileChunkSample`)
  */
 export const ProfileChunkSampleSchema = z
   .object({
@@ -1126,6 +1232,10 @@ export const ProfileChunkSampleSchema = z
  *   string keys in `thread_metadata`.
  * - Time is carried as `elapsed_since_start_ns` (uint64 nanoseconds since the
  *   start of the profile). V1 samples never carry an absolute `timestamp`.
+ *
+ * Upstream references in getsentry/sentry:
+ * - `static/app/types/profiling.d.ts` (`SentrySampledProfileSample`)
+ * - `src/sentry/api/endpoints/project_profiling_profile.py`
  */
 export const TransactionProfileSampleSchema = z
   .object({
@@ -1195,6 +1305,14 @@ const ProfileReleaseSchema = z
  * single transaction and always include a `transaction` object. vroom emits
  * both `Sample.thread_id` and `Transaction.active_thread_id` as `uint64`, so
  * both are accepted as number or string here and normalized to strings.
+ *
+ * Upstream source of truth in getsentry/sentry:
+ * - `src/sentry/api/endpoints/project_profiling_profile.py`
+ * - `static/app/types/profiling.d.ts` (`SentrySampledProfile`)
+ *
+ * The project profiling endpoint largely proxies the profiling-service payload
+ * and only normalizes release metadata, so this schema should track the wire
+ * payload Sentry consumes rather than introducing stricter local requirements.
  */
 export const TransactionProfileSchema = z
   .object({

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -7,33 +7,33 @@
  */
 import type { z } from "zod";
 import type {
-  Event,
-  Issue,
-  AutofixRunState,
-  Trace,
-  TraceSpan,
-  GenericEvent,
-  ExternalIssueList,
-} from "../api-client/types";
-import type {
+  AutofixRunStepRootCauseAnalysisSchema,
+  DefaultEventSchema,
   ErrorEntrySchema,
   ErrorEventSchema,
-  DefaultEventSchema,
-  GenericEventSchema,
   EventSchema,
   FrameInterface,
-  RequestEntrySchema,
+  GenericEventSchema,
   MessageEntrySchema,
-  ThreadsEntrySchema,
+  RequestEntrySchema,
   SentryApiService,
-  AutofixRunStepRootCauseAnalysisSchema,
+  ThreadsEntrySchema,
 } from "../api-client";
+import type {
+  AutofixRunState,
+  Event,
+  ExternalIssueList,
+  GenericEvent,
+  Issue,
+  Trace,
+  TraceSpan,
+} from "../api-client/types";
+import { logIssue } from "../telem/logging";
 import {
   getOutputForAutofixStep,
-  isTerminalStatus,
   getStatusDisplayName,
+  isTerminalStatus,
 } from "./tool-helpers/seer";
-import { logIssue } from "../telem/logging";
 import { formatUserGeoSummary } from "./user-formatting";
 
 /**
@@ -1784,7 +1784,9 @@ export function formatIssueOutput({
   } else {
     // For regular errors and other issues
     output += `**Description**: ${issue.title}\n`;
-    output += `**Culprit**: ${issue.culprit}\n`;
+    if (issue.culprit) {
+      output += `**Culprit**: ${issue.culprit}\n`;
+    }
   }
 
   if (issue.firstSeen) {

--- a/packages/mcp-core/src/tools/analyze-issue-with-seer.test.ts
+++ b/packages/mcp-core/src/tools/analyze-issue-with-seer.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { autofixStateFixture, mswServer } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
-import { mswServer, autofixStateFixture } from "@sentry/mcp-server-mocks";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import analyzeIssueWithSeer from "./analyze-issue-with-seer.js";
 
 describe("analyze_issue_with_seer", () => {
@@ -270,7 +270,7 @@ describe("analyze_issue_with_seer", () => {
             instruction: "Focus on memory leaks",
           });
           return HttpResponse.json({
-            run_id: "new-run-123",
+            run_id: 123,
           });
         },
       ),
@@ -298,7 +298,7 @@ describe("analyze_issue_with_seer", () => {
     const result = await promise;
 
     expect(result).toContain("Starting new analysis...");
-    expect(result).toContain("Analysis started with Run ID: new-run-123");
+    expect(result).toContain("Analysis started with Run ID: 123");
     expect(result).toContain("## Analysis Complete");
   });
 

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -1,17 +1,18 @@
-import { describe, it, expect } from "vitest";
-import { http, HttpResponse } from "msw";
 import {
-  mswServer,
+  createCspEvent,
+  createCspIssue,
   createDefaultEvent,
   createGenericEvent,
-  createUnknownEvent,
   createPerformanceEvent,
   createPerformanceIssue,
   createRegressedIssue,
+  createUnknownEvent,
   createUnsupportedIssue,
-  createCspIssue,
-  createCspEvent,
+  issueNullCulpritFixture,
+  mswServer,
 } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import getIssueDetails from "./get-issue-details.js";
 
 const baseContext = {
@@ -259,6 +260,33 @@ describe("get_issue_details", () => {
       - To search for specific occurrences or filter events within this issue, use \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', naturalLanguageQuery='your query')\`
       "
     `);
+  });
+
+  it("omits null culprit values from issue output", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/",
+        () => HttpResponse.json(issueNullCulpritFixture),
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    expect(result).toContain(
+      "**Description**: Error: Tool list_issues is already registered",
+    );
+    expect(result).not.toContain("**Culprit**:");
+    expect(result).not.toContain("**Culprit**: null");
   });
 
   it("displays team assignment correctly", async () => {

--- a/packages/mcp-core/src/tools/get-profile-details.test.ts
+++ b/packages/mcp-core/src/tools/get-profile-details.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { http, HttpResponse } from "msw";
 import {
   mswServer,
+  transactionProfileV1MissingFunctionFixture,
   transactionProfileV1Fixture,
 } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import getProfileDetails from "./get-profile-details";
 
 const baseContext = {
@@ -87,6 +88,35 @@ describe("get_profile_details", () => {
       );
       expect(result).toContain("**Project**: backend");
       expect(result).toContain("cursor.execute");
+    });
+
+    it("formats transaction profiles even when frames omit function names", async () => {
+      mswServer.use(
+        http.get(
+          `https://sentry.io/api/0/projects/sentry-mcp-evals/backend/profiling/profiles/${transactionProfileV1Fixture.profile_id}/`,
+          () => HttpResponse.json(transactionProfileV1MissingFunctionFixture),
+          { once: true },
+        ),
+        http.get(
+          `https://us.sentry.io/api/0/projects/sentry-mcp-evals/backend/profiling/profiles/${transactionProfileV1Fixture.profile_id}/`,
+          () => HttpResponse.json(transactionProfileV1MissingFunctionFixture),
+          { once: true },
+        ),
+      );
+
+      const result = await getProfileDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlugOrId: "backend",
+          profileId: transactionProfileV1Fixture.profile_id,
+          regionUrl: null,
+          focusOnUserCode: true,
+        },
+        baseContext,
+      );
+
+      expect(result).toContain("## Top Frames by Occurrence");
+      expect(result).toContain("| `unknown` | main.py:42 | 3 | User Code |");
     });
 
     it("fetches a transaction profile from a numeric project ID", async () => {

--- a/packages/mcp-core/src/tools/profile/formatter.ts
+++ b/packages/mcp-core/src/tools/profile/formatter.ts
@@ -637,9 +637,10 @@ function formatTopFramesByOccurrence(
 
   const rows = sortedFrames.map(([frameIdx, count]) => {
     const frame = profile.frames[frameIdx]!;
+    const functionName = frame.function ?? frame.raw_function ?? "unknown";
     const funcName = frame.class_name
-      ? `${frame.class_name}.${frame.function}`
-      : frame.function;
+      ? `${frame.class_name}.${functionName}`
+      : functionName;
 
     const rawLocation =
       frame.filename && frame.lineno

--- a/packages/mcp-server-mocks/src/fixtures/autofix-state-explorer.json
+++ b/packages/mcp-server-mocks/src/fixtures/autofix-state-explorer.json
@@ -1,0 +1,22 @@
+{
+  "autofix": {
+    "run_id": 21831,
+    "status": "IN_PROGRESS",
+    "blocks": [
+      {
+        "type": "root_cause",
+        "title": "Investigate failing request",
+        "status": "COMPLETED"
+      },
+      {
+        "type": "solution",
+        "title": "Draft fix plan",
+        "status": "IN_PROGRESS"
+      }
+    ],
+    "updated_at": "2026-04-22T12:00:00Z",
+    "pending_user_input": null,
+    "repo_pr_states": {},
+    "coding_agents": {}
+  }
+}

--- a/packages/mcp-server-mocks/src/fixtures/issue-null-culprit.json
+++ b/packages/mcp-server-mocks/src/fixtures/issue-null-culprit.json
@@ -1,0 +1,40 @@
+{
+  "id": "6507376925",
+  "shareId": null,
+  "shortId": "CLOUDFLARE-MCP-41",
+  "title": "Error: Tool list_issues is already registered",
+  "culprit": null,
+  "permalink": "https://sentry.sentry.io/issues/6507376925/",
+  "logger": "",
+  "level": "error",
+  "status": "unresolved",
+  "statusDetails": {},
+  "substatus": null,
+  "isPublic": false,
+  "platform": "node",
+  "project": {
+    "id": "4505138086019073",
+    "name": "sentry-mcp-evals",
+    "slug": "sentry-mcp-evals",
+    "platform": "node"
+  },
+  "type": "error",
+  "metadata": {
+    "type": "Error",
+    "value": "Tool list_issues is already registered"
+  },
+  "numComments": 0,
+  "assignedTo": null,
+  "isBookmarked": false,
+  "isSubscribed": false,
+  "subscriptionDetails": null,
+  "hasSeen": false,
+  "annotations": [],
+  "issueType": "error",
+  "issueCategory": "error",
+  "isUnhandled": true,
+  "count": "1",
+  "userCount": 1,
+  "firstSeen": "2025-04-11T22:51:19.403000Z",
+  "lastSeen": "2025-04-11T22:51:19.403000Z"
+}

--- a/packages/mcp-server-mocks/src/fixtures/tags.json
+++ b/packages/mcp-server-mocks/src/fixtures/tags.json
@@ -2,96 +2,96 @@
   {
     "key": "transaction",
     "name": "Transaction",
-    "totalValues": 1080
+    "uniqueValues": 1080
   },
   {
     "key": "runtime.name",
     "name": "Runtime.Name",
-    "totalValues": 1080
+    "uniqueValues": 1080
   },
   {
     "key": "level",
     "name": "Level",
-    "totalValues": 1144
+    "uniqueValues": 1144
   },
   {
     "key": "device",
     "name": "Device",
-    "totalValues": 25
+    "uniqueValues": 25
   },
   {
     "key": "os",
     "name": "OS",
-    "totalValues": 1133
+    "uniqueValues": 1133
   },
   {
     "key": "user",
     "name": "User",
-    "totalValues": 1080
+    "uniqueValues": 1080
   },
   {
     "key": "runtime",
     "name": "Runtime",
-    "totalValues": 1080
+    "uniqueValues": 1080
   },
   {
     "key": "release",
     "name": "Release",
-    "totalValues": 1135
+    "uniqueValues": 1135
   },
   {
     "key": "url",
     "name": "URL",
-    "totalValues": 1080
+    "uniqueValues": 1080
   },
   {
     "key": "uptime_rule",
     "name": "Uptime Rule",
-    "totalValues": 9
+    "uniqueValues": 9
   },
   {
     "key": "server_name",
     "name": "Server",
-    "totalValues": 1080
+    "uniqueValues": 1080
   },
   {
     "key": "browser",
     "name": "Browser",
-    "totalValues": 56
+    "uniqueValues": 56
   },
   {
     "key": "os.name",
     "name": "Os.Name",
-    "totalValues": 1135
+    "uniqueValues": 1135
   },
   {
     "key": "device.family",
     "name": "Device.Family",
-    "totalValues": 25
+    "uniqueValues": 25
   },
   {
     "key": "replayId",
     "name": "Replayid",
-    "totalValues": 55
+    "uniqueValues": 55
   },
   {
     "key": "client_os.name",
     "name": "Client Os.Name",
-    "totalValues": 1
+    "uniqueValues": 1
   },
   {
     "key": "environment",
     "name": "Environment",
-    "totalValues": 1144
+    "uniqueValues": 1144
   },
   {
     "key": "service",
     "name": "Service",
-    "totalValues": 1135
+    "uniqueValues": 1135
   },
   {
     "key": "browser.name",
     "name": "Browser.Name",
-    "totalValues": 56
+    "uniqueValues": 56
   }
 ]

--- a/packages/mcp-server-mocks/src/fixtures/transaction-profile-v1-missing-function.json
+++ b/packages/mcp-server-mocks/src/fixtures/transaction-profile-v1-missing-function.json
@@ -1,0 +1,91 @@
+{
+  "event_id": "cfe78a5c892d4a64a962d837673398d2",
+  "profile_id": "cfe78a5c892d4a64a962d837673398d2",
+  "platform": "python",
+  "environment": "production",
+  "release": {
+    "version": "backend@1.2.3"
+  },
+  "version": "2",
+  "profile": {
+    "frames": [
+      {
+        "filename": "main.py",
+        "in_app": true,
+        "lineno": 42,
+        "module": "app.main",
+        "abs_path": "/app/src/main.py",
+        "platform": "python",
+        "lang": "python"
+      },
+      {
+        "filename": "db.py",
+        "function": "execute_query",
+        "in_app": true,
+        "lineno": 118,
+        "module": "app.db",
+        "abs_path": "/app/src/db.py",
+        "platform": "python",
+        "lang": "python"
+      },
+      {
+        "filename": "connection.py",
+        "function": "cursor.execute",
+        "in_app": false,
+        "lineno": 230,
+        "module": "psycopg2.extensions",
+        "abs_path": "/usr/lib/python3.11/site-packages/psycopg2/extensions.py",
+        "platform": "python",
+        "lang": "python"
+      }
+    ],
+    "samples": [
+      {
+        "stack_id": 0,
+        "thread_id": 1,
+        "elapsed_since_start_ns": 0
+      },
+      {
+        "stack_id": 1,
+        "thread_id": 1,
+        "elapsed_since_start_ns": 50000000
+      },
+      {
+        "stack_id": 1,
+        "thread_id": 1,
+        "elapsed_since_start_ns": 100000000
+      }
+    ],
+    "stacks": [
+      [0],
+      [0, 1, 2]
+    ],
+    "thread_metadata": {
+      "1": {
+        "name": "MainThread",
+        "priority": 10
+      }
+    }
+  },
+  "transaction": {
+    "name": "/api/users",
+    "trace_id": "a4d1aae7216b47ff8117cf4e09ce9d0a",
+    "id": "7ca573c0f4814912aaa9bdc77d1a7d51",
+    "active_thread_id": 1,
+    "relative_start_ns": 0,
+    "relative_end_ns": 120000000
+  },
+  "device": {
+    "model": "MacBook Pro",
+    "classification": "high",
+    "arch": "arm64"
+  },
+  "os": {
+    "name": "macOS",
+    "version": "14.4"
+  },
+  "client_sdk": {
+    "name": "sentry.python",
+    "version": "2.24.1"
+  }
+}

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -27,6 +27,9 @@ import { setupServer } from "msw/node";
 import autofixStateFixture from "./fixtures/autofix-state.json" with {
   type: "json",
 };
+import autofixStateExplorerFixture from "./fixtures/autofix-state-explorer.json" with {
+  type: "json",
+};
 import clientKeyFixture from "./fixtures/client-key.json" with { type: "json" };
 import eventAttachmentsFixture from "./fixtures/event-attachments.json" with {
   type: "json",
@@ -59,6 +62,9 @@ import flamegraphFixture from "./fixtures/flamegraph.json" with {
 import transactionProfileV1Fixture from "./fixtures/transaction-profile-v1.json" with {
   type: "json",
 };
+import transactionProfileV1MissingFunctionFixture from "./fixtures/transaction-profile-v1-missing-function.json" with {
+  type: "json",
+};
 import profileChunkFixture from "./fixtures/profile-chunk.json" with {
   type: "json",
 };
@@ -66,6 +72,9 @@ import issueTagValuesFixture from "./fixtures/issue-tag-values.json" with {
   type: "json",
 };
 import issueFixture from "./fixtures/issue.json" with { type: "json" };
+import issueNullCulpritFixture from "./fixtures/issue-null-culprit.json" with {
+  type: "json",
+};
 import organizationFixture from "./fixtures/organization.json" with {
   type: "json",
 };
@@ -1401,6 +1410,7 @@ export const mswServer = setupServer(
 // Export fixtures for use in tests
 export {
   autofixStateFixture,
+  autofixStateExplorerFixture,
   eventsFixture as eventFixture,
   replayDetailsFixture,
   replayRecordingSegmentsFixture,
@@ -1412,6 +1422,7 @@ export {
   traceEventFixture,
   flamegraphFixture,
   transactionProfileV1Fixture,
+  transactionProfileV1MissingFunctionFixture,
   organizationFixture,
   releaseFixture,
   clientKeyFixture,
@@ -1421,6 +1432,7 @@ export {
   eventsSpansFixture,
   eventsSpansEmptyFixture,
   issueFixture,
+  issueNullCulpritFixture,
   eventsFixture,
   projectFixture,
   teamFixture,

--- a/packages/mcp-server-mocks/src/payloads.ts
+++ b/packages/mcp-server-mocks/src/payloads.ts
@@ -9,6 +9,9 @@
 import autofixStateFixture from "./fixtures/autofix-state.json" with {
   type: "json",
 };
+import autofixStateExplorerFixture from "./fixtures/autofix-state-explorer.json" with {
+  type: "json",
+};
 import clientKeyFixture from "./fixtures/client-key.json" with { type: "json" };
 import eventAttachmentsFixture from "./fixtures/event-attachments.json" with {
   type: "json",
@@ -32,7 +35,13 @@ import flamegraphFixture from "./fixtures/flamegraph.json" with {
 import transactionProfileV1Fixture from "./fixtures/transaction-profile-v1.json" with {
   type: "json",
 };
+import transactionProfileV1MissingFunctionFixture from "./fixtures/transaction-profile-v1-missing-function.json" with {
+  type: "json",
+};
 import issueFixture from "./fixtures/issue.json" with { type: "json" };
+import issueNullCulpritFixture from "./fixtures/issue-null-culprit.json" with {
+  type: "json",
+};
 import issueTagValuesFixture from "./fixtures/issue-tag-values.json" with {
   type: "json",
 };
@@ -93,6 +102,7 @@ const issueFixture2 = {
 // Export all fixtures
 export {
   autofixStateFixture,
+  autofixStateExplorerFixture,
   clientKeyFixture,
   eventAttachmentsFixture,
   eventFixture,
@@ -102,8 +112,10 @@ export {
   eventsSpansFixture,
   flamegraphFixture,
   transactionProfileV1Fixture,
+  transactionProfileV1MissingFunctionFixture,
   issueFixture,
   issueFixture2,
+  issueNullCulpritFixture,
   issueTagValuesFixture,
   organizationFixture,
   performanceEventFixture,


### PR DESCRIPTION
Align the Sentry API client schemas with the payloads that upstream Sentry actually serializes.

While tracing the profile parsing failure, I found a few places where we had drifted from upstream: nullable issue culprits, tag count fields that come back as `uniqueValues` or omit `topValues`, numeric Seer `run_id`, explorer autofix state, and sampled profile frames without `function`. This updates the validators and profile formatter to accept those shapes and adds source-of-truth comments pointing back to the upstream endpoint and serializer code.

I considered keeping the regression coverage as one-off test mutations, but moved the audited edge cases into shared mock fixtures instead so future coverage comes from realistic payloads. The org tags fixture now uses the upstream `uniqueValues` field, and there are dedicated fixtures for explorer autofix, null culprits, and missing profile frame functions.

Verified with `pnpm run tsc`, `pnpm run lint`, and `pnpm run test`.