### PR TITLE
feat(seer): Label generated analysis output

### DIFF
--- a/packages/mcp-core/src/internal/formatting.test.ts
+++ b/packages/mcp-core/src/internal/formatting.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   formatEventOutput,
   formatFrameHeader,
+  formatIssueOutput,
   getSeerActionabilityLabel,
 } from "./formatting";
-import type { Event } from "../api-client/types";
+import type { SentryApiService } from "../api-client";
+import type { AutofixRunState, Event, Issue } from "../api-client/types";
 import {
   EventBuilder,
   createFrame,
@@ -93,6 +95,66 @@ describe("getSeerActionabilityLabel", () => {
     expect(getSeerActionabilityLabel(0.25)).toBe("super_low");
     expect(getSeerActionabilityLabel(0.1)).toBe("super_low");
     expect(getSeerActionabilityLabel(0)).toBe("super_low");
+  });
+});
+
+describe("formatIssueOutput", () => {
+  it("does not use Seer provenance tags as fallback summary text", () => {
+    const output = formatIssueOutput({
+      organizationSlug: "sentry-mcp-evals",
+      issue: {
+        shortId: "CLOUDFLARE-MCP-42",
+        title: "Retry job failed",
+        count: "1",
+        userCount: 1,
+        status: "unresolved",
+        project: {
+          name: "cloudflare-mcp",
+          slug: "cloudflare-mcp",
+        },
+      } as Issue,
+      event: new EventBuilder("javascript").withId("event-1").build(),
+      apiService: {
+        getIssueUrl: () => "https://sentry.example/issues/CLOUDFLARE-MCP-42",
+      } as unknown as SentryApiService,
+      autofixState: {
+        autofix: {
+          run_id: 42,
+          request: {},
+          status: "COMPLETED",
+          updated_at: "2025-04-09T22:39:50.778146",
+          steps: [
+            {
+              type: "solution",
+              key: "solution_step_with_a_name_long_enough_to_match_summary_filter",
+              index: 0,
+              status: "COMPLETED",
+              title: "Proposed Solution",
+              output_stream: null,
+              progress: [],
+              description: "",
+              solution: [
+                {
+                  code_snippet_and_analysis:
+                    "Use the canonical issue identifier before retrying the analysis request so the summary remains readable.",
+                  is_active: true,
+                  is_most_important_event: true,
+                  relevant_code_file: null,
+                  timeline_item_type: "internal_code",
+                  title: "Normalize the issue identifier",
+                },
+              ],
+            },
+          ],
+        },
+      } as AutofixRunState,
+    });
+
+    expect(output).toContain("**Summary:**");
+    expect(output).toContain(
+      "Use the canonical issue identifier before retrying the analysis request so the summary remains readable.",
+    );
+    expect(output).not.toContain("<seer_analysis");
   });
 });
 

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -1654,7 +1654,9 @@ function formatSeerSummary(autofixState: AutofixRunState | undefined): string {
         parts.push(solutionDescription.trim());
       } else {
         // Fallback to extracting from output if no description
-        const solutionOutput = getOutputForAutofixStep(solutionStep);
+        const solutionOutput = getOutputForAutofixStep(solutionStep, {
+          includeProvenanceTags: false,
+        });
         const lines = solutionOutput.split("\n");
         const firstParagraph = lines.find(
           (line) =>

--- a/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
@@ -109,5 +109,33 @@ describe("seer-utils", () => {
 
       expect(output).toBe("## Proposed Solution\n\n");
     });
+
+    it("does not stringify null solution descriptions", () => {
+      const output = getOutputForAutofixStep({
+        type: "solution",
+        key: "solution",
+        index: 0,
+        status: "COMPLETED",
+        title: "Proposed Solution",
+        output_stream: null,
+        progress: [],
+        description: null,
+        solution: [
+          {
+            code_snippet_and_analysis:
+              "Use the canonical issue identifier before retrying.",
+            is_active: true,
+            is_most_important_event: true,
+            relevant_code_file: null,
+            timeline_item_type: "internal_code",
+            title: "Normalize the issue identifier",
+          },
+        ],
+      });
+
+      expect(output).toContain("Normalize the issue identifier");
+      expect(output).not.toContain("null");
+      expect(output).not.toContain("undefined");
+    });
   });
 });

--- a/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
@@ -4,6 +4,7 @@ import {
   isHumanInterventionStatus,
   getStatusDisplayName,
   getHumanInterventionGuidance,
+  getOutputForAutofixStep,
 } from "./seer";
 
 describe("seer-utils", () => {
@@ -74,6 +75,39 @@ describe("seer-utils", () => {
     it("returns empty string for other statuses", () => {
       expect(getHumanInterventionGuidance("COMPLETED")).toBe("");
       expect(getHumanInterventionGuidance("PROCESSING")).toBe("");
+    });
+  });
+
+  describe("getOutputForAutofixStep", () => {
+    it("keeps the heading when a completed root cause step has no generated output", () => {
+      const output = getOutputForAutofixStep({
+        type: "root_cause_analysis",
+        key: "root_cause_analysis",
+        index: 0,
+        status: "COMPLETED",
+        title: "Root Cause Analysis",
+        output_stream: null,
+        progress: [],
+        causes: [],
+      });
+
+      expect(output).toBe("## Root Cause Analysis\n\n");
+    });
+
+    it("keeps the heading when a completed solution step has no generated output", () => {
+      const output = getOutputForAutofixStep({
+        type: "solution",
+        key: "solution",
+        index: 0,
+        status: "COMPLETED",
+        title: "Proposed Solution",
+        output_stream: null,
+        progress: [],
+        description: "",
+        solution: [],
+      });
+
+      expect(output).toBe("## Proposed Solution\n\n");
     });
   });
 });

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -159,12 +159,6 @@ export function getOutputForAutofixStep(
       return heading;
     }
 
-    if (typedStep.status === "FAILED") {
-      body += `**Sentry hit an error completing this step.\n\n`;
-    } else if (typedStep.status !== "COMPLETED") {
-      body += `**Sentry is still working on this step.**\n\n`;
-    }
-
     return wrapSeerAnalysisOutput({
       output: body,
       runId: options.runId,

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -130,6 +130,10 @@ export function getOutputForAutofixStep(
         body += `${entry.code_snippet_and_analysis}\n\n`;
       }
     }
+    if (!body.trim()) {
+      return heading;
+    }
+
     return wrapSeerAnalysisOutput({
       output: body,
       runId: options.runId,
@@ -146,6 +150,10 @@ export function getOutputForAutofixStep(
       if (entry.code_snippet_and_analysis) {
         body += `${entry.code_snippet_and_analysis}\n\n`;
       }
+    }
+
+    if (!body.trim()) {
+      return heading;
     }
 
     if (typedStep.status === "FAILED") {

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -81,11 +81,17 @@ function wrapSeerAnalysisOutput({
   output,
   runId,
   step,
+  includeProvenanceTags,
 }: {
   output: string;
   runId?: number;
   step: string;
+  includeProvenanceTags: boolean;
 }): string {
+  if (!includeProvenanceTags) {
+    return `${output.trimEnd()}\n`;
+  }
+
   const attrs = [
     runId === undefined ? null : `run_id="${escapeXmlAttribute(runId)}"`,
     `step="${escapeXmlAttribute(step)}"`,
@@ -96,8 +102,9 @@ function wrapSeerAnalysisOutput({
 
 export function getOutputForAutofixStep(
   step: z.infer<typeof AutofixRunStepSchema>,
-  options: { runId?: number } = {},
+  options: { runId?: number; includeProvenanceTags?: boolean } = {},
 ) {
+  const includeProvenanceTags = options.includeProvenanceTags ?? true;
   const heading = `## ${step.title}\n\n`;
 
   if (step.status === "FAILED") {
@@ -127,6 +134,7 @@ export function getOutputForAutofixStep(
       output: body,
       runId: options.runId,
       step: step.key,
+      includeProvenanceTags,
     });
   }
 
@@ -150,6 +158,7 @@ export function getOutputForAutofixStep(
       output: body,
       runId: options.runId,
       step: step.key,
+      includeProvenanceTags,
     });
   }
 
@@ -172,6 +181,7 @@ export function getOutputForAutofixStep(
       output: body,
       runId: options.runId,
       step: step.key,
+      includeProvenanceTags,
     });
   }
 

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -144,7 +144,10 @@ export function getOutputForAutofixStep(
 
   if (step.type === "solution") {
     const typedStep = step as z.infer<typeof AutofixRunStepSolutionSchema>;
-    let body = `${typedStep.description}\n\n`;
+    let body =
+      typeof typedStep.description === "string"
+        ? `${typedStep.description}\n\n`
+        : "";
     for (const entry of typedStep.solution) {
       body += `**${entry.title}**\n`;
       if (entry.code_snippet_and_analysis) {

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -69,64 +69,111 @@ export function getHumanInterventionGuidance(status: string): string {
   return "";
 }
 
+function escapeXmlAttribute(value: string | number): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function wrapSeerAnalysisOutput({
+  output,
+  runId,
+  step,
+}: {
+  output: string;
+  runId?: number;
+  step: string;
+}): string {
+  const attrs = [
+    runId === undefined ? null : `run_id="${escapeXmlAttribute(runId)}"`,
+    `step="${escapeXmlAttribute(step)}"`,
+  ].filter(Boolean);
+
+  return `<seer_analysis ${attrs.join(" ")}>\n${output.trimEnd()}\n</seer_analysis>\n`;
+}
+
 export function getOutputForAutofixStep(
   step: z.infer<typeof AutofixRunStepSchema>,
+  options: { runId?: number } = {},
 ) {
-  let output = `## ${step.title}\n\n`;
+  const heading = `## ${step.title}\n\n`;
 
   if (step.status === "FAILED") {
-    output += `**Sentry hit an error completing this step.\n\n`;
-    return output;
+    return `${heading}**Sentry hit an error completing this step.\n\n`;
   }
 
   if (step.status !== "COMPLETED") {
-    output += `**Sentry is still working on this step. Please check back in a minute.**\n\n`;
-    return output;
+    return `${heading}**Sentry is still working on this step. Please check back in a minute.**\n\n`;
   }
 
   if (step.type === "root_cause_analysis") {
     const typedStep = step as z.infer<
       typeof AutofixRunStepRootCauseAnalysisSchema
     >;
+    let body = "";
 
     for (const cause of typedStep.causes) {
       if (cause.description) {
-        output += `${cause.description}\n\n`;
+        body += `${cause.description}\n\n`;
       }
       for (const entry of cause.root_cause_reproduction) {
-        output += `**${entry.title}**\n\n`;
-        output += `${entry.code_snippet_and_analysis}\n\n`;
+        body += `**${entry.title}**\n\n`;
+        body += `${entry.code_snippet_and_analysis}\n\n`;
       }
     }
-    return output;
+    return wrapSeerAnalysisOutput({
+      output: body,
+      runId: options.runId,
+      step: step.key,
+    });
   }
 
   if (step.type === "solution") {
     const typedStep = step as z.infer<typeof AutofixRunStepSolutionSchema>;
-    output += `${typedStep.description}\n\n`;
+    let body = `${typedStep.description}\n\n`;
     for (const entry of typedStep.solution) {
-      output += `**${entry.title}**\n`;
-      output += `${entry.code_snippet_and_analysis}\n\n`;
+      body += `**${entry.title}**\n`;
+      if (entry.code_snippet_and_analysis) {
+        body += `${entry.code_snippet_and_analysis}\n\n`;
+      }
     }
 
     if (typedStep.status === "FAILED") {
-      output += `**Sentry hit an error completing this step.\n\n`;
+      body += `**Sentry hit an error completing this step.\n\n`;
     } else if (typedStep.status !== "COMPLETED") {
-      output += `**Sentry is still working on this step.**\n\n`;
+      body += `**Sentry is still working on this step.**\n\n`;
     }
 
-    return output;
+    return wrapSeerAnalysisOutput({
+      output: body,
+      runId: options.runId,
+      step: step.key,
+    });
   }
 
   const typedStep = step as z.infer<typeof AutofixRunStepDefaultSchema>;
+  let body = "";
+  let hasGeneratedOutput = false;
   if (typedStep.insights && typedStep.insights.length > 0) {
+    hasGeneratedOutput = true;
     for (const entry of typedStep.insights) {
-      output += `**${entry.insight}**\n`;
-      output += `${entry.justification}\n\n`;
+      body += `**${entry.insight}**\n`;
+      body += `${entry.justification}\n\n`;
     }
   } else if (step.output_stream) {
-    output += `${step.output_stream}\n`;
+    hasGeneratedOutput = true;
+    body += `${step.output_stream}\n`;
   }
 
-  return output;
+  if (hasGeneratedOutput) {
+    return wrapSeerAnalysisOutput({
+      output: body,
+      runId: options.runId,
+      step: step.key,
+    });
+  }
+
+  return heading;
 }

--- a/packages/mcp-core/src/tools/analyze-issue-with-seer.test.ts
+++ b/packages/mcp-core/src/tools/analyze-issue-with-seer.test.ts
@@ -37,8 +37,132 @@ describe("analyze_issue_with_seer", () => {
     expect(result).toContain("# Seer Analysis for Issue CLOUDFLARE-MCP-45");
     expect(result).toContain("Found existing analysis (Run ID: 13)");
     expect(result).toContain("## Analysis Complete");
-    expect(result).toContain("## 1. **Root Cause Analysis**");
+    expect(result).toContain(
+      '<seer_analysis run_id="13" step="root_cause_analysis">',
+    );
     expect(result).toContain("The analysis has completed successfully.");
+  });
+
+  it("wraps completed Seer-authored sections with provenance tags", async () => {
+    mswServer.use(
+      http.get(
+        "*/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-TAGS/autofix/",
+        () =>
+          HttpResponse.json({
+            autofix: {
+              run_id: 4242,
+              request: {},
+              status: "COMPLETED",
+              updated_at: "2025-04-09T22:39:50.778146",
+              steps: [
+                {
+                  type: "root_cause_analysis",
+                  key: "root_cause_analysis",
+                  index: 0,
+                  status: "COMPLETED",
+                  title: "Root Cause Analysis",
+                  output_stream: null,
+                  progress: [],
+                  causes: [
+                    {
+                      description: "The request used the wrong bottle ID.",
+                      id: 1,
+                      root_cause_reproduction: [
+                        {
+                          code_snippet_and_analysis:
+                            "The bottle lookup threw after receiving ID 3216.",
+                          is_most_important_event: true,
+                          relevant_code_file: null,
+                          timeline_item_type: "internal_code",
+                          title: "Lookup path",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: "solution",
+                  key: "solution",
+                  index: 1,
+                  status: "COMPLETED",
+                  title: "Proposed Solution",
+                  output_stream: null,
+                  progress: [],
+                  description:
+                    "Use the canonical bottle ID for both batched calls.",
+                  solution: [
+                    {
+                      code_snippet_and_analysis:
+                        "Pass the same ID to both procedures.",
+                      is_active: true,
+                      is_most_important_event: true,
+                      relevant_code_file: null,
+                      timeline_item_type: "internal_code",
+                      title: "Share canonical ID",
+                    },
+                    {
+                      code_snippet_and_analysis: null,
+                      is_active: true,
+                      is_most_important_event: false,
+                      relevant_code_file: null,
+                      timeline_item_type: "repro_test",
+                      title: "Add regression coverage",
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+      ),
+    );
+
+    const result = await analyzeIssueWithSeer.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        instruction: undefined,
+        issueId: "CLOUDFLARE-MCP-TAGS",
+        issueUrl: undefined,
+      },
+      {
+        constraints: {
+          organizationSlug: undefined,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    expect(typeof result).toBe("string");
+    if (typeof result !== "string") {
+      throw new Error("Expected analyze_issue_with_seer to return text output");
+    }
+
+    expect(result.trim()).toMatchInlineSnapshot(`
+      "# Seer Analysis for Issue CLOUDFLARE-MCP-TAGS
+
+      Found existing analysis (Run ID: 4242)
+
+      ## Analysis Complete
+
+      <seer_analysis run_id="4242" step="root_cause_analysis">
+      The request used the wrong bottle ID.
+
+      **Lookup path**
+
+      The bottle lookup threw after receiving ID 3216.
+      </seer_analysis>
+
+      <seer_analysis run_id="4242" step="solution">
+      Use the canonical bottle ID for both batched calls.
+
+      **Share canonical ID**
+      Pass the same ID to both procedures.
+
+      **Add regression coverage**
+      </seer_analysis>"
+    `);
+    expect(result).not.toContain("null");
   });
 
   it("handles network errors with retry", async () => {

--- a/packages/mcp-core/src/tools/analyze-issue-with-seer.ts
+++ b/packages/mcp-core/src/tools/analyze-issue-with-seer.ts
@@ -168,7 +168,9 @@ export default defineTool({
         output += `## Analysis ${getStatusDisplayName(existingStatus)}\n\n`;
 
         for (const step of autofixState.autofix.steps) {
-          output += getOutputForAutofixStep(step);
+          output += getOutputForAutofixStep(step, {
+            runId: autofixState.autofix.run_id,
+          });
           output += "\n";
         }
 
@@ -206,7 +208,9 @@ export default defineTool({
 
         // Add all step outputs
         for (const step of autofixState.autofix.steps) {
-          output += getOutputForAutofixStep(step);
+          output += getOutputForAutofixStep(step, {
+            runId: autofixState.autofix.run_id,
+          });
           output += "\n";
         }
 
@@ -281,7 +285,9 @@ export default defineTool({
     if (autofixState.autofix) {
       output += `**Current Status**: ${getStatusDisplayName(autofixState.autofix.status)}\n\n`;
       for (const step of autofixState.autofix.steps) {
-        output += getOutputForAutofixStep(step);
+        output += getOutputForAutofixStep(step, {
+          runId: autofixState.autofix.run_id,
+        });
         output += "\n";
       }
     }


### PR DESCRIPTION
Wrap Seer-authored analysis content in `<seer_analysis>` tags so downstream agents can distinguish generated guidance from status and polling text.

The formatter now passes through `run_id` and `step` attributes on generated sections, omits redundant markdown headings around those sections, and avoids rendering null solution snippets from Seer payloads.