### PR TITLE
issue-triage: link related tickets in rewritten body and comment

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -89,7 +89,7 @@ Return whether the close succeeded, the canonical duplicate, labels applied, com
 
 Goal: diagnose the issue and judge whether the report is valid or needs correction.
 
-Inputs include `repositoryContext`. Use `context` for the current issue and labels. If `repositoryContext.checkoutAvailable` is true, inspect code under `repositoryContext.repoPath`.
+Inputs include `repositoryContext` and `duplicateSearch`. Use `context` for the current issue and labels. If `repositoryContext.checkoutAvailable` is true, inspect code under `repositoryContext.repoPath`. Treat `duplicateSearch.candidates` (which may include both open and closed issues) as candidate related tickets — they were not strong enough to close as a duplicate, but they may still describe related work, prior fixes, follow-ups, or the same subsystem.
 
 1. Read `AGENTS.md`, relevant docs, and neighboring files before making claims about expected behavior.
 2. Diagnose the concern:
@@ -102,10 +102,17 @@ Inputs include `repositoryContext`. Use `context` for the current issue and labe
    - Run targeted tests, typechecks, or package scripts only when they are directly relevant and reasonably scoped.
    - Do not run broad or destructive commands unless the repo documentation makes them the standard validation path.
    - If dependencies are missing or validation is too expensive, say so in `evidence` and mark validity conservatively.
-4. Decide whether the original ticket accurately describes the concern.
+4. Review `duplicateSearch.candidates` and any related issues you discovered while searching the repo. For each one you decide to cite:
+   - Confirm the connection is concrete (same subsystem, prior attempt at the same fix, blocked-by, follow-up to a closed fix, etc.). Do not link issues just because they share a label or topic.
+   - Closed issues are fair game and often the most useful — link the issue that fixed or rejected the same concern, the regression source, or the prior decision.
+   - Prefer linking inline in `Analysis` or `Next Steps` where the link adds context to a specific bullet (for example "regression of #123" or "previously rejected in #456 (closed, wontfix)").
+   - If a related ticket is worth surfacing but does not fit naturally inside a bullet, list it in the `References` section of the body template instead of forcing it inline.
+   - Use short GitHub-style references (`#123`) for issues in the same repository. Use full `owner/repo#123` form only for cross-repo links.
+5. Decide whether the original ticket accurately describes the concern.
    - If it is misleading, underspecified, or mixes symptoms with a different root concern, set `should_update_issue` to true.
    - Propose a clearer title and body using the template below.
    - The "Original report" footer must preserve the title and body from `context.issue`, not a paraphrase.
+   - If `should_update_issue` is false but you found related tickets worth recording, surface them through the comment posted in `apply-triage-update` instead of rewriting the body.
 
 ### Output style
 
@@ -141,6 +148,11 @@ Use this body template when updating the issue. Keep the leading callout exactly
 - [Concrete action for maintainers or reporter.]
 - [Concrete action.]
 
+## References
+
+- #[number] — [why this ticket is related, e.g. "prior fix for the same crash, reverted in <commit>"]
+- [owner/repo#number] — [why this cross-repo ticket is related]
+
 ---
 
 <details>
@@ -153,7 +165,7 @@ Use this body template when updating the issue. Keep the leading callout exactly
 </details>
 ```
 
-Omit `Analysis` or `Next Steps` if there is nothing concrete to put there. Never omit `Problem` or the original-report footer.
+Omit `Analysis`, `Next Steps`, or `References` if there is nothing concrete to put there — an empty `References` section is worse than none. Never omit `Problem` or the original-report footer. Only include a ticket in `References` if you could not reasonably link it inline; do not duplicate inline links here.
 
 Return:
 
@@ -171,7 +183,7 @@ Return:
 
 Goal: apply non-duplicate triage results to the issue.
 
-Inputs include `diagnosis`. Use `context` for the current issue and labels. Mutations must be based on `diagnosis`, not free-form reinterpretation.
+Inputs include `diagnosis` and `duplicateSearch`. Use `context` for the current issue and labels. Mutations must be based on `diagnosis`, not free-form reinterpretation. `duplicateSearch.candidates` is available so that comments can cite related open or closed tickets when the diagnosis did not already pull them inline into the body.
 
 1. Re-fetch issue state before mutating only if needed to avoid editing a closed or changed issue.
 2. Apply only labels from `diagnosis.labels_to_apply` that exist in `context.labels`.
@@ -184,6 +196,7 @@ Inputs include `diagnosis`. Use `context` for the current issue and labels. Muta
    - Summarize validation that succeeded or failed.
    - Ask for missing reproduction details when validity is `unclear`.
    - For security-sensitive reports, avoid exploit details and request maintainer review.
+   - When `diagnosis.should_update_issue` is false but `duplicateSearch.candidates` contains tickets that are clearly related (including closed ones), link them in the comment with one short phrase explaining the connection. Skip this if the rewritten body already cites the same tickets.
    - Use `gh issue comment <issueNumber> --body-file <path>` with a real file path; do not use `--body-file -` or stdin redirection.
 5. Do not close non-duplicate issues.
 6. Run each `gh` mutation in its own bash invocation. Do not chain a mutation (`gh issue edit`, `gh issue comment`, `gh issue close`) with a follow-up read (`gh issue view`) using `&&` — a hang in the mutation will block the entire chain and exhaust the stage timeout.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `search-duplicates` stage already returns up to five candidate issues (open and closed) that weren't strong enough to close as duplicates. Those candidates are passed through to `diagnose-and-validate` and `apply-triage-update` by the Flue handler, but the skill prompt never told the model to do anything with them. This change wires that context into the rewrite.

## Changes (`.agents/skills/issue-triage/SKILL.md`, also reachable via the `.claude/skills/issue-triage` symlink)

- `diagnose-and-validate`: documents `duplicateSearch` as an input and adds a new step instructing the model to review `duplicateSearch.candidates` (plus anything turned up while searching the repo) and decide which ones to cite. Closed issues are explicitly called out as fair game — they're often the most useful link (regression source, prior fix, prior decision).
- Linking guidance is concrete: confirm the connection before citing, prefer inline links inside `Analysis` / `Next Steps` bullets when they add context to a specific point, and fall back to a new optional `References` section only when a related ticket is worth surfacing but doesn't fit naturally inline. Use `#123` for same-repo and `owner/repo#123` for cross-repo.
- Body template gains an optional `## References` section between `Next Steps` and the `Original report` footer. The accompanying rule says to drop the section when empty and not to duplicate inline links there.
- `apply-triage-update`: documents `duplicateSearch` as an input and adds a comment bullet for the `should_update_issue: false` path so we can still surface relevant tickets via a comment when the body wasn't rewritten (with a guard against duplicating links the body already carries).

## Validation

- `pnpm run lint` — passes.
- `pnpm run tsc` — passes.
- `pnpm run test` — 304 tests across all packages pass. No code paths reference this skill prompt by content; behavioral verification has to come from the next live triage run.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C08J1NSPU6S/p1778276776473579?thread_ts=1778276776.473579&cid=C08J1NSPU6S)

<div><a href="https://cursor.com/agents/bc-a3491215-9f92-553d-811a-c22a079f8ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3491215-9f92-553d-811a-c22a079f8ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

