### PR TITLE
docs(mcp-core): Encode stdio stderr invariant for log routing

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -16,6 +16,19 @@ Log levels are controlled by:
 
 Implementation: @packages/mcp-server/src/telem/logging.ts
 
+## Stdio Transport Invariant: Logs MUST Go to Stderr
+
+The MCP stdio transport reserves **stdout** for JSON-RPC frames. Any non-JSON-RPC line written to stdout makes the client fail framing and close the transport. **All log output — every level, every sink that writes to a console — must go to stderr.**
+
+This is enforced in @packages/mcp-core/src/telem/logging.ts via `STDERR_CONSOLE_LEVEL_MAP`, which routes every LogTape level through `console.error` (Node sends `console.error`/`console.warn` to stderr; `console.log`/`console.info`/`console.debug` go to stdout). Severity is preserved inside the JSON record (e.g. `"level":"INFO"`); the map only controls which `console.*` method is invoked.
+
+Regression history: #922 — LogTape's default level map sent `info`/`debug` records through `console.info`/`console.debug`, landing structured JSON on stdout and breaking stdio clients.
+
+**Rules for new code:**
+- Do not call `console.log`, `console.info`, or `console.debug` anywhere reachable from the stdio entry point. Use `logInfo`/`logDebug` instead.
+- Do not introduce new LogTape sinks that write to stdout.
+- Do not change `STDERR_CONSOLE_LEVEL_MAP` to map any level to a non-stderr method. The regression test in `logging.test.ts` enforces this for `info`.
+
 ## Using the Log Helpers
 
 ### logInfo() - Routine telemetry

--- a/packages/mcp-core/src/telem/logging.ts
+++ b/packages/mcp-core/src/telem/logging.ts
@@ -28,6 +28,15 @@ const ROOT_LOG_CATEGORY = ["sentry", "mcp"] as const;
 
 type SinkId = "console" | "sentry";
 
+// Invariant: every log level routes through `console.error` so LogTape's
+// console sink writes to stderr, never stdout. The MCP stdio transport
+// reserves stdout for JSON-RPC frames — any non-JSON-RPC line on stdout
+// (LogTape records carry `@timestamp`/`level`/`message`/`logger`/`properties`,
+// not `jsonrpc`/`id`/`method`) fails client framing and closes the transport.
+// Severity is preserved inside the JSON record (e.g. `"level":"INFO"`); this
+// map only controls which `console.*` method is called. Do not promote levels
+// back to `console.info`/`console.debug` — Node sends those to stdout and
+// re-introduces the stdio disconnect bug fixed in #922.
 const STDERR_CONSOLE_LEVEL_MAP = {
   trace: "error",
   debug: "error",


### PR DESCRIPTION
Encode the "logs MUST go to stderr" invariant in two places so future contributors do not accidentally re-route LogTape records to stdout: a load-bearing comment on `STDERR_CONSOLE_LEVEL_MAP` in `packages/mcp-core/src/telem/logging.ts`, and a new "Stdio Transport Invariant" section in `docs/logging.md`.

The MCP stdio transport reserves stdout for JSON-RPC frames. LogTape's default level map sends `info`/`debug` records through `console.info`/`console.debug`, which Node writes to stdout — that breaks stdio clients because the structured records (`@timestamp`, `level`, `message`, `logger`, `properties`) fail JSON-RPC framing and the transport closes.

The runtime fix and regression test landed in #922; this change is documentation-only and exists to make the constraint survive future refactors of the level map or new console sinks.

Refs #922