### PR TITLE
fix(oauth): restore sign-out telemetry and cut probe volume

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -141,9 +141,12 @@ const mcpHandler: ExportedHandler<Env> = {
 
     // Grants created before refreshToken was stored in props are stale and
     // can no longer be silently refreshed. Revoke and force clean re-auth.
+    // Attribute values intentionally avoid the substring "token" because
+    // Sentry's default PII scrubber replaces it with "[Filtered]" on ingest,
+    // making the `reason` dimension unusable for diagnosis.
     if (!rawProps.refreshToken) {
       Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-        attributes: { reason: "missing_refresh_token" },
+        attributes: { reason: "stale_props_no_refresh" },
       });
       return revokeStaleGrant(
         ctx,
@@ -156,7 +159,7 @@ const mcpHandler: ExportedHandler<Env> = {
 
     if (rawProps.upstreamTokenInvalid) {
       Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-        attributes: { reason: "invalid_upstream_token" },
+        attributes: { reason: "upstream_rejected" },
       });
       return revokeStaleGrant(
         ctx,

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -431,10 +431,13 @@ export type TokenExchangeEnv = {
   SENTRY_HOST?: string;
 };
 
+// Attribute values intentionally avoid the substring "token" because Sentry's
+// default PII scrubber replaces it with "[Filtered]" on ingest, making metrics
+// grouped by `outcome` unusable for diagnosis.
 export type TokenExchangeOutcome =
-  | "cached_token_still_valid_local"
-  | "cached_token_still_valid_probed"
-  | "upstream_token_invalid"
+  | "cached_valid_local"
+  | "cached_valid_probed"
+  | "upstream_rejected"
   | "verification_indeterminate";
 
 const SAFE_WINDOW_MS = 2 * 60 * 1000; // 2 minutes
@@ -475,6 +478,17 @@ function buildInvalidGrantTokenExchangeResult(
   };
 }
 
+function recordProbeStatus(status: number | undefined): void {
+  if (typeof status !== "number") {
+    return;
+  }
+  // The @sentry/cloudflare SDK does not attach http.response.status_code to
+  // outgoing http.client spans in this handler, so do it manually. Queries
+  // in Discover can then split upstream_rejected outcomes by 401 vs 403 vs 400
+  // without introducing a new metric.
+  Sentry.getActiveSpan()?.setAttribute("mcp.oauth.probe.status", status);
+}
+
 async function probeUpstreamAccessToken(
   props: WorkerProps,
   env: TokenExchangeEnv,
@@ -485,20 +499,24 @@ async function probeUpstreamAccessToken(
       host: env.SENTRY_HOST || "sentry.io",
     });
     await api.getAuthenticatedUser();
-    return "cached_token_still_valid_probed";
+    recordProbeStatus(200);
+    return "cached_valid_probed";
   } catch (error) {
     if (error instanceof ApiRateLimitError) {
+      recordProbeStatus(error.status);
       return "verification_indeterminate";
     }
 
     if (error instanceof ApiClientError) {
-      return "upstream_token_invalid";
+      recordProbeStatus(error.status);
+      return "upstream_rejected";
     }
 
     if (typeof error === "object" && error !== null) {
       const status = "status" in error ? error.status : undefined;
       if (typeof status === "number" && status >= 400 && status < 500) {
-        return "upstream_token_invalid";
+        recordProbeStatus(status);
+        return "upstream_rejected";
       }
     }
 
@@ -554,7 +572,7 @@ export async function tokenExchangeCallback(
   if (expiresAt && Number.isFinite(expiresAt)) {
     const remainingMs = expiresAt - Date.now();
     if (remainingMs > SAFE_WINDOW_MS) {
-      recordTokenExchangeOutcome("cached_token_still_valid_local", {
+      recordTokenExchangeOutcome("cached_valid_local", {
         grant_shape: "refreshable",
       });
       return buildSuccessfulTokenExchangeResult(
@@ -570,15 +588,25 @@ export async function tokenExchangeCallback(
   // issue.
   const outcome = await probeUpstreamAccessToken(props, env);
   switch (outcome) {
-    case "cached_token_still_valid_probed":
+    case "cached_valid_probed": {
       recordTokenExchangeOutcome(outcome, {
         grant_shape: "refreshable",
       });
+      // Extend the cached expiry by twice the wrapper TTL so the next
+      // refresh can take the local fast path instead of re-probing upstream.
+      // Any Sentry-side revocation still surfaces on real MCP tool calls,
+      // which hit the upstream API directly with the user's access token.
+      const nextProps = {
+        ...props,
+        accessTokenExpiresAt:
+          Date.now() + PROBED_ACCESS_TOKEN_TTL_SECONDS * 2 * 1000,
+      } satisfies WorkerProps & Record<string, unknown>;
       return buildSuccessfulTokenExchangeResult(
-        props,
+        nextProps,
         PROBED_ACCESS_TOKEN_TTL_SECONDS,
       );
-    case "upstream_token_invalid":
+    }
+    case "upstream_rejected":
       recordTokenExchangeOutcome(outcome, {
         grant_shape: "refreshable",
       });


### PR DESCRIPTION
Restore diagnosability of OAuth sign-out telemetry and reduce upstream probe load.

Three small changes to `packages/mcp-cloudflare/src/server`, motivated by investigating reports of sessions being forced to re-auth.

## 1. Scrubber bypass (diagnosability)

Sentry's default PII scrubber matches the substring `"token"` in attribute values and replaces it with `[Filtered]` on ingest. This left the `outcome` dimension on `mcp.oauth.token_exchange` (~533K/14d) and the `reason` dimension on `mcp.oauth.grant_revoked` (~66K/14d) entirely bucketed under `[Filtered]`, with no way to tell which branch produced each event.

Renames:

| Before | After |
|---|---|
| `cached_token_still_valid_local` | `cached_valid_local` |
| `cached_token_still_valid_probed` | `cached_valid_probed` |
| `upstream_token_invalid` | `upstream_rejected` |
| `missing_refresh_token` | `stale_props_no_refresh` |
| `invalid_upstream_token` | `upstream_rejected` |

## 2. Probe status on span

`@sentry/cloudflare` does not attach `http.response.status_code` to the outgoing `GET /api/0/auth/` probe span — all ~80K probe spans in the last 7d had `http.status_code=null`. Attach `mcp.oauth.probe.status` manually so Discover queries can split `upstream_rejected` outcomes by actual upstream status (401 vs 403 vs 400 vs 429) without introducing a new metric.

## 3. Cut probe thrashing

On `cached_valid_probed`, extend `accessTokenExpiresAt` by twice `PROBED_ACCESS_TOKEN_TTL_SECONDS` so the next wrapper refresh takes the local fast path instead of re-probing upstream. Halves upstream probe volume for grants past the initial 30d window. Safe: any Sentry-side revocation still surfaces immediately on real MCP tool calls, which hit the upstream API directly with the user's access token.

## Verification after deploy

- `metric mcp.oauth.token_exchange grouped by outcome` shows 4 real buckets instead of `[Filtered]`.
- `metric mcp.oauth.grant_revoked grouped by reason` splits cleanly into `stale_props_no_refresh` vs `upstream_rejected`.
- Spans with `has:mcp.oauth.probe.status` expose the 401/403/400/429 distribution, letting us confirm whether 403s are being misclassified as invalid tokens.
- Probe volume against `/api/0/auth/` roughly halved.

No user-visible behavior change.