### PR TITLE
fix(issue-triage): forbid stdin redirection with bridged gh CLI

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -28,6 +28,16 @@ Use `context.issue` as the source of truth for the current title, body, comments
 - Only apply labels that already exist in the repository.
 - Prefer conservative decisions when evidence is weak. Do not close uncertain duplicates.
 
+### Shell sandbox limits
+
+The sandbox runs a simulated bash. External commands such as `gh` and `git` are bridged through a host shim that **does not forward stdin from the simulated shell into the real process**. This has two important consequences:
+
+- **Never** use shell stdin redirection (`<`, `<<`, `<<<`) or process substitution to feed input into `gh`, `git`, or any other bridged command. The redirected bytes are read by the simulated shell but are never piped to the spawned process. The command will hang forever waiting on stdin and may corrupt the issue when it is finally killed.
+- **Never** use `--body-file -`, `--body -`, or any other "read from stdin" flag with `gh`. There is no usable stdin. Always pass content via a real file path on disk (for example `/workspace/<file>.md`) using the explicit `--body-file <path>` or `--body "<inline>"` forms.
+- **Never** chain a mutating `gh issue edit` with a verification command using `&&`. Run mutations in their own bash invocation so a hang in the mutation cannot also block any follow-up work.
+
+If you need to pass multi-line content to a bridged command, write it to a file first (with the `write` tool or `cat > path <<'EOF' ... EOF`) and then reference that file with `--body-file <path>`.
+
 ## Stage: `search-duplicates`
 
 Goal: determine whether the new issue is a confirmed duplicate.
@@ -59,7 +69,7 @@ Inputs include `duplicateSearch`. Use its `duplicate` value as the canonical iss
 1. Use `context` for the current issue and labels.
 2. Re-read the canonical issue if needed.
 3. Apply an existing duplicate label only if one exists, for example `duplicate` or `Duplicate`.
-4. Add a comment that links the canonical issue. Do not include issue titles, bodies, or comments in shell arguments; write the comment body to a temporary file and pass it with `--body-file`.
+4. Add a comment that links the canonical issue. Do not include issue titles, bodies, or comments in shell arguments; write the comment body to a real file path (for example `/workspace/issue-<issueNumber>-comment.md`) and pass it with `--body-file <path>`. Do not use `--body-file -` or stdin redirection — see [Shell sandbox limits](#shell-sandbox-limits).
 
 ```md
 Thanks for the report. This appears to duplicate #<number>.
@@ -68,9 +78,10 @@ Closing this so discussion and updates stay in one place. Please follow #<number
 ```
 
 5. Post and close the current issue with:
-   - `gh issue comment <issueNumber> --body-file <file>`
+   - `gh issue comment <issueNumber> --body-file <path>`
    - `gh issue close <issueNumber> --reason duplicate --duplicate-of <number>`
    - Include `--repo <repository>` when provided.
+   - Run each `gh` mutation in its own bash invocation. Do not chain mutations together with `&&` or chain a mutation with a verification call.
 
 Return whether the close succeeded, the canonical duplicate, labels applied, comment status, and a short summary.
 
@@ -151,13 +162,17 @@ Inputs include `diagnosis`. Use `context` for the current issue and labels. Muta
 1. Re-fetch issue state before mutating only if needed to avoid editing a closed or changed issue.
 2. Apply only labels from `diagnosis.labels_to_apply` that exist in `context.labels`.
 3. If `diagnosis.should_update_issue` is true:
-   - Use `gh issue edit <issueNumber> --title ...` when `proposed_title` is present.
-   - Use `gh issue edit <issueNumber> --body-file <file>` when `proposed_body` is present.
+   - Write the proposed body to a real file (for example `/workspace/issue-<issueNumber>-body.md`) using the `write` tool or a `cat > path <<'EOF' ... EOF` heredoc before invoking `gh`.
+   - Use `gh issue edit <issueNumber> --title "..." --body-file <path>` in a single invocation when both `proposed_title` and `proposed_body` are present, or run the title-only and body-only forms in separate bash invocations.
+   - **Never** use `--body-file -` or any shell stdin redirection (`<`, `<<`, `<<<`) with `gh`. The bridged `gh` shim does not forward stdin and the command will hang and then wipe the issue body when it is killed. See [Shell sandbox limits](#shell-sandbox-limits).
    - The updated body must keep the exact original report from `context.issue` in the footer using the "Original Report" details block.
 4. Post a concise comment when it adds useful context:
    - Summarize validation that succeeded or failed.
    - Ask for missing reproduction details when validity is `unclear`.
    - For security-sensitive reports, avoid exploit details and request maintainer review.
+   - Use `gh issue comment <issueNumber> --body-file <path>` with a real file path; do not use `--body-file -` or stdin redirection.
 5. Do not close non-duplicate issues.
+6. Run each `gh` mutation in its own bash invocation. Do not chain a mutation (`gh issue edit`, `gh issue comment`, `gh issue close`) with a follow-up read (`gh issue view`) using `&&` — a hang in the mutation will block the entire chain and exhaust the stage timeout.
+7. Do not re-run the same `gh issue edit` to verify a previous edit. If the first invocation returned exit code 0, trust it and move on.
 
 Return title/body update status, labels applied, comment status, human-review status, and a short summary.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Tighten the `issue-triage` skill prompt so the agent never tries to feed input into `gh` via shell stdin redirection or `--body-file -`.

## Why

Run [25576059392](https://github.com/getsentry/sentry-mcp/actions/runs/25576059392/job/75094855441) hung for 5 minutes and then failed during the `apply-triage-update` stage:

```
21:08:53 [flue] tool:start  bash  $ gh issue edit 941 --repo getsentry/sentry-mcp --body-file - < /workspace/issue-941-body.md && gh issue view 941 ...
21:13:53 [flue] Agent error: terminated
```

The agent had already run a successful `gh issue edit ... --body-file /workspace/issue-941-body.md --title "..."` a few seconds earlier, then re-ran the edit using `--body-file -` to "verify" the result. That second invocation hung until the 5-minute stage timeout, and along the way wiped the body of [issue #941](https://github.com/getsentry/sentry-mcp/issues/941) to an empty string.

### Root cause

The agent shells out through Flue's `defineCommand`:

```ts
const gh = defineCommand("gh", {
  env: { GH_TOKEN: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN },
});
```

The `env` form in `@flue/sdk/dist/node/index.mjs` runs commands via `child_process.execFile(name, args, mergedOpts)` — it never forwards stdin from the simulated `just-bash` shell into the spawned process. When the model uses shell redirection (`< file`) or `--body-file -`, the redirected bytes are read by the simulated shell and then dropped on the floor; the real `gh` process is launched with an unwritten stdin pipe and blocks on `read()` forever.

`just-bash` is itself a "simulated bash environment with virtual filesystem" (see the package README), so any feature that depends on the OS shell forwarding stdin into a bridged binary is unsafe.

### Fix

Update `.agents/skills/issue-triage/SKILL.md` to make the limitation explicit, since this is a prompt-level mitigation:

- New "Shell sandbox limits" subsection in the global rules forbidding stdin redirection (`<`, `<<`, `<<<`), process substitution, and `--body-file -` / `--body -` against any bridged command (`gh`, `git`, ...).
- `apply-triage-update` and `close-duplicate` stages now require:
  - Writing the body/comment to a real file path first (e.g. `/workspace/issue-<n>-body.md`).
  - Always passing it via `--body-file <path>`.
  - Running each `gh` mutation in its own bash invocation (no `&&` chains with verification reads).
  - Trusting a successful `gh issue edit` exit code instead of re-running it to verify, which is exactly what triggered the hang.

## Notes / follow-ups

- The body of issue #941 is currently empty because of this bug. The cloud agent does not have `issues:write`, so I could not restore it from this branch — a maintainer should re-run the triage agent (or paste the proposed body back manually) once this lands.
- A more thorough fix would be to make `defineCommand` properly forward `just-bash`'s stdin into `execFile`, but that's an upstream `@flue/sdk` change. The SKILL update is a defensive mitigation that prevents the failure mode regardless.
- I considered also enforcing this at the `defineCommand` layer (e.g. wrapping `gh` to reject `--body-file -`), but the function-form `defineCommand` in flue 0.3.11 only receives `args` (not the bash `ctx`), so we can't currently do that without forking the wrapper.

## Quality gate

- `pnpm run lint` ✅
- `pnpm run tsc` ✅
- `pnpm run test` not run — change is prompt-only and there are no tests covering the SKILL prose. The triage agent is exercised end-to-end on the next opened issue.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C08J1NSPU6S/p1778274858751669?thread_ts=1778274858.751669&cid=C08J1NSPU6S)

<div><a href="https://cursor.com/agents/bc-c28a3a46-11f6-50ef-86f6-b3206838b753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c28a3a46-11f6-50ef-86f6-b3206838b753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

