### PR TITLE
fix(cloudflare): emit single resource_metadata in WWW-Authenticate (#939)

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.test.ts
+++ b/packages/mcp-cloudflare/src/server/index.test.ts
@@ -231,4 +231,84 @@ describe("worker entrypoint", () => {
       'Bearer error="invalid_token", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp/sentry"',
     );
   });
+
+  it("replaces an existing resource_metadata with the path-specific one (RFC 9110 §11.2)", async () => {
+    // The Cloudflare OAuth provider library emits its own resource_metadata
+    // pointing at the origin (which 404s on this deployment). We must replace
+    // it rather than append, so the challenge contains exactly one
+    // resource_metadata parameter.
+    mockOAuthProviderFetch.mockResolvedValueOnce(
+      new Response("unauthorized", {
+        status: 401,
+        headers: {
+          "WWW-Authenticate":
+            'Bearer realm="OAuth", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"',
+        },
+      }),
+    );
+
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/mcp"),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+    const header = response.headers.get("WWW-Authenticate")!;
+    expect(header).toBe(
+      'Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp"',
+    );
+    // Defensive: ensure resource_metadata only appears once.
+    expect(header.match(/resource_metadata\s*=/gi)?.length).toBe(1);
+  });
+
+  it("removes pre-existing resource_metadata even when it appears first in the challenge", async () => {
+    mockOAuthProviderFetch.mockResolvedValueOnce(
+      new Response("unauthorized", {
+        status: 401,
+        headers: {
+          "WWW-Authenticate":
+            'Bearer resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource", error="invalid_token"',
+        },
+      }),
+    );
+
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/mcp"),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+    const header = response.headers.get("WWW-Authenticate")!;
+    expect(header).toBe(
+      'Bearer error="invalid_token", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(header.match(/resource_metadata\s*=/gi)?.length).toBe(1);
+  });
+
+  it("ignores commas inside quoted error_description values when parsing the challenge", async () => {
+    mockOAuthProviderFetch.mockResolvedValueOnce(
+      new Response("unauthorized", {
+        status: 401,
+        headers: {
+          "WWW-Authenticate":
+            'Bearer realm="OAuth", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing, invalid, or expired access token"',
+        },
+      }),
+    );
+
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/mcp"),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+    const header = response.headers.get("WWW-Authenticate")!;
+    expect(header).toBe(
+      'Bearer realm="OAuth", error="invalid_token", error_description="Missing, invalid, or expired access token", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(header.match(/resource_metadata\s*=/gi)?.length).toBe(1);
+  });
 });

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -26,9 +26,63 @@ import {
 import { setSentryUserFromRequest } from "./utils/sentry-user";
 
 /**
+ * Splits a WWW-Authenticate Bearer challenge into its scheme and individual
+ * `auth-param`s while respecting quoted-string commas. Returns `null` when
+ * the header doesn't follow the `<scheme> <params>` shape we expect.
+ */
+function splitChallenge(
+  headerValue: string,
+): { scheme: string; params: string[] } | null {
+  const firstSpace = headerValue.indexOf(" ");
+  if (firstSpace === -1) return { scheme: headerValue, params: [] };
+  const scheme = headerValue.slice(0, firstSpace);
+  const rest = headerValue.slice(firstSpace + 1).trim();
+
+  const params: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  let escaping = false;
+  for (let i = 0; i < rest.length; i++) {
+    const c = rest[i];
+    if (escaping) {
+      current += c;
+      escaping = false;
+      continue;
+    }
+    if (inQuotes && c === "\\") {
+      current += c;
+      escaping = true;
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = !inQuotes;
+      current += c;
+      continue;
+    }
+    if (!inQuotes && c === ",") {
+      const trimmed = current.trim();
+      if (trimmed) params.push(trimmed);
+      current = "";
+      continue;
+    }
+    current += c;
+  }
+  if (inQuotes) return null;
+  const trimmed = current.trim();
+  if (trimmed) params.push(trimmed);
+  return { scheme, params };
+}
+
+/**
  * RFC 9728 §3.1: Patch 401 responses on MCP routes to include a
  * `resource_metadata` parameter in the WWW-Authenticate header so
  * clients can discover the protected-resource metadata endpoint.
+ *
+ * The underlying OAuth library may already set its own `resource_metadata`
+ * pointing at the (path-less) origin metadata URL, which 404s on this
+ * deployment. We strip any pre-existing `resource_metadata` parameter and
+ * replace it with our path-specific one so the challenge contains exactly
+ * one such param, as required by RFC 9110 §11.2.
  */
 function patchWwwAuthenticate(response: Response, url: URL): Response {
   if (response.status !== 401 || !url.pathname.startsWith("/mcp")) {
@@ -40,11 +94,26 @@ function patchWwwAuthenticate(response: Response, url: URL): Response {
   }
   const prmUrl = `${url.protocol}//${url.host}/.well-known/oauth-protected-resource${url.pathname}${url.search}`;
   const newResponse = new Response(response.body, response);
-  // RFC 7235: first param is space-separated from scheme, subsequent params are comma-separated
-  const separator = existing.includes(" ") ? "," : "";
+
+  const parsed = splitChallenge(existing);
+  if (!parsed) {
+    // Fall back to a freshly built challenge if the existing header doesn't
+    // parse cleanly; better to send a single valid challenge than to risk
+    // emitting another malformed one.
+    newResponse.headers.set(
+      "WWW-Authenticate",
+      `Bearer resource_metadata="${prmUrl}"`,
+    );
+    return newResponse;
+  }
+
+  const filteredParams = parsed.params.filter(
+    (p) => !/^resource_metadata\s*=/i.test(p),
+  );
+  filteredParams.push(`resource_metadata="${prmUrl}"`);
   newResponse.headers.set(
     "WWW-Authenticate",
-    `${existing}${separator} resource_metadata="${prmUrl}"`,
+    `${parsed.scheme} ${filteredParams.join(", ")}`,
   );
   return newResponse;
 }

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -25,52 +25,27 @@ import {
 } from "./utils/rate-limiter";
 import { setSentryUserFromRequest } from "./utils/sentry-user";
 
-/**
- * Splits a WWW-Authenticate Bearer challenge into its scheme and individual
- * `auth-param`s while respecting quoted-string commas. Returns `null` when
- * the header doesn't follow the `<scheme> <params>` shape we expect.
- */
-function splitChallenge(
-  headerValue: string,
-): { scheme: string; params: string[] } | null {
-  const firstSpace = headerValue.indexOf(" ");
-  if (firstSpace === -1) return { scheme: headerValue, params: [] };
-  const scheme = headerValue.slice(0, firstSpace);
-  const rest = headerValue.slice(firstSpace + 1).trim();
+const AUTH_PARAM_SEPARATOR = /,\s*(?=[A-Za-z_][A-Za-z0-9_-]*\s*=)/;
+const AUTH_CHALLENGE = /^(\S+)(?:\s+(.+))?$/;
+const RESOURCE_METADATA_PARAM = /^resource_metadata\s*=/i;
 
-  const params: string[] = [];
-  let current = "";
-  let inQuotes = false;
-  let escaping = false;
-  for (let i = 0; i < rest.length; i++) {
-    const c = rest[i];
-    if (escaping) {
-      current += c;
-      escaping = false;
-      continue;
-    }
-    if (inQuotes && c === "\\") {
-      current += c;
-      escaping = true;
-      continue;
-    }
-    if (c === '"') {
-      inQuotes = !inQuotes;
-      current += c;
-      continue;
-    }
-    if (!inQuotes && c === ",") {
-      const trimmed = current.trim();
-      if (trimmed) params.push(trimmed);
-      current = "";
-      continue;
-    }
-    current += c;
+function replaceResourceMetadataParam(
+  headerValue: string,
+  resourceMetadataUrl: string,
+): string {
+  const match = headerValue.match(AUTH_CHALLENGE);
+  if (!match) {
+    return headerValue;
   }
-  if (inQuotes) return null;
-  const trimmed = current.trim();
-  if (trimmed) params.push(trimmed);
-  return { scheme, params };
+
+  const [, scheme, params = ""] = match;
+  const filteredParams = params
+    .split(AUTH_PARAM_SEPARATOR)
+    .map((param) => param.trim())
+    .filter((param) => param && !RESOURCE_METADATA_PARAM.test(param));
+
+  filteredParams.push(`resource_metadata="${resourceMetadataUrl}"`);
+  return `${scheme} ${filteredParams.join(", ")}`;
 }
 
 /**
@@ -95,25 +70,9 @@ function patchWwwAuthenticate(response: Response, url: URL): Response {
   const prmUrl = `${url.protocol}//${url.host}/.well-known/oauth-protected-resource${url.pathname}${url.search}`;
   const newResponse = new Response(response.body, response);
 
-  const parsed = splitChallenge(existing);
-  if (!parsed) {
-    // Fall back to a freshly built challenge if the existing header doesn't
-    // parse cleanly; better to send a single valid challenge than to risk
-    // emitting another malformed one.
-    newResponse.headers.set(
-      "WWW-Authenticate",
-      `Bearer resource_metadata="${prmUrl}"`,
-    );
-    return newResponse;
-  }
-
-  const filteredParams = parsed.params.filter(
-    (p) => !/^resource_metadata\s*=/i.test(p),
-  );
-  filteredParams.push(`resource_metadata="${prmUrl}"`);
   newResponse.headers.set(
     "WWW-Authenticate",
-    `${parsed.scheme} ${filteredParams.join(", ")}`,
+    replaceResourceMetadataParam(existing, prmUrl),
   );
   return newResponse;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [#939](https://github.com/getsentry/sentry-mcp/issues/939).

401 responses on `/mcp*` routes could emit a `WWW-Authenticate` Bearer challenge with two `resource_metadata` parameters. That violates [RFC 9110 §11.2](https://datatracker.ietf.org/doc/html/rfc9110#section-11.2-4), where each auth-param name can occur only once per challenge. Spec-strict clients such as the Rust `rmcp` crate read the first value, which points at the root protected-resource metadata URL that this deployment intentionally returns as 404.

The duplicate came from two layers adding metadata. Cloudflare `workers-oauth-provider` already returns a challenge like:

```http
WWW-Authenticate: Bearer realm="OAuth", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource", error="invalid_token"
```

The worker then appended its own path-specific metadata URL, which is the value MCP clients need for `/mcp`, `/mcp/:org`, and `/mcp/:org/:project`.

This PR preserves the provider challenge, removes only any existing `resource_metadata=...` auth-param, and appends the path-specific RFC 9728 metadata URL. The implementation is intentionally narrow: it is not a general `WWW-Authenticate` parser, but it preserves provider fields such as `realm`, `error`, and `error_description` while ensuring the final challenge has exactly one `resource_metadata` parameter.

After the fix, the challenge is shaped like:

```http
WWW-Authenticate: Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp"
```

Regression tests cover an OAuth-provider-style duplicate, the case where `resource_metadata` is the first auth-param, and quoted error descriptions containing commas.

Verified locally with:

```bash
pnpm --filter @sentry/mcp-cloudflare test -- src/server/index.test.ts
pnpm --filter @sentry/mcp-cloudflare tsc
pnpm run lint
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C08J1NSPU6S/p1778439816209129?thread_ts=1778439816.209129&cid=C08J1NSPU6S)

<div><a href="https://cursor.com/agents/bc-676125c5-090b-5ce6-a6c4-008d56fb3572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-676125c5-090b-5ce6-a6c4-008d56fb3572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
