### PR TITLE
fix(cloudflare): Show requested OAuth redirect URI

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -200,6 +200,10 @@ export interface ApprovalDialogOptions {
     projectSlug: string | null;
   } | null;
   /**
+   * The specific redirect URI selected for this authorization request.
+   */
+  redirectUri?: string | null;
+  /**
    * Arbitrary state data to pass through the approval flow
    * Will be encoded in the form and returned when approval is complete
    */
@@ -275,7 +279,7 @@ export async function renderApprovalDialog(
   request: Request,
   options: ApprovalDialogOptions,
 ): Promise<Response> {
-  const { client, server, scope, state, cookieSecret } = options;
+  const { client, server, scope, redirectUri, state, cookieSecret } = options;
 
   // Use static skill definitions bundled at build time
   const skills: SkillDefinition[] = skillDefinitions as SkillDefinition[];
@@ -317,25 +321,23 @@ export async function renderApprovalDialog(
     ? sanitizeHtml(sanitizeHrefUrl(client.tosUri))
     : "";
 
-  // Get redirect URIs
-  const redirectUris =
-    client?.redirectUris && client.redirectUris.length > 0
-      ? client.redirectUris.map((uri) => sanitizeHtml(uri))
-      : [];
+  const redirectWarningUri =
+    typeof redirectUri === "string" && redirectUri.length > 0
+      ? sanitizeHtml(redirectUri)
+      : client?.redirectUris?.length === 1
+        ? sanitizeHtml(client.redirectUris[0])
+        : null;
 
-  // Generate redirect URI warnings
-  const redirectWarningsHtml = redirectUris
-    .map((uri) => {
-      return `
+  const redirectWarningsHtml = redirectWarningUri
+    ? `
         <div class="redirect-warning">
-          <div class="redirect-uri-display">${uri}</div>
+          <div class="redirect-uri-display">${redirectWarningUri}</div>
           <div class="redirect-warning-text">
             After approval, you will be redirected to this URL. Only approve if you recognize and trust this destination.
           </div>
         </div>
-      `;
-    })
-    .join("");
+      `
+    : "";
 
   const scopeHtml = scope
     ? `

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -58,6 +58,39 @@ describe("oauth authorize routes", () => {
       expect(html).toContain("<form");
       expect(html).toContain('name="state"');
     });
+
+    it("renders only the requested redirect URI when the client has multiple registered URIs", async () => {
+      mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
+        clientId: "test-client",
+        redirectUri: "https://example.com/requested-callback",
+        scope: ["read"],
+        state: "orig",
+      });
+      mockOAuthProvider.lookupClient.mockResolvedValueOnce({
+        clientId: "test-client",
+        clientName: "Test Client",
+        redirectUris: [
+          "https://example.com/requested-callback",
+          "https://example.com/another-callback",
+          "https://example.com/fallback-callback",
+        ],
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+
+      const request = new Request("http://localhost/oauth/authorize", {
+        method: "GET",
+      });
+      const response = await app.fetch(request, testEnv as Env);
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("https://example.com/requested-callback");
+      expect(html).not.toContain("https://example.com/another-callback");
+      expect(html).not.toContain("https://example.com/fallback-callback");
+      expect(
+        html.match(/After approval, you will be redirected to this URL\./g),
+      ).toHaveLength(1);
+    });
   });
 
   describe("POST /oauth/authorize", () => {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -165,6 +165,7 @@ export default new Hono<{ Bindings: Env }>()
         name: "Sentry MCP",
       },
       scope: approvalScope,
+      redirectUri: oauthReqInfoWithResource.redirectUri,
       state: { oauthReqInfo: oauthReqInfoWithResource },
       cookieSecret: c.env.COOKIE_SECRET,
     });


### PR DESCRIPTION
Fix the OAuth approval dialog so it only shows the redirect URI for the active authorization request. Clients with multiple registered callbacks were rendering one warning box per URI, which made the destination prompt noisy and misleading.

**Redirect URI Rendering**

The authorize route now passes the validated request redirect URI into the approval dialog. The dialog renders that URI and only falls back to the client's single registered redirect URI when no explicit request URI is present.

**Regression Coverage**

Add an authorize-route regression test for a client with multiple registered redirect URIs and assert that only the requested callback is displayed.