### PR TITLE
feat(oauth): add client_family, user tagging, and new lifecycle metrics

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -2,6 +2,7 @@ import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import * as Sentry from "@sentry/cloudflare";
 import { SCOPES } from "../constants";
 import app from "./app";
+import { resolveClientFamily } from "./lib/client-family";
 import sentryMcpHandler from "./lib/mcp-handler";
 import { tokenExchangeCallback } from "./oauth";
 import getSentryConfig from "./sentry.config";
@@ -138,6 +139,8 @@ const wrappedOAuthProvider = {
       }
     }
 
+    const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
+
     // --- Phase 2: Let the OAuth library handle the request ---
     // We normalize any CORS headers it returns in the response handling below.
     const oAuthProvider = new OAuthProvider({
@@ -149,7 +152,8 @@ const wrappedOAuthProvider = {
       authorizeEndpoint: "/oauth/authorize",
       tokenEndpoint: "/oauth/token",
       clientRegistrationEndpoint: "/oauth/register",
-      tokenExchangeCallback: (options) => tokenExchangeCallback(options, env),
+      tokenExchangeCallback: (options) =>
+        tokenExchangeCallback(options, env, clientFamily),
       scopesSupported: Object.keys(SCOPES),
       // Expire grants after 30 days to prevent unbounded KV accumulation.
       // Sentry access tokens also have a 30-day lifetime, so re-auth is
@@ -158,6 +162,16 @@ const wrappedOAuthProvider = {
     });
 
     const response = await oAuthProvider.fetch(request, env, ctx);
+
+    if (
+      request.method === "POST" &&
+      url.pathname === "/oauth/register" &&
+      response.ok
+    ) {
+      Sentry.metrics.count("mcp.oauth.register", 1, {
+        attributes: { client_family: clientFamily },
+      });
+    }
 
     // --- Phase 3: Patch headers, then apply our CORS policy ---
     const patched = patchWwwAuthenticate(response, url);

--- a/packages/mcp-cloudflare/src/server/lib/client-family.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/client-family.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveClientFamily } from "./client-family";
+
+describe("resolveClientFamily", () => {
+  it.each([
+    ["claude-code/2.1.118 (cli)", "claude-code"],
+    ["Cursor/3.1.15 (darwin arm64)", "cursor"],
+    ["copilot/1.0.34", "copilot"],
+    ["opencode/1.4.7", "opencode"],
+    ["Claude-User", "claude-desktop"],
+    ["codex-cli/1.0.0", "codex"],
+    ["ReactorNetty/1.2.12", "reactor-netty"],
+    ["Java-http-client/21.0.10", "java-http-client"],
+    ["Go-http-client/1.1", "go-http-client"],
+    ["python-httpx/0.28.1", "python"],
+    ["Python/3.12 aiohttp/3.13.5", "python"],
+    ["Bun/1.3.13", "bun"],
+    ["node", "node"],
+    ["node-fetch/1.0", "node"],
+    ["axios/1.15.0", "other"],
+    ["", "unknown"],
+    [null, "unknown"],
+    [undefined, "unknown"],
+  ])("maps %s → %s", (input, expected) => {
+    expect(resolveClientFamily(input)).toBe(expected);
+  });
+});

--- a/packages/mcp-cloudflare/src/server/lib/client-family.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/client-family.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveClientFamily } from "./client-family";
+import {
+  resolveClientFamily,
+  resolveClientFamilyFromName,
+} from "./client-family";
 
 describe("resolveClientFamily", () => {
   it.each([
@@ -23,5 +26,24 @@ describe("resolveClientFamily", () => {
     [undefined, "unknown"],
   ])("maps %s → %s", (input, expected) => {
     expect(resolveClientFamily(input)).toBe(expected);
+  });
+});
+
+describe("resolveClientFamilyFromName", () => {
+  it.each([
+    ["Claude Code", "claude-code"],
+    ["claude-code", "claude-code"],
+    ["Claude", "claude-desktop"],
+    ["Claude Desktop", "claude-desktop"],
+    ["Cursor", "cursor"],
+    ["GitHub Copilot", "copilot"],
+    ["Codex CLI", "codex"],
+    ["opencode", "opencode"],
+    ["Some Random Client", "other"],
+    ["", "unknown"],
+    [null, "unknown"],
+    [undefined, "unknown"],
+  ])("maps %s → %s", (input, expected) => {
+    expect(resolveClientFamilyFromName(input)).toBe(expected);
   });
 });

--- a/packages/mcp-cloudflare/src/server/lib/client-family.ts
+++ b/packages/mcp-cloudflare/src/server/lib/client-family.ts
@@ -1,0 +1,31 @@
+// Bucket User-Agent into a fixed set of values so it's safe to use as a
+// metric attribute (raw UAs are unbounded cardinality).
+export function resolveClientFamily(
+  userAgent: string | null | undefined,
+): string {
+  if (!userAgent) return "unknown";
+
+  const ua = userAgent.toLowerCase();
+
+  if (ua.startsWith("claude-code/")) return "claude-code";
+  if (ua.startsWith("cursor/")) return "cursor";
+  if (ua.startsWith("copilot/")) return "copilot";
+  if (ua.startsWith("opencode/")) return "opencode";
+  if (ua.startsWith("claude-user")) return "claude-desktop";
+  if (ua.includes("codex")) return "codex";
+
+  if (ua.startsWith("reactornetty/")) return "reactor-netty";
+  if (ua.startsWith("java-http-client/")) return "java-http-client";
+  if (ua.startsWith("go-http-client/")) return "go-http-client";
+  if (
+    ua.startsWith("python-httpx/") ||
+    ua.startsWith("python/") ||
+    ua.startsWith("aiohttp/")
+  ) {
+    return "python";
+  }
+  if (ua.startsWith("bun/")) return "bun";
+  if (ua === "node" || ua.startsWith("node-fetch/")) return "node";
+
+  return "other";
+}

--- a/packages/mcp-cloudflare/src/server/lib/client-family.ts
+++ b/packages/mcp-cloudflare/src/server/lib/client-family.ts
@@ -1,5 +1,9 @@
 // Bucket User-Agent into a fixed set of values so it's safe to use as a
-// metric attribute (raw UAs are unbounded cardinality).
+// metric attribute (raw UAs are unbounded cardinality). Use this on
+// endpoints the MCP client hits directly (/oauth/register, /oauth/token,
+// /mcp); on browser-navigated endpoints (/oauth/authorize, /oauth/callback)
+// use `resolveClientFamilyFromName` with the DCR-registered client name
+// instead.
 export function resolveClientFamily(
   userAgent: string | null | undefined,
 ): string {
@@ -26,6 +30,28 @@ export function resolveClientFamily(
   }
   if (ua.startsWith("bun/")) return "bun";
   if (ua === "node" || ua.startsWith("node-fetch/")) return "node";
+
+  return "other";
+}
+
+// Resolver for DCR-registered `client_name` values. Order matters:
+// check "claude code" before "claude" so Claude Code doesn't bucket as
+// Claude Desktop.
+export function resolveClientFamilyFromName(
+  name: string | null | undefined,
+): string {
+  if (!name) return "unknown";
+
+  const n = name.toLowerCase();
+
+  if (n.includes("claude code") || n.includes("claude-code")) {
+    return "claude-code";
+  }
+  if (n.includes("cursor")) return "cursor";
+  if (n.includes("copilot")) return "copilot";
+  if (n.includes("codex")) return "codex";
+  if (n.includes("opencode")) return "opencode";
+  if (n.includes("claude")) return "claude-desktop";
 
   return "other";
 }

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -23,6 +23,7 @@ import {
   MCP_RATE_LIMIT_EXCEEDED_MESSAGE,
 } from "../utils/rate-limiter";
 import { annotateResponseMetric } from "../metrics";
+import { resolveClientFamily } from "./client-family";
 import { verifyConstraintsAccess } from "./constraint-utils";
 
 /**
@@ -128,6 +129,8 @@ const mcpHandler: ExportedHandler<Env> = {
     const accessToken = rawProps.accessToken as string;
     const clientId = rawProps.clientId as string;
     const sentryHost = env.SENTRY_HOST || "sentry.io";
+    const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
+    Sentry.setUser({ id: userId });
 
     // Parse and validate granted skills (primary authorization method)
     // Legacy tokens without grantedSkills are no longer supported
@@ -139,14 +142,14 @@ const mcpHandler: ExportedHandler<Env> = {
       return revokeStaleGrant(ctx, env, userId, clientId, "legacy grant");
     }
 
-    // Grants created before refreshToken was stored in props are stale and
-    // can no longer be silently refreshed. Revoke and force clean re-auth.
-    // Attribute values intentionally avoid the substring "token" because
-    // Sentry's default PII scrubber replaces it with "[Filtered]" on ingest,
-    // making the `reason` dimension unusable for diagnosis.
+    // Attribute values avoid the substring "token" so Sentry's default PII
+    // scrubber doesn't replace them with "[Filtered]" on ingest.
     if (!rawProps.refreshToken) {
       Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-        attributes: { reason: "stale_props_no_refresh" },
+        attributes: {
+          reason: "stale_props_no_refresh",
+          client_family: clientFamily,
+        },
       });
       return revokeStaleGrant(
         ctx,
@@ -159,7 +162,10 @@ const mcpHandler: ExportedHandler<Env> = {
 
     if (rawProps.upstreamTokenInvalid) {
       Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-        attributes: { reason: "upstream_rejected" },
+        attributes: {
+          reason: "upstream_rejected",
+          client_family: clientFamily,
+        },
       });
       return revokeStaleGrant(
         ctx,

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -6,6 +6,7 @@ import type { z } from "zod";
 import {
   ApiClientError,
   ApiRateLimitError,
+  ApiServerError,
   SentryApiService,
 } from "@sentry/mcp-core/api-client";
 import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
@@ -431,9 +432,8 @@ export type TokenExchangeEnv = {
   SENTRY_HOST?: string;
 };
 
-// Attribute values intentionally avoid the substring "token" because Sentry's
-// default PII scrubber replaces it with "[Filtered]" on ingest, making metrics
-// grouped by `outcome` unusable for diagnosis.
+// Values avoid the substring "token" so Sentry's default PII scrubber
+// doesn't replace them with "[Filtered]" on ingest.
 export type TokenExchangeOutcome =
   | "cached_valid_local"
   | "cached_valid_probed"
@@ -478,7 +478,11 @@ function buildInvalidGrantTokenExchangeResult(
   };
 }
 
-type ProbeResult = { outcome: TokenExchangeOutcome; status?: number };
+type ProbeResult = {
+  outcome: TokenExchangeOutcome;
+  status?: number;
+  reason?: "rate_limit" | "server_error" | "unknown";
+};
 
 async function probeUpstreamAccessToken(
   props: WorkerProps,
@@ -493,7 +497,19 @@ async function probeUpstreamAccessToken(
     return { outcome: "cached_valid_probed", status: 200 };
   } catch (error) {
     if (error instanceof ApiRateLimitError) {
-      return { outcome: "verification_indeterminate", status: error.status };
+      return {
+        outcome: "verification_indeterminate",
+        status: error.status,
+        reason: "rate_limit",
+      };
+    }
+
+    if (error instanceof ApiServerError) {
+      return {
+        outcome: "verification_indeterminate",
+        status: error.status,
+        reason: "server_error",
+      };
     }
 
     if (error instanceof ApiClientError) {
@@ -502,15 +518,24 @@ async function probeUpstreamAccessToken(
 
     if (typeof error === "object" && error !== null) {
       const status = "status" in error ? error.status : undefined;
-      if (typeof status === "number" && status >= 400 && status < 500) {
-        return { outcome: "upstream_rejected", status };
+      if (typeof status === "number") {
+        if (status >= 400 && status < 500) {
+          return { outcome: "upstream_rejected", status };
+        }
+        if (status >= 500) {
+          return {
+            outcome: "verification_indeterminate",
+            status,
+            reason: "server_error",
+          };
+        }
       }
     }
 
     logIssue(error, {
       loggerScope: ["cloudflare", "oauth", "refresh"],
     });
-    return { outcome: "verification_indeterminate" };
+    return { outcome: "verification_indeterminate", reason: "unknown" };
   }
 }
 
@@ -525,6 +550,7 @@ async function probeUpstreamAccessToken(
 export async function tokenExchangeCallback(
   options: TokenExchangeCallbackOptions,
   env: TokenExchangeEnv,
+  clientFamily = "unknown",
 ): Promise<TokenExchangeCallbackResult | undefined> {
   if (options.grantType !== "refresh_token") {
     return undefined;
@@ -561,6 +587,7 @@ export async function tokenExchangeCallback(
     if (remainingMs > SAFE_WINDOW_MS) {
       recordTokenExchangeOutcome("cached_valid_local", {
         grant_shape: "refreshable",
+        client_family: clientFamily,
       });
       return buildSuccessfulTokenExchangeResult(
         props,
@@ -573,15 +600,21 @@ export async function tokenExchangeCallback(
   // report invalid/expired bearer tokens here as 400 or 401, so treat any 4xx
   // as an expected probe failure and fall back to re-auth without creating an
   // issue.
-  const { outcome, status } = await probeUpstreamAccessToken(props, env);
-  // Carried as a metric attribute (not a span attribute) because Sentry.getActiveSpan()
-  // is undefined inside tokenExchangeCallback — the workers-oauth-provider invokes
-  // the callback outside the request span context.
+  const { outcome, status, reason } = await probeUpstreamAccessToken(
+    props,
+    env,
+  );
+  // Metric attribute (not span attribute): Sentry.getActiveSpan() is
+  // undefined inside tokenExchangeCallback.
   const outcomeAttributes: Record<string, string> = {
     grant_shape: "refreshable",
+    client_family: clientFamily,
   };
   if (typeof status === "number") {
     outcomeAttributes.probe_status = String(status);
+  }
+  if (reason) {
+    outcomeAttributes.probe_reason = reason;
   }
   switch (outcome) {
     case "cached_valid_probed": {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -64,9 +64,27 @@ export default new Hono<{ Bindings: Env }>()
       // Log invalid redirect URI errors without sending them to Sentry
       const errorMessage = err instanceof Error ? err.message : String(err);
       if (errorMessage.includes("Invalid redirect URI")) {
+        // parseAuthRequest threw before producing a request, so read the
+        // attempted values directly from the query string.
+        const authUrl = new URL(c.req.url);
+        const attemptedClientId = authUrl.searchParams.get("client_id");
+        const attemptedRedirectUri = authUrl.searchParams.get("redirect_uri");
+        let registeredUris: string[] | undefined;
+        if (attemptedClientId) {
+          try {
+            const client =
+              await c.env.OAUTH_PROVIDER.lookupClient(attemptedClientId);
+            registeredUris = client?.redirectUris;
+          } catch {}
+        }
         logWarn(`OAuth authorization failed: ${errorMessage}`, {
           loggerScope: ["cloudflare", "oauth", "authorize"],
-          extra: { error: errorMessage },
+          extra: {
+            error: errorMessage,
+            clientId: attemptedClientId,
+            redirectUri: attemptedRedirectUri,
+            registeredUris,
+          },
         });
         return c.text("Invalid redirect URI", 400);
       }
@@ -194,6 +212,8 @@ export default new Hono<{ Bindings: Env }>()
           extra: {
             clientId: oauthReqWithSkills.clientId,
             redirectUri: oauthReqWithSkills.redirectUri,
+            registeredUris: client?.redirectUris,
+            clientName: client?.clientName,
           },
         });
         return c.text("Invalid redirect URI", 400);

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -70,11 +70,13 @@ export default new Hono<{ Bindings: Env }>()
         const attemptedClientId = authUrl.searchParams.get("client_id");
         const attemptedRedirectUri = authUrl.searchParams.get("redirect_uri");
         let registeredUris: string[] | undefined;
+        let clientName: string | undefined;
         if (attemptedClientId) {
           try {
             const client =
               await c.env.OAUTH_PROVIDER.lookupClient(attemptedClientId);
             registeredUris = client?.redirectUris;
+            clientName = client?.clientName;
           } catch {}
         }
         logWarn(`OAuth authorization failed: ${errorMessage}`, {
@@ -84,6 +86,7 @@ export default new Hono<{ Bindings: Env }>()
             clientId: attemptedClientId,
             redirectUri: attemptedRedirectUri,
             registeredUris,
+            clientName,
           },
         });
         return c.text("Invalid redirect URI", 400);

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
 import * as Sentry from "@sentry/cloudflare";
 import { clientIdAlreadyApproved } from "../../lib/approval-dialog";
-import { resolveClientFamily } from "../../lib/client-family";
+import { resolveClientFamilyFromName } from "../../lib/client-family";
 import type { Env, WorkerProps } from "../../types";
 import { SENTRY_TOKEN_URL } from "../constants";
 import {
@@ -308,9 +308,19 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   });
 
   Sentry.setUser({ id: payload.user.id });
+  // /oauth/callback is browser-navigated, so the User-Agent is the user's
+  // browser, not the MCP client. Derive client family from the DCR-registered
+  // client_name instead.
+  let callbackClientName: string | undefined;
+  try {
+    const callbackClient = await c.env.OAUTH_PROVIDER.lookupClient(
+      oauthReqInfo.clientId,
+    );
+    callbackClientName = callbackClient?.clientName;
+  } catch {}
   Sentry.metrics.count("mcp.oauth.callback_completed", 1, {
     attributes: {
-      client_family: resolveClientFamily(c.req.header("user-agent")),
+      client_family: resolveClientFamilyFromName(callbackClientName),
     },
   });
 

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
+import * as Sentry from "@sentry/cloudflare";
 import { clientIdAlreadyApproved } from "../../lib/approval-dialog";
+import { resolveClientFamily } from "../../lib/client-family";
 import type { Env, WorkerProps } from "../../types";
 import { SENTRY_TOKEN_URL } from "../constants";
 import {
@@ -303,6 +305,13 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
 
       // Note: sentryHost and mcpUrl come from env, not OAuth props
     } as WorkerProps,
+  });
+
+  Sentry.setUser({ id: payload.user.id });
+  Sentry.metrics.count("mcp.oauth.callback_completed", 1, {
+    attributes: {
+      client_family: resolveClientFamily(c.req.header("user-agent")),
+    },
   });
 
   // Use manual redirect instead of Response.redirect() to allow middleware to add headers

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -173,10 +173,12 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   }
 
   // Validate redirectUri is registered for this client
+  let registeredClientName: string | undefined;
   try {
     const client = await c.env.OAUTH_PROVIDER.lookupClient(
       oauthReqInfo.clientId,
     );
+    registeredClientName = client?.clientName;
     const uriIsAllowed =
       Array.isArray(client?.redirectUris) &&
       client.redirectUris.includes(oauthReqInfo.redirectUri);
@@ -310,17 +312,10 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   Sentry.setUser({ id: payload.user.id });
   // /oauth/callback is browser-navigated, so the User-Agent is the user's
   // browser, not the MCP client. Derive client family from the DCR-registered
-  // client_name instead.
-  let callbackClientName: string | undefined;
-  try {
-    const callbackClient = await c.env.OAUTH_PROVIDER.lookupClient(
-      oauthReqInfo.clientId,
-    );
-    callbackClientName = callbackClient?.clientName;
-  } catch {}
+  // client_name (resolved above).
   Sentry.metrics.count("mcp.oauth.callback_completed", 1, {
     attributes: {
-      client_family: resolveClientFamilyFromName(callbackClientName),
+      client_family: resolveClientFamilyFromName(registeredClientName),
     },
   });
 

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -188,6 +188,8 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
         extra: {
           clientId: oauthReqInfo.clientId,
           redirectUri: oauthReqInfo.redirectUri,
+          registeredUris: client?.redirectUris,
+          clientName: registeredClientName,
         },
       });
       return c.text("Authorization failed: Invalid redirect URL", 400);


### PR DESCRIPTION
Telemetry-only follow-up to #916/#917. The existing OAuth metrics couldn't answer "which client type" or "which user," and the `Invalid redirect URI` warnings (~1K/day) had no structured context.

## New helper

`lib/client-family.ts` maps a User-Agent into a fixed bucket (`claude-code`, `cursor`, `codex`, `copilot`, `claude-desktop`, `opencode`, `reactor-netty`, `java-http-client`, `go-http-client`, `python`, `bun`, `node`, `other`, `unknown`) safe for use as a metric attribute.

## Changes

- `mcp.oauth.grant_revoked`: preceded by `Sentry.setUser({ id })` and tagged with `client_family`. Previously user-untagged, so per-user sign-out queries returned null.
- `mcp.oauth.token_exchange`: tagged with `client_family`, threaded through `tokenExchangeCallback` from the request's User-Agent.
- **New** `mcp.oauth.callback_completed` counter on successful `/oauth/callback`. Pairs with `grant_revoked` to derive session lifetime.
- **New** `mcp.oauth.register` counter emitted from the OAuth wrapper after the library handles `/oauth/register`.
- `probeUpstreamAccessToken` routes `ApiServerError` (5xx) into `verification_indeterminate` with `probe_reason: "server_error"` instead of falling through to `logIssue` (fixes a pre-existing bug where upstream 5xx transients created Sentry issues). Rate limits get `"rate_limit"`, unknown errors `"unknown"`.
- Both `Invalid redirect URI` log sites in `authorize.ts` now include `clientId`, `redirectUri`, `registeredUris`, and `clientName` as structured fields.

Scrubber-safe attribute naming from #916 is preserved.

## Verification after deploy

- `metric mcp.oauth.grant_revoked filtered by user.id:"1"` — now returns data.
- `metric mcp.oauth.grant_revoked grouped by client_family, reason` — per-client sign-out split.
- `metric mcp.oauth.callback_completed grouped by client_family` — re-auth rate per client.
- `metric mcp.oauth.register grouped by client_family` — DCR storm attribution.
- `metric mcp.oauth.token_exchange filtered by outcome:verification_indeterminate grouped by probe_reason`.
- `Invalid redirect URI` logs carry `clientId`/`redirectUri`/`registeredUris`/`clientName`.