### PR TITLE
fix(triage): Avoid over-polishing low-signal issues

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -49,9 +49,14 @@ Goal: determine whether the new issue is a confirmed duplicate.
    - Search exact or near-exact title terms.
    - Search distinctive error messages, stack frame names, package names, command names, or API names from the issue body.
    - Search open and closed issues in the same repository with `gh search issues --repo <repository>`.
+   - Add `--limit 10` to every `gh search issues` command.
    - Exclude the current issue number from candidates.
-3. Fetch candidate issue details only when needed to compare substance.
-4. Compare candidates against the current issue.
+3. Keep search terms specific.
+   - Do not search generic language, stack, or repo terms by themselves, such as `typescript`, `javascript`, `python`, `rust`, `language`, `rewrite`, `error`, or `timeout`.
+   - For low-signal rewrite requests like "rewrite in Rust" with body "because Rust is good", search only the exact title and exact distinctive body phrase. Do not fan out to generic terms.
+   - Stop searching once you have enough information to decide `unique` or `uncertain`.
+4. Fetch candidate issue details only when needed to compare substance.
+5. Compare candidates against the current issue.
 
 A duplicate must be the same underlying bug, request, or docs problem. Broad topic overlap is not enough.
 

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-triage
-description: Use when asked to triage newly opened GitHub issues, diagnose issue validity, search for duplicates, close confirmed duplicates, or rewrite unclear issue descriptions with a concise engineering update and a friendly follow-up comment.
+description: Use when asked to triage newly opened GitHub issues, diagnose issue validity, search for duplicates, close confirmed duplicates, leave concise scope notes, or rewrite unclear issue descriptions.
 ---
 
 # Issue Triage
@@ -34,9 +34,11 @@ Comments are where the bot can be friendly. They should:
 
 - Start with `Triage bot here.`
 - Use first person for what was checked or changed.
-- Be brief: one short opener, optional bullets for what was checked, and a hand-off line.
-- Avoid jokes, hype, exclamation points, and long explanations.
+- Sound casually professional: direct, human, and a little less stiff. A hint of Gen Z is fine; slang and memes are not.
+- Be brief: one short opener, optional bullets only when they add real signal, and a hand-off line when useful.
+- Avoid jokes, hype, exclamation points, corporate report phrasing, and long explanations.
 - Never claim more confidence than the evidence supports.
+- Do not say "I tightened the issue description" unless the edit was genuinely just a cleanup. Prefer concrete wording like "I left the issue open for maintainer review, but this needs a clearer problem statement."
 
 ## Stage: `search-duplicates`
 
@@ -62,7 +64,7 @@ Return:
 
 ## Stage: `diagnose-and-validate`
 
-Goal: diagnose, validate, decide whether to tighten the issue, and draft the comment used when the body changes.
+Goal: diagnose, validate, decide whether to tighten the issue, and draft any short triage comment that should be posted.
 
 If `repositoryContext.checkoutAvailable` is true, inspect code under `repositoryContext.repoPath`. Treat `duplicateSearch.candidates` as possible related tickets, not duplicates.
 
@@ -78,54 +80,87 @@ If `repositoryContext.checkoutAvailable` is true, inspect code under `repository
    - Do not run broad or destructive commands unless the repo documentation makes them the standard validation path.
    - If dependencies are missing or validation is too expensive, say so in `evidence` and mark validity conservatively.
 4. Cite related issues only when the connection is concrete. Use `#123` for same-repo issues.
-5. Decide whether the original ticket accurately describes the concern.
+5. Decide the issue disposition:
+   - `actionable`: enough detail exists for a maintainer to act.
+   - `needs_more_info`: likely valid, but missing concrete repro, motivation, or acceptance criteria.
+   - `low_actionability`: the request has a recognizable shape but little useful signal.
+   - `impractical_scope`: the request is broad enough that it needs a proposal, owner, migration plan, or product decision before normal issue triage makes sense.
+   - `unclear`: the concern cannot be identified.
+6. Choose the rewrite mode before drafting anything:
+   - `none`: leave the issue body alone. Use this for weak or low-signal reports when rewriting would launder them into a better-looking ticket than they are.
+   - `light_cleanup`: keep the reporter's actual request, remove noise, and make it easier to scan.
+   - `technical_diagnosis`: use only for bugs, docs, setup failures, or concrete API behavior where repository evidence matters.
+   - `scope_clarification`: use for broad feature or maintenance requests when a small rewrite helps show what is missing without over-professionalizing the ask.
+7. Decide whether the original ticket accurately describes the concern.
    - Set `should_update_issue` to true when the current title/body is misleading, underspecified, hard to scan, or missing analysis that would help maintainers act.
    - Do not rewrite just to add ceremony. If the report is already clear and actionable, leave it alone.
+   - Do not turn a one-line or low-signal request into a polished internal spec. Preserve the quality signal maintainers need to see.
    - When updating, propose a clearer title only if the current title is generic or misleading.
    - When updating, propose a full replacement body that keeps all relevant repro details, errors, links, and reporter-supplied facts.
-   - Also provide `update_comment`, a friendly comment the handler will post only if the issue body actually changes.
+   - Also provide `update_comment`, a friendly comment the handler will post if the body actually changes.
+8. Decide whether to comment without editing:
+   - Set `should_comment` to true when the best next step is a short ask for missing context, a scope note for maintainer review, or a concise explanation that the request is not actionable as written.
+   - Provide `triage_comment` when `should_comment` is true.
+   - Keep broad/impractical feature requests open for human review unless duplicate status is confirmed by the duplicate stage.
+
+### Low-Signal and Impractical Requests
+
+Broad rewrites, architecture migrations, and "X would be better" requests need more restraint than normal feature requests. A request to rewrite this repository in another language is not automatically actionable just because the repository is in a different language today.
+
+For these issues:
+
+- Do not inventory the whole repository unless it changes the decision.
+- Do not add `Findings` that merely prove the repo uses its current stack.
+- Do not use `technical_diagnosis` unless there is a concrete technical claim to validate.
+- Prefer `rewrite_mode: "none"` plus a short `triage_comment`, or `rewrite_mode: "scope_clarification"` with a very small body.
+- Ask for the missing problem statement, affected users, current-stack limitation, expected benefit, migration plan, and maintenance owner only when that would help.
+
+For example, a report like "rewrite this in Python" with body "python is good" should not become a full ticket with repository architecture findings. A better body, if editing is useful at all, is:
+
+```md
+Request to rewrite Sentry MCP in Python.
+
+As written, this is too broad to evaluate. A useful proposal would need a concrete problem with the current TypeScript/Node implementation, expected user benefit, and a migration and maintenance plan.
+```
 
 ### Issue Body
 
 - No greeting, no bot voice, no apology, no "I checked", and no automation note.
-- Lead with the concrete concern and current understanding.
-- Prefer short sections and bullets. Use at most `## Summary`, `## Findings`, `## Next Steps`, and `## Related`; drop any section that does not add concrete value.
-- Include the validation performed or the reason validation was not possible.
+- Lead with the concrete concern and current understanding. For low-signal issues, keep that low signal visible.
+- Prefer short sections and bullets. Use no headings for very small issues. Do not force `Next Steps` when another section, or no section, fits better.
+- Include validation only when it is useful to the issue.
+- Only include validation for concrete bug/docs/setup/API claims. For broad scope requests, say what is missing instead of pretending a technical validation happened.
 - Fill gaps from repository analysis, but do not invent facts or confidence.
 - Preserve important original details inline instead of hiding them in a long footer.
 - Do not add empty sections, placeholders, or a full "original report" archive unless that is the only practical way to avoid losing important context.
 
-Template:
+Choose sections based on the issue:
+
+- `## Summary` for a short restatement when the issue needs framing.
+- `## Reproduction` for concrete bug reports with steps, commands, inputs, or observed/expected behavior.
+- `## Findings` for real repository or API evidence, not generic facts like "this repo uses TypeScript."
+- `## Missing Context` for vague requests or support reports that need specific details.
+- `## Scope` for broad feature or maintenance requests where feasibility is the main concern.
+- `## Related` for concrete same-repo issue links.
+
+For small issues, use a compact body without headings:
 
 ```md
-## Summary
+[One or two sentences stating the ask and current confidence.]
 
-[1-3 concise sentences describing the actual concern and current confidence.]
-
-## Findings
-
-- [Concrete finding from the report or repository, with a file/symbol/doc reference.]
-- [Validation performed and result, or "Not validated: <reason>".]
-
-## Next Steps
-
-- [Concrete action for maintainers or the reporter.]
-
-## Related
-
-- #123 - [short reason this issue matters]
+[Optional second paragraph with the single most important missing detail or maintainer-facing note.]
 ```
 
 ### Update Comment
 
-When `should_update_issue` is true, draft `update_comment` using [Comment Voice](#comment-voice). Explain that the bot tightened the description, then summarize the highest-signal validation.
+When `should_update_issue` is true, draft `update_comment` using [Comment Voice](#comment-voice). Match the edit: mention light cleanup, scope clarification, or technical findings only when that is what changed.
 
 Example:
 
 ```md
 Triage bot here.
 
-I tightened the issue description after checking the report and repository context so the current concern is easier to scan.
+I cleaned up the report a bit so the concrete failure is easier to scan.
 
 What I checked:
 - `packages/foo/src/bar.ts` has the code path mentioned in the stack trace.
@@ -138,12 +173,16 @@ Return:
 
 - `severity`: `low`, `medium`, `high`, or `critical`
 - `category`: `bug`, `documentation`, `feature_request`, `support`, `security`, `maintenance`, or `unknown`
+- `disposition`: `actionable`, `needs_more_info`, `low_actionability`, `impractical_scope`, or `unclear`
+- `rewrite_mode`: `none`, `light_cleanup`, `technical_diagnosis`, or `scope_clarification`
 - `validity`: `confirmed`, `likely`, `not_reproducible`, or `unclear`
 - `summary`: concise diagnosis
 - `evidence`: concrete observations and validation attempts
 - `labels_to_apply`: existing labels only
+- `should_comment`
 - `should_update_issue`
 - `proposed_title` when a clearer title is needed
 - `proposed_body` when `should_update_issue` is true
+- `triage_comment` when `should_comment` is true
 - `update_comment` when `should_update_issue` is true
 - `needs_human_review`: true for security-sensitive, high-risk, ambiguous, or destructive cases

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -469,7 +469,7 @@ function selectTriageComment(
     return undefined;
   }
 
-  return diagnosis.triage_comment?.trim() || buildIssueUpdateComment(diagnosis);
+  return diagnosis.triage_comment?.trim();
 }
 
 async function applyTriageUpdate(

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -56,6 +56,7 @@ const duplicateSearchSchema = v.object({
   candidates: v.array(duplicateCandidateSchema),
   rationale: v.string(),
 });
+type DuplicateSearch = v.InferOutput<typeof duplicateSearchSchema>;
 
 const diagnosisSchema = v.object({
   severity: severitySchema,
@@ -74,6 +75,7 @@ const diagnosisSchema = v.object({
   update_comment: v.optional(v.string()),
   needs_human_review: v.boolean(),
 });
+type Diagnosis = v.InferOutput<typeof diagnosisSchema>;
 
 const updateSchema = v.object({
   title_updated: v.boolean(),
@@ -83,6 +85,45 @@ const updateSchema = v.object({
   needs_human_review: v.boolean(),
   summary: v.string(),
 });
+
+function summarizeAgentFailure(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (message.includes("404 status code")) {
+    return "The triage model returned a provider error before producing structured output.";
+  }
+
+  if (message.includes("Gateway Timeout")) {
+    return "The triage model timed out before producing structured output.";
+  }
+
+  return "The triage agent failed before producing structured output.";
+}
+
+function buildDuplicateSearchFailure(error: unknown): DuplicateSearch {
+  return {
+    status: "uncertain",
+    candidates: [],
+    rationale: summarizeAgentFailure(error),
+  };
+}
+
+function buildDiagnosisFailure(error: unknown): Diagnosis {
+  return {
+    severity: "low",
+    category: "unknown",
+    disposition: "unclear",
+    rewrite_mode: "none",
+    validity: "unclear",
+    summary:
+      "Automated triage could not complete, so the issue is left unchanged for maintainer review.",
+    evidence: [summarizeAgentFailure(error)],
+    labels_to_apply: [],
+    should_comment: false,
+    should_update_issue: false,
+    needs_human_review: true,
+  };
+}
 
 const gh = defineCommand("gh", {
   env: {
@@ -622,17 +663,25 @@ export default async function ({ init, payload }: FlueContext) {
     issueNumber,
     repository,
   );
-  const duplicateSearch = await session.skill("issue-triage", {
-    args: {
-      stage: "search-duplicates",
-      issueNumber,
-      repository,
-      context: initialContext,
-    },
-    commands: [gh],
-    result: duplicateSearchSchema,
-    timeout: 300_000,
-  });
+  let duplicateSearch: DuplicateSearch;
+  try {
+    duplicateSearch = await session.skill("issue-triage", {
+      args: {
+        stage: "search-duplicates",
+        issueNumber,
+        repository,
+        context: initialContext,
+      },
+      commands: [gh],
+      result: duplicateSearchSchema,
+      timeout: 300_000,
+    });
+  } catch (error) {
+    console.warn(
+      `[issue-triage] Duplicate search failed: ${summarizeAgentFailure(error)}`,
+    );
+    duplicateSearch = buildDuplicateSearchFailure(error);
+  }
 
   if (duplicateSearch.status === "duplicate") {
     if (!duplicateSearch.duplicate) {
@@ -676,19 +725,27 @@ export default async function ({ init, payload }: FlueContext) {
     issueNumber,
     repository,
   );
-  const diagnosis = await session.skill("issue-triage", {
-    args: {
-      stage: "diagnose-and-validate",
-      issueNumber,
-      repository,
-      context: diagnosisContext,
-      repositoryContext,
-      duplicateSearch,
-    },
-    commands,
-    result: diagnosisSchema,
-    timeout: 900_000,
-  });
+  let diagnosis: Diagnosis;
+  try {
+    diagnosis = await session.skill("issue-triage", {
+      args: {
+        stage: "diagnose-and-validate",
+        issueNumber,
+        repository,
+        context: diagnosisContext,
+        repositoryContext,
+        duplicateSearch,
+      },
+      commands,
+      result: diagnosisSchema,
+      timeout: 900_000,
+    });
+  } catch (error) {
+    console.warn(
+      `[issue-triage] Diagnosis failed: ${summarizeAgentFailure(error)}`,
+    );
+    diagnosis = buildDiagnosisFailure(error);
+  }
 
   const updateContext = await readIssueContext(
     session,

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -81,8 +81,6 @@ const updateSchema = v.object({
   labels_applied: v.array(v.string()),
   comment_posted: v.boolean(),
   needs_human_review: v.boolean(),
-  disposition: dispositionSchema,
-  rewrite_mode: rewriteModeSchema,
   summary: v.string(),
 });
 
@@ -445,8 +443,6 @@ async function applyTriageUpdate(
       labels_applied: [],
       comment_posted: false,
       needs_human_review: true,
-      disposition: "unclear",
-      rewrite_mode: "none",
       summary: "Skipped triage update because the issue is already closed.",
     };
   }
@@ -496,8 +492,6 @@ async function applyTriageUpdate(
     labels_applied: labelsApplied,
     comment_posted: commentPosted,
     needs_human_review: diagnosis.needs_human_review,
-    disposition: diagnosis.disposition,
-    rewrite_mode: diagnosis.rewrite_mode,
     summary:
       changed.length > 0
         ? `Updated issue ${changed.join(", ")}.`

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -27,6 +27,19 @@ const categorySchema = v.picklist([
   "maintenance",
   "unknown",
 ]);
+const dispositionSchema = v.picklist([
+  "actionable",
+  "needs_more_info",
+  "low_actionability",
+  "impractical_scope",
+  "unclear",
+]);
+const rewriteModeSchema = v.picklist([
+  "none",
+  "light_cleanup",
+  "technical_diagnosis",
+  "scope_clarification",
+]);
 
 const duplicateCandidateSchema = v.object({
   number: v.pipe(v.number(), v.integer(), v.minValue(1)),
@@ -47,13 +60,17 @@ const duplicateSearchSchema = v.object({
 const diagnosisSchema = v.object({
   severity: severitySchema,
   category: categorySchema,
+  disposition: dispositionSchema,
+  rewrite_mode: rewriteModeSchema,
   validity: v.picklist(["confirmed", "likely", "not_reproducible", "unclear"]),
   summary: v.string(),
   evidence: v.array(v.string()),
   labels_to_apply: v.array(v.string()),
+  should_comment: v.boolean(),
   should_update_issue: v.boolean(),
   proposed_title: v.optional(v.string()),
   proposed_body: v.optional(v.string()),
+  triage_comment: v.optional(v.string()),
   update_comment: v.optional(v.string()),
   needs_human_review: v.boolean(),
 });
@@ -64,6 +81,8 @@ const updateSchema = v.object({
   labels_applied: v.array(v.string()),
   comment_posted: v.boolean(),
   needs_human_review: v.boolean(),
+  disposition: dispositionSchema,
+  rewrite_mode: rewriteModeSchema,
   summary: v.string(),
 });
 
@@ -356,17 +375,34 @@ function buildIssueUpdateComment(
     .map((item) => item.trim())
     .filter(Boolean)
     .slice(0, 3);
-  const lines = [
-    "Triage bot here.",
-    "",
-    "I tightened the issue description after checking the report and repository context so the current concern is easier to scan.",
-  ];
+  const lines = ["Triage bot here.", ""];
+
+  switch (diagnosis.rewrite_mode) {
+    case "light_cleanup":
+      lines.push(
+        "I did a light cleanup so the issue is easier to scan without changing the ask.",
+      );
+      break;
+    case "scope_clarification":
+      lines.push(
+        "I trimmed this to the current ask and what is still missing for maintainers.",
+      );
+      break;
+    case "technical_diagnosis":
+      lines.push(
+        "I updated the issue with the repository context that seemed relevant.",
+      );
+      break;
+    case "none":
+      lines.push("I added a short triage note for maintainer review.");
+      break;
+  }
 
   if (diagnosis.summary.trim()) {
     lines.push("", `Current read: ${diagnosis.summary.trim()}`);
   }
 
-  if (evidence.length > 0) {
+  if (diagnosis.rewrite_mode === "technical_diagnosis" && evidence.length > 0) {
     lines.push("", "What I checked:");
     for (const item of evidence) {
       lines.push(`- ${item}`);
@@ -376,6 +412,25 @@ function buildIssueUpdateComment(
   lines.push("", "A maintainer will take it from here.");
 
   return lines.join("\n");
+}
+
+function selectTriageComment(
+  diagnosis: v.InferOutput<typeof diagnosisSchema>,
+  bodyUpdated: boolean,
+) {
+  if (bodyUpdated) {
+    return (
+      diagnosis.update_comment?.trim() ||
+      diagnosis.triage_comment?.trim() ||
+      buildIssueUpdateComment(diagnosis)
+    );
+  }
+
+  if (!diagnosis.should_comment) {
+    return undefined;
+  }
+
+  return diagnosis.triage_comment?.trim() || buildIssueUpdateComment(diagnosis);
 }
 
 async function applyTriageUpdate(
@@ -390,6 +445,8 @@ async function applyTriageUpdate(
       labels_applied: [],
       comment_posted: false,
       needs_human_review: true,
+      disposition: "unclear",
+      rewrite_mode: "none",
       summary: "Skipped triage update because the issue is already closed.",
     };
   }
@@ -415,12 +472,14 @@ async function applyTriageUpdate(
       diagnosis.proposed_body,
     );
 
-    if (bodyUpdated) {
-      commentPosted = await postComment(
-        session,
-        context,
-        diagnosis.update_comment?.trim() || buildIssueUpdateComment(diagnosis),
-      );
+    const comment = selectTriageComment(diagnosis, bodyUpdated);
+    if (comment) {
+      commentPosted = await postComment(session, context, comment);
+    }
+  } else {
+    const comment = selectTriageComment(diagnosis, false);
+    if (comment) {
+      commentPosted = await postComment(session, context, comment);
     }
   }
 
@@ -428,6 +487,7 @@ async function applyTriageUpdate(
     titleUpdated ? "title" : null,
     bodyUpdated ? "body" : null,
     labelsApplied.length > 0 ? "labels" : null,
+    commentPosted ? "comment" : null,
   ].filter(Boolean);
 
   return {
@@ -436,6 +496,8 @@ async function applyTriageUpdate(
     labels_applied: labelsApplied,
     comment_posted: commentPosted,
     needs_human_review: diagnosis.needs_human_review,
+    disposition: diagnosis.disposition,
+    rewrite_mode: diagnosis.rewrite_mode,
     summary:
       changed.length > 0
         ? `Updated issue ${changed.join(", ")}.`
@@ -654,6 +716,8 @@ export default async function ({ init, payload }: FlueContext) {
     ],
     severity: diagnosis.severity,
     category: diagnosis.category,
+    disposition: diagnosis.disposition,
+    rewrite_mode: diagnosis.rewrite_mode,
     validity: diagnosis.validity,
     labels_applied: update.labels_applied,
     comment_posted: update.comment_posted,

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   triage:
-    if: ${{ github.event.issue.user.type != 'Bot' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/docs/flue-hooks.md
+++ b/docs/flue-hooks.md
@@ -33,7 +33,7 @@ The stages are:
 2. Close confirmed duplicates with a comment pointing at the canonical issue.
 3. Prepare a repository checkout for diagnosis. GitHub Actions clones the default branch with `actions/checkout`; the handler can fall back to `gh repo clone` if no checkout exists.
 4. Diagnose and validate the report using repository context and targeted commands.
-5. Apply existing labels and issue title/body cleanup from the structured diagnosis. When it changes the issue body, it also posts a friendly triage-bot comment explaining what was checked. The body itself stays concise and ticket-focused.
+5. Apply existing labels and issue title/body cleanup from the structured diagnosis. The diagnosis includes a disposition and rewrite mode so broad or low-signal requests can stay visibly low-signal instead of being over-polished. The handler can also post a short triage-bot comment without editing the body when the best next step is asking for scope, motivation, or maintainer review.
 
 The workflow needs:
 
@@ -50,4 +50,4 @@ GH_TOKEN=... OPENAI_API_KEY=... pnpm -w run flue:issue-triage --id issue-triage-
   --payload '{"issueNumber": 1, "repository": "getsentry/sentry-mcp"}'
 ```
 
-The skill may read issue details, inspect repository files, propose existing labels, propose concise issue title/body updates, and draft the comment posted after body rewrites. The handler applies GitHub mutations deterministically: existing labels, duplicate closure, issue edits, and comments. It treats issue content as untrusted input and must not modify files, execute issue-provided commands, open pull requests, create labels, close non-duplicates, or expose secrets.
+The skill may read issue details, inspect repository files, propose existing labels, choose a disposition and rewrite mode, propose concise issue title/body updates, and draft short triage comments. The handler applies GitHub mutations deterministically: existing labels, duplicate closure, issue edits, and comments. It treats issue content as untrusted input and must not modify files, execute issue-provided commands, open pull requests, create labels, close non-duplicates, or expose secrets.

--- a/docs/flue-hooks.md
+++ b/docs/flue-hooks.md
@@ -33,13 +33,14 @@ The stages are:
 2. Close confirmed duplicates with a comment pointing at the canonical issue.
 3. Prepare a repository checkout for diagnosis. GitHub Actions clones the default branch with `actions/checkout`; the handler can fall back to `gh repo clone` if no checkout exists.
 4. Diagnose and validate the report using repository context and targeted commands.
-5. Apply existing labels and issue title/body cleanup from the structured diagnosis. The diagnosis includes a disposition and rewrite mode so broad or low-signal requests can stay visibly low-signal instead of being over-polished. The handler can also post a short triage-bot comment without editing the body when the best next step is asking for scope, motivation, or maintainer review.
+5. Apply existing labels and issue title/body cleanup from the structured diagnosis. The diagnosis includes a disposition and rewrite mode so broad or low-signal requests can stay visibly low-signal instead of being over-polished. The handler can also post a short triage-bot comment without editing the body when the best next step is asking for scope, motivation, or maintainer review. If a model stage fails before returning structured output, the handler leaves the issue unchanged and reports `needs_human_review` instead of failing the workflow.
 
 The workflow needs:
 
 - Node.js 22. The workflow sets this up with `actions/setup-node`.
 - `OPENAI_API_KEY` as a GitHub Actions secret.
 - Optional `FLUE_TRIAGE_MODEL` as a GitHub Actions variable. Defaults to `openai/gpt-5`.
+- The workflow runs for bot-authored issues too, because Sentry-created issues appear as bot submissions and still need triage.
 
   Reasoning models work despite a known pi-ai bug because the agent installs a small `onPayload` hook on the Flue session's pi-agent-core harness that adds `include: ["reasoning.encrypted_content"]` to every OpenAI Responses request. Without it, every multi-turn call against `openai/gpt-5` (or any other reasoning model) 404s with `Items are not persisted when 'store' is set to false`: [`@mariozechner/pi-ai`](https://github.com/badlogic/pi-mono) hardcodes `store: false` on the OpenAI Responses API while still replaying the `rs_*` reasoning IDs from earlier turns. With encrypted content inlined the replay carries the full reasoning blob, so OpenAI never has to look the IDs up. Drop the hook once @flue/sdk exposes [`reasoning`/`thinkingLevel`](https://github.com/withastro/flue/pull/69) (merged into Flue `main` but unreleased) or pi-ai stops hardcoding `store: false` ([badlogic/pi-mono#3369](https://github.com/badlogic/pi-mono/issues/3369), [pi-mono#1504](https://github.com/badlogic/pi-mono/pull/1504)).
 


### PR DESCRIPTION
Teach the issue triage hook to distinguish low-actionability and impractical scope requests from actionable reports. The hook can now leave concise scope comments without rewriting the issue body, keeping weak reports visibly weak instead of turning them into polished specs.

**Triage Contract**

Adds disposition and rewrite mode fields, plus a comment-only path, so the handler can apply labels/comments independently from title/body edits. If no issue update happened and the model did not provide explicit comment text, the handler now posts nothing instead of inventing a fallback comment.

**Issue Writing Guidance**

Updates the issue-triage skill to prefer flexible sections, avoid fake repository findings, cap duplicate searches, and avoid generic repo-wide search terms for low-signal rewrite requests.

**Workflow Resilience**

Runs issue triage for Sentry-authored bot issues and makes model-stage failures fall back to human review instead of failing the issue-opened workflow.

Refs GH-948
Refs GH-950
Refs GH-951