### PR TITLE
fix(telemetry): Preserve request IP in Sentry user context

### DIFF
--- a/docs/cloudflare/oauth-architecture.md
+++ b/docs/cloudflare/oauth-architecture.md
@@ -277,7 +277,7 @@ When an MCP client's token expires:
 
 ```typescript
 // tokenExchangeCallback in src/server/oauth/helpers.ts
-export async function tokenExchangeCallback(options, env) {
+export async function tokenExchangeCallback(options, env, request, clientFamily) {
   // Only handle MCP refresh_token requests
   if (options.grantType !== "refresh_token") {
     return undefined;

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -57,7 +57,7 @@ Attributes:
 - `probe_status` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
 - `probe_reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
 
-User is set via `Sentry.setUser({ id: rawProps.id })` in the callback, so metrics can be filtered by `user.id`. Sub-30d sign-outs surface via `mcp.oauth.grant_revoked{reason:upstream_rejected_in_use}`, not on this metric.
+User context is set from the stored user ID and current request, so metrics can be filtered by `user.id` and events retain the request IP when available. Sub-30d sign-outs surface via `mcp.oauth.grant_revoked{reason:upstream_rejected_in_use}`, not on this metric.
 
 ### `mcp.oauth.grant_revoked` (counter)
 
@@ -67,7 +67,7 @@ Attributes:
 
 - `reason` — `stale_props_no_refresh` / `upstream_rejected` / `upstream_rejected_in_use`
 - `client_family`
-- `user.id` (via `Sentry.setUser`)
+- `user.id` (via Sentry user context)
 
 `upstream_rejected_in_use` indicates Sentry returned 401 to a tool call while the stored access token still looked locally valid — the sub-30d sign-out signal users typically report. The grant is revoked via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`, short-circuiting the death-spiral where subsequent refreshes kept handing out wrapper tokens backed by a dead upstream token.
 

--- a/docs/releases/cloudflare.md
+++ b/docs/releases/cloudflare.md
@@ -109,7 +109,8 @@ const oAuthProvider = new OAuthProvider({
   authorizeEndpoint: "/oauth/authorize",
   tokenEndpoint: "/oauth/token",
   clientRegistrationEndpoint: "/oauth/register",
-  tokenExchangeCallback: (options) => tokenExchangeCallback(options, env),
+  tokenExchangeCallback: (options) =>
+    tokenExchangeCallback(options, env, request, clientFamily),
   scopesSupported: Object.keys(SCOPES),
   refreshTokenTTL: 30 * 24 * 60 * 60,
 });

--- a/docs/security.md
+++ b/docs/security.md
@@ -157,6 +157,7 @@ Key endpoints:
 ```typescript
 interface ServerContext {
   userId?: string;
+  userIpAddress?: string;
   clientId: string;
   accessToken: string;
   grantedSkills: Set<Skill>;  // Primary authorization method

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -1,19 +1,18 @@
-import { Hono, type Context } from "hono";
+import { logIssue } from "@sentry/mcp-core/telem/logging";
+import { type Context, Hono } from "hono";
 import { csrf } from "hono/csrf";
 import { secureHeaders } from "hono/secure-headers";
-import * as Sentry from "@sentry/cloudflare";
-import type { Env } from "./types";
-import sentryOauth from "./oauth";
-import chatOauth from "./routes/chat-oauth";
-import chat from "./routes/chat";
-import search from "./routes/search";
-import metadata from "./routes/metadata";
-import { logIssue } from "@sentry/mcp-core/telem/logging";
-import { createRequestLogger } from "./logging";
-import mcpRoutes from "./routes/mcp";
-import { getClientIp } from "./utils/client-ip";
-import { createProtectedResourceMetadataResponse } from "./protected-resource-metadata";
 import { createScopedAuthorizationServerMetadataResponse } from "./authorization-server-metadata";
+import { createRequestLogger } from "./logging";
+import sentryOauth from "./oauth";
+import { createProtectedResourceMetadataResponse } from "./protected-resource-metadata";
+import chat from "./routes/chat";
+import chatOauth from "./routes/chat-oauth";
+import mcpRoutes from "./routes/mcp";
+import metadata from "./routes/metadata";
+import search from "./routes/search";
+import type { Env } from "./types";
+import { setSentryUserFromRequest } from "./utils/sentry-user";
 
 /** Derive the base URL (origin) from the current request. */
 function getBaseUrl(c: Context): string {
@@ -90,16 +89,9 @@ const app = new Hono<{
   Bindings: Env;
 }>()
   .use("*", createRequestLogger())
-  // Set user IP address for Sentry (optional in local dev)
+  // Seed Sentry telemetry context with the request IP when available.
   .use("*", async (c, next) => {
-    const clientIP = getClientIp(c.req.raw);
-
-    if (clientIP) {
-      Sentry.setUser({ ip_address: clientIP });
-    }
-    // In local development, IP extraction may fail - this is expected and safe to ignore
-    // as it's only used for Sentry telemetry context
-
+    setSentryUserFromRequest(c.req.raw);
     await next();
   })
   // Apply security middleware globally

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -4,6 +4,12 @@ import { SCOPES } from "../constants";
 import app from "./app";
 import { resolveClientFamily } from "./lib/client-family";
 import sentryMcpHandler from "./lib/mcp-handler";
+import {
+  type RateLimitScope,
+  extractResponseMetricOptions,
+  recordResponseMetric,
+  stripResponseMetricHeaders,
+} from "./metrics";
 import { tokenExchangeCallback } from "./oauth";
 import getSentryConfig from "./sentry.config";
 import type { Env } from "./types";
@@ -14,15 +20,10 @@ import {
   stripCorsHeaders,
 } from "./utils/cors";
 import {
-  checkRateLimit,
   MCP_RATE_LIMIT_EXCEEDED_MESSAGE,
+  checkRateLimit,
 } from "./utils/rate-limiter";
-import {
-  extractResponseMetricOptions,
-  recordResponseMetric,
-  stripResponseMetricHeaders,
-  type RateLimitScope,
-} from "./metrics";
+import { setSentryUserFromRequest } from "./utils/sentry-user";
 
 /**
  * RFC 9728 §3.1: Patch 401 responses on MCP routes to include a
@@ -82,6 +83,7 @@ function finalizeResponse(
 const wrappedOAuthProvider = {
   fetch: async (request: Request, env: Env, ctx: ExecutionContext) => {
     const url = new URL(request.url);
+    setSentryUserFromRequest(request);
 
     // --- Phase 1: Intercept preflight before the library can respond ---
     // Public metadata gets restrictive CORS; everything else gets a bare 204
@@ -153,7 +155,7 @@ const wrappedOAuthProvider = {
       tokenEndpoint: "/oauth/token",
       clientRegistrationEndpoint: "/oauth/register",
       tokenExchangeCallback: (options) =>
-        tokenExchangeCallback(options, env, clientFamily),
+        tokenExchangeCallback(options, env, request, clientFamily),
       scopesSupported: Object.keys(SCOPES),
       // Expire grants after 30 days to prevent unbounded KV accumulation.
       // Sentry access tokens also have a 30-day lifetime, so re-auth is

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -9,20 +9,21 @@
  */
 
 import type { ExportedHandler } from "@cloudflare/workers-types";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
+import * as Sentry from "@sentry/cloudflare";
 import { buildServer } from "@sentry/mcp-core/server";
 import { parseSkills } from "@sentry/mcp-core/skills";
 import { logWarn } from "@sentry/mcp-core/telem/logging";
 import type { ServerContext } from "@sentry/mcp-core/types";
 import { createMcpHandler } from "agents/mcp";
-import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
-import * as Sentry from "@sentry/cloudflare";
+import { annotateResponseMetric } from "../metrics";
 import type { WorkerProps } from "../types";
 import type { Env } from "../types";
 import {
-  checkRateLimit,
   MCP_RATE_LIMIT_EXCEEDED_MESSAGE,
+  checkRateLimit,
 } from "../utils/rate-limiter";
-import { annotateResponseMetric } from "../metrics";
+import { setSentryUserFromRequest } from "../utils/sentry-user";
 import { resolveClientFamily } from "./client-family";
 import { verifyConstraintsAccess } from "./constraint-utils";
 
@@ -155,7 +156,10 @@ const mcpHandler: ExportedHandler<Env> = {
     const sentryHost = env.SENTRY_HOST || "sentry.io";
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
     const requestGrantId = getRequestGrantId(request);
-    Sentry.setUser({ id: userId });
+    const { ip_address: userIpAddress } = setSentryUserFromRequest(
+      request,
+      userId,
+    );
 
     // Parse and validate granted skills (primary authorization method)
     // Legacy tokens without grantedSkills are no longer supported
@@ -311,6 +315,7 @@ const mcpHandler: ExportedHandler<Env> = {
     let upstreamUnauthorizedHandled = false;
     const serverContext: ServerContext = {
       userId,
+      userIpAddress,
       clientId,
       accessToken,
       grantedSkills: validSkills,

--- a/packages/mcp-cloudflare/src/server/mcp.test.ts
+++ b/packages/mcp-cloudflare/src/server/mcp.test.ts
@@ -36,7 +36,14 @@ function createOAuthApi() {
       tokenEndpoint: "/oauth/token",
       clientRegistrationEndpoint: "/oauth/register",
       tokenExchangeCallback: (options) =>
-        tokenExchangeCallback(options, workerEnv),
+        tokenExchangeCallback(
+          options,
+          workerEnv,
+          new Request("https://mcp.sentry.dev/oauth/token", {
+            headers: { "CF-Connecting-IP": "192.0.2.1" },
+          }),
+          "unknown",
+        ),
       scopesSupported: Object.keys(SCOPES),
     },
     workerEnv,

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -1,14 +1,25 @@
 import type { TokenExchangeCallbackOptions } from "@cloudflare/workers-oauth-provider";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkerProps } from "../types";
-const { logIssue, logWarn } = vi.hoisted(() => ({
-  logIssue: vi.fn(),
-  logWarn: vi.fn(),
-}));
+const { logIssue, logWarn, sentryMetricsCount, sentrySetUser } = vi.hoisted(
+  () => ({
+    logIssue: vi.fn(),
+    logWarn: vi.fn(),
+    sentryMetricsCount: vi.fn(),
+    sentrySetUser: vi.fn(),
+  }),
+);
 
 vi.mock("@sentry/mcp-core/telem/logging", () => ({
   logIssue,
   logWarn,
+}));
+
+vi.mock("@sentry/cloudflare", () => ({
+  metrics: {
+    count: sentryMetricsCount,
+  },
+  setUser: sentrySetUser,
 }));
 
 import {
@@ -48,6 +59,26 @@ function createRefreshOptions(
 
 const TEST_ENV = { SENTRY_HOST: "sentry.io" };
 
+function createTokenExchangeTelemetryRequest(): Request {
+  return new Request("https://mcp.sentry.dev/oauth/token", {
+    headers: {
+      "CF-Connecting-IP": "192.0.2.1",
+    },
+  });
+}
+
+function callTokenExchangeCallback(
+  options: TokenExchangeCallbackOptions,
+  clientFamily = "unknown",
+): ReturnType<typeof tokenExchangeCallback> {
+  return tokenExchangeCallback(
+    options,
+    TEST_ENV,
+    createTokenExchangeTelemetryRequest(),
+    clientFamily,
+  );
+}
+
 describe("tokenExchangeCallback", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -55,6 +86,8 @@ describe("tokenExchangeCallback", () => {
     logWarn.mockReset();
     logIssue.mockReturnValue(undefined);
     logWarn.mockReturnValue(undefined);
+    sentryMetricsCount.mockReset();
+    sentrySetUser.mockReset();
   });
 
   it("should return undefined for non-refresh_token grant types", async () => {
@@ -67,15 +100,33 @@ describe("tokenExchangeCallback", () => {
       props: {} as WorkerProps,
     };
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toBeUndefined();
   });
 
   it("should return undefined when no refresh token in props", async () => {
     const options = createRefreshOptions({ refreshToken: undefined });
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toBeUndefined();
+  });
+
+  it("sets user ID and IP address for refresh token telemetry", async () => {
+    const options = createRefreshOptions({
+      accessTokenExpiresAt: Date.now() + 10 * 60 * 1000,
+    });
+    const request = new Request("https://mcp.sentry.dev/oauth/token", {
+      headers: {
+        "CF-Connecting-IP": "192.0.2.1",
+      },
+    });
+
+    await tokenExchangeCallback(options, TEST_ENV, request, "claude");
+
+    expect(sentrySetUser).toHaveBeenCalledWith({
+      id: "user-id",
+      ip_address: "192.0.2.1",
+    });
   });
 
   it("should mark the grant invalid when the upstream token is truly expired", async () => {
@@ -90,7 +141,7 @@ describe("tokenExchangeCallback", () => {
       }),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toEqual({
       newProps: expect.objectContaining({
         upstreamTokenInvalid: true,
@@ -114,7 +165,7 @@ describe("tokenExchangeCallback", () => {
       }),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toEqual({
       newProps: expect.objectContaining({
         upstreamTokenInvalid: true,
@@ -138,7 +189,7 @@ describe("tokenExchangeCallback", () => {
       }),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toBeUndefined();
   });
 
@@ -150,7 +201,7 @@ describe("tokenExchangeCallback", () => {
 
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toBeUndefined();
   });
 
@@ -167,7 +218,7 @@ describe("tokenExchangeCallback", () => {
       }),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toBeUndefined();
   });
 
@@ -179,7 +230,7 @@ describe("tokenExchangeCallback", () => {
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toEqual({
       newProps: expect.objectContaining({
         accessToken: "old-access-token",
@@ -210,7 +261,7 @@ describe("tokenExchangeCallback", () => {
       ),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toEqual({
       newProps: expect.not.objectContaining({
         upstreamTokenInvalid: true,
@@ -231,7 +282,7 @@ describe("tokenExchangeCallback", () => {
       }),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toEqual({
       newProps: expect.objectContaining({
         upstreamTokenInvalid: true,
@@ -253,7 +304,7 @@ describe("tokenExchangeCallback", () => {
       }),
     );
 
-    const result = await tokenExchangeCallback(options, TEST_ENV);
+    const result = await callTokenExchangeCallback(options);
     expect(result).toEqual({
       newProps: expect.objectContaining({
         upstreamTokenInvalid: true,

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -2,7 +2,7 @@ import type {
   TokenExchangeCallbackOptions,
   TokenExchangeCallbackResult,
 } from "@cloudflare/workers-oauth-provider";
-import type { z } from "zod";
+import * as Sentry from "@sentry/cloudflare";
 import {
   ApiClientError,
   ApiRateLimitError,
@@ -10,9 +10,10 @@ import {
   SentryApiService,
 } from "@sentry/mcp-core/api-client";
 import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
-import { TokenResponseSchema } from "./constants";
+import type { z } from "zod";
 import type { WorkerProps } from "../types";
-import * as Sentry from "@sentry/cloudflare";
+import { setSentryUserFromRequest } from "../utils/sentry-user";
+import { TokenResponseSchema } from "./constants";
 
 function escapeHtml(value: string): string {
   return value
@@ -550,7 +551,8 @@ async function probeUpstreamAccessToken(
 export async function tokenExchangeCallback(
   options: TokenExchangeCallbackOptions,
   env: TokenExchangeEnv,
-  clientFamily = "unknown",
+  request: Request,
+  clientFamily: string,
 ): Promise<TokenExchangeCallbackResult | undefined> {
   if (options.grantType !== "refresh_token") {
     return undefined;
@@ -558,7 +560,7 @@ export async function tokenExchangeCallback(
 
   const rawProps = options.props as StoredGrantProps;
 
-  Sentry.setUser({ id: rawProps.id });
+  setSentryUserFromRequest(request, rawProps.id);
 
   if (!rawProps.refreshToken) {
     // Stale grant from before refreshToken was stored in props.

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -1,9 +1,12 @@
-import { Hono } from "hono";
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
 import * as Sentry from "@sentry/cloudflare";
+import { getScopesForSkills, parseSkills } from "@sentry/mcp-core/skills";
+import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
+import { Hono } from "hono";
 import { clientIdAlreadyApproved } from "../../lib/approval-dialog";
 import { resolveClientFamilyFromName } from "../../lib/client-family";
 import type { Env, WorkerProps } from "../../types";
+import { setSentryUserFromRequest } from "../../utils/sentry-user";
 import { SENTRY_TOKEN_URL } from "../constants";
 import {
   createOAuthFailureResponse,
@@ -11,10 +14,8 @@ import {
   getOAuthCallbackFailureDetails,
   validateResourceParameter,
 } from "../helpers";
-import { verifyAndParseState, type OAuthState } from "../state";
-import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
-import { parseSkills, getScopesForSkills } from "@sentry/mcp-core/skills";
 import { parseResourceMcpConstraints } from "../resource-scope";
+import { type OAuthState, verifyAndParseState } from "../state";
 
 /**
  * Extended AuthRequest that includes skills and resource parameter
@@ -319,7 +320,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
     } as WorkerProps,
   });
 
-  Sentry.setUser({ id: payload.user.id });
+  setSentryUserFromRequest(c.req.raw, payload.user.id);
   // /oauth/callback is browser-navigated, so the User-Agent is the user's
   // browser, not the MCP client. Derive client family from the DCR-registered
   // client_name (resolved above).

--- a/packages/mcp-cloudflare/src/server/utils/sentry-user.test.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-user.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setSentryUserFromRequest } from "./sentry-user";
+
+const { setUser } = vi.hoisted(() => ({
+  setUser: vi.fn(),
+}));
+
+vi.mock("@sentry/cloudflare", () => ({
+  setUser,
+}));
+
+describe("setSentryUserFromRequest", () => {
+  beforeEach(() => {
+    setUser.mockReset();
+  });
+
+  it("sets user ID and IP address in the same Sentry user context", () => {
+    const user = setSentryUserFromRequest(
+      new Request("https://mcp.sentry.dev/mcp", {
+        headers: {
+          "CF-Connecting-IP": "192.0.2.1",
+        },
+      }),
+      "user-123",
+    );
+
+    expect(user).toEqual({
+      id: "user-123",
+      ip_address: "192.0.2.1",
+    });
+    expect(setUser).toHaveBeenCalledWith({
+      id: "user-123",
+      ip_address: "192.0.2.1",
+    });
+  });
+});

--- a/packages/mcp-cloudflare/src/server/utils/sentry-user.ts
+++ b/packages/mcp-cloudflare/src/server/utils/sentry-user.ts
@@ -1,0 +1,28 @@
+import * as Sentry from "@sentry/cloudflare";
+import { getClientIp } from "./client-ip";
+
+type SentryUserContext = {
+  id?: string;
+  ip_address?: string;
+};
+
+export function setSentryUserFromRequest(
+  request: Request,
+  userId?: string | null,
+): SentryUserContext {
+  const user: SentryUserContext = {};
+  const clientIP = getClientIp(request);
+
+  if (userId) {
+    user.id = userId;
+  }
+  if (clientIP) {
+    user.ip_address = clientIP;
+  }
+
+  if (Object.keys(user).length > 0) {
+    Sentry.setUser(user);
+  }
+
+  return user;
+}

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { setUser } from "@sentry/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildServer } from "./server";
-import type { ServerContext } from "./types";
 import type { ToolConfig } from "./tools/types";
+import type { ServerContext } from "./types";
 
 // Mock the Sentry core module
 vi.mock("@sentry/core", () => ({
@@ -47,6 +48,10 @@ async function listRegisteredTools(server: ReturnType<typeof buildServer>) {
 }
 
 describe("buildServer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   const baseContext: ServerContext = {
     accessToken: "test-token",
     grantedSkills: new Set(["inspect", "triage", "project-management", "seer"]),
@@ -69,6 +74,43 @@ describe("buildServer", () => {
     annotations: {},
     handler: async () => "result",
     ...options,
+  });
+
+  describe("telemetry context", () => {
+    it("sets user ID and IP address together for tool calls", async () => {
+      const server = buildServer({
+        context: {
+          ...baseContext,
+          userId: "user-123",
+          userIpAddress: "192.0.2.1",
+        },
+        tools: {
+          example_tool: createMockTool("example_tool", {
+            annotations: { readOnlyHint: true },
+          }),
+        },
+      });
+      const registeredTools = (
+        server as unknown as {
+          _registeredTools: Record<
+            string,
+            {
+              handler: (
+                params: Record<string, unknown>,
+                extra: unknown,
+              ) => Promise<unknown>;
+            }
+          >;
+        }
+      )._registeredTools;
+
+      await registeredTools.example_tool?.handler({}, {});
+
+      expect(setUser).toHaveBeenCalledWith({
+        id: "user-123",
+        ip_address: "192.0.2.1",
+      });
+    });
   });
 
   describe("experimental tool filtering", () => {

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -1,3 +1,4 @@
+import type { ServerOptions } from "@modelcontextprotocol/sdk/server/index.js";
 /**
  * MCP Server Configuration and Request Handling Infrastructure.
  *
@@ -19,35 +20,34 @@
  * ```
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ServerOptions } from "@modelcontextprotocol/sdk/server/index.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
-  ServerRequest,
   ServerNotification,
+  ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
+import {
+  getActiveSpan,
+  setTag,
+  setUser,
+  wrapMcpServerWithSentry,
+} from "@sentry/core";
+import { isApiAuthenticationErrorDeep } from "./api-client";
+import { MCP_SERVER_NAME } from "./constants";
+import {
+  getConstraintKeysToFilter,
+  getConstraintParametersToInject,
+} from "./internal/constraint-helpers";
+import { formatErrorForUser } from "./internal/error-handling";
+import { type Skill, isEnabledBySkills } from "./skills";
+import { type LogIssueOptions, logIssue } from "./telem/logging";
 import tools from "./tools/index";
 import {
   type ToolConfig,
-  resolveDescription,
   isToolVisibleInMode,
+  resolveDescription,
 } from "./tools/types";
-import type { ServerContext, ProjectCapabilities } from "./types";
-import { isApiAuthenticationErrorDeep } from "./api-client";
-import {
-  setTag,
-  setUser,
-  getActiveSpan,
-  wrapMcpServerWithSentry,
-} from "@sentry/core";
-import { logIssue, type LogIssueOptions } from "./telem/logging";
-import { formatErrorForUser } from "./internal/error-handling";
+import type { ProjectCapabilities, ServerContext } from "./types";
 import { LIB_VERSION } from "./version";
-import { MCP_SERVER_NAME } from "./constants";
-import { isEnabledBySkills, type Skill } from "./skills";
-import {
-  getConstraintParametersToInject,
-  getConstraintKeysToFilter,
-} from "./internal/constraint-helpers";
 
 /**
  * Creates and configures a complete MCP server with Sentry instrumentation.
@@ -307,9 +307,13 @@ function configureServer({
         }
 
         if (context.userId) {
-          setUser({
+          const user = {
             id: context.userId,
-          });
+            ...(context.userIpAddress
+              ? { ip_address: context.userIpAddress }
+              : {}),
+          };
+          setUser(user);
         }
         if (context.clientId) {
           setTag("client.id", context.clientId);

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -48,6 +48,7 @@ export type ServerContext = {
   accessToken: string;
   openaiBaseUrl?: string;
   userId?: string | null;
+  userIpAddress?: string | null;
   clientId?: string;
   /** Primary authorization method - granted skills for tool access control */
   grantedSkills?: Set<Skill> | ReadonlySet<Skill>;


### PR DESCRIPTION
Preserve the request IP in Sentry user context when setting authenticated user IDs.

Sentry setUser replaces the full user object, so the prior ID-only calls dropped the request IP seeded by middleware. This adds a shared Cloudflare helper that combines the stored user ID and request ip_address, passes the request through token exchange explicitly, and forwards the IP into core tool telemetry.

Also updates tests and docs around the combined user context.