### PR TITLE
feat(oauth): classify upstream_rejected by scheduled-expiry

### DIFF
--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -575,6 +575,7 @@ export async function tokenExchangeCallback(
     accessToken: rawProps.accessToken as string,
     refreshToken: rawProps.refreshToken,
     accessTokenExpiresAt: rawProps.accessTokenExpiresAt,
+    upstreamExpiresAt: rawProps.upstreamExpiresAt,
     clientId: rawProps.clientId as string,
     scope: rawProps.scope as string,
     grantedScopes: rawProps.grantedScopes,
@@ -633,9 +634,24 @@ export async function tokenExchangeCallback(
         PROBED_ACCESS_TOKEN_TTL_SECONDS,
       );
     }
-    case "upstream_rejected":
-      recordTokenExchangeOutcome(outcome, outcomeAttributes);
+    case "upstream_rejected": {
+      // Classify the rejection against the original upstream expiry (never
+      // mutated by probe-extension). Splits 401s into natural 30d rollovers
+      // vs premature Sentry-side invalidation (SSO expiry, org changes, etc.).
+      const upstreamExpiresAt = props.upstreamExpiresAt;
+      const expiredOnSchedule =
+        typeof upstreamExpiresAt === "number" &&
+        Number.isFinite(upstreamExpiresAt)
+          ? Date.now() >= upstreamExpiresAt
+            ? "true"
+            : "false"
+          : "unknown";
+      recordTokenExchangeOutcome(outcome, {
+        ...outcomeAttributes,
+        expired_on_schedule: expiredOnSchedule,
+      });
       return buildInvalidGrantTokenExchangeResult(props);
+    }
     case "verification_indeterminate":
       recordTokenExchangeOutcome(outcome, outcomeAttributes);
       return undefined;

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -297,6 +297,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       // Cache upstream expiry so future refresh grants can avoid
       // unnecessary upstream refresh calls when still valid
       accessTokenExpiresAt,
+      upstreamExpiresAt: accessTokenExpiresAt,
       clientId: oauthReqInfo.clientId,
       scope: oauthReqInfo.scope.join(" "),
       // Scopes derived from skills - for backward compatibility with old MCP clients

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -17,7 +17,11 @@ export type WorkerProps = {
   // Sentry-specific fields
   accessToken: string;
   refreshToken: string;
-  accessTokenExpiresAt?: number; // Timestamp when the upstream access token expires
+  accessTokenExpiresAt?: number; // Cached validity deadline; extended on successful probe.
+  // Scheduled upstream expiry from the original callback payload. Never
+  // mutated after grant creation so probe-failure classification can compare
+  // against the real upstream lifetime (not a probe-extended deadline).
+  upstreamExpiresAt?: number;
   upstreamTokenInvalid?: boolean;
   clientId: string;
   scope: string;


### PR DESCRIPTION
Follow-up to #918. Adds a single new metric attribute, `expired_on_schedule`, on the `upstream_rejected` outcome of `mcp.oauth.token_exchange`.

## Context

After #918 we can see 100% of forced sign-outs are `upstream_rejected` with `probe_status: 401` — Sentry is rejecting the cached access token. But we can't tell whether that's:

- **Natural 30d expiry** — expected, nothing to do
- **Premature Sentry-side invalidation** — SSO session end, org membership change, password change, admin revocation

Users reporting "signed out in way less than 30 days" would indicate the second bucket dominates. This telemetry answers that directly.

## Change

- `upstreamExpiresAt` added to `WorkerProps` — the scheduled upstream expiry captured at `/oauth/callback`, never mutated. Can't reuse `accessTokenExpiresAt` because the probe-success extension in #916 bumps it forward by 2h on every successful probe, destroying the real-expiry signal.
- Callback sets `upstreamExpiresAt: accessTokenExpiresAt` at grant creation.
- `upstream_rejected` switch case emits `expired_on_schedule: "true" | "false" | "unknown"`:
  - `"true"`  — `Date.now() >= upstreamExpiresAt` (natural rollover)
  - `"false"` — still within scheduled lifetime (premature invalidation)
  - `"unknown"` — legacy grant without the field (drains as users re-auth)

## Verification after deploy

`metric mcp.oauth.token_exchange filtered by outcome:upstream_rejected grouped by expired_on_schedule, client_family` over 24h. If the `"false"` bucket dominates for `claude-code` / `cursor` / `claude-desktop`, sub-30-day sign-outs are real and Sentry-side invalidation is the cause. If `"true"` dominates, sign-outs are just 30d rollovers.