### PR TITLE
telem(cloudflare): promote User-Agent to a Sentry tag

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -80,10 +80,6 @@ function finalizeResponse(
 //      - Public metadata endpoints → restrictive read-only CORS (`*`, GET only)
 //      - Everything else → strip all CORS headers the library added
 
-// Sentry tag values are truncated server-side to 200 chars; do it here so
-// the value the Sentry UI shows matches what we put on the scope.
-const USER_AGENT_TAG_MAX_LENGTH = 200;
-
 const wrappedOAuthProvider = {
   fetch: async (request: Request, env: Env, ctx: ExecutionContext) => {
     const url = new URL(request.url);
@@ -94,10 +90,7 @@ const wrappedOAuthProvider = {
     // aren't tag-indexed.
     const userAgent = request.headers.get("user-agent");
     if (userAgent) {
-      Sentry.setTag(
-        "user_agent",
-        userAgent.slice(0, USER_AGENT_TAG_MAX_LENGTH),
-      );
+      Sentry.setTag("user_agent", userAgent);
     }
 
     // --- Phase 1: Intercept preflight before the library can respond ---

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -79,9 +79,26 @@ function finalizeResponse(
 //   3. On the way out, apply our CORS policy:
 //      - Public metadata endpoints → restrictive read-only CORS (`*`, GET only)
 //      - Everything else → strip all CORS headers the library added
+
+// Sentry tag values are truncated server-side to 200 chars; do it here so
+// the value the Sentry UI shows matches what we put on the scope.
+const USER_AGENT_TAG_MAX_LENGTH = 200;
+
 const wrappedOAuthProvider = {
   fetch: async (request: Request, env: Env, ctx: ExecutionContext) => {
     const url = new URL(request.url);
+
+    // Promote the User-Agent into a tag on the per-request isolation scope
+    // (created by Sentry.withSentry) so it's queryable in the aggregate UI.
+    // The header is already captured as a request context, but contexts
+    // aren't tag-indexed.
+    const userAgent = request.headers.get("user-agent");
+    if (userAgent) {
+      Sentry.setTag(
+        "user_agent",
+        userAgent.slice(0, USER_AGENT_TAG_MAX_LENGTH),
+      );
+    }
 
     // --- Phase 1: Intercept preflight before the library can respond ---
     // Public metadata gets restrictive CORS; everything else gets a bare 204


### PR DESCRIPTION
## Summary

- The User-Agent header is already captured on every event as part of `request.headers` (a context), but Sentry contexts aren't tag-indexed — that blocks group-by / filter on User-Agent in the aggregate UI (Issues, Transactions, Discover).
- Set `user_agent` as a tag on the per-request isolation scope created by `Sentry.withSentry`. This applies to both error and transaction events for that request without needing `beforeSendTransaction`.

## Why a tag and not the existing `client_family` bucket

`client_family` (set as a metric attribute) is intentionally low-cardinality. The raw User-Agent is what's needed to investigate one-off clients (e.g. specific Cursor / IDE versions hitting an edge case) which the bucketed family hides.

## Test plan

- [ ] Deploy to staging and confirm the `user_agent` tag appears on transactions hitting `/mcp` and `/oauth/*`
- [ ] Confirm tag shows up in Issues filter dropdown and Discover
- [ ] Verify `pnpm run tsc && pnpm run lint && pnpm run test` (passing locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)