### PR TITLE
issue-triage: lighter, engineering-focused output template

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -105,41 +105,55 @@ Inputs include `repositoryContext`. Use `context` for the current issue and labe
 4. Decide whether the original ticket accurately describes the concern.
    - If it is misleading, underspecified, or mixes symptoms with a different root concern, set `should_update_issue` to true.
    - Propose a clearer title and body using the template below.
-   - The "Original Report" footer must preserve the title and body from `context.issue`, not a paraphrase.
+   - The "Original report" footer must preserve the title and body from `context.issue`, not a paraphrase.
 
-Use this body template when updating the issue:
+### Output style
+
+These are engineering tickets. Match the tone of a peer writing for other engineers:
+
+- Lead with the core problem statement, not background or marketing prose.
+- Prefer bullets over paragraphs. Reference concrete files, functions, commands, docs, or APIs.
+- Keep prose light. No "users may benefit", "this would enable", or aspirational framing.
+- Drop a section entirely if you have nothing concrete to say. Two tight sections beat four padded ones.
+- Do not restate the title in `Problem`. Add information; do not repeat it.
+- Keep `proposed_title` short and specific. Prefer the shape "<verb> <subsystem>: <change>" or "<subsystem>: <symptom>".
+
+### Body template
+
+Use this body template when updating the issue. Keep the leading callout exactly as written so it is obvious the body was rewritten by the Issue Triage skill.
 
 ```md
-## Summary
-[Clear statement of the actual concern.]
+> [!NOTE]
+> This issue was rewritten by the Issue Triage skill to clarify scope. The original report is preserved at the bottom.
 
-## Evidence
-- [What was observed in the report or repository.]
-- [Validation performed and result.]
+## Problem
 
-## Impact
-[Who or what is affected, or "Unknown" if not clear.]
+[1–3 sentence statement of the actual concern.]
+
+## Analysis
+
+- [Concrete finding from the report or repository, with a file or symbol reference.]
+- [Concrete finding.]
+- [Validation performed and result, or "Not validated: <reason>".]
 
 ## Next Steps
-- [Concrete follow-up for maintainers or reporter.]
+
+- [Concrete action for maintainers or reporter.]
+- [Concrete action.]
 
 ---
 
-## Original Report
-
 <details>
-<summary>Original issue text</summary>
+<summary>Original report</summary>
 
-### Original Title
-
-[original title]
-
-### Original Body
+**Title:** [original title]
 
 [original body, or "_No body provided._"]
 
 </details>
 ```
+
+Omit `Analysis` or `Next Steps` if there is nothing concrete to put there. Never omit `Problem` or the original-report footer.
 
 Return:
 
@@ -165,7 +179,7 @@ Inputs include `diagnosis`. Use `context` for the current issue and labels. Muta
    - Write the proposed body to a real file (for example `/workspace/issue-<issueNumber>-body.md`) using the `write` tool or a `cat > path <<'EOF' ... EOF` heredoc before invoking `gh`.
    - Use `gh issue edit <issueNumber> --title "..." --body-file <path>` in a single invocation when both `proposed_title` and `proposed_body` are present, or run the title-only and body-only forms in separate bash invocations.
    - **Never** use `--body-file -` or any shell stdin redirection (`<`, `<<`, `<<<`) with `gh`. The bridged `gh` shim does not forward stdin and the command will hang and then wipe the issue body when it is killed. See [Shell sandbox limits](#shell-sandbox-limits).
-   - The updated body must keep the exact original report from `context.issue` in the footer using the "Original Report" details block.
+   - The updated body must keep the exact original report from `context.issue` in the footer using the "Original report" details block, and must keep the leading `> [!NOTE]` Issue Triage callout from the body template.
 4. Post a concise comment when it adds useful context:
    - Summarize validation that succeeded or failed.
    - Ask for missing reproduction details when validity is `unclear`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tighten the output of the Issue Triage skill so rewritten GitHub issue bodies read like engineering tickets, not PRDs.

Driven by feedback on a representative mediocre output: [getsentry/sentry-mcp#941](https://github.com/getsentry/sentry-mcp/issues/941). That body had four sections (`Summary` / `Evidence` / `Impact` / `Next Steps`), an `Impact` paragraph written in product/marketing tone, and no clear signal that an automation had rewritten it.

## What changes

In `.agents/skills/issue-triage/SKILL.md` (hard-linked to `.claude/skills/issue-triage/SKILL.md`):

- **New body template.** Replace `Summary` / `Evidence` / `Impact` / `Next Steps` with `Problem` / `Analysis` / `Next Steps`. Analysis is bullets only — no impact prose.
- **Clear callout at the top.** A leading `> [!NOTE]` GitHub callout explicitly credits the Issue Triage skill as the rewriter and points readers to the preserved original at the bottom. The `apply-triage-update` guard now requires both the original-report block and this callout.
- **Output style rules.** New `Output style` subsection in `diagnose-and-validate`:
  - Lead with the problem; no background/marketing prose.
  - Prefer bullets; reference concrete files, symbols, commands, docs.
  - Drop sections that have nothing concrete to say (only `Problem` and the original-report footer are mandatory).
  - Don't restate the title in `Problem`.
  - Keep `proposed_title` short and specific (`<verb> <subsystem>: <change>` or `<subsystem>: <symptom>`).
- **Simpler original-report footer.** Single `<details>` block with a bold inline title — no nested H3s.

## Before / after

The original body of [#941](https://github.com/getsentry/sentry-mcp/issues/941) (heavy `Impact` prose, 5-bullet `Evidence`, 4 sections) becomes something closer to:

```md
> [!NOTE]
> This issue was rewritten by the Issue Triage skill to clarify scope. The original report is preserved at the bottom.

## Problem

The MCP capability bundles are surfaced to users as "skills", which collides with Claude/MCP "skills" and is also too coarse — there is no per-tool allow/deny.

## Analysis

- Skill registry lives in `packages/mcp-core/src/skills.ts` (`inspect`, `seer`, `docs`, `triage`, `project-management`).
- `packages/mcp-core/src/server.ts` filters tools via `context.grantedSkills`; the OAuth approval UI in `packages/mcp-cloudflare` renders these as user-facing skill checkboxes.
- stdio transport exposes the bundles via `--skills` / `MCP_SKILLS` and `--disable-skills` / `MCP_DISABLE_SKILLS`. There is no `--tools` / `--disable-tools` equivalent.
- Not validated: no behavioral tests run; this is a naming/design change.

## Next Steps

- Decide public terminology (toolsets vs. skills) and the back-compat story for existing `grantedSkills` tokens.
- Decide granularity: named toolsets only, per-tool allow/deny, or both.
- Update core types, generated definitions, OAuth approval UI, stdio flags/env, and docs in lockstep.

---

<details>
<summary>Original report</summary>

**Title:** Rename skill-based permissions to toolsets and add more granular controls

_No body provided._

</details>
```

## Validation

Markdown-only change to a Flue agent skill prompt; no TypeScript surface, no tests, and no `generate-definitions` codegen affected (that script targets the user-facing MCP toolset registry, not the issue-triage skill consumed via `.flue/agents/issue-triage.ts`). The skill is interpreted at runtime by the LLM following SKILL.md, so end-to-end validation requires running the Flue triage agent against a real issue — that part is left to the next real triage run.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C08J1NSPU6S/p1778275991665319?thread_ts=1778275991.665319&cid=C08J1NSPU6S)

<div><a href="https://cursor.com/agents/bc-d9a4d22b-e1c4-52df-aa31-9e693bd5555d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9a4d22b-e1c4-52df-aa31-9e693bd5555d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

