### PR TITLE
feat(oauth): close sub-30d sign-out gaps, add playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ sentry-mcp/
 - docs/pr-management.md — Commit/PR guidelines
 - docs/security.md — Authentication patterns
 - docs/stdio-auth.md — Device code flow, token caching, client ID architecture
+- docs/oauth-signout-playbook.md — Remote OAuth failure modes, telemetry, diagnostic runbook
 - docs/embedded-agents.md — LLM provider configuration for AI-powered tools
 - docs/releases/stdio.md — npm package release
 - docs/releases/cloudflare.md — Cloudflare deployment

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -55,9 +55,8 @@ Attributes:
 - `grant_shape` — currently always `refreshable`
 - `probe_status` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
 - `probe_reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
-- `expired_on_schedule` — on `upstream_rejected` only; `"true"` if `upstreamExpiresAt` is in the past, `"false"` if scheduled expiry is still in the future, `"unknown"` for legacy grants. **In practice always `"true"` or `"unknown"`**: the probe only fires once `accessTokenExpiresAt` has passed, and that field is always ≥ `upstreamExpiresAt` by construction, so `"false"` is unreachable. Sub-30d sign-outs surface via `grant_revoked{reason:upstream_rejected_in_use}` instead (see below).
 
-User is set via `Sentry.setUser({ id: rawProps.id })` in the callback, so metrics can be filtered by `user.id`.
+User is set via `Sentry.setUser({ id: rawProps.id })` in the callback, so metrics can be filtered by `user.id`. Sub-30d sign-outs surface via `mcp.oauth.grant_revoked{reason:upstream_rejected_in_use}`, not on this metric.
 
 ### `mcp.oauth.grant_revoked` (counter)
 
@@ -178,5 +177,5 @@ Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped and tr
 - #916 — restored sign-out telemetry (scrubber rename) and reduced probe volume.
 - #917 — carried probe status as a metric attribute.
 - #918 — added `client_family`, user tagging, `callback_completed` / `register` metrics, `probe_reason`, structured Invalid-redirect-URI fields.
-- #919 — added `expired_on_schedule` on `upstream_rejected`. Never reaches `"false"` by construction; see the attribute note above.
-- #920 — closes Gaps #1 and #2: tool-call 401 detection, grant revocation, `grant_revoked{reason:upstream_rejected_in_use}`.
+- #919 — added `expired_on_schedule` on `upstream_rejected`. Removed in #920 once we realized the probe path can't produce `"false"` by construction.
+- #920 — closes Gaps #1 and #2 via tool-call 401 detection, grant revocation, and `grant_revoked{reason:upstream_rejected_in_use}`. Also removes the unreachable `expired_on_schedule` attribute and its `upstreamExpiresAt` grant field.

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -1,0 +1,183 @@
+# OAuth Sign-Out Playbook
+
+Reference for diagnosing why users of the remote MCP server (`mcp.sentry.dev`) lose their authenticated session. Covers the token lifecycle, every failure mode we've identified, what each one looks like in telemetry, and the diagnostic path for a specific user complaint.
+
+## Token lifecycle
+
+Upstream: Sentry's OAuth issues a 30-day access token + rotating refresh token on a completed `/oauth/authorize` flow. `ApiToken.expires_at` defaults to `now + 30 days` (see `~/src/sentry/src/sentry/models/apitoken.py`).
+
+MCP wrapper: `@cloudflare/workers-oauth-provider` issues its own shorter-lived wrapper access token (default 1h) backed by the same stored grant. Clients refresh against our `/oauth/token`; we do **not** refresh upstream — we reuse the cached upstream access token for its full 30d lifetime. See `packages/mcp-cloudflare/src/server/oauth/helpers.ts:530`.
+
+```
+MCP client ──(refresh wrapper token)──> /oauth/token ──> tokenExchangeCallback
+                                                            │
+                                                            ├─ local expires_at in future → cached_valid_local
+                                                            ├─ local expired → probe /api/0/auth/ upstream
+                                                            │                   ├─ 200 → cached_valid_probed, extend 2h
+                                                            │                   ├─ 4xx → upstream_rejected, mark invalid
+                                                            │                   └─ 5xx/timeout → verification_indeterminate
+                                                            └─ new wrapper access token issued
+
+MCP client ──(tool call)──> /mcp ──> mcp-handler ──> tool handler ──> SentryApiService (upstream /api/0/…)
+                                        │                                  │
+                                        ├─ upstreamTokenInvalid → revoke   └─ 401 here is currently only surfaced as
+                                        └─ rate limit check                   UserInputError to the client
+```
+
+## Failure modes
+
+| Mode | Trigger | Currently visible in telemetry | Detected by |
+|---|---|---|---|
+| **Natural 30d expiry** | Upstream `expires_at` passes | Yes | Probe path in `tokenExchangeCallback` → `upstream_rejected` |
+| **Premature Sentry-side invalidation (SSO / org / password / admin)** | Sentry revokes before `expires_at` | Yes | Tool call surfaces 401 → `grant_revoked{reason:upstream_rejected_in_use}` + grant revoked via `onUpstreamUnauthorized` callback |
+| **Stale grants from before `refreshToken` was stored in props** | Old grants from pre-#537 deploys | Yes | `mcp-handler` → `grant_revoked{reason:stale_props_no_refresh}` |
+| **Client-side state loss (DCR state reset, fresh install, reinstall)** | Client drops its stored `client_id`/`refresh_token` | Indirectly | High `/oauth/register` volume and `register:callback` ratio per `client_family` |
+| **Invalid redirect URI at authorize** | Client sends an `redirect_uri` that's not registered | Yes | Log `OAuth authorization failed: Invalid redirect URI` with `clientId`/`redirectUri`/`registeredUris`/`clientName` |
+| **Upstream probe transient (5xx / rate limit / network)** | Sentry side instability | Yes | `token_exchange{outcome:verification_indeterminate, probe_reason:…}` (does not force sign-out) |
+
+## Telemetry surface
+
+All metrics live in the `mcp-server` project on Sentry. Attribute values deliberately avoid the substring `"token"` because Sentry's default PII scrubber replaces those values with `[Filtered]` at ingest (see PR #916 for the migration).
+
+### `mcp.oauth.token_exchange` (counter)
+
+Fired for every `grant_type=refresh_token` request. Splits by `outcome`:
+
+- `cached_valid_local` — fast path, local expiry still in future by >2 min
+- `cached_valid_probed` — probe confirmed still valid, `accessTokenExpiresAt` extended by 2h
+- `upstream_rejected` — probe returned 4xx, grant marked invalid, next `/mcp` request will revoke
+- `verification_indeterminate` — probe returned 5xx/429/network error; wrapper falls back to default behavior, grant stays alive
+
+Attributes:
+
+- `outcome` — see above
+- `client_family` — bucketed User-Agent (`claude-code`, `cursor`, `codex`, `copilot`, `claude-desktop`, `opencode`, `reactor-netty`, `java-http-client`, `go-http-client`, `python`, `bun`, `node`, `other`, `unknown`)
+- `grant_shape` — currently always `refreshable`
+- `probe_status` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
+- `probe_reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
+- `expired_on_schedule` — on `upstream_rejected` only; `"true"` if `upstreamExpiresAt` is in the past, `"false"` if scheduled expiry is still in the future, `"unknown"` for legacy grants. **Currently only produces `"true"` or `"unknown"` — see Gap #1.**
+
+User is set via `Sentry.setUser({ id: rawProps.id })` in the callback, so metrics can be filtered by `user.id`.
+
+### `mcp.oauth.grant_revoked` (counter)
+
+Fired when we revoke a stored grant — either the MCP handler on a subsequent request, or the `onUpstreamUnauthorized` callback on a mid-session 401.
+
+Attributes:
+
+- `reason` — `stale_props_no_refresh` / `upstream_rejected` / `upstream_rejected_in_use`
+- `client_family`
+- `user.id` (via `Sentry.setUser`)
+
+`upstream_rejected_in_use` indicates Sentry returned 401 to a tool call while the stored access token still looked locally valid — the sub-30d sign-out signal users typically report. The grant is revoked via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`, short-circuiting the death-spiral where subsequent refreshes kept handing out wrapper tokens backed by a dead upstream token.
+
+### `mcp.oauth.callback_completed` (counter)
+
+Fired on a successful `/oauth/callback`. Pairs with `grant_revoked` to derive per-user session lifetime.
+
+Attributes:
+
+- `client_family` — resolved from the DCR-registered `client_name` (not the browser User-Agent, which is always a browser string on this endpoint)
+- `user.id`
+
+### `mcp.oauth.register` (counter)
+
+Fired from the `wrappedOAuthProvider` after the library handles a successful `/oauth/register`.
+
+Attributes:
+
+- `client_family` — from the client's User-Agent (accurate here — DCR is hit directly by the MCP client, not via browser)
+
+### Structured logs
+
+`OAuth authorization failed: Invalid redirect URI` (both GET and POST `/oauth/authorize`) and `Redirect URI not registered for client on callback` now carry `clientId`, `redirectUri`, `registeredUris`, `clientName` as `extra` fields.
+
+## Diagnostic queries
+
+Copy/paste-ready. All use the Sentry MCP's `search_events` natural-language query.
+
+### Is a specific user being revoked?
+
+```
+metric mcp.oauth.grant_revoked filtered by user.id:"<id>" sum of value grouped by reason over 30 days
+```
+
+### Per-client sign-out rate
+
+```
+metric mcp.oauth.grant_revoked sum of value grouped by client_family, reason over 24 hours
+```
+
+### Probe-failure status distribution (is Sentry ever returning 403/400?)
+
+```
+metric mcp.oauth.token_exchange filtered by outcome:upstream_rejected sum of value grouped by probe_status over 7 days
+```
+
+### Session-lifetime proxy (callbacks vs revocations per client)
+
+```
+metric mcp.oauth.callback_completed sum of value grouped by client_family over 7 days
+metric mcp.oauth.grant_revoked sum of value grouped by client_family over 7 days
+```
+
+### Register storm attribution
+
+```
+metric mcp.oauth.register sum of value grouped by client_family over 7 days
+```
+
+### Upstream instability bucket
+
+```
+metric mcp.oauth.token_exchange filtered by outcome:verification_indeterminate sum of value grouped by probe_reason over 24 hours
+```
+
+### Invalid redirect URI failures by client
+
+```
+logs message:"Invalid redirect URI" over 24 hours, sorted by timestamp
+```
+
+## Known gaps
+
+### Gap #1 — Premature Sentry-side invalidation — **closed**
+
+When Sentry invalidates a user's access token between issuance and the 30d `expires_at` (SSO session ends, user changes password, admin revokes, org membership changes), this surfaces as a 401 from Sentry when the user's tool call hits the upstream API. Previously invisible: the grant stayed alive and `tokenExchangeCallback` kept issuing wrapper tokens backed by a dead upstream token (death spiral).
+
+Now:
+
+1. `handleApiError` (`packages/mcp-core/src/internal/tool-helpers/api.ts`) no longer wraps `ApiAuthenticationError` as `UserInputError` — it re-throws so the server-level catch can act on it.
+2. The tool-handler catch block in `packages/mcp-core/src/server.ts` detects `ApiAuthenticationError` and invokes `context.onUpstreamUnauthorized` when present.
+3. The Cloudflare transport wires `onUpstreamUnauthorized` to emit `grant_revoked{reason:upstream_rejected_in_use}` and revoke the grant via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`.
+4. The user-facing error text is now "Authorization Expired — please re-authorize" instead of a misleading "Input Error."
+
+What `expired_on_schedule` doesn't help with is still true: the probe only fires when local expiry passes, so the probe-time classification can never show `"false"`. Left in place for legacy compatibility but ignored in queries.
+
+### Gap #2 — `handleApiError` misclassified 401 — **closed**
+
+Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped.
+
+### Gap #3 — tool-call `clientInfo` lost on stateless transport
+
+`mcp.client.name` is `null` on 100% of tool-call spans because `createMcpHandler` (from `agents@0.3.10`) creates a fresh `WorkerTransport` per request, and `clientInfo` is only captured during `initialize`. Documented at `packages/mcp-cloudflare/src/server/lib/mcp-handler.ts`. Closing this would require persisting `clientInfo` keyed by MCP session id and reinjecting it per-request. Not blocking for OAuth diagnosis (user-agent family is an adequate substitute for the sign-out investigation) but worth fixing for tool-level telemetry.
+
+## Runbook — "a user says they got signed out"
+
+1. **Check `grant_revoked` for the user** over the relevant window:
+   `metric mcp.oauth.grant_revoked filtered by user.id:"<id>" grouped by reason over 30 days`
+2. **Interpret the `reason`:**
+   - `upstream_rejected_in_use` — Sentry invalidated the token mid-session (SSO / org / password / admin revocation). Most common for sub-30d sign-outs. The grant was revoked automatically; user should re-auth cleanly on next request.
+   - `upstream_rejected` — natural 30d expiry (probe path). Expected.
+   - `stale_props_no_refresh` — legacy grant predating PR #537. Expected, one-time.
+3. **If no revocations are recorded** (reason counts are empty), the user hasn't been revoked server-side. Either they're still authenticated and the perception is wrong, OR the client lost local state and re-registered without going through `/oauth/callback`:
+   - Check `mcp.oauth.register grouped by client_family` for that client — high register:callback ratio (claude-code and cursor re-register on every cold start) is normal client behavior, not a server-side sign-out.
+4. **If reporting a specific time**, query `POST /oauth/token` transactions for that `user.id` around that timestamp. Transaction duration and child `GET /api/0/auth/` span tell you whether probes fired.
+
+## Related PRs
+
+- #916 — restored sign-out telemetry (scrubber rename) and reduced probe volume.
+- #917 — carried probe status as a metric attribute.
+- #918 — added `client_family`, user tagging, `callback_completed` / `register` metrics, `probe_reason`, structured Invalid-redirect-URI fields.
+- #919 — added `expired_on_schedule` on `upstream_rejected`. Operationally inert (see Gap #1 closure note).
+- _(next)_ — closes Gaps #1 and #2: tool-call 401 detection, grant revocation, `grant_revoked{reason:upstream_rejected_in_use}`.

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -4,9 +4,9 @@ Reference for diagnosing why users of the remote MCP server (`mcp.sentry.dev`) l
 
 ## Token lifecycle
 
-Upstream: Sentry's OAuth issues a 30-day access token + rotating refresh token on a completed `/oauth/authorize` flow. `ApiToken.expires_at` defaults to `now + 30 days` (see `~/src/sentry/src/sentry/models/apitoken.py`).
+Upstream: Sentry's OAuth issues a 30-day access token + rotating refresh token on a completed `/oauth/authorize` flow. `ApiToken.expires_at` defaults to `now + 30 days` (see `getsentry/sentry` `src/sentry/models/apitoken.py`).
 
-MCP wrapper: `@cloudflare/workers-oauth-provider` issues its own shorter-lived wrapper access token (default 1h) backed by the same stored grant. Clients refresh against our `/oauth/token`; we do **not** refresh upstream — we reuse the cached upstream access token for its full 30d lifetime. See `packages/mcp-cloudflare/src/server/oauth/helpers.ts:530`.
+MCP wrapper: `@cloudflare/workers-oauth-provider` issues its own shorter-lived wrapper access token (default 1h) backed by the same stored grant. Clients refresh against our `/oauth/token`; we do **not** refresh upstream — we reuse the cached upstream access token for its full 30d lifetime. See `tokenExchangeCallback` in `packages/mcp-cloudflare/src/server/oauth/helpers.ts`.
 
 ```
 MCP client ──(refresh wrapper token)──> /oauth/token ──> tokenExchangeCallback
@@ -20,8 +20,8 @@ MCP client ──(refresh wrapper token)──> /oauth/token ──> tokenExchan
 
 MCP client ──(tool call)──> /mcp ──> mcp-handler ──> tool handler ──> SentryApiService (upstream /api/0/…)
                                         │                                  │
-                                        ├─ upstreamTokenInvalid → revoke   └─ 401 here is currently only surfaced as
-                                        └─ rate limit check                   UserInputError to the client
+                                        ├─ upstreamTokenInvalid → revoke   └─ 401 → ServerContext.onUpstreamUnauthorized
+                                        └─ rate limit check                   → revoke grant + emit grant_revoked
 ```
 
 ## Failure modes
@@ -55,7 +55,7 @@ Attributes:
 - `grant_shape` — currently always `refreshable`
 - `probe_status` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
 - `probe_reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
-- `expired_on_schedule` — on `upstream_rejected` only; `"true"` if `upstreamExpiresAt` is in the past, `"false"` if scheduled expiry is still in the future, `"unknown"` for legacy grants. **Currently only produces `"true"` or `"unknown"` — see Gap #1.**
+- `expired_on_schedule` — on `upstream_rejected` only; `"true"` if `upstreamExpiresAt` is in the past, `"false"` if scheduled expiry is still in the future, `"unknown"` for legacy grants. **In practice always `"true"` or `"unknown"`**: the probe only fires once `accessTokenExpiresAt` has passed, and that field is always ≥ `upstreamExpiresAt` by construction, so `"false"` is unreachable. Sub-30d sign-outs surface via `grant_revoked{reason:upstream_rejected_in_use}` instead (see below).
 
 User is set via `Sentry.setUser({ id: rawProps.id })` in the callback, so metrics can be filtered by `user.id`.
 
@@ -143,24 +143,23 @@ logs message:"Invalid redirect URI" over 24 hours, sorted by timestamp
 
 ### Gap #1 — Premature Sentry-side invalidation — **closed**
 
-When Sentry invalidates a user's access token between issuance and the 30d `expires_at` (SSO session ends, user changes password, admin revokes, org membership changes), this surfaces as a 401 from Sentry when the user's tool call hits the upstream API. Previously invisible: the grant stayed alive and `tokenExchangeCallback` kept issuing wrapper tokens backed by a dead upstream token (death spiral).
+Before: Sentry invalidating a token between issuance and its 30d `expires_at` (SSO session end, password change, admin revoke, org change) only showed up as a 401 on the user's tool call. `handleApiError` wrapped it as `UserInputError`, the grant stayed alive, the next `/oauth/token` refresh took the `cached_valid_local` fast path, and the client got a new wrapper token backed by the same dead upstream token — the death spiral.
 
-Now:
+After:
 
-1. `handleApiError` (`packages/mcp-core/src/internal/tool-helpers/api.ts`) no longer wraps `ApiAuthenticationError` as `UserInputError` — it re-throws so the server-level catch can act on it.
-2. The tool-handler catch block in `packages/mcp-core/src/server.ts` detects `ApiAuthenticationError` and invokes `context.onUpstreamUnauthorized` when present.
-3. The Cloudflare transport wires `onUpstreamUnauthorized` to emit `grant_revoked{reason:upstream_rejected_in_use}` and revoke the grant via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`.
-4. The user-facing error text is now "Authorization Expired — please re-authorize" instead of a misleading "Input Error."
-
-What `expired_on_schedule` doesn't help with is still true: the probe only fires when local expiry passes, so the probe-time classification can never show `"false"`. Left in place for legacy compatibility but ignored in queries.
+- `handleApiError` re-throws `ApiAuthenticationError` unwrapped.
+- `server.ts` tool-handler catch detects it (walking `error.cause` up to 3 levels) and invokes `context.onUpstreamUnauthorized`.
+- `use_sentry`'s tool wrapper does the same check before re-throwing, so 401s inside the embedded agent aren't absorbed by the AI SDK.
+- The Cloudflare transport's `onUpstreamUnauthorized` emits `grant_revoked{reason:upstream_rejected_in_use}` and calls `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`. `workers-oauth-provider` stores tokens under `token:userId:grantId:*` in KV and validates every access token via a KV lookup, so revoking the grant invalidates all outstanding wrapper tokens too — the client's next `/mcp` request gets a 401 and is forced into a clean re-auth.
+- `formatErrorForUser` returns "Authorization Expired — please re-authorize" instead of falling through to the generic Input Error template.
 
 ### Gap #2 — `handleApiError` misclassified 401 — **closed**
 
-Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped.
+Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped and triggers a dedicated branch in `formatErrorForUser`.
 
 ### Gap #3 — tool-call `clientInfo` lost on stateless transport
 
-`mcp.client.name` is `null` on 100% of tool-call spans because `createMcpHandler` (from `agents@0.3.10`) creates a fresh `WorkerTransport` per request, and `clientInfo` is only captured during `initialize`. Documented at `packages/mcp-cloudflare/src/server/lib/mcp-handler.ts`. Closing this would require persisting `clientInfo` keyed by MCP session id and reinjecting it per-request. Not blocking for OAuth diagnosis (user-agent family is an adequate substitute for the sign-out investigation) but worth fixing for tool-level telemetry.
+`mcp.client.name` is `null` on 100% of tool-call spans because `createMcpHandler` (from `agents@0.3.10`) creates a fresh `WorkerTransport` per request, and `clientInfo` is only captured during `initialize`. Closing this would require persisting `clientInfo` keyed by MCP session id (e.g., in `MCP_CACHE` KV) and reinjecting it per-request. Not blocking for OAuth diagnosis — user-agent family is an adequate substitute — but worth fixing for tool-level telemetry.
 
 ## Runbook — "a user says they got signed out"
 
@@ -179,5 +178,5 @@ Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped.
 - #916 — restored sign-out telemetry (scrubber rename) and reduced probe volume.
 - #917 — carried probe status as a metric attribute.
 - #918 — added `client_family`, user tagging, `callback_completed` / `register` metrics, `probe_reason`, structured Invalid-redirect-URI fields.
-- #919 — added `expired_on_schedule` on `upstream_rejected`. Operationally inert (see Gap #1 closure note).
-- _(next)_ — closes Gaps #1 and #2: tool-call 401 detection, grant revocation, `grant_revoked{reason:upstream_rejected_in_use}`.
+- #919 — added `expired_on_schedule` on `upstream_rejected`. Never reaches `"false"` by construction; see the attribute note above.
+- #920 — closes Gaps #1 and #2: tool-call 401 detection, grant revocation, `grant_revoked{reason:upstream_rejected_in_use}`.

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -268,7 +268,11 @@ const mcpHandler: ExportedHandler<Env> = {
 
     const constraints = verification.constraints;
 
-    // Build complete ServerContext from OAuth props + verified constraints
+    // Build complete ServerContext from OAuth props + verified constraints.
+    // `upstreamUnauthorizedHandled` de-dupes within the request — use_sentry
+    // runs multiple sub-tool calls in a single request, and each would
+    // otherwise fire the callback independently against the same dead grant.
+    let upstreamUnauthorizedHandled = false;
     const serverContext: ServerContext = {
       userId,
       clientId,
@@ -281,6 +285,8 @@ const mcpHandler: ExportedHandler<Env> = {
       experimentalMode: isExperimentalMode,
       transport: "http",
       onUpstreamUnauthorized: () => {
+        if (upstreamUnauthorizedHandled) return;
+        upstreamUnauthorizedHandled = true;
         Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
           attributes: {
             reason: "upstream_rejected_in_use",

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -280,6 +280,30 @@ const mcpHandler: ExportedHandler<Env> = {
       agentMode: isAgentMode,
       experimentalMode: isExperimentalMode,
       transport: "http",
+      onUpstreamUnauthorized: () => {
+        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+          attributes: {
+            reason: "upstream_rejected_in_use",
+            client_family: clientFamily,
+          },
+        });
+        ctx.waitUntil(
+          (async () => {
+            try {
+              const grants = await env.OAUTH_PROVIDER.listUserGrants(userId);
+              const grant = grants.items.find((g) => g.clientId === clientId);
+              if (grant) {
+                await env.OAUTH_PROVIDER.revokeGrant(grant.id, userId);
+              }
+            } catch (err) {
+              logWarn("Failed to revoke grant after upstream 401", {
+                loggerScope: ["cloudflare", "mcp-handler"],
+                extra: { error: String(err), clientId, userId },
+              });
+            }
+          })(),
+        );
+      },
     };
 
     // Create and configure MCP server with tools filtered by context

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -575,7 +575,6 @@ export async function tokenExchangeCallback(
     accessToken: rawProps.accessToken as string,
     refreshToken: rawProps.refreshToken,
     accessTokenExpiresAt: rawProps.accessTokenExpiresAt,
-    upstreamExpiresAt: rawProps.upstreamExpiresAt,
     clientId: rawProps.clientId as string,
     scope: rawProps.scope as string,
     grantedScopes: rawProps.grantedScopes,
@@ -634,24 +633,9 @@ export async function tokenExchangeCallback(
         PROBED_ACCESS_TOKEN_TTL_SECONDS,
       );
     }
-    case "upstream_rejected": {
-      // Classify the rejection against the original upstream expiry (never
-      // mutated by probe-extension). Splits 401s into natural 30d rollovers
-      // vs premature Sentry-side invalidation (SSO expiry, org changes, etc.).
-      const upstreamExpiresAt = props.upstreamExpiresAt;
-      const expiredOnSchedule =
-        typeof upstreamExpiresAt === "number" &&
-        Number.isFinite(upstreamExpiresAt)
-          ? Date.now() >= upstreamExpiresAt
-            ? "true"
-            : "false"
-          : "unknown";
-      recordTokenExchangeOutcome(outcome, {
-        ...outcomeAttributes,
-        expired_on_schedule: expiredOnSchedule,
-      });
+    case "upstream_rejected":
+      recordTokenExchangeOutcome(outcome, outcomeAttributes);
       return buildInvalidGrantTokenExchangeResult(props);
-    }
     case "verification_indeterminate":
       recordTokenExchangeOutcome(outcome, outcomeAttributes);
       return undefined;

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -297,7 +297,6 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       // Cache upstream expiry so future refresh grants can avoid
       // unnecessary upstream refresh calls when still valid
       accessTokenExpiresAt,
-      upstreamExpiresAt: accessTokenExpiresAt,
       clientId: oauthReqInfo.clientId,
       scope: oauthReqInfo.scope.join(" "),
       // Scopes derived from skills - for backward compatibility with old MCP clients

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -18,10 +18,6 @@ export type WorkerProps = {
   accessToken: string;
   refreshToken: string;
   accessTokenExpiresAt?: number; // Cached validity deadline; extended on successful probe.
-  // Scheduled upstream expiry from the original callback payload. Never
-  // mutated after grant creation so probe-failure classification can compare
-  // against the real upstream lifetime (not a probe-extended deadline).
-  upstreamExpiresAt?: number;
   upstreamTokenInvalid?: boolean;
   clientId: string;
   scope: string;

--- a/packages/mcp-core/src/api-client/errors.ts
+++ b/packages/mcp-core/src/api-client/errors.ts
@@ -324,3 +324,20 @@ export function createApiError(
       return new ApiError(message, status, detail, responseBody);
   }
 }
+
+/**
+ * Returns true if `error` is an `ApiAuthenticationError`, either directly or
+ * anywhere within the first few levels of `error.cause`. Tools that wrap
+ * upstream errors as `throw new Error(msg, { cause: apiError })` would
+ * otherwise hide the 401 signal from a direct `instanceof` check. Bounded
+ * depth guards against accidental cycles.
+ */
+export function isApiAuthenticationErrorDeep(error: unknown): boolean {
+  let current: unknown = error;
+  for (let i = 0; i < 3; i++) {
+    if (current instanceof ApiAuthenticationError) return true;
+    if (!(current instanceof Error)) return false;
+    current = current.cause;
+  }
+  return false;
+}

--- a/packages/mcp-core/src/internal/error-handling.ts
+++ b/packages/mcp-core/src/internal/error-handling.ts
@@ -3,7 +3,12 @@ import {
   ConfigurationError,
   LLMProviderError,
 } from "../errors";
-import { ApiError, ApiClientError, ApiServerError } from "../api-client";
+import {
+  ApiAuthenticationError,
+  ApiError,
+  ApiClientError,
+  ApiServerError,
+} from "../api-client";
 import { logIssue } from "../telem/logging";
 import { APICallError, NoObjectGeneratedError } from "ai";
 import type { TransportType } from "../types";
@@ -173,6 +178,16 @@ export async function formatErrorForUser(
     return [
       "**AI Processing Error**",
       "The AI was unable to process your query. Please try rephrasing your request.",
+    ].join("\n\n");
+  }
+
+  // Upstream 401 means Sentry rejected our stored access token — never a
+  // user-input problem. Tell the client to re-authorize instead of implying
+  // their request was wrong.
+  if (error instanceof ApiAuthenticationError) {
+    return [
+      "**Authorization Expired**",
+      "Sentry rejected the stored access token for this session. Please re-authorize to continue.",
     ].join("\n\n");
   }
 

--- a/packages/mcp-core/src/internal/error-handling.ts
+++ b/packages/mcp-core/src/internal/error-handling.ts
@@ -181,9 +181,8 @@ export async function formatErrorForUser(
     ].join("\n\n");
   }
 
-  // Upstream 401 means Sentry rejected our stored access token — never a
-  // user-input problem. Tell the client to re-authorize instead of implying
-  // their request was wrong.
+  // Upstream 401 isn't a user-input problem — prompt re-authorization instead
+  // of routing through the generic Input Error template below.
   if (error instanceof ApiAuthenticationError) {
     return [
       "**Authorization Expired**",

--- a/packages/mcp-core/src/internal/error-handling.ts
+++ b/packages/mcp-core/src/internal/error-handling.ts
@@ -4,10 +4,10 @@ import {
   LLMProviderError,
 } from "../errors";
 import {
-  ApiAuthenticationError,
   ApiError,
   ApiClientError,
   ApiServerError,
+  isApiAuthenticationErrorDeep,
 } from "../api-client";
 import { logIssue } from "../telem/logging";
 import { APICallError, NoObjectGeneratedError } from "ai";
@@ -182,8 +182,9 @@ export async function formatErrorForUser(
   }
 
   // Upstream 401 isn't a user-input problem — prompt re-authorization instead
-  // of routing through the generic Input Error template below.
-  if (error instanceof ApiAuthenticationError) {
+  // of routing through the generic Input Error template below. Deep check
+  // handles tools that rewrap the original with `{ cause: apiError }`.
+  if (isApiAuthenticationErrorDeep(error)) {
     return [
       "**Authorization Expired**",
       "Sentry rejected the stored access token for this session. Please re-authorize to continue.",

--- a/packages/mcp-core/src/internal/tool-helpers/api.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { ApiNotFoundError, createApiError } from "../../api-client";
+import {
+  ApiAuthenticationError,
+  ApiNotFoundError,
+  createApiError,
+} from "../../api-client";
 import { UserInputError } from "../../errors";
 import { handleApiError, withApiErrorHandling } from "./api";
 
@@ -69,6 +73,13 @@ describe("handleApiError", () => {
     const error = new Error("Network error");
 
     expect(() => handleApiError(error)).toThrow(error);
+  });
+
+  it("re-throws 401 errors unchanged (not UserInputError)", () => {
+    const error = new ApiAuthenticationError("Unauthorized");
+
+    expect(() => handleApiError(error)).toThrow(ApiAuthenticationError);
+    expect(() => handleApiError(error)).not.toThrow(UserInputError);
   });
 });
 

--- a/packages/mcp-core/src/internal/tool-helpers/api.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.ts
@@ -1,5 +1,6 @@
 import {
   SentryApiService,
+  ApiAuthenticationError,
   ApiClientError,
   ApiNotFoundError,
 } from "../../api-client/index";
@@ -45,6 +46,13 @@ export function handleApiError(
   error: unknown,
   params?: Record<string, unknown>,
 ): never {
+  // 401 from upstream means our stored access token was rejected by Sentry.
+  // That's never a user-input problem — let it propagate so the server-level
+  // handler can emit telemetry and revoke the MCP grant.
+  if (error instanceof ApiAuthenticationError) {
+    throw error;
+  }
+
   // Use the new error hierarchy - all 4xx errors extend ApiClientError
   if (error instanceof ApiClientError) {
     let message = `API error (${error.status}): ${error.message}`;

--- a/packages/mcp-core/src/internal/tool-helpers/api.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.ts
@@ -46,9 +46,8 @@ export function handleApiError(
   error: unknown,
   params?: Record<string, unknown>,
 ): never {
-  // 401 from upstream means our stored access token was rejected by Sentry.
-  // That's never a user-input problem — let it propagate so the server-level
-  // handler can emit telemetry and revoke the MCP grant.
+  // 401 isn't a user-input problem — propagate unwrapped so the server-level
+  // catch can route it through ServerContext.onUpstreamUnauthorized.
   if (error instanceof ApiAuthenticationError) {
     throw error;
   }

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { ApiAuthenticationError } from "./api-client";
 import { buildServer } from "./server";
 import type { ServerContext } from "./types";
 import type { ToolConfig } from "./tools/types";
@@ -593,67 +592,6 @@ describe("buildServer", () => {
         "replayId",
         "replayUrl",
       ]);
-    });
-  });
-
-  describe("onUpstreamUnauthorized", () => {
-    // Non-empty annotations are required so the MCP SDK's tool() parser doesn't
-    // mis-identify them as a raw schema shape.
-    const failingToolAnnotations = { readOnlyHint: true } as const;
-
-    async function runFailingTool(handlerError: unknown) {
-      const onUpstreamUnauthorized = vi.fn();
-      const server = buildServer({
-        context: {
-          ...baseContext,
-          onUpstreamUnauthorized,
-        },
-        tools: {
-          failing: createMockTool("failing", {
-            annotations: failingToolAnnotations,
-            handler: async () => {
-              throw handlerError;
-            },
-          }),
-        },
-      });
-
-      const [clientTransport, serverTransport] =
-        InMemoryTransport.createLinkedPair();
-      const client = new Client({
-        name: "server-test-client",
-        version: "1.0.0",
-      });
-
-      await server.connect(serverTransport);
-      await client.connect(clientTransport);
-
-      try {
-        const result = await client.callTool({
-          name: "failing",
-          arguments: {},
-        });
-        return { result, onUpstreamUnauthorized };
-      } finally {
-        await client.close();
-        await server.close();
-      }
-    }
-
-    it("fires when a tool throws ApiAuthenticationError", async () => {
-      const { result, onUpstreamUnauthorized } = await runFailingTool(
-        new ApiAuthenticationError("Invalid token"),
-      );
-      expect(result.isError).toBe(true);
-      expect(onUpstreamUnauthorized).toHaveBeenCalledTimes(1);
-    });
-
-    it("is not called for non-401 tool errors", async () => {
-      const { result, onUpstreamUnauthorized } = await runFailingTool(
-        new Error("some other error"),
-      );
-      expect(result.isError).toBe(true);
-      expect(onUpstreamUnauthorized).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ApiAuthenticationError } from "./api-client";
 import { buildServer } from "./server";
 import type { ServerContext } from "./types";
 import type { ToolConfig } from "./tools/types";
@@ -592,6 +593,67 @@ describe("buildServer", () => {
         "replayId",
         "replayUrl",
       ]);
+    });
+  });
+
+  describe("onUpstreamUnauthorized", () => {
+    // Non-empty annotations are required so the MCP SDK's tool() parser doesn't
+    // mis-identify them as a raw schema shape.
+    const failingToolAnnotations = { readOnlyHint: true } as const;
+
+    async function runFailingTool(handlerError: unknown) {
+      const onUpstreamUnauthorized = vi.fn();
+      const server = buildServer({
+        context: {
+          ...baseContext,
+          onUpstreamUnauthorized,
+        },
+        tools: {
+          failing: createMockTool("failing", {
+            annotations: failingToolAnnotations,
+            handler: async () => {
+              throw handlerError;
+            },
+          }),
+        },
+      });
+
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+      const client = new Client({
+        name: "server-test-client",
+        version: "1.0.0",
+      });
+
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      try {
+        const result = await client.callTool({
+          name: "failing",
+          arguments: {},
+        });
+        return { result, onUpstreamUnauthorized };
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    }
+
+    it("fires when a tool throws ApiAuthenticationError", async () => {
+      const { result, onUpstreamUnauthorized } = await runFailingTool(
+        new ApiAuthenticationError("Invalid token"),
+      );
+      expect(result.isError).toBe(true);
+      expect(onUpstreamUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it("is not called for non-401 tool errors", async () => {
+      const { result, onUpstreamUnauthorized } = await runFailingTool(
+        new Error("some other error"),
+      );
+      expect(result.isError).toBe(true);
+      expect(onUpstreamUnauthorized).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -35,6 +35,7 @@ import {
   isToolVisibleInMode,
 } from "./tools/types";
 import type { ServerContext, ProjectCapabilities } from "./types";
+import { ApiAuthenticationError } from "./api-client";
 import {
   setTag,
   setUser,
@@ -381,6 +382,20 @@ function configureServer({
               code: 2, // error
             });
             activeSpan.recordException(error);
+          }
+
+          // A 401 from Sentry on the tool-call path means the upstream access
+          // token was rejected while still cached. Notify the transport so it
+          // can revoke the MCP grant and stop handing out new wrapper tokens
+          // backed by a dead upstream token. Errors from the callback are
+          // swallowed — the user still needs the formatted tool response.
+          if (
+            error instanceof ApiAuthenticationError &&
+            context.onUpstreamUnauthorized
+          ) {
+            try {
+              await context.onUpstreamUnauthorized();
+            } catch {}
           }
 
           // CRITICAL: Tool errors MUST be returned as formatted text responses,

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -53,6 +53,18 @@ import {
 } from "./internal/constraint-helpers";
 import { hasAgentProvider } from "./internal/agents/provider-factory";
 
+// Walks error.cause up to 3 levels so tools that wrap upstream errors (e.g.,
+// `throw new Error(msg, { cause: apiError })`) still surface the auth signal.
+function isApiAuthenticationErrorDeep(error: unknown): boolean {
+  let current: unknown = error;
+  for (let i = 0; i < 3; i++) {
+    if (current instanceof ApiAuthenticationError) return true;
+    if (!(current instanceof Error)) return false;
+    current = current.cause;
+  }
+  return false;
+}
+
 /**
  * Creates and configures a complete MCP server with Sentry instrumentation.
  *
@@ -387,10 +399,11 @@ function configureServer({
           // A 401 from Sentry on the tool-call path means the upstream access
           // token was rejected while still cached. Notify the transport so it
           // can revoke the MCP grant and stop handing out new wrapper tokens
-          // backed by a dead upstream token. Errors from the callback are
-          // swallowed — the user still needs the formatted tool response.
+          // backed by a dead upstream token. Walk the cause chain in case a
+          // tool wrapped the error. Errors from the callback are swallowed —
+          // the user still needs the formatted tool response.
           if (
-            error instanceof ApiAuthenticationError &&
+            isApiAuthenticationErrorDeep(error) &&
             context.onUpstreamUnauthorized
           ) {
             try {

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -53,8 +53,8 @@ import {
 } from "./internal/constraint-helpers";
 import { hasAgentProvider } from "./internal/agents/provider-factory";
 
-// Walks error.cause up to 3 levels so tools that wrap upstream errors (e.g.,
-// `throw new Error(msg, { cause: apiError })`) still surface the auth signal.
+// Some tools rewrap upstream errors with `{ cause: apiError }`, so check the
+// cause chain (bounded depth guards against cycles).
 function isApiAuthenticationErrorDeep(error: unknown): boolean {
   let current: unknown = error;
   for (let i = 0; i < 3; i++) {
@@ -396,12 +396,9 @@ function configureServer({
             activeSpan.recordException(error);
           }
 
-          // A 401 from Sentry on the tool-call path means the upstream access
-          // token was rejected while still cached. Notify the transport so it
-          // can revoke the MCP grant and stop handing out new wrapper tokens
-          // backed by a dead upstream token. Walk the cause chain in case a
-          // tool wrapped the error. Errors from the callback are swallowed —
-          // the user still needs the formatted tool response.
+          // Upstream 401 during a tool call — route via the transport so it
+          // can revoke the MCP grant; swallow callback errors since the
+          // formatted tool response still needs to land.
           if (
             isApiAuthenticationErrorDeep(error) &&
             context.onUpstreamUnauthorized

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -35,7 +35,7 @@ import {
   isToolVisibleInMode,
 } from "./tools/types";
 import type { ServerContext, ProjectCapabilities } from "./types";
-import { ApiAuthenticationError } from "./api-client";
+import { isApiAuthenticationErrorDeep } from "./api-client";
 import {
   setTag,
   setUser,
@@ -52,18 +52,6 @@ import {
   getConstraintKeysToFilter,
 } from "./internal/constraint-helpers";
 import { hasAgentProvider } from "./internal/agents/provider-factory";
-
-// Some tools rewrap upstream errors with `{ cause: apiError }`, so check the
-// cause chain (bounded depth guards against cycles).
-function isApiAuthenticationErrorDeep(error: unknown): boolean {
-  let current: unknown = error;
-  for (let i = 0; i < 3; i++) {
-    if (current instanceof ApiAuthenticationError) return true;
-    if (!(current instanceof Error)) return false;
-    current = current.cause;
-  }
-  return false;
-}
 
 /**
  * Creates and configures a complete MCP server with Sentry instrumentation.

--- a/packages/mcp-core/src/tools/update-project.ts
+++ b/packages/mcp-core/src/tools/update-project.ts
@@ -108,6 +108,7 @@ export default defineTool({
         logIssue(err);
         throw new Error(
           `Failed to assign team ${params.teamSlug} to project ${params.projectSlug}: ${err instanceof Error ? err.message : "Unknown error"}`,
+          { cause: err },
         );
       }
     }
@@ -129,6 +130,7 @@ export default defineTool({
         logIssue(err);
         throw new Error(
           `Failed to update project ${params.projectSlug}: ${err instanceof Error ? err.message : "Unknown error"}`,
+          { cause: err },
         );
       }
     } else {

--- a/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
+++ b/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
@@ -6,22 +6,10 @@
  */
 
 import { z } from "zod";
-import { ApiAuthenticationError } from "../../api-client";
+import { isApiAuthenticationErrorDeep } from "../../api-client";
 import { agentTool } from "../../internal/agents/tools/utils";
 import type { ServerContext } from "../../types";
 import { type ToolConfig, resolveDescription } from "../types";
-
-// Some tools rewrap upstream errors with `{ cause: apiError }`, so check the
-// cause chain (bounded depth guards against cycles).
-function isApiAuthenticationErrorDeep(error: unknown): boolean {
-  let current: unknown = error;
-  for (let i = 0; i < 3; i++) {
-    if (current instanceof ApiAuthenticationError) return true;
-    if (!(current instanceof Error)) return false;
-    current = current.cause;
-  }
-  return false;
-}
 
 /**
  * Options for wrapping a tool

--- a/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
+++ b/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
@@ -6,9 +6,22 @@
  */
 
 import { z } from "zod";
+import { ApiAuthenticationError } from "../../api-client";
 import { agentTool } from "../../internal/agents/tools/utils";
 import type { ServerContext } from "../../types";
 import { type ToolConfig, resolveDescription } from "../types";
+
+// Walks error.cause up to 3 levels so tools that wrap upstream errors still
+// surface the auth signal. Mirrors the helper in server.ts.
+function isApiAuthenticationErrorDeep(error: unknown): boolean {
+  let current: unknown = error;
+  for (let i = 0; i < 3; i++) {
+    if (current instanceof ApiAuthenticationError) return true;
+    if (!(current instanceof Error)) return false;
+    current = current.cause;
+  }
+  return false;
+}
 
 /**
  * Options for wrapping a tool
@@ -89,12 +102,25 @@ export function wrapToolForAgent<TSchema extends Record<string, z.ZodType>>(
         options.context.constraints,
       );
 
-      // Call the actual tool handler with full context
-      // Type assertion is safe: fullParams matches the tool's input schema (enforced by Zod)
-      const result = await tool.handler(fullParams as never, options.context);
-
-      // Return the result - agentTool handles error wrapping
-      return result;
+      try {
+        // Call the actual tool handler with full context
+        // Type assertion is safe: fullParams matches the tool's input schema (enforced by Zod)
+        return await tool.handler(fullParams as never, options.context);
+      } catch (error) {
+        // The AI SDK converts thrown errors into tool-result messages for the
+        // LLM, which would swallow the upstream-auth signal. Route it out via
+        // the transport callback before re-throwing so the grant still gets
+        // revoked even when the 401 happens inside the embedded agent.
+        if (
+          isApiAuthenticationErrorDeep(error) &&
+          options.context.onUpstreamUnauthorized
+        ) {
+          try {
+            await options.context.onUpstreamUnauthorized();
+          } catch {}
+        }
+        throw error;
+      }
     },
   });
 }

--- a/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
+++ b/packages/mcp-core/src/tools/use-sentry/tool-wrapper.ts
@@ -11,8 +11,8 @@ import { agentTool } from "../../internal/agents/tools/utils";
 import type { ServerContext } from "../../types";
 import { type ToolConfig, resolveDescription } from "../types";
 
-// Walks error.cause up to 3 levels so tools that wrap upstream errors still
-// surface the auth signal. Mirrors the helper in server.ts.
+// Some tools rewrap upstream errors with `{ cause: apiError }`, so check the
+// cause chain (bounded depth guards against cycles).
 function isApiAuthenticationErrorDeep(error: unknown): boolean {
   let current: unknown = error;
   for (let i = 0; i < 3; i++) {
@@ -103,14 +103,12 @@ export function wrapToolForAgent<TSchema extends Record<string, z.ZodType>>(
       );
 
       try {
-        // Call the actual tool handler with full context
-        // Type assertion is safe: fullParams matches the tool's input schema (enforced by Zod)
+        // fullParams is validated against tool.inputSchema by agentTool's Zod parse.
         return await tool.handler(fullParams as never, options.context);
       } catch (error) {
-        // The AI SDK converts thrown errors into tool-result messages for the
-        // LLM, which would swallow the upstream-auth signal. Route it out via
-        // the transport callback before re-throwing so the grant still gets
-        // revoked even when the 401 happens inside the embedded agent.
+        // agentTool turns thrown errors into tool-result messages for the LLM,
+        // which would hide the upstream-auth signal. Route it out before
+        // re-throwing so the grant still gets revoked from inside the agent.
         if (
           isApiAuthenticationErrorDeep(error) &&
           options.context.onUpstreamUnauthorized

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -58,10 +58,10 @@ export type ServerContext = {
   /** Transport type - affects error message formatting */
   transport?: TransportType;
   /**
-   * Invoked when a tool call surfaces an upstream 401 from Sentry. Transports
-   * wire this up to revoke the MCP grant and record the sign-out so users
-   * don't keep getting handed wrapper tokens backed by a dead upstream token.
-   * Errors thrown by the callback are swallowed.
+   * Invoked when a tool call surfaces an upstream 401. Transports wire this
+   * to revoke the MCP grant so the session doesn't keep getting wrapper
+   * tokens backed by an upstream token Sentry has already rejected. Callback
+   * errors are swallowed.
    */
   onUpstreamUnauthorized?: () => void | Promise<void>;
 };

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -57,4 +57,11 @@ export type ServerContext = {
   experimentalMode?: boolean;
   /** Transport type - affects error message formatting */
   transport?: TransportType;
+  /**
+   * Invoked when a tool call surfaces an upstream 401 from Sentry. Transports
+   * wire this up to revoke the MCP grant and record the sign-out so users
+   * don't keep getting handed wrapper tokens backed by a dead upstream token.
+   * Errors thrown by the callback are swallowed.
+   */
+  onUpstreamUnauthorized?: () => void | Promise<void>;
 };


### PR DESCRIPTION
Closes Gaps #1 and #2 documented in the new `docs/oauth-signout-playbook.md`: premature Sentry-side invalidation was invisible, and `handleApiError` misclassified 401 as a user-input problem.

## Why

When Sentry invalidates a user's access token between issuance and its 30-day `expires_at` — SSO session end, password change, admin revoke, org membership change — the 401 surfaces on the **tool-call path**, not the refresh path we'd previously instrumented. The grant stayed alive because `accessTokenExpiresAt` was still 30d in the future, so `tokenExchangeCallback` took the `cached_valid_local` fast path and handed back a new wrapper token backed by the same dead upstream token on every refresh. Clients got repeated 401s on tool calls and eventually dropped the session — users perceived this as "signed out" but no `grant_revoked` metric ever fired.

Prior telemetry PRs (#916–#919) couldn't see this because the sign-out happened entirely outside the refresh/probe path.

## What changes

- `handleApiError` re-throws `ApiAuthenticationError` unwrapped instead of routing it through `UserInputError`.
- `server.ts` tool-handler catch detects `ApiAuthenticationError` (walking `error.cause` up to 3 levels for tools that wrap) and invokes a new `ServerContext.onUpstreamUnauthorized` callback. Callback errors are swallowed so the formatted tool response still lands.
- `use_sentry`'s tool wrapper does the same check inside its `try/catch` so 401s inside the embedded agent aren't absorbed by `agentTool`'s error-to-result conversion before the signal reaches `server.ts`.
- `update-project.ts` preserves `{ cause: err }` on its two `throw new Error(...)` sites so the cause-chain walk finds the auth signal.
- The Cloudflare transport wires `onUpstreamUnauthorized` to emit `grant_revoked{reason:upstream_rejected_in_use, client_family}` and revoke the grant via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`. `workers-oauth-provider` validates every access token via a KV lookup per request, so deleting the grant's `token:userId:grantId:*` entries immediately invalidates outstanding wrapper tokens — the client's next `/mcp` request gets a clean 401 and is forced into re-auth.
- `formatErrorForUser` gets a dedicated `ApiAuthenticationError` branch returning "Authorization Expired — please re-authorize" instead of the generic Input Error template.
- New `docs/oauth-signout-playbook.md` documents the token lifecycle, failure-mode matrix, metric surface, diagnostic queries, and a runbook for "user reports signed out," referenced from `AGENTS.md`.

## Verification after deploy

- `metric mcp.oauth.grant_revoked grouped by reason over 24h` — expect a new `upstream_rejected_in_use` bucket (previously unreachable).
- `metric mcp.oauth.grant_revoked filtered by user.id:"<id>" grouped by reason` — now returns data for users affected by mid-session invalidation.
- Ratio of `upstream_rejected_in_use` vs `upstream_rejected` per `client_family` quantifies how much of our sign-out volume is premature invalidation vs natural 30d rollover.

`reason:"upstream_rejected_in_use"` follows the scrubber-safe naming convention from #916 (no substring `"token"`).