### PR TITLE
fix(oauth): stop cascading grant revocation across concurrent sessions

### DIFF
--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -80,10 +80,6 @@ Attributes:
 - `client_family` — resolved from the DCR-registered `client_name` (not the browser User-Agent, which is always a browser string on this endpoint)
 - `user.id`
 
-### `mcp.oauth.concurrent_grant_observed` (counter)
-
-Fired during `/oauth/callback`, before `completeAuthorization`. Counts the number of existing grants for the same `(userId, clientId)` pair. Each callback that finds N existing grants emits a counter increment of N. Sum across queries gives total concurrent grants observed; ratio against `callback_completed` shows how often re-auth happens while the user has another active session of the same client. Tags: `client_family`, `user.id`.
-
 ### `mcp.oauth.register` (counter)
 
 Fired from the `wrappedOAuthProvider` after the library handles a successful `/oauth/register`.
@@ -171,7 +167,7 @@ Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped and tr
 
 We now pass `revokeExistingGrants: false` to `completeAuthorization`. Multiple grants for the same `(userId, clientId)` coexist; each lives until its own `refreshTokenTTL` (30d) or an explicit revoke. This matches how mainstream OAuth servers (Google, GitHub, Auth0, etc.) behave; the library's prior default was an unusual policy.
 
-Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real concern at current scale. The new `mcp.oauth.concurrent_grant_observed` metric counts how often re-auth happens while another session of the same `(userId, clientId)` is active, replacing what would have been an invisible cascade-revoke event under the prior default.
+Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real concern at current scale. Library-side auto-revokes are no longer happening, so the cascade event is structurally eliminated rather than counted; if visibility into "user re-authed while another session was active" becomes useful, a metric pre-callback would need its own paginated `listUserGrants` call per callback (skipped here for cost).
 
 ## Runbook — "a user says they got signed out"
 

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -34,6 +34,7 @@ MCP client ──(tool call)──> /mcp ──> mcp-handler ──> tool handle
 | **Client-side state loss (DCR state reset, fresh install, reinstall)** | Client drops its stored `client_id`/`refresh_token` | Indirectly | High `/oauth/register` volume and `register:callback` ratio per `client_family` |
 | **Invalid redirect URI at authorize** | Client sends an `redirect_uri` that's not registered | Yes | Log `OAuth authorization failed: Invalid redirect URI` with `clientId`/`redirectUri`/`registeredUris`/`clientName` |
 | **Upstream probe transient (5xx / rate limit / network)** | Sentry side instability | Yes | `token_exchange{outcome:verification_indeterminate, probe_reason:…}` (does not force sign-out) |
+| **Same-user concurrent session interference** | Another session of the same user re-authorizes | Resolved by passing `revokeExistingGrants: false` — see Gap #4 below | n/a after fix |
 
 ## Telemetry surface
 
@@ -159,6 +160,14 @@ Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped and tr
 ### Gap #3 — tool-call `clientInfo` lost on stateless transport
 
 `mcp.client.name` is `null` on 100% of tool-call spans because `createMcpHandler` (from `agents@0.3.10`) creates a fresh `WorkerTransport` per request, and `clientInfo` is only captured during `initialize`. Closing this would require persisting `clientInfo` keyed by MCP session id (e.g., in `MCP_CACHE` KV) and reinjecting it per-request. Not blocking for OAuth diagnosis — user-agent family is an adequate substitute — but worth fixing for tool-level telemetry.
+
+### Gap #4 — Same-user concurrent session interference — **closed**
+
+`workers-oauth-provider`'s `completeAuthorization` defaulted to revoking every existing grant for `(userId, clientId)` whenever a new authorization completed. Because Claude Code persists its DCR `client_id` across processes (e.g., across project folders, or after an update triggers re-auth in one session), one process re-authorizing would silently invalidate every other active session for the same user. The affected sessions saw 401s from the OAuth library on their next `/mcp` request — *before* reaching our handler — so no `grant_revoked` metric ever fired. See issue #924.
+
+We now pass `revokeExistingGrants: false` to `completeAuthorization`. Multiple grants for the same `(userId, clientId)` coexist; each lives until its own `refreshTokenTTL` (30d) or an explicit revoke. This matches how mainstream OAuth servers (Google, GitHub, Auth0, etc.) behave; the library's prior default was an unusual policy.
+
+Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real concern at current scale. Library-side auto-revokes remain the only revocation pathway invisible to our metrics — a follow-up could explicitly count `listUserGrants` matches before each completion.
 
 ## Runbook — "a user says they got signed out"
 

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -80,6 +80,10 @@ Attributes:
 - `client_family` — resolved from the DCR-registered `client_name` (not the browser User-Agent, which is always a browser string on this endpoint)
 - `user.id`
 
+### `mcp.oauth.concurrent_grant_observed` (counter)
+
+Fired during `/oauth/callback`, before `completeAuthorization`. Counts the number of existing grants for the same `(userId, clientId)` pair. Each callback that finds N existing grants emits a counter increment of N. Sum across queries gives total concurrent grants observed; ratio against `callback_completed` shows how often re-auth happens while the user has another active session of the same client. Tags: `client_family`, `user.id`.
+
 ### `mcp.oauth.register` (counter)
 
 Fired from the `wrappedOAuthProvider` after the library handles a successful `/oauth/register`.
@@ -167,7 +171,7 @@ Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped and tr
 
 We now pass `revokeExistingGrants: false` to `completeAuthorization`. Multiple grants for the same `(userId, clientId)` coexist; each lives until its own `refreshTokenTTL` (30d) or an explicit revoke. This matches how mainstream OAuth servers (Google, GitHub, Auth0, etc.) behave; the library's prior default was an unusual policy.
 
-Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real concern at current scale. Library-side auto-revokes remain the only revocation pathway invisible to our metrics — a follow-up could explicitly count `listUserGrants` matches before each completion.
+Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real concern at current scale. The new `mcp.oauth.concurrent_grant_observed` metric counts how often re-auth happens while another session of the same `(userId, clientId)` is active, replacing what would have been an invisible cascade-revoke event under the prior default.
 
 ## Runbook — "a user says they got signed out"
 

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext, RateLimit } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
-import mcpHandler, { createOnUpstreamUnauthorized } from "./mcp-handler";
+import mcpHandler from "./mcp-handler";
 
 interface OAuthProps {
   id: string;
@@ -150,8 +150,6 @@ describe("MCP Handler", () => {
       );
       expect(ctx.waitUntil).toHaveBeenCalled();
 
-      // Drive the scheduled revoke task and confirm we revoke the exact
-      // grant from the bearer token, not whatever listUserGrants returns.
       await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
       expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledTimes(1);
       expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledWith(
@@ -162,9 +160,6 @@ describe("MCP Handler", () => {
     });
 
     it("targets the exact grant when multiple grants exist for the same client", async () => {
-      // Simulate the multi-session case enabled by `revokeExistingGrants:false`:
-      // listUserGrants would return another active session's grant first, but
-      // the request's own bearer-token grant is what should be revoked.
       const request = createMcpRequest(
         "tools/list",
         {},
@@ -205,9 +200,6 @@ describe("MCP Handler", () => {
       await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
 
       expect(response.status).toBe(401);
-      // No grantId means we can't safely target a specific grant. Return
-      // the 401 but skip the KV revoke rather than risk killing another
-      // session via a clientId-based fallback.
       expect(env.OAUTH_PROVIDER.revokeGrant).not.toHaveBeenCalled();
     });
 
@@ -416,65 +408,6 @@ describe("MCP Handler", () => {
 
       expect(toolNames).toContain("search_docs");
       expect(toolNames).not.toContain("get_issue_details");
-    });
-  });
-
-  describe("createOnUpstreamUnauthorized", () => {
-    function buildDeps(overrides: { requestGrantId?: string | null } = {}) {
-      const env = createTestEnv();
-      const ctx = {
-        waitUntil: vi.fn(),
-        passThroughOnException: vi.fn(),
-      } as unknown as ExecutionContext;
-      const deps = {
-        ctx,
-        env,
-        userId: "test-user-123",
-        clientId: "test-client",
-        clientFamily: "claude-code",
-        requestGrantId:
-          "requestGrantId" in overrides
-            ? (overrides.requestGrantId ?? null)
-            : "request-grant",
-      };
-      return { deps, ctx, env };
-    }
-
-    it("revokes the request's specific grant", async () => {
-      const { deps, ctx, env } = buildDeps();
-
-      createOnUpstreamUnauthorized(deps)();
-      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-
-      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledExactlyOnceWith(
-        "request-grant",
-        "test-user-123",
-      );
-      expect(env.OAUTH_PROVIDER.listUserGrants).not.toHaveBeenCalled();
-    });
-
-    it("skips revoke when grantId is missing", async () => {
-      const { deps, ctx, env } = buildDeps({ requestGrantId: null });
-
-      createOnUpstreamUnauthorized(deps)();
-      // No waitUntil scheduled when we have nothing safe to revoke.
-      expect(ctx.waitUntil).not.toHaveBeenCalled();
-      expect(env.OAUTH_PROVIDER.revokeGrant).not.toHaveBeenCalled();
-    });
-
-    it("latches: subsequent invocations are no-ops", async () => {
-      // Mirrors the use_sentry agent path where N inner-tool calls each
-      // see the upstream 401 within one /mcp request.
-      const { deps, ctx, env } = buildDeps();
-      const callback = createOnUpstreamUnauthorized(deps);
-
-      callback();
-      callback();
-      callback();
-      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-
-      expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
-      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -40,17 +40,23 @@ function createMcpRequest(
   options: {
     path?: string;
     id?: number | string;
+    bearerToken?: string;
   } = {},
 ): Request {
-  const { path = "/mcp", id = 1 } = options;
+  const { path = "/mcp", id = 1, bearerToken } = options;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    "CF-Connecting-IP": "192.0.2.1",
+  };
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
 
   return new Request(`http://localhost${path}`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      "CF-Connecting-IP": "192.0.2.1",
-    },
+    headers,
     body: JSON.stringify({
       jsonrpc: "2.0",
       method,
@@ -123,7 +129,13 @@ describe("MCP Handler", () => {
     });
 
     it("should revoke and reject stale grants missing a refresh token", async () => {
-      const request = createMcpRequest("tools/list");
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        {
+          bearerToken: "test-user-123:specific-grant-id:secret",
+        },
+      );
       const ctx = createMcpContext({
         refreshToken: undefined as unknown as string,
       });
@@ -137,6 +149,66 @@ describe("MCP Handler", () => {
         "invalid_token",
       );
       expect(ctx.waitUntil).toHaveBeenCalled();
+
+      // Drive the scheduled revoke task and confirm we revoke the exact
+      // grant from the bearer token, not whatever listUserGrants returns.
+      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledTimes(1);
+      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledWith(
+        "specific-grant-id",
+        "test-user-123",
+      );
+      expect(env.OAUTH_PROVIDER.listUserGrants).not.toHaveBeenCalled();
+    });
+
+    it("targets the exact grant when multiple grants exist for the same client", async () => {
+      // Simulate the multi-session case enabled by `revokeExistingGrants:false`:
+      // listUserGrants would return another active session's grant first, but
+      // the request's own bearer-token grant is what should be revoked.
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        {
+          bearerToken: "test-user-123:request-specific-grant:secret",
+        },
+      );
+      const ctx = createMcpContext({
+        refreshToken: undefined as unknown as string,
+      });
+      const env = createTestEnv();
+      (
+        env.OAUTH_PROVIDER.listUserGrants as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        items: [
+          { id: "other-active-session-grant", clientId: "test-client" },
+          { id: "request-specific-grant", clientId: "test-client" },
+        ],
+      });
+
+      await mcpHandler.fetch!(request, env, ctx);
+      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledExactlyOnceWith(
+        "request-specific-grant",
+        "test-user-123",
+      );
+    });
+
+    it("skips revoke when bearer token is missing or malformed", async () => {
+      const request = createMcpRequest("tools/list");
+      const ctx = createMcpContext({
+        refreshToken: undefined as unknown as string,
+      });
+      const env = createTestEnv();
+
+      const response = await mcpHandler.fetch!(request, env, ctx);
+      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+      expect(response.status).toBe(401);
+      // No grantId means we can't safely target a specific grant. Return
+      // the 401 but skip the KV revoke rather than risk killing another
+      // session via a clientId-based fallback.
+      expect(env.OAUTH_PROVIDER.revokeGrant).not.toHaveBeenCalled();
     });
 
     it("should reject tokens with no valid skills", async () => {

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext, RateLimit } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
-import mcpHandler from "./mcp-handler";
+import mcpHandler, { createOnUpstreamUnauthorized } from "./mcp-handler";
 
 interface OAuthProps {
   id: string;
@@ -416,6 +416,65 @@ describe("MCP Handler", () => {
 
       expect(toolNames).toContain("search_docs");
       expect(toolNames).not.toContain("get_issue_details");
+    });
+  });
+
+  describe("createOnUpstreamUnauthorized", () => {
+    function buildDeps(overrides: { requestGrantId?: string | null } = {}) {
+      const env = createTestEnv();
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+      const deps = {
+        ctx,
+        env,
+        userId: "test-user-123",
+        clientId: "test-client",
+        clientFamily: "claude-code",
+        requestGrantId:
+          "requestGrantId" in overrides
+            ? (overrides.requestGrantId ?? null)
+            : "request-grant",
+      };
+      return { deps, ctx, env };
+    }
+
+    it("revokes the request's specific grant", async () => {
+      const { deps, ctx, env } = buildDeps();
+
+      createOnUpstreamUnauthorized(deps)();
+      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledExactlyOnceWith(
+        "request-grant",
+        "test-user-123",
+      );
+      expect(env.OAUTH_PROVIDER.listUserGrants).not.toHaveBeenCalled();
+    });
+
+    it("skips revoke when grantId is missing", async () => {
+      const { deps, ctx, env } = buildDeps({ requestGrantId: null });
+
+      createOnUpstreamUnauthorized(deps)();
+      // No waitUntil scheduled when we have nothing safe to revoke.
+      expect(ctx.waitUntil).not.toHaveBeenCalled();
+      expect(env.OAUTH_PROVIDER.revokeGrant).not.toHaveBeenCalled();
+    });
+
+    it("latches: subsequent invocations are no-ops", async () => {
+      // Mirrors the use_sentry agent path where N inner-tool calls each
+      // see the upstream 401 within one /mcp request.
+      const { deps, ctx, env } = buildDeps();
+      const callback = createOnUpstreamUnauthorized(deps);
+
+      callback();
+      callback();
+      callback();
+      await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+      expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+      expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -42,13 +42,10 @@ function escapeAuthenticateHeaderValue(value: string): string {
 }
 
 /**
- * The wrapper bearer token format from `@cloudflare/workers-oauth-provider` is
- * `userId:grantId:secret`. The library validates the token before our handler
- * runs, so when we're here the format is known to be correct. Pulling the
- * grantId out lets us target the exact grant for the current request — under
- * `revokeExistingGrants: false`, multiple grants for the same `(userId,
- * clientId)` may coexist, so finding by clientId would risk killing the wrong
- * session.
+ * Extracts the grantId from the wrapper bearer token (format
+ * `userId:grantId:secret`, validated by the library before our handler runs).
+ * Concurrent grants per `(userId, clientId)` mean a clientId-based lookup
+ * cannot safely identify the request's own grant.
  */
 export function getRequestGrantId(request: Request): string | null {
   const auth = request.headers.get("Authorization");
@@ -58,60 +55,6 @@ export function getRequestGrantId(request: Request): string | null {
   const parts = match[1].split(":");
   if (parts.length !== 3) return null;
   return parts[1] || null;
-}
-
-/**
- * Builds the `onUpstreamUnauthorized` callback the MCP core invokes when a
- * tool-call surfaces an upstream 401. Latches so an agent that runs N
- * sub-tool calls within one /mcp request emits at most one revocation —
- * see `revokeExistingGrants:false` and PR #925 for context. Falls back to
- * a logWarn (no revoke) when we can't identify the grant from the bearer
- * token, since revoking by clientId could now kill another active session.
- */
-export function createOnUpstreamUnauthorized(deps: {
-  ctx: ExecutionContext;
-  env: Env;
-  userId: string;
-  clientId: string;
-  clientFamily: string;
-  requestGrantId: string | null;
-}): () => void {
-  const { ctx, env, userId, clientId, clientFamily, requestGrantId } = deps;
-  let handled = false;
-  return () => {
-    if (handled) return;
-    handled = true;
-    if (!requestGrantId) {
-      logWarn("Cannot revoke grant after upstream 401 without grantId", {
-        loggerScope: ["cloudflare", "mcp-handler"],
-        extra: { clientId, userId },
-      });
-      return;
-    }
-    Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-      attributes: {
-        reason: "upstream_rejected_in_use",
-        client_family: clientFamily,
-      },
-    });
-    ctx.waitUntil(
-      (async () => {
-        try {
-          await env.OAUTH_PROVIDER.revokeGrant(requestGrantId, userId);
-        } catch (err) {
-          logWarn("Failed to revoke grant after upstream 401", {
-            loggerScope: ["cloudflare", "mcp-handler"],
-            extra: {
-              error: String(err),
-              clientId,
-              userId,
-              grantId: requestGrantId,
-            },
-          });
-        }
-      })(),
-    );
-  };
 }
 
 /**
@@ -232,9 +175,7 @@ const mcpHandler: ExportedHandler<Env> = {
     }
 
     // Attribute values avoid the substring "token" so Sentry's default PII
-    // scrubber doesn't replace them with "[Filtered]" on ingest. Only emit
-    // when we're actually going to revoke; otherwise the count drifts away
-    // from "grants we actually deleted from KV".
+    // scrubber doesn't replace them with "[Filtered]" on ingest.
     if (!rawProps.refreshToken) {
       if (requestGrantId) {
         Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
@@ -366,6 +307,8 @@ const mcpHandler: ExportedHandler<Env> = {
     const constraints = verification.constraints;
 
     // Build complete ServerContext from OAuth props + verified constraints.
+    // Latched so use_sentry's multi-tool runs revoke at most once per request.
+    let upstreamUnauthorizedHandled = false;
     const serverContext: ServerContext = {
       userId,
       clientId,
@@ -377,14 +320,40 @@ const mcpHandler: ExportedHandler<Env> = {
       agentMode: isAgentMode,
       experimentalMode: isExperimentalMode,
       transport: "http",
-      onUpstreamUnauthorized: createOnUpstreamUnauthorized({
-        ctx,
-        env,
-        userId,
-        clientId,
-        clientFamily,
-        requestGrantId,
-      }),
+      onUpstreamUnauthorized: () => {
+        if (upstreamUnauthorizedHandled) return;
+        upstreamUnauthorizedHandled = true;
+        if (!requestGrantId) {
+          logWarn("Cannot revoke grant after upstream 401 without grantId", {
+            loggerScope: ["cloudflare", "mcp-handler"],
+            extra: { clientId, userId },
+          });
+          return;
+        }
+        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+          attributes: {
+            reason: "upstream_rejected_in_use",
+            client_family: clientFamily,
+          },
+        });
+        ctx.waitUntil(
+          (async () => {
+            try {
+              await env.OAUTH_PROVIDER.revokeGrant(requestGrantId, userId);
+            } catch (err) {
+              logWarn("Failed to revoke grant after upstream 401", {
+                loggerScope: ["cloudflare", "mcp-handler"],
+                extra: {
+                  error: String(err),
+                  clientId,
+                  userId,
+                  grantId: requestGrantId,
+                },
+              });
+            }
+          })(),
+        );
+      },
     };
 
     // Create and configure MCP server with tools filtered by context

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -42,29 +42,56 @@ function escapeAuthenticateHeaderValue(value: string): string {
 }
 
 /**
- * Revokes the OAuth grant for the given user/client pair in the background,
- * then returns a 401 response prompting re-authorization.
+ * The wrapper bearer token format from `@cloudflare/workers-oauth-provider` is
+ * `userId:grantId:secret`. The library validates the token before our handler
+ * runs, so when we're here the format is known to be correct. Pulling the
+ * grantId out lets us target the exact grant for the current request — under
+ * `revokeExistingGrants: false`, multiple grants for the same `(userId,
+ * clientId)` may coexist, so finding by clientId would risk killing the wrong
+ * session.
+ */
+function getRequestGrantId(request: Request): string | null {
+  const auth = request.headers.get("Authorization");
+  if (!auth) return null;
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  const parts = match[1].split(":");
+  if (parts.length !== 3) return null;
+  return parts[1] || null;
+}
+
+/**
+ * Revokes the OAuth grant for the current request in the background, then
+ * returns a 401 response prompting re-authorization.
  */
 function revokeStaleGrant(
   ctx: ExecutionContext,
   env: Env,
   userId: string,
   clientId: string,
+  grantId: string | null,
   logLabel: string,
   errorDescription = "Token requires re-authorization",
 ): Response {
   ctx.waitUntil(
     (async () => {
+      if (!grantId) {
+        // Without a grantId, falling back to clientId-based lookup would
+        // risk revoking another active session. Log and skip — the user
+        // will still see the 401 and re-auth, just leaving the stale grant
+        // behind to expire naturally (refreshTokenTTL = 30d).
+        logWarn(`Cannot revoke ${logLabel} without grantId`, {
+          loggerScope: ["cloudflare", "mcp-handler"],
+          extra: { clientId, userId },
+        });
+        return;
+      }
       try {
-        const grants = await env.OAUTH_PROVIDER.listUserGrants(userId);
-        const grant = grants.items.find((g) => g.clientId === clientId);
-        if (grant) {
-          await env.OAUTH_PROVIDER.revokeGrant(grant.id, userId);
-        }
+        await env.OAUTH_PROVIDER.revokeGrant(grantId, userId);
       } catch (err) {
         logWarn(`Failed to revoke ${logLabel}`, {
           loggerScope: ["cloudflare", "mcp-handler"],
-          extra: { error: String(err), clientId, userId },
+          extra: { error: String(err), clientId, userId, grantId },
         });
       }
     })(),
@@ -130,6 +157,7 @@ const mcpHandler: ExportedHandler<Env> = {
     const clientId = rawProps.clientId as string;
     const sentryHost = env.SENTRY_HOST || "sentry.io";
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
+    const requestGrantId = getRequestGrantId(request);
     Sentry.setUser({ id: userId });
 
     // Parse and validate granted skills (primary authorization method)
@@ -139,7 +167,14 @@ const mcpHandler: ExportedHandler<Env> = {
         loggerScope: ["cloudflare", "mcp-handler"],
         extra: { clientId, userId },
       });
-      return revokeStaleGrant(ctx, env, userId, clientId, "legacy grant");
+      return revokeStaleGrant(
+        ctx,
+        env,
+        userId,
+        clientId,
+        requestGrantId,
+        "legacy grant",
+      );
     }
 
     // Attribute values avoid the substring "token" so Sentry's default PII
@@ -156,6 +191,7 @@ const mcpHandler: ExportedHandler<Env> = {
         env,
         userId,
         clientId,
+        requestGrantId,
         "stale grant (missing refresh token)",
       );
     }
@@ -172,6 +208,7 @@ const mcpHandler: ExportedHandler<Env> = {
         env,
         userId,
         clientId,
+        requestGrantId,
         "stale grant (invalid upstream token)",
         "Upstream authorization is no longer valid",
       );
@@ -293,18 +330,29 @@ const mcpHandler: ExportedHandler<Env> = {
             client_family: clientFamily,
           },
         });
+        if (!requestGrantId) {
+          // Same reasoning as revokeStaleGrant: without a grantId, falling
+          // back to clientId-based lookup would risk killing another active
+          // session now that grants can coexist.
+          logWarn("Cannot revoke grant after upstream 401 without grantId", {
+            loggerScope: ["cloudflare", "mcp-handler"],
+            extra: { clientId, userId },
+          });
+          return;
+        }
         ctx.waitUntil(
           (async () => {
             try {
-              const grants = await env.OAUTH_PROVIDER.listUserGrants(userId);
-              const grant = grants.items.find((g) => g.clientId === clientId);
-              if (grant) {
-                await env.OAUTH_PROVIDER.revokeGrant(grant.id, userId);
-              }
+              await env.OAUTH_PROVIDER.revokeGrant(requestGrantId, userId);
             } catch (err) {
               logWarn("Failed to revoke grant after upstream 401", {
                 loggerScope: ["cloudflare", "mcp-handler"],
-                extra: { error: String(err), clientId, userId },
+                extra: {
+                  error: String(err),
+                  clientId,
+                  userId,
+                  grantId: requestGrantId,
+                },
               });
             }
           })(),

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -178,14 +178,18 @@ const mcpHandler: ExportedHandler<Env> = {
     }
 
     // Attribute values avoid the substring "token" so Sentry's default PII
-    // scrubber doesn't replace them with "[Filtered]" on ingest.
+    // scrubber doesn't replace them with "[Filtered]" on ingest. Only emit
+    // when we're actually going to revoke; otherwise the count drifts away
+    // from "grants we actually deleted from KV".
     if (!rawProps.refreshToken) {
-      Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-        attributes: {
-          reason: "stale_props_no_refresh",
-          client_family: clientFamily,
-        },
-      });
+      if (requestGrantId) {
+        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+          attributes: {
+            reason: "stale_props_no_refresh",
+            client_family: clientFamily,
+          },
+        });
+      }
       return revokeStaleGrant(
         ctx,
         env,
@@ -197,12 +201,14 @@ const mcpHandler: ExportedHandler<Env> = {
     }
 
     if (rawProps.upstreamTokenInvalid) {
-      Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-        attributes: {
-          reason: "upstream_rejected",
-          client_family: clientFamily,
-        },
-      });
+      if (requestGrantId) {
+        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+          attributes: {
+            reason: "upstream_rejected",
+            client_family: clientFamily,
+          },
+        });
+      }
       return revokeStaleGrant(
         ctx,
         env,
@@ -324,22 +330,23 @@ const mcpHandler: ExportedHandler<Env> = {
       onUpstreamUnauthorized: () => {
         if (upstreamUnauthorizedHandled) return;
         upstreamUnauthorizedHandled = true;
-        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-          attributes: {
-            reason: "upstream_rejected_in_use",
-            client_family: clientFamily,
-          },
-        });
         if (!requestGrantId) {
           // Same reasoning as revokeStaleGrant: without a grantId, falling
           // back to clientId-based lookup would risk killing another active
-          // session now that grants can coexist.
+          // session now that grants can coexist. Skip the metric too so the
+          // count stays aligned with grants we actually deleted from KV.
           logWarn("Cannot revoke grant after upstream 401 without grantId", {
             loggerScope: ["cloudflare", "mcp-handler"],
             extra: { clientId, userId },
           });
           return;
         }
+        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+          attributes: {
+            reason: "upstream_rejected_in_use",
+            client_family: clientFamily,
+          },
+        });
         ctx.waitUntil(
           (async () => {
             try {

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -50,7 +50,7 @@ function escapeAuthenticateHeaderValue(value: string): string {
  * clientId)` may coexist, so finding by clientId would risk killing the wrong
  * session.
  */
-function getRequestGrantId(request: Request): string | null {
+export function getRequestGrantId(request: Request): string | null {
   const auth = request.headers.get("Authorization");
   if (!auth) return null;
   const match = auth.match(/^Bearer\s+(.+)$/i);
@@ -58,6 +58,60 @@ function getRequestGrantId(request: Request): string | null {
   const parts = match[1].split(":");
   if (parts.length !== 3) return null;
   return parts[1] || null;
+}
+
+/**
+ * Builds the `onUpstreamUnauthorized` callback the MCP core invokes when a
+ * tool-call surfaces an upstream 401. Latches so an agent that runs N
+ * sub-tool calls within one /mcp request emits at most one revocation —
+ * see `revokeExistingGrants:false` and PR #925 for context. Falls back to
+ * a logWarn (no revoke) when we can't identify the grant from the bearer
+ * token, since revoking by clientId could now kill another active session.
+ */
+export function createOnUpstreamUnauthorized(deps: {
+  ctx: ExecutionContext;
+  env: Env;
+  userId: string;
+  clientId: string;
+  clientFamily: string;
+  requestGrantId: string | null;
+}): () => void {
+  const { ctx, env, userId, clientId, clientFamily, requestGrantId } = deps;
+  let handled = false;
+  return () => {
+    if (handled) return;
+    handled = true;
+    if (!requestGrantId) {
+      logWarn("Cannot revoke grant after upstream 401 without grantId", {
+        loggerScope: ["cloudflare", "mcp-handler"],
+        extra: { clientId, userId },
+      });
+      return;
+    }
+    Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+      attributes: {
+        reason: "upstream_rejected_in_use",
+        client_family: clientFamily,
+      },
+    });
+    ctx.waitUntil(
+      (async () => {
+        try {
+          await env.OAUTH_PROVIDER.revokeGrant(requestGrantId, userId);
+        } catch (err) {
+          logWarn("Failed to revoke grant after upstream 401", {
+            loggerScope: ["cloudflare", "mcp-handler"],
+            extra: {
+              error: String(err),
+              clientId,
+              userId,
+              grantId: requestGrantId,
+            },
+          });
+        }
+      })(),
+    );
+  };
 }
 
 /**
@@ -312,10 +366,6 @@ const mcpHandler: ExportedHandler<Env> = {
     const constraints = verification.constraints;
 
     // Build complete ServerContext from OAuth props + verified constraints.
-    // `upstreamUnauthorizedHandled` de-dupes within the request — use_sentry
-    // runs multiple sub-tool calls in a single request, and each would
-    // otherwise fire the callback independently against the same dead grant.
-    let upstreamUnauthorizedHandled = false;
     const serverContext: ServerContext = {
       userId,
       clientId,
@@ -327,44 +377,14 @@ const mcpHandler: ExportedHandler<Env> = {
       agentMode: isAgentMode,
       experimentalMode: isExperimentalMode,
       transport: "http",
-      onUpstreamUnauthorized: () => {
-        if (upstreamUnauthorizedHandled) return;
-        upstreamUnauthorizedHandled = true;
-        if (!requestGrantId) {
-          // Same reasoning as revokeStaleGrant: without a grantId, falling
-          // back to clientId-based lookup would risk killing another active
-          // session now that grants can coexist. Skip the metric too so the
-          // count stays aligned with grants we actually deleted from KV.
-          logWarn("Cannot revoke grant after upstream 401 without grantId", {
-            loggerScope: ["cloudflare", "mcp-handler"],
-            extra: { clientId, userId },
-          });
-          return;
-        }
-        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
-          attributes: {
-            reason: "upstream_rejected_in_use",
-            client_family: clientFamily,
-          },
-        });
-        ctx.waitUntil(
-          (async () => {
-            try {
-              await env.OAUTH_PROVIDER.revokeGrant(requestGrantId, userId);
-            } catch (err) {
-              logWarn("Failed to revoke grant after upstream 401", {
-                loggerScope: ["cloudflare", "mcp-handler"],
-                extra: {
-                  error: String(err),
-                  clientId,
-                  userId,
-                  grantId: requestGrantId,
-                },
-              });
-            }
-          })(),
-        );
-      },
+      onUpstreamUnauthorized: createOnUpstreamUnauthorized({
+        ctx,
+        env,
+        userId,
+        clientId,
+        clientFamily,
+        requestGrantId,
+      }),
     };
 
     // Create and configure MCP server with tools filtered by context

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -286,6 +286,13 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       label: userLabel,
     },
     scope: oauthReqInfo.scope,
+    // Default revokes every existing grant for (userId, clientId), which
+    // cascades a sign-out to every other concurrent session of the same
+    // user — common when Claude Code processes share DCR credentials
+    // across project folders. Our props don't drift between re-auths in a
+    // way that would require server-forced single-grant semantics, so
+    // allow concurrent grants instead. See issue #924.
+    revokeExistingGrants: false,
     // Props are available via ExecutionContext.props in the MCP handler
     props: {
       // OAuth standard fields

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -279,6 +279,39 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // Return back to the MCP client a new token
   const accessTokenExpiresAt = getUpstreamTokenExpiryTimestamp(payload);
   const userLabel = getUpstreamUserLabel(payload);
+
+  // Count grants we're about to allow to coexist (under the prior library
+  // default they would have been silently revoked). Best-effort: failures
+  // here must not block auth.
+  const callbackClientFamily =
+    resolveClientFamilyFromName(registeredClientName);
+  let concurrentGrantCount = 0;
+  try {
+    let cursor: string | undefined;
+    do {
+      const page = await c.env.OAUTH_PROVIDER.listUserGrants(payload.user.id, {
+        cursor,
+      });
+      for (const g of page.items) {
+        if (g.clientId === oauthReqInfo.clientId) concurrentGrantCount++;
+      }
+      cursor = page.cursor ?? undefined;
+    } while (cursor);
+  } catch (err) {
+    logWarn("Failed to count concurrent grants on callback", {
+      loggerScope: ["cloudflare", "oauth", "callback"],
+      extra: { error: String(err), clientId: oauthReqInfo.clientId },
+    });
+  }
+  if (concurrentGrantCount > 0) {
+    Sentry.setUser({ id: payload.user.id });
+    Sentry.metrics.count(
+      "mcp.oauth.concurrent_grant_observed",
+      concurrentGrantCount,
+      { attributes: { client_family: callbackClientFamily } },
+    );
+  }
+
   const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
     request: oauthReqInfo as AuthRequest,
     userId: payload.user.id,
@@ -323,9 +356,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // browser, not the MCP client. Derive client family from the DCR-registered
   // client_name (resolved above).
   Sentry.metrics.count("mcp.oauth.callback_completed", 1, {
-    attributes: {
-      client_family: resolveClientFamilyFromName(registeredClientName),
-    },
+    attributes: { client_family: callbackClientFamily },
   });
 
   // Use manual redirect instead of Response.redirect() to allow middleware to add headers

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -280,38 +280,6 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   const accessTokenExpiresAt = getUpstreamTokenExpiryTimestamp(payload);
   const userLabel = getUpstreamUserLabel(payload);
 
-  // Count grants we're about to allow to coexist (under the prior library
-  // default they would have been silently revoked). Best-effort: failures
-  // here must not block auth.
-  const callbackClientFamily =
-    resolveClientFamilyFromName(registeredClientName);
-  let concurrentGrantCount = 0;
-  try {
-    let cursor: string | undefined;
-    do {
-      const page = await c.env.OAUTH_PROVIDER.listUserGrants(payload.user.id, {
-        cursor,
-      });
-      for (const g of page.items) {
-        if (g.clientId === oauthReqInfo.clientId) concurrentGrantCount++;
-      }
-      cursor = page.cursor ?? undefined;
-    } while (cursor);
-  } catch (err) {
-    logWarn("Failed to count concurrent grants on callback", {
-      loggerScope: ["cloudflare", "oauth", "callback"],
-      extra: { error: String(err), clientId: oauthReqInfo.clientId },
-    });
-  }
-  if (concurrentGrantCount > 0) {
-    Sentry.setUser({ id: payload.user.id });
-    Sentry.metrics.count(
-      "mcp.oauth.concurrent_grant_observed",
-      concurrentGrantCount,
-      { attributes: { client_family: callbackClientFamily } },
-    );
-  }
-
   const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
     request: oauthReqInfo as AuthRequest,
     userId: payload.user.id,
@@ -356,7 +324,9 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // browser, not the MCP client. Derive client family from the DCR-registered
   // client_name (resolved above).
   Sentry.metrics.count("mcp.oauth.callback_completed", 1, {
-    attributes: { client_family: callbackClientFamily },
+    attributes: {
+      client_family: resolveClientFamilyFromName(registeredClientName),
+    },
   });
 
   // Use manual redirect instead of Response.redirect() to allow middleware to add headers


### PR DESCRIPTION
Closes #924.

## Why

`workers-oauth-provider`'s `completeAuthorization` defaulted to revoking every existing grant for `(userId, clientId)` whenever a new authorization completed. Because Claude Code persists its DCR `client_id` across processes — e.g. across project folders, or after an update triggers re-auth in one process — a fresh auth in any one session silently revoked every other active session for the same user.

The cascade was invisible to our telemetry. Affected sessions hit 401 from the OAuth library on their next `/mcp` request *before* reaching our handler, so `mcp.oauth.grant_revoked` never fired. Triggered this investigation when an active session in one project folder got disconnected after a Claude Code update in a different folder.

## What changes

**Behavior fix.** Pass `revokeExistingGrants: false` to `completeAuthorization` in `packages/mcp-cloudflare/src/server/oauth/routes/callback.ts`. Multiple grants per `(userId, clientId)` now coexist until each one's `refreshTokenTTL` (30d) or an explicit revoke. This matches how mainstream OAuth servers behave (Google, GitHub, Auth0, etc.); the library's prior default was an unusual policy.

The MCP authorization spec, OAuth 2.1, and RFC 7591 (DCR) are all silent on this — it's a server-policy choice. The library's docs justify their default with "prevents stale tokens from causing infinite re-auth loops when props change," which assumes a client that triggers re-auth on observed prop drift. Our MCP clients don't behave that way, so the safeguard isn't load-bearing for us.

**Targeted revocation.** With concurrent grants now allowed, the existing `revokeStaleGrant` and `onUpstreamUnauthorized` paths in `mcp-handler.ts` would have arbitrarily picked a grant via `listUserGrants(userId).find(g => g.clientId === clientId)` — re-introducing the same cross-session sign-out via a different code path. Pull the grantId off the wrapper bearer token (the library encodes it as `userId:grantId:secret`, validated before our handler runs) and revoke that specific grant. If the bearer is missing or malformed, log and skip the revoke rather than risk killing another session — the user still gets the 401, the stale grant just expires naturally via `refreshTokenTTL`.

**Metric gating.** `mcp.oauth.grant_revoked` now only emits when we will actually revoke, so the count tracks KV deletes rather than user-facing 401s without cleanup.

**Tests.** Three integration tests through `mcpHandler.fetch`:
- The stale-grant path revokes the exact grantId from the bearer token and does not call `listUserGrants`.
- When `listUserGrants` would surface another active session for the same `clientId`, only the request's own grant is revoked.
- A request without a bearer header skips the revoke entirely.

The `onUpstreamUnauthorized` callback uses identical `requestGrantId` extraction and grant-targeting logic; covering it directly would require an end-to-end MCP tool execution test (mocking SentryApiService to throw 401 through `buildServer`/`createMcpHandler`). Out of scope here.

**Playbook.** `docs/oauth-signout-playbook.md` adds Gap #4 documenting the failure mode and fix.

## Trade-offs

- Each fresh auth leaves the prior grant in KV until its own 30-day TTL. Bounded cost; revisit if KV pressure grows.
- Library-side cascade events are now structurally eliminated rather than counted. If "user re-authed while another session was active" becomes a useful signal, it would need its own pre-callback `listUserGrants` pass — skipped here for the per-callback cost.

## Verification after deploy

- The "user reports signed out, no `grant_revoked` for them, but a fresh `/oauth/callback` near the same time" pattern that triggered #924 should drop off.
- Active grants per user can grow modestly (each user keeping a longer tail across machines/projects).