### PR TITLE
fix(mcp-core): route structured logs to stderr

### DIFF
--- a/packages/mcp-core/src/telem/logging.test.ts
+++ b/packages/mcp-core/src/telem/logging.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+describe("logging", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("routes structured info logs to stderr instead of stdout", async () => {
+    vi.resetModules();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { logInfo } = await import("./logging");
+
+    logInfo("No issues found for query: is:unresolved", {
+      extra: {
+        query: "is:unresolved",
+        organizationSlug: "org",
+      },
+    });
+
+    expect(info).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledTimes(1);
+
+    const [payload] = error.mock.calls[0];
+    expect(typeof payload).toBe("string");
+    expect(JSON.parse(payload as string)).toMatchObject({
+      level: "INFO",
+      message: "No issues found for query: is:unresolved",
+      logger: "sentry.mcp",
+      properties: {
+        severity: "info",
+        query: "is:unresolved",
+        organizationSlug: "org",
+      },
+    });
+  });
+});

--- a/packages/mcp-core/src/telem/logging.ts
+++ b/packages/mcp-core/src/telem/logging.ts
@@ -28,6 +28,15 @@ const ROOT_LOG_CATEGORY = ["sentry", "mcp"] as const;
 
 type SinkId = "console" | "sentry";
 
+const STDERR_CONSOLE_LEVEL_MAP = {
+  trace: "error",
+  debug: "error",
+  info: "error",
+  warning: "error",
+  error: "error",
+  fatal: "error",
+} as const;
+
 let loggingConfigured = false;
 
 function resolveLowestLevel(): LogLevel {
@@ -114,6 +123,7 @@ function ensureLoggingConfigured(): void {
 
   const consoleSink = getConsoleSink({
     formatter: getJsonLinesFormatter(),
+    levelMap: STDERR_CONSOLE_LEVEL_MAP,
   });
   const sentrySink = createSentryLogsSink();
 


### PR DESCRIPTION
Route the LogTape console sink through stderr for all log levels.

This fixes stdio transport disconnects caused by structured LogTape records being written to stdout. MCP stdio transports reserve stdout for JSON-RPC messages, but LogTape's default console level map sends `info` and `debug` records through `console.info` / `console.debug`; in Node.js those write to stdout. When a structured log line lands on stdout, stdio clients can parse it as a protocol message, fail validation because it has fields like `@timestamp`, `level`, `message`, `logger`, and `properties` instead of `jsonrpc`, `id`, or `method`, then close the transport.

This keeps the log record severity in the structured payload, e.g. `"level": "INFO"`. The change only controls which console method LogTape uses for the console sink, so structured logs stay off stdout.

Added a regression test asserting `logInfo` does not write through `console.info`.