### PR TITLE
feat(mcp-core): Tag get_sentry_resource spans with resolved resource type

### DIFF
--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { setTag } from "@sentry/core";
+import { getActiveSpan, setTag } from "@sentry/core";
 import { defineTool } from "../internal/tool-helpers/define";
 import { UserInputError } from "../errors";
 import type { ServerContext } from "../types";
@@ -467,6 +467,8 @@ export default defineTool({
     if (resolved.spanId) {
       setTag("trace.span_id", resolved.spanId);
     }
+
+    getActiveSpan()?.setAttribute("sentry-mcp.resource-type", resolved.type);
 
     // Recognized but not yet fully supported types return guidance messages
     if (resolved.type === "monitor" || resolved.type === "release") {


### PR DESCRIPTION
Add a `sentry-mcp.resource-type` attribute on the active span inside `get_sentry_resource`, set to the resolved type (`issue`, `event`, `trace`, `span`, `breadcrumbs`, `replay`, `profile`, `monitor`, `release`).

The surrounding `mcp.server` span only sees the tool name and raw arguments. When a caller passes just a `url` (no `resourceType`), there is no span attribute that reflects what was actually fetched, so span-level analysis can't segment traffic by resource type.

The existing `setTag("resource.type", ...)` in this handler tags Sentry *events*, which is a separate surface from span attributes — both are kept.

The attribute name uses our `sentry-mcp.*` namespace (matching `sentry-mcp.constraint-organization` / `sentry-mcp.constraint-project` in `server.ts`) rather than the OTel MCP `mcp.*` namespace, which is reserved for spec-defined keys.