### PR TITLE
issue-triage: comment instead of rewriting the body

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: issue-triage
-description: Use when asked to triage newly opened GitHub issues, diagnose issue validity, search for duplicates, close confirmed duplicates, or rewrite unclear issue reports while preserving the original report.
+description: Use when asked to triage newly opened GitHub issues, diagnose issue validity, search for duplicates, close confirmed duplicates, sharpen unclear titles, or post a triage comment summarizing what the bot found.
 ---
 
 # Issue Triage
 
-You triage a newly opened GitHub issue. The Flue handler calls this one skill with a `stage` argument and expects that stage only. Follow the stage-specific workflow below.
+You are a triage bot for a newly opened GitHub issue. The Flue handler calls this one skill with a `stage` argument and expects that stage only. Follow the stage-specific workflow below.
+
+You are not rewriting the issue. Your job is to read it, search for duplicates, optionally inspect the repository, and leave a short triage comment. You may sharpen the title when the existing one is misleading, but the issue body always stays as the reporter wrote it.
+
+## Voice
+
+Comments you post on the issue should sound like a friendly, slightly informal triage teammate:
+
+- Open with a short greeting like "Triage bot here 👋" so it is obvious a bot wrote the comment.
+- Be helpful and direct. Light personality is fine; avoid try-hard humor, exclamation points, or filler.
+- Speak in first person ("I checked …", "I could not reproduce …"). One or two sentences plus tight bullets.
+- Close with a short hand-off line that reminds the reader a human will follow up, e.g. "A maintainer will take it from here."
+- Never claim more confidence than the evidence supports.
 
 ## Handler Contract
 
@@ -71,11 +83,13 @@ Inputs include `duplicateSearch`. Use its `duplicate` value as the canonical iss
 3. Apply an existing duplicate label only if one exists, for example `duplicate` or `Duplicate`.
 4. Add a comment that links the canonical issue. Do not include issue titles, bodies, or comments in shell arguments; write the comment body to a real file path (for example `/workspace/issue-<issueNumber>-comment.md`) and pass it with `--body-file <path>`. Do not use `--body-file -` or stdin redirection — see [Shell sandbox limits](#shell-sandbox-limits).
 
-```md
-Thanks for the report. This appears to duplicate #<number>.
+   Use the [Voice](#voice) above. Template:
 
-Closing this so discussion and updates stay in one place. Please follow #<number> for progress.
-```
+   ```md
+   Triage bot here 👋 — looks like this is the same thing as #<number>, so I'm closing this one to keep the discussion in one place.
+
+   Please follow #<number> for updates. A maintainer will take it from here if I got the match wrong.
+   ```
 
 5. Post and close the current issue with:
    - `gh issue comment <issueNumber> --body-file <path>`
@@ -87,7 +101,7 @@ Return whether the close succeeded, the canonical duplicate, labels applied, com
 
 ## Stage: `diagnose-and-validate`
 
-Goal: diagnose the issue and judge whether the report is valid or needs correction.
+Goal: diagnose the issue, decide if the title needs sharpening, and draft a triage comment. **You do not rewrite the issue body.** The reporter's body always stays as written.
 
 Inputs include `repositoryContext` and `duplicateSearch`. Use `context` for the current issue and labels. If `repositoryContext.checkoutAvailable` is true, inspect code under `repositoryContext.repoPath`. Treat `duplicateSearch.candidates` (which may include both open and closed issues) as candidate related tickets — they were not strong enough to close as a duplicate, but they may still describe related work, prior fixes, follow-ups, or the same subsystem.
 
@@ -102,104 +116,83 @@ Inputs include `repositoryContext` and `duplicateSearch`. Use `context` for the 
    - Run targeted tests, typechecks, or package scripts only when they are directly relevant and reasonably scoped.
    - Do not run broad or destructive commands unless the repo documentation makes them the standard validation path.
    - If dependencies are missing or validation is too expensive, say so in `evidence` and mark validity conservatively.
-4. Review `duplicateSearch.candidates` and any related issues you discovered while searching the repo. For each one you decide to cite:
+4. Review `duplicateSearch.candidates` and any related issues you discovered while searching the repo. For each one you decide to cite in the comment:
    - Confirm the connection is concrete (same subsystem, prior attempt at the same fix, blocked-by, follow-up to a closed fix, etc.). Do not link issues just because they share a label or topic.
    - Closed issues are fair game and often the most useful — link the issue that fixed or rejected the same concern, the regression source, or the prior decision.
-   - Prefer linking inline in `Analysis` or `Next Steps` where the link adds context to a specific bullet (for example "regression of #123" or "previously rejected in #456 (closed, wontfix)").
-   - If a related ticket is worth surfacing but does not fit naturally inside a bullet, list it in the `References` section of the body template instead of forcing it inline.
    - Use short GitHub-style references (`#123`) for issues in the same repository. Use full `owner/repo#123` form only for cross-repo links.
-5. Decide whether the original ticket accurately describes the concern.
-   - If it is misleading, underspecified, or mixes symptoms with a different root concern, set `should_update_issue` to true.
-   - Propose a clearer title and body using the template below.
-   - The "Original report" footer must preserve the title and body from `context.issue`, not a paraphrase.
-   - If `should_update_issue` is false but you found related tickets worth recording, surface them through the comment posted in `apply-triage-update` instead of rewriting the body.
+5. Decide whether the title needs sharpening.
+   - Set `should_update_title` to true only when the current title is misleading, generic, or hides the real subsystem (for example "bug" or "doesn't work").
+   - When sharpening, propose a short, specific title. Prefer the shape "<verb> <subsystem>: <change>" or "<subsystem>: <symptom>". Do not editorialize or change the meaning of the report.
+   - Never touch the issue body. There is no `proposed_body` field.
 
-### Output style
+### Comment style
 
-These are engineering tickets. Match the tone of a peer writing for other engineers:
+The comment is the triage bot's voice talking to the reporter and maintainers. Follow [Voice](#voice). Additional guidance:
 
-- Lead with the core problem statement, not background or marketing prose.
-- Prefer bullets over paragraphs. Reference concrete files, functions, commands, docs, or APIs.
-- Keep prose light. No "users may benefit", "this would enable", or aspirational framing.
-- Drop a section entirely if you have nothing concrete to say. Two tight sections beat four padded ones.
-- Do not restate the title in `Problem`. Add information; do not repeat it.
-- Keep `proposed_title` short and specific. Prefer the shape "<verb> <subsystem>: <change>" or "<subsystem>: <symptom>".
+- Keep it short. One opener line, then tight bullets. A few short sentences total beats a long writeup.
+- Lead with what you found, not with restating the title.
+- Reference concrete files, symbols, commands, or docs when you have them. Skip the bullet if you do not.
+- Drop a section entirely if you have nothing concrete to put there. Empty sections look worse than none.
+- For `validity: unclear`, say what you would need to reproduce instead of guessing.
+- For security-sensitive reports, do not include exploit details. Note that a maintainer needs to take a look.
+- Cite related tickets inline ("Looks related to #123, which …"). Do not paste long quoted excerpts.
 
-### Body template
+### Comment template
 
-Use this body template when updating the issue. Keep the leading callout exactly as written so it is obvious the body was rewritten by the Issue Triage skill.
+Use this template for `proposed_comment`. Drop any section that has nothing concrete to add. The opener and sign-off must always be present.
 
 ```md
-> [!NOTE]
-> This issue was rewritten by the Issue Triage skill to clarify scope. The original report is preserved at the bottom.
+Triage bot here 👋
 
-## Problem
+[1–2 sentence diagnosis. What this looks like, and how confident I am.]
 
-[1–3 sentence statement of the actual concern.]
+**What I checked**
 
-## Analysis
+- [Concrete finding from the report or repo, with a file/symbol/doc reference.]
+- [Validation performed and result, or "Couldn't validate: <reason>".]
 
-- [Concrete finding from the report or repository, with a file or symbol reference.]
-- [Concrete finding.]
-- [Validation performed and result, or "Not validated: <reason>".]
+**Suggested next steps**
 
-## Next Steps
+- [Concrete action for the reporter or maintainers.]
 
-- [Concrete action for maintainers or reporter.]
-- [Concrete action.]
+**Related**
 
-## References
+- #[number] — [one short phrase on the connection]
 
-- #[number] — [why this ticket is related, e.g. "prior fix for the same crash, reverted in <commit>"]
-- [owner/repo#number] — [why this cross-repo ticket is related]
-
----
-
-<details>
-<summary>Original report</summary>
-
-**Title:** [original title]
-
-[original body, or "_No body provided._"]
-
-</details>
+A maintainer will take it from here.
 ```
-
-Omit `Analysis`, `Next Steps`, or `References` if there is nothing concrete to put there — an empty `References` section is worse than none. Never omit `Problem` or the original-report footer. Only include a ticket in `References` if you could not reasonably link it inline; do not duplicate inline links here.
 
 Return:
 
 - `severity`: `low`, `medium`, `high`, or `critical`
 - `category`: `bug`, `documentation`, `feature_request`, `support`, `security`, `maintenance`, or `unknown`
 - `validity`: `confirmed`, `likely`, `not_reproducible`, or `unclear`
-- `summary`: concise diagnosis
+- `summary`: concise diagnosis (used for the run log, not posted to the issue)
 - `evidence`: concrete observations and validation attempts
 - `labels_to_apply`: existing labels only
-- `should_update_issue`
-- `proposed_title` and `proposed_body` when an update is needed
+- `should_update_title`
+- `proposed_title` when `should_update_title` is true; omit otherwise
+- `proposed_comment`: the comment body to post on the issue, following the template above
 - `needs_human_review`: true for security-sensitive, high-risk, ambiguous, or destructive cases
 
 ## Stage: `apply-triage-update`
 
-Goal: apply non-duplicate triage results to the issue.
+Goal: apply non-duplicate triage results to the issue. The triage bot only changes labels and (optionally) the title, then posts the comment from `diagnosis.proposed_comment`. **It never edits the issue body.**
 
-Inputs include `diagnosis` and `duplicateSearch`. Use `context` for the current issue and labels. Mutations must be based on `diagnosis`, not free-form reinterpretation. `duplicateSearch.candidates` is available so that comments can cite related open or closed tickets when the diagnosis did not already pull them inline into the body.
+Inputs include `diagnosis` and `duplicateSearch`. Use `context` for the current issue and labels. Mutations must be based on `diagnosis`, not free-form reinterpretation.
 
 1. Re-fetch issue state before mutating only if needed to avoid editing a closed or changed issue.
 2. Apply only labels from `diagnosis.labels_to_apply` that exist in `context.labels`.
-3. If `diagnosis.should_update_issue` is true:
-   - Write the proposed body to a real file (for example `/workspace/issue-<issueNumber>-body.md`) using the `write` tool or a `cat > path <<'EOF' ... EOF` heredoc before invoking `gh`.
-   - Use `gh issue edit <issueNumber> --title "..." --body-file <path>` in a single invocation when both `proposed_title` and `proposed_body` are present, or run the title-only and body-only forms in separate bash invocations.
-   - **Never** use `--body-file -` or any shell stdin redirection (`<`, `<<`, `<<<`) with `gh`. The bridged `gh` shim does not forward stdin and the command will hang and then wipe the issue body when it is killed. See [Shell sandbox limits](#shell-sandbox-limits).
-   - The updated body must keep the exact original report from `context.issue` in the footer using the "Original report" details block, and must keep the leading `> [!NOTE]` Issue Triage callout from the body template.
-4. Post a concise comment when it adds useful context:
-   - Summarize validation that succeeded or failed.
-   - Ask for missing reproduction details when validity is `unclear`.
-   - For security-sensitive reports, avoid exploit details and request maintainer review.
-   - When `diagnosis.should_update_issue` is false but `duplicateSearch.candidates` contains tickets that are clearly related (including closed ones), link them in the comment with one short phrase explaining the connection. Skip this if the rewritten body already cites the same tickets.
-   - Use `gh issue comment <issueNumber> --body-file <path>` with a real file path; do not use `--body-file -` or stdin redirection.
+3. If `diagnosis.should_update_title` is true and `diagnosis.proposed_title` is set, update only the title:
+   - Run `gh issue edit <issueNumber> --title "<proposed_title>"` (with `--repo <repository>` when provided).
+   - **Do not** pass `--body` or `--body-file` to `gh issue edit`. The reporter's body must remain untouched.
+   - Skip this step if `should_update_title` is false or `proposed_title` is missing or equal to the current title.
+4. Post the triage comment from `diagnosis.proposed_comment`:
+   - Always post it. The triage run is a comment-driven workflow; if `proposed_comment` is empty, treat that as a skill error and surface it in the summary instead of silently skipping.
+   - Write the comment body to a real file path (for example `/workspace/issue-<issueNumber>-comment.md`) and pass it with `--body-file <path>`. **Never** use `--body-file -` or any shell stdin redirection (`<`, `<<`, `<<<`) — see [Shell sandbox limits](#shell-sandbox-limits).
+   - Run `gh issue comment <issueNumber> --body-file <path>` (with `--repo <repository>` when provided).
 5. Do not close non-duplicate issues.
 6. Run each `gh` mutation in its own bash invocation. Do not chain a mutation (`gh issue edit`, `gh issue comment`, `gh issue close`) with a follow-up read (`gh issue view`) using `&&` — a hang in the mutation will block the entire chain and exhaust the stage timeout.
 7. Do not re-run the same `gh issue edit` to verify a previous edit. If the first invocation returned exit code 0, trust it and move on.
 
-Return title/body update status, labels applied, comment status, human-review status, and a short summary.
+Return title update status, labels applied, comment status, human-review status, and a short summary.

--- a/.agents/skills/issue-triage/SOURCES.md
+++ b/.agents/skills/issue-triage/SOURCES.md
@@ -4,7 +4,7 @@
 
 | Source | Use |
 | --- | --- |
-| User request in this session | Defines required behavior: duplicate search and closure, repository checkout, diagnosis, validation, issue rewrite with original report footer, and deterministic context passed into a cohesive skill. |
+| User request in this session | Defines required behavior: duplicate search and closure, repository checkout, diagnosis, validation, sharpening the title when needed, and posting a short triage-bot comment instead of rewriting the issue body. |
 | Flue README issue triage example | Confirms GitHub Actions + CLI-only Flue agent pattern, `sandbox: "local"`, staged skill calls, command grants, and structured Valibot results. |
 | `gh issue --help`, `gh issue view --help`, `gh issue edit --help`, `gh issue close --help`, `gh search issues --help`, `gh label list --help` | Confirms available GitHub CLI commands and flags for reading issues, searching duplicates, editing bodies, closing issues, and listing labels. |
 | Repository `AGENTS.md` | Supplies project workflow constraints, security expectations, and quality gate expectations. |
@@ -17,8 +17,9 @@
 | Close confirmed duplicates with a note | `close-duplicate` stage |
 | Clone or prepare repository correctly | Flue handler `prepareRepository()` plus GitHub Actions checkout |
 | Diagnose and validate issue concern | `diagnose-and-validate` stage |
-| Rewrite unclear issues in better format | `apply-triage-update` stage |
-| Preserve original report in footer | `diagnose-and-validate` body template and `apply-triage-update` guard |
+| Sharpen unclear titles when needed | `diagnose-and-validate` (`should_update_title`) and `apply-triage-update` (title-only edit) |
+| Post a triage-bot comment summarizing findings | `diagnose-and-validate` (`proposed_comment` template) and `apply-triage-update` (`gh issue comment`) |
+| Never rewrite the reporter's issue body | `apply-triage-update` guards: no `--body`/`--body-file` on `gh issue edit` |
 | Pass trusted issue and label context into the model | Flue handler `readIssueContext()` before each model stage |
 | Avoid prompt injection from issue content | Global rules |
 

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -56,15 +56,14 @@ const diagnosisSchema = v.object({
   summary: v.string(),
   evidence: v.array(v.string()),
   labels_to_apply: v.array(v.string()),
-  should_update_issue: v.boolean(),
+  should_update_title: v.boolean(),
   proposed_title: v.optional(v.string()),
-  proposed_body: v.optional(v.string()),
+  proposed_comment: v.string(),
   needs_human_review: v.boolean(),
 });
 
 const updateSchema = v.object({
   title_updated: v.boolean(),
-  body_updated: v.boolean(),
   labels_applied: v.array(v.string()),
   comment_posted: v.boolean(),
   needs_human_review: v.boolean(),
@@ -405,7 +404,6 @@ export default async function ({ init, payload }: FlueContext) {
     labels_applied: update.labels_applied,
     comment_posted: update.comment_posted,
     title_updated: update.title_updated,
-    body_updated: update.body_updated,
     needs_human_review: update.needs_human_review,
     summary: update.summary,
   };

--- a/docs/flue-hooks.md
+++ b/docs/flue-hooks.md
@@ -33,7 +33,7 @@ The stages are:
 2. Close confirmed duplicates with a comment pointing at the canonical issue.
 3. Prepare a repository checkout for diagnosis. GitHub Actions clones the default branch with `actions/checkout`; the handler can fall back to `gh repo clone` if no checkout exists.
 4. Diagnose and validate the report using repository context and targeted commands.
-5. Apply labels, comments, and issue title/body cleanup. When it rewrites the body, it keeps the original report in an `Original Report` footer.
+5. Apply existing labels, optionally sharpen the title, and post a short triage-bot comment summarizing what the bot found. The reporter's issue body is never rewritten.
 
 The workflow needs:
 
@@ -50,4 +50,4 @@ GH_TOKEN=... OPENAI_API_KEY=... pnpm -w run flue:issue-triage --id issue-triage-
   --payload '{"issueNumber": 1, "repository": "getsentry/sentry-mcp"}'
 ```
 
-The skill may read issue details, inspect repository files, apply existing labels, close confirmed duplicates, and post concise comments. It treats issue content as untrusted input and must not modify files, execute issue-provided commands, open pull requests, create labels, close non-duplicates, or expose secrets.
+The skill may read issue details, inspect repository files, apply existing labels, close confirmed duplicates, sharpen issue titles, and post a short triage comment. It treats issue content as untrusted input and must not modify the issue body, modify repository files, execute issue-provided commands, open pull requests, create labels, close non-duplicates, or expose secrets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Flue `issue-triage` action used to rewrite the issue body into a templated `Problem / Analysis / Next Steps` shape with the original report tucked into an `<details>` footer. For a triage bot that's heavy-handed: the reporter's writeup gets buried, the issue stops looking like the issue they filed, and the bot ends up doing maintainer-level editorialization automatically.

The ask: act more like a triage bot — friendly, brief, comments on the issue, leaves the body alone, but can still tighten a misleading title.

## What changed

**Comment, don't rewrite.**

- The `diagnose-and-validate` stage now produces a `proposed_comment` (the bot's triage note) instead of a `proposed_body`.
- The `apply-triage-update` stage posts that comment via `gh issue comment` and never edits the body — `--body` / `--body-file` are explicitly forbidden on `gh issue edit`. The reporter's body always stays as written.

**Titles can still be sharpened.**

- A new `should_update_title` flag drives a title-only `gh issue edit` when the existing title is misleading, generic, or hides the subsystem.
- Title edits never touch the body.

**A bit of personality.**

A new `Voice` section in the skill encodes the triage-bot tone:

- Open with a short greeting — `Triage bot here 👋`.
- First person, light personality, no try-hard humor or filler.
- Tight diagnosis + bullets + one hand-off line ("A maintainer will take it from here.").

The duplicate-close template gets the same voice for consistency.

## Files

- `.agents/skills/issue-triage/SKILL.md` — new `Voice` section, comment template replaces body template, both `diagnose-and-validate` and `apply-triage-update` stages rewritten around the comment-first flow. (`.claude/skills/issue-triage/SKILL.md` is a symlink so it picks up the change automatically.)
- `.flue/agents/issue-triage.ts` — Valibot schemas: `should_update_issue` / `proposed_body` → `should_update_title` / `proposed_comment`; drop `body_updated` from `updateSchema` and the handler return.
- `.agents/skills/issue-triage/SOURCES.md` — coverage matrix updated to match.
- `docs/flue-hooks.md` — stage description and trust note updated to say the bot posts a comment and may sharpen the title, but never rewrites the body.

## Tests

- `pnpm run lint` — clean.
- `pnpm run tsc` — clean across all packages.
- `pnpm run test` — all 304 cloudflare tests + the rest of the workspace pass.
- `pnpm --filter @sentry/mcp-core generate-definitions` — definitions unchanged (this skill isn't bundled into the MCP-exposed skill set).

This is a behavior change to a GitHub Actions agent that runs against real issues on `issues.opened`; there's no local end-to-end harness to dry-run it against without an actual issue. The behavior is fully driven by the `SKILL.md` instructions plus the Valibot schemas in the handler — both updated together so the model can no longer return a `proposed_body`.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C08J1NSPU6S/p1778278441236559?thread_ts=1778278441.236559&cid=C08J1NSPU6S)

<div><a href="https://cursor.com/agents/bc-a0e546c1-0357-50a3-a093-cb865efc3aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0e546c1-0357-50a3-a093-cb865efc3aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

