### PR TITLE
fix(telemetry): Align MCP attributes with semantic names

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,251 @@
+# Telemetry
+
+## Goal
+
+Use this when investigating Sentry MCP production incidents across the
+Cloudflare HTTP server, stdio package, MCP tools, OAuth flows, and test-client
+agent mode.
+
+Primary backend: Sentry Logs, Issues, Spans/Traces, and Metrics in the MCP
+server projects. Start with a Sentry event, trace ID, route, user, client
+family, OAuth symptom, tool name, resource URL, or GenAI/model symptom, then use
+the pivots and recipes below.
+
+## Where To Query
+
+| Starting Point | Query Surface | Pivot | Answers | Next Step |
+| -------------- | ------------- | ----- | ------- | --------- |
+| `trace_id` from an issue, span, or log | Sentry Traces and Logs | `span_id` | full request/tool timeline and failing span | inspect child spans and logs |
+| Sentry `event_id` | Sentry Issue/Event | `trace_id`, `http.route`, `gen_ai.tool.name` | exception context and owning request/tool | query trace logs |
+| HTTP route or status symptom | Sentry Metrics and Logs | `http.route`, `http.response.status_code` | route volume, status mix, local rate limits | inspect matching traces |
+| OAuth sign-out or refresh symptom | Sentry Metrics and Logs | `app.client.family`, `app.oauth.*` | refresh outcome, revoked grants, client family | inspect user trace or request logs |
+| MCP tool name | Sentry Spans and Issues | `gen_ai.tool.name` | failing or slow tool calls | inspect tool span and Sentry API spans |
+| Sentry resource URL/type | Sentry Spans | `app.resource.type` | `get_sentry_resource` dispatch behavior | inspect resolved type and downstream tool |
+| Agent/model/token symptom | Sentry Spans | `gen_ai.*` | provider, model, token, and agent behavior | inspect agent and tool spans |
+| Client or transport symptom | Sentry Logs, Spans, Metrics | `app.transport`, `app.client.family`, `user_agent.original` | stdio vs HTTP, client bucket, and request family | compare route or OAuth metrics |
+
+## Investigation Pivots
+
+| Pivot | Meaning | Found In | First Query |
+| ----- | ------- | -------- | ----------- |
+| `trace_id` | one request, tool call, or agent run trace | issues, logs, spans | open trace |
+| `span_id` | one request, tool, model, or API span | logs, spans | inspect span |
+| `event_id` | captured Sentry error | Sentry issue/event | open event |
+| `user.id` | authenticated Sentry user ID | events, logs, metrics | user request or OAuth history |
+| `http.route` | normalized Cloudflare route template | metrics, logs, spans | route health |
+| `http.response.status_code` | final HTTP response code | metrics, logs, spans | response distribution |
+| `app.response.reason` | application local response reason | metrics | local rate-limit diagnosis |
+| `app.rate_limit.scope` | local rate-limit scope | metrics | IP vs user rate limits |
+| `app.route.group` | coarse route family | metrics | `mcp`, `oauth`, `chat`, `search` |
+| `app.transport` | MCP transport | tags, spans | `http`, `sse`, or `stdio` |
+| `mcp.session.id` | MCP session identity | spans | session timeline |
+| `gen_ai.tool.name` | MCP tool being called | spans, issues | tool timeline |
+| `app.resource.type` | resolved Sentry resource type | spans | resource dispatch |
+| `app.constraint.organization_slug` | active organization constraint | spans | constrained session behavior |
+| `app.constraint.project_slug` | active project constraint | spans | constrained session behavior |
+| `app.client.family` | bucketed MCP client family | metrics | client-specific OAuth behavior |
+| `app.oauth.token_exchange.outcome` | OAuth refresh outcome | metrics | token refresh diagnosis |
+| `app.oauth.grant_revoked.reason` | wrapper grant revoke reason | metrics | sign-out diagnosis |
+| `app.oauth.probe.status_code` | upstream probe HTTP status | metrics | Sentry token validity probe result |
+| `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
+| `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
+| `app.server.version` | MCP server package version | tags | release/version behavior |
+| `gen_ai.provider.name` | GenAI provider | spans, tags | provider-specific model behavior |
+| `gen_ai.request.model` | requested GenAI model | spans | model-specific behavior |
+| `user_agent.original` | original HTTP user agent | request data, spans | client identification |
+
+## Query Recipes
+
+Trace log history after opening a Sentry event or span.
+
+```text
+dataset=logs query='trace_id:"<trace_id>"'
+fields=timestamp,level,message,trace_id,span_id,http.route,http.response.status_code,app.request.duration_ms,error.type,exception.message
+sort=timestamp
+```
+
+Captured errors for a route, tool, or OAuth symptom.
+
+```text
+dataset=issues query='http.route:"<route>" OR gen_ai.tool.name:"<tool_name>" OR app.oauth.grant_revoked.reason:"<reason>"'
+fields=timestamp,event_id,trace_id,http.route,gen_ai.tool.name,app.oauth.grant_revoked.reason,error.type,exception.message
+sort=-timestamp
+```
+
+HTTP response rates by route and status.
+
+```text
+dataset=metrics query='metric:app.server.response http.route:"<route>"'
+fields=timestamp,metric,http.request.method,http.route,http.response.status_code,app.response.status_class,app.route.group,value
+aggregate=sum(value) by http.route,http.response.status_code
+```
+
+Local rate-limit volume and scope.
+
+```text
+dataset=metrics query='metric:app.server.response app.response.reason:local_rate_limit'
+fields=timestamp,metric,http.route,app.rate_limit.scope,user.id,value
+aggregate=sum(value) by http.route,app.rate_limit.scope
+```
+
+OAuth refresh outcomes by client family.
+
+```text
+dataset=metrics query='metric:app.oauth.token_exchange'
+fields=timestamp,metric,app.oauth.token_exchange.outcome,app.oauth.grant.shape,app.client.family,app.oauth.probe.status_code,app.oauth.probe.reason,user.id,value
+aggregate=sum(value) by app.oauth.token_exchange.outcome,app.client.family
+```
+
+Grant revocations for sign-out reports.
+
+```text
+dataset=metrics query='metric:app.oauth.grant_revoked user.id:"<user_id>"'
+fields=timestamp,metric,app.oauth.grant_revoked.reason,app.client.family,user.id,value
+aggregate=sum(value) by app.oauth.grant_revoked.reason,app.client.family
+```
+
+Register and callback volume by client family.
+
+```text
+dataset=metrics query='metric:app.oauth.register OR metric:app.oauth.callback_completed'
+fields=timestamp,metric,app.client.family,value
+aggregate=sum(value) by metric,app.client.family
+```
+
+Tool execution timeline for a slow or failing tool.
+
+```text
+dataset=spans query='gen_ai.tool.name:"<tool_name>"'
+fields=timestamp,trace,span_id,span.op,span.duration,gen_ai.tool.name,app.constraint.organization_slug,app.constraint.project_slug,error.type
+sort=-timestamp
+```
+
+Resource dispatch behavior for `get_sentry_resource`.
+
+```text
+dataset=spans query='app.resource.type:"<resource_type>"'
+fields=timestamp,trace,span_id,span.duration,app.resource.type,gen_ai.tool.name,error.type
+sort=-timestamp
+```
+
+Agent/model calls for provider, token, or cost symptoms.
+
+```text
+dataset=spans query='has:gen_ai.provider.name OR has:gen_ai.request.model'
+fields=timestamp,trace,span_id,span.duration,gen_ai.provider.name,gen_ai.request.model,gen_ai.operation.name,gen_ai.usage.input_tokens,gen_ai.usage.output_tokens,error.type
+sort=-timestamp
+```
+
+Stdio sessions by configured host or mode.
+
+```text
+dataset=spans query='app.transport:stdio app.upstream.host:"<host>"'
+fields=timestamp,trace,span_id,app.server.version,app.server.mode.agent,app.server.mode.experimental,app.url.full,error.type
+sort=-timestamp
+```
+
+## Domains
+
+### Cloudflare HTTP Server
+
+The hosted MCP server returned an unexpected status, rate-limited a customer, or
+logged a request problem.
+
+Metrics: `app.server.response`
+
+Attributes: `http.request.method`, `http.route`,
+`http.response.status_code`, `app.response.status_class`,
+`app.route.group`, `app.response.reason`, `app.rate_limit.scope`,
+`app.request.duration_ms`
+
+### OAuth And Client Registration
+
+Users report sign-outs, refresh loops, DCR churn, or callback/register
+imbalance.
+
+Metrics: `app.oauth.token_exchange`, `app.oauth.grant_revoked`,
+`app.oauth.callback_completed`, `app.oauth.register`
+
+Attributes: `app.oauth.token_exchange.outcome`, `app.oauth.grant.shape`,
+`app.oauth.probe.status_code`, `app.oauth.probe.reason`,
+`app.oauth.grant_revoked.reason`, `app.client.family`, `user.id`
+
+### MCP Tool Execution
+
+A tool is slow, failing, affected by session constraints, or calling the wrong
+Sentry API path.
+
+Spans: tool call spans and downstream Sentry API spans
+
+Attributes: `gen_ai.tool.name`, `mcp.session.id`,
+`app.constraint.organization_slug`, `app.constraint.project_slug`,
+`app.transport`, `user.id`
+
+### Resource Resolution
+
+`get_sentry_resource` routes a URL or ID to the wrong resource handler, or a
+supported-looking URL returns guidance instead of data.
+
+Spans: `get_sentry_resource` tool span and downstream resource tool span
+
+Attributes: `app.resource.type`, `gen_ai.tool.name`, `trace_id`, `span_id`
+
+### Stdio Transport
+
+Local package startup, host selection, agent mode, experimental mode, or token
+resolution behaves differently than the hosted server.
+
+Attributes: `app.server.version`, `app.transport`, `app.server.mode.agent`,
+`app.server.mode.experimental`, `app.upstream.host`, `app.url.full`
+
+### Agent And GenAI
+
+The test client or embedded agent has provider, model, token, or tool-call
+issues.
+
+Spans: GenAI agent/model/tool spans
+
+Attributes: `gen_ai.provider.name`, `gen_ai.request.model`,
+`gen_ai.operation.name`, `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.tool.name`
+
+## Configuration
+
+| Setting | Controls | Default |
+| ------- | -------- | ------- |
+| `VITE_SENTRY_DSN` | Cloudflare Sentry telemetry | disabled when unset |
+| `VITE_SENTRY_ENVIRONMENT` | Cloudflare Sentry environment | development |
+| `SENTRY_DSN` | stdio and Node telemetry | disabled when unset |
+| `SENTRY_RELEASE` | stdio release tag | unset |
+| `SENTRY_HOST` | upstream Sentry host and `app.upstream.host` | `sentry.io` |
+| `NODE_ENV` | stdio environment | production fallback in packaged runtime |
+
+## Attribute Notes
+
+- `http.*`, `network.*`, and `gen_ai.*` fields follow OpenTelemetry semantic
+  conventions where applicable.
+- `mcp.*` fields are reserved for current or draft OpenTelemetry MCP semantic
+  attributes, such as `mcp.method.name`, `mcp.protocol.version`,
+  `mcp.resource.uri`, and `mcp.session.id`.
+- `app.*` fields are Sentry MCP application-owned attributes for product
+  concepts that are not part of the MCP semantic convention, such as OAuth
+  outcomes, route groups, constraints, and local response reasons.
+- Keep metric attributes low-cardinality. Avoid raw URLs, tokens, prompts,
+  full request bodies, or other high-cardinality or sensitive values.
+- Do not log secrets. Authorization headers and access tokens must remain
+  scrubbed.
+- Update this document, `docs/monitoring.md`, and
+  `packages/mcp-core/src/internal/agents/tools/data/mcp.json` when adding or
+  renaming telemetry fields. Do not add unit tests solely to assert telemetry
+  attribute spelling.
+
+## References
+
+- `docs/monitoring.md`
+- `docs/oauth-signout-playbook.md`
+- `docs/error-handling.md`
+- `packages/mcp-cloudflare/src/server/metrics.ts`
+- `packages/mcp-cloudflare/src/server/oauth/helpers.ts`
+- `packages/mcp-core/src/internal/agents/tools/data/mcp.json`
+- [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [OpenTelemetry MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -27,7 +27,7 @@ export async function createTracedToolHandler<T extends ToolName>(
     name,
     async (context: ServerContext, params: ToolParams<T>) => {
       const attributes = {
-        "mcp.tool.name": name,
+        "gen_ai.tool.name": name,
         ...extractMcpParameters(params),
       };
 
@@ -133,21 +133,32 @@ process.on("uncaughtException", (error) => {
 Sentry follows OpenTelemetry semantic conventions for consistent observability.
 
 ### MCP Attributes (Model Context Protocol)
-Based on [OpenTelemetry MCP conventions](https://github.com/open-telemetry/semantic-conventions/blob/3097fb0af5b9492b0e3f55dc5f6c21a3dc2be8df/docs/registry/attributes/mcp.md) (currently in **draft form**):
+Based on the current [OpenTelemetry MCP conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/), keep `mcp.*` limited to the documented MCP semantic attributes:
 
-- `mcp.method.name` - The name of the request or notification method (e.g., "notifications/cancelled", "initialize", "notifications/initialized")
-- `mcp.prompt.name` - The name of the prompt or prompt template provided in the request or response (e.g., "analyze-code")
-- `mcp.request.argument.<key>` - Additional arguments passed to the request within `params` object (e.g., "mcp.request.argument.location='Seattle, WA'", "mcp.request.argument.a='42'")
-- `mcp.request.id` - A unique identifier for the request (e.g., "42")
-- `mcp.resource.uri` - The value of the resource uri (e.g., "postgres://database/customers/schema", "file:///home/user/documents/report.pdf")
+- `mcp.method.name` - The name of the request or notification method (e.g., "notifications/cancelled", "initialize", "tools/call")
+- `mcp.protocol.version` - The MCP protocol version (e.g., "2025-06-18")
+- `mcp.resource.uri` - The value of the resource URI (e.g., "postgres://database/customers/schema", "file:///home/user/documents/report.pdf")
 - `mcp.session.id` - Identifies MCP session (e.g., "191c4850af6c49e08843a3f6c80e5046")
-- `mcp.tool.name` - The name of the tool provided in the request (e.g., "get-weather", "execute_command")
 
-### Custom MCP Attributes
-These are custom attributes - *not in draft spec* - we've added to enhance MCP observability:
+Current MCP spans also use related OpenTelemetry attributes outside the `mcp.*` namespace:
 
-- `mcp.resource.name` - The name of the resource (e.g., "sentry-docs-platform", "sentry-query-syntax")
-- `mcp.transport` - The transport method used for MCP communication (values: "http", "sse", "stdio")
+- `gen_ai.prompt.name` - The prompt or prompt template name
+- `gen_ai.tool.name` - The tool name
+- `jsonrpc.request.id` - The JSON-RPC request ID
+- `rpc.response.status_code` - The JSON-RPC response status or error code
+- `network.transport` - Transport protocol (`pipe` for stdio, `tcp` or `quic` for HTTP)
+
+### Application-Owned Attributes
+These are Sentry MCP application attributes that are not part of the MCP semantic convention:
+
+- `app.resource.type` - Resolved Sentry resource type for `get_sentry_resource`
+- `app.transport` - The product transport label (values: "http", "sse", "stdio")
+- `app.constraint.organization_slug` - Session organization constraint
+- `app.constraint.project_slug` - Session project constraint
+- `app.server.mode.agent` - Whether stdio started in agent mode
+- `app.server.mode.experimental` - Whether experimental tools are enabled
+- `app.upstream.host` - Upstream Sentry host configured for the server
+- `app.url.full` - MCP URL configured for stdio
 
 ### User Agent Tracking
 
@@ -165,7 +176,7 @@ Based on [OpenTelemetry network conventions](https://github.com/open-telemetry/s
 ### GenAI Attributes (Generative AI)
 Based on [OpenTelemetry GenAI conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/gen-ai.md):
 
-- `gen_ai.system` - The AI system being used (e.g., "anthropic")
+- `gen_ai.provider.name` - The AI provider name (e.g., "anthropic")
 - `gen_ai.request.model` - Name of the GenAI model
 - `gen_ai.request.max_tokens` - Maximum tokens to generate
 - `gen_ai.operation.name` - Type of operation (e.g., "chat")
@@ -177,10 +188,8 @@ Follows the format: `{mcp.method.name} {target}` per OpenTelemetry MCP semantic 
 
 - Tools: `tools/call {tool_name}` (e.g., `tools/call find_issues`)
 - Prompts: `prompts/get {prompt_name}` (e.g., `prompts/get analyze-code`)
-- Resources: `resources/read {resource_uri}` (e.g., `resources/read https://github.com/...`)
-- Client: `mcp.client/{target}` (e.g., `mcp.client/agent`)
-- Connect: `mcp.connect/{transport}` (e.g., `mcp.connect/stdio`)
-- Auth: `mcp.auth/{method}` (e.g., `mcp.auth/oauth`)
+- Resources: `resources/read` by default. Do not include resource URIs in span names unless explicitly opted in because they can be high-cardinality.
+- Connect/auth spans may use local names such as `mcp.connect/stdio` and `mcp.auth/oauth`; these are span names, not semantic attribute namespaces.
 
 **Note**: Span names are flexible and can be adjusted based on your needs. However, attribute names MUST follow the OpenTelemetry semantic conventions exactly as specified above.
 
@@ -188,13 +197,13 @@ Follows the format: `{mcp.method.name} {target}` per OpenTelemetry MCP semantic 
 ```typescript
 // MCP Tool Execution
 {
-  "mcp.tool.name": "find_issues",
+  "gen_ai.tool.name": "find_issues",
   "mcp.session.id": "191c4850af6c49e08843a3f6c80e5046"
 }
 
 // GenAI Agent
 {
-  "gen_ai.system": "anthropic",
+  "gen_ai.provider.name": "anthropic",
   "gen_ai.request.model": "claude-3-5-sonnet-20241022",
   "gen_ai.operation.name": "chat",
   "gen_ai.usage.input_tokens": 150,
@@ -205,7 +214,7 @@ Follows the format: `{mcp.method.name} {target}` per OpenTelemetry MCP semantic 
 {
   "network.transport": "pipe",  // "pipe" for stdio, "tcp" for SSE
   "mcp.session.id": "191c4850af6c49e08843a3f6c80e5046",
-  "mcp.transport": "stdio",  // Custom attribute: "stdio" or "sse"
+  "app.transport": "stdio",  // Custom attribute: "stdio" or "sse"
   "service.version": "1.2.3"  // Version of the MCP server/client
 }
 
@@ -213,8 +222,8 @@ Follows the format: `{mcp.method.name} {target}` per OpenTelemetry MCP semantic 
 {
   "mcp.session.id": "191c4850af6c49e08843a3f6c80e5046",
   "network.transport": "pipe",  // "pipe" for stdio, "tcp" for SSE
-  "mcp.transport": "stdio",  // Custom attribute: "stdio" or "sse"
-  "gen_ai.system": "anthropic",
+  "app.transport": "stdio",  // Custom attribute: "stdio" or "sse"
+  "gen_ai.provider.name": "anthropic",
   "gen_ai.request.model": "claude-3-5-sonnet-20241022",
   "gen_ai.operation.name": "chat",
   "service.version": "1.2.3"  // Version of the MCP client
@@ -241,30 +250,30 @@ Follows the format: `{mcp.method.name} {target}` per OpenTelemetry MCP semantic 
 For Cloudflare HTTP traffic we send custom Metrics product counters through the
 JavaScript SDK metrics API:
 
-- `mcp.server.response` - Count of tracked HTTP responses
+- `app.server.response` - Count of tracked HTTP responses
 
 Shared low-cardinality attributes:
 
 - `http.request.method` - HTTP method
 - `http.route` - Normalized route template
 - `http.response.status_code` - Final HTTP status code
-- `http.status_class` - Status family such as `2xx` or `4xx`
-- `sentry.route.group` - Coarse route family: `mcp`, `oauth`, `chat`, or `search`
+- `app.response.status_class` - Status family such as `2xx` or `4xx`
+- `app.route.group` - Coarse route family: `mcp`, `oauth`, `chat`, or `search`
 
 Optional local rate-limit attributes:
 
-- `sentry.response.reason` - `local_rate_limit`
-- `sentry.rate_limit.scope` - `ip` or `user`
+- `app.response.reason` - `local_rate_limit`
+- `app.rate_limit.scope` - `ip` or `user`
 
 Interpretation:
 
-- Use `sum(mcp.server.response)` grouped by `http.route` and
+- Use `sum(app.server.response)` grouped by `http.route` and
   `http.response.status_code` for response rates
-- Use `sum(mcp.server.response)` filtered by
-  `sentry.response.reason=local_rate_limit` to measure when we rate-limited the
+- Use `sum(app.server.response)` filtered by
+  `app.response.reason=local_rate_limit` to measure when we rate-limited the
   customer
-- Upstream/provider 429s increment `mcp.server.response` with status `429`, but
-  do not include `sentry.response.reason`
+- Upstream/provider 429s increment `app.server.response` with status `429`, but
+  do not include `app.response.reason`
 
 ### Traces Configuration
 ```typescript

--- a/docs/oauth-signout-playbook.md
+++ b/docs/oauth-signout-playbook.md
@@ -29,20 +29,20 @@ MCP client ──(tool call)──> /mcp ──> mcp-handler ──> tool handle
 | Mode | Trigger | Currently visible in telemetry | Detected by |
 |---|---|---|---|
 | **Natural 30d expiry** | Upstream `expires_at` passes | Yes | Probe path in `tokenExchangeCallback` → `upstream_rejected` |
-| **Premature Sentry-side invalidation (SSO / org / password / admin)** | Sentry revokes before `expires_at` | Yes | Tool call surfaces 401 → `grant_revoked{reason:upstream_rejected_in_use}` + grant revoked via `onUpstreamUnauthorized` callback |
-| **Stale grants from before `refreshToken` was stored in props** | Old grants from pre-#537 deploys | Yes | `mcp-handler` → `grant_revoked{reason:stale_props_no_refresh}` |
-| **Client-side state loss (DCR state reset, fresh install, reinstall)** | Client drops its stored `client_id`/`refresh_token` | Indirectly | High `/oauth/register` volume and `register:callback` ratio per `client_family` |
+| **Premature Sentry-side invalidation (SSO / org / password / admin)** | Sentry revokes before `expires_at` | Yes | Tool call surfaces 401 → `app.oauth.grant_revoked.reason:upstream_rejected_in_use` + grant revoked via `onUpstreamUnauthorized` callback |
+| **Stale grants from before `refreshToken` was stored in props** | Old grants from pre-#537 deploys | Yes | `mcp-handler` → `app.oauth.grant_revoked.reason:stale_props_no_refresh` |
+| **Client-side state loss (DCR state reset, fresh install, reinstall)** | Client drops its stored `client_id`/`refresh_token` | Indirectly | High `/oauth/register` volume and `register:callback` ratio per `app.client.family` |
 | **Invalid redirect URI at authorize** | Client sends an `redirect_uri` that's not registered | Yes | Log `OAuth authorization failed: Invalid redirect URI` with `clientId`/`redirectUri`/`registeredUris`/`clientName` |
-| **Upstream probe transient (5xx / rate limit / network)** | Sentry side instability | Yes | `token_exchange{outcome:verification_indeterminate, probe_reason:…}` (does not force sign-out) |
+| **Upstream probe transient (5xx / rate limit / network)** | Sentry side instability | Yes | `app.oauth.token_exchange.outcome:verification_indeterminate` with `app.oauth.probe.reason` (does not force sign-out) |
 | **Same-user concurrent session interference** | Another session of the same user re-authorizes | Resolved by passing `revokeExistingGrants: false` — see Gap #4 below | n/a after fix |
 
 ## Telemetry surface
 
 All metrics live in the `mcp-server` project on Sentry. Attribute values deliberately avoid the substring `"token"` because Sentry's default PII scrubber replaces those values with `[Filtered]` at ingest (see PR #916 for the migration).
 
-### `mcp.oauth.token_exchange` (counter)
+### `app.oauth.token_exchange` (counter)
 
-Fired for every `grant_type=refresh_token` request. Splits by `outcome`:
+Fired for every `grant_type=refresh_token` request. Splits by `app.oauth.token_exchange.outcome`:
 
 - `cached_valid_local` — fast path, local expiry still in future by >2 min
 - `cached_valid_probed` — probe confirmed still valid, `accessTokenExpiresAt` extended by 2h
@@ -51,42 +51,42 @@ Fired for every `grant_type=refresh_token` request. Splits by `outcome`:
 
 Attributes:
 
-- `outcome` — see above
-- `client_family` — bucketed User-Agent (`claude-code`, `cursor`, `codex`, `copilot`, `claude-desktop`, `opencode`, `reactor-netty`, `java-http-client`, `go-http-client`, `python`, `bun`, `node`, `other`, `unknown`)
-- `grant_shape` — currently always `refreshable`
-- `probe_status` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
-- `probe_reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
+- `app.oauth.token_exchange.outcome` — see above
+- `app.client.family` — bucketed User-Agent (`claude-code`, `cursor`, `codex`, `copilot`, `claude-desktop`, `opencode`, `reactor-netty`, `java-http-client`, `go-http-client`, `python`, `bun`, `node`, `other`, `unknown`)
+- `app.oauth.grant.shape` — currently always `refreshable`
+- `app.oauth.probe.status_code` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
+- `app.oauth.probe.reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
 
-User context is set from the stored user ID and current request, so metrics can be filtered by `user.id` and events retain the request IP when available. Sub-30d sign-outs surface via `mcp.oauth.grant_revoked{reason:upstream_rejected_in_use}`, not on this metric.
+User context is set from the stored user ID and current request, so metrics can be filtered by `user.id` and events retain the request IP when available. Sub-30d sign-outs surface via `app.oauth.grant_revoked` with `app.oauth.grant_revoked.reason:upstream_rejected_in_use`, not on this metric.
 
-### `mcp.oauth.grant_revoked` (counter)
+### `app.oauth.grant_revoked` (counter)
 
 Fired when we revoke a stored grant — either the MCP handler on a subsequent request, or the `onUpstreamUnauthorized` callback on a mid-session 401.
 
 Attributes:
 
-- `reason` — `stale_props_no_refresh` / `upstream_rejected` / `upstream_rejected_in_use`
-- `client_family`
+- `app.oauth.grant_revoked.reason` — `stale_props_no_refresh` / `upstream_rejected` / `upstream_rejected_in_use`
+- `app.client.family`
 - `user.id` (via Sentry user context)
 
 `upstream_rejected_in_use` indicates Sentry returned 401 to a tool call while the stored access token still looked locally valid — the sub-30d sign-out signal users typically report. The grant is revoked via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`, short-circuiting the death-spiral where subsequent refreshes kept handing out wrapper tokens backed by a dead upstream token.
 
-### `mcp.oauth.callback_completed` (counter)
+### `app.oauth.callback_completed` (counter)
 
 Fired on a successful `/oauth/callback`. Pairs with `grant_revoked` to derive per-user session lifetime.
 
 Attributes:
 
-- `client_family` — resolved from the DCR-registered `client_name` (not the browser User-Agent, which is always a browser string on this endpoint)
+- `app.client.family` — resolved from the DCR-registered `client_name` (not the browser User-Agent, which is always a browser string on this endpoint)
 - `user.id`
 
-### `mcp.oauth.register` (counter)
+### `app.oauth.register` (counter)
 
 Fired from the `wrappedOAuthProvider` after the library handles a successful `/oauth/register`.
 
 Attributes:
 
-- `client_family` — from the client's User-Agent (accurate here — DCR is hit directly by the MCP client, not via browser)
+- `app.client.family` — from the client's User-Agent (accurate here — DCR is hit directly by the MCP client, not via browser)
 
 ### Structured logs
 
@@ -99,38 +99,38 @@ Copy/paste-ready. All use the Sentry MCP's `search_events` natural-language quer
 ### Is a specific user being revoked?
 
 ```
-metric mcp.oauth.grant_revoked filtered by user.id:"<id>" sum of value grouped by reason over 30 days
+metric app.oauth.grant_revoked filtered by user.id:"<id>" sum of value grouped by app.oauth.grant_revoked.reason over 30 days
 ```
 
 ### Per-client sign-out rate
 
 ```
-metric mcp.oauth.grant_revoked sum of value grouped by client_family, reason over 24 hours
+metric app.oauth.grant_revoked sum of value grouped by app.client.family, app.oauth.grant_revoked.reason over 24 hours
 ```
 
 ### Probe-failure status distribution (is Sentry ever returning 403/400?)
 
 ```
-metric mcp.oauth.token_exchange filtered by outcome:upstream_rejected sum of value grouped by probe_status over 7 days
+metric app.oauth.token_exchange filtered by app.oauth.token_exchange.outcome:upstream_rejected sum of value grouped by app.oauth.probe.status_code over 7 days
 ```
 
 ### Session-lifetime proxy (callbacks vs revocations per client)
 
 ```
-metric mcp.oauth.callback_completed sum of value grouped by client_family over 7 days
-metric mcp.oauth.grant_revoked sum of value grouped by client_family over 7 days
+metric app.oauth.callback_completed sum of value grouped by app.client.family over 7 days
+metric app.oauth.grant_revoked sum of value grouped by app.client.family over 7 days
 ```
 
 ### Register storm attribution
 
 ```
-metric mcp.oauth.register sum of value grouped by client_family over 7 days
+metric app.oauth.register sum of value grouped by app.client.family over 7 days
 ```
 
 ### Upstream instability bucket
 
 ```
-metric mcp.oauth.token_exchange filtered by outcome:verification_indeterminate sum of value grouped by probe_reason over 24 hours
+metric app.oauth.token_exchange filtered by app.oauth.token_exchange.outcome:verification_indeterminate sum of value grouped by app.oauth.probe.reason over 24 hours
 ```
 
 ### Invalid redirect URI failures by client
@@ -150,7 +150,7 @@ After:
 - `handleApiError` re-throws `ApiAuthenticationError` unwrapped.
 - `server.ts` tool-handler catch detects it (walking `error.cause` up to 3 levels) and invokes `context.onUpstreamUnauthorized`.
 - `use_sentry`'s tool wrapper does the same check before re-throwing, so 401s inside the embedded agent aren't absorbed by the AI SDK.
-- The Cloudflare transport's `onUpstreamUnauthorized` emits `grant_revoked{reason:upstream_rejected_in_use}` and calls `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`. `workers-oauth-provider` stores tokens under `token:userId:grantId:*` in KV and validates every access token via a KV lookup, so revoking the grant invalidates all outstanding wrapper tokens too — the client's next `/mcp` request gets a 401 and is forced into a clean re-auth.
+- The Cloudflare transport's `onUpstreamUnauthorized` emits `app.oauth.grant_revoked` with `app.oauth.grant_revoked.reason:upstream_rejected_in_use` and calls `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`. `workers-oauth-provider` stores tokens under `token:userId:grantId:*` in KV and validates every access token via a KV lookup, so revoking the grant invalidates all outstanding wrapper tokens too — the client's next `/mcp` request gets a 401 and is forced into a clean re-auth.
 - `formatErrorForUser` returns "Authorization Expired — please re-authorize" instead of falling through to the generic Input Error template.
 
 ### Gap #2 — `handleApiError` misclassified 401 — **closed**
@@ -159,7 +159,7 @@ Fixed alongside Gap #1. `ApiAuthenticationError` now propagates unwrapped and tr
 
 ### Gap #3 — tool-call `clientInfo` lost on stateless transport
 
-`mcp.client.name` is `null` on 100% of tool-call spans because `createMcpHandler` (from `agents@0.3.10`) creates a fresh `WorkerTransport` per request, and `clientInfo` is only captured during `initialize`. Closing this would require persisting `clientInfo` keyed by MCP session id (e.g., in `MCP_CACHE` KV) and reinjecting it per-request. Not blocking for OAuth diagnosis — user-agent family is an adequate substitute — but worth fixing for tool-level telemetry.
+`app.client.name` is `null` on 100% of tool-call spans because `createMcpHandler` (from `agents@0.3.10`) creates a fresh `WorkerTransport` per request, and `clientInfo` is only captured during `initialize`. Closing this would require persisting `clientInfo` keyed by MCP session id (e.g., in `MCP_CACHE` KV) and reinjecting it per-request. Not blocking for OAuth diagnosis — user-agent family is an adequate substitute — but worth fixing for tool-level telemetry.
 
 ### Gap #4 — Same-user concurrent session interference — **closed**
 
@@ -172,19 +172,19 @@ Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real con
 ## Runbook — "a user says they got signed out"
 
 1. **Check `grant_revoked` for the user** over the relevant window:
-   `metric mcp.oauth.grant_revoked filtered by user.id:"<id>" grouped by reason over 30 days`
+   `metric app.oauth.grant_revoked filtered by user.id:"<id>" grouped by app.oauth.grant_revoked.reason over 30 days`
 2. **Interpret the `reason`:**
    - `upstream_rejected_in_use` — Sentry invalidated the token mid-session (SSO / org / password / admin revocation). Most common for sub-30d sign-outs. The grant was revoked automatically; user should re-auth cleanly on next request.
    - `upstream_rejected` — natural 30d expiry (probe path). Expected.
    - `stale_props_no_refresh` — legacy grant predating PR #537. Expected, one-time.
 3. **If no revocations are recorded** (reason counts are empty), the user hasn't been revoked server-side. Either they're still authenticated and the perception is wrong, OR the client lost local state and re-registered without going through `/oauth/callback`:
-   - Check `mcp.oauth.register grouped by client_family` for that client — high register:callback ratio (claude-code and cursor re-register on every cold start) is normal client behavior, not a server-side sign-out.
+   - Check `app.oauth.register grouped by app.client.family` for that client — high register:callback ratio (claude-code and cursor re-register on every cold start) is normal client behavior, not a server-side sign-out.
 4. **If reporting a specific time**, query `POST /oauth/token` transactions for that `user.id` around that timestamp. Transaction duration and child `GET /api/0/auth/` span tell you whether probes fired.
 
 ## Related PRs
 
 - #916 — restored sign-out telemetry (scrubber rename) and reduced probe volume.
 - #917 — carried probe status as a metric attribute.
-- #918 — added `client_family`, user tagging, `callback_completed` / `register` metrics, `probe_reason`, structured Invalid-redirect-URI fields.
+- #918 — added client family, user tagging, `callback_completed` / `register` metrics, probe reason, structured Invalid-redirect-URI fields.
 - #919 — added `expired_on_schedule` on `upstream_rejected`. Removed in #920 once we realized the probe path can't produce `"false"` by construction.
-- #920 — closes Gaps #1 and #2 via tool-call 401 detection, grant revocation, and `grant_revoked{reason:upstream_rejected_in_use}`. Also removes the unreachable `expired_on_schedule` attribute and its `upstreamExpiresAt` grant field.
+- #920 — closes Gaps #1 and #2 via tool-call 401 detection, grant revocation, and `app.oauth.grant_revoked.reason:upstream_rejected_in_use`. Also removes the unreachable `expired_on_schedule` attribute and its `upstreamExpiresAt` grant field.

--- a/docs/search-events-api-patterns.md
+++ b/docs/search-events-api-patterns.md
@@ -136,7 +136,8 @@ https://us.sentry.io/api/0/organizations/sentry/events/?dataset=spans&field=ai.m
 Instead of using `span.op` patterns, use `has:` queries for more flexible attribute-based filtering:
 - HTTP requests: `has:request.url` instead of `span.op:http*`
 - Database queries: `has:db.statement` or `has:db.system` instead of `span.op:db*`
-- AI/LLM calls: `has:ai.model.id` or `has:mcp.tool.name`
+- AI/LLM calls: `has:ai.model.id`
+- MCP tool calls: `has:gen_ai.tool.name`
 
 ### Aggregate Functions
 
@@ -207,8 +208,8 @@ Dataset: metrics
 
 ### Tool Calls by Model (Aggregate)
 ```
-Query: has:mcp.tool.name
-Fields: ["ai.model.id", "mcp.tool.name", "count()"]
+Query: has:gen_ai.tool.name
+Fields: ["ai.model.id", "gen_ai.tool.name", "count()"]
 Sort: -count()
 Dataset: spans
 ```

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -198,8 +198,8 @@ const wrappedOAuthProvider = {
       url.pathname === "/oauth/register" &&
       response.ok
     ) {
-      Sentry.metrics.count("mcp.oauth.register", 1, {
-        attributes: { client_family: clientFamily },
+      Sentry.metrics.count("app.oauth.register", 1, {
+        attributes: { "app.client.family": clientFamily },
       });
     }
 

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -182,10 +182,10 @@ const mcpHandler: ExportedHandler<Env> = {
     // scrubber doesn't replace them with "[Filtered]" on ingest.
     if (!rawProps.refreshToken) {
       if (requestGrantId) {
-        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+        Sentry.metrics.count("app.oauth.grant_revoked", 1, {
           attributes: {
-            reason: "stale_props_no_refresh",
-            client_family: clientFamily,
+            "app.oauth.grant_revoked.reason": "stale_props_no_refresh",
+            "app.client.family": clientFamily,
           },
         });
       }
@@ -201,10 +201,10 @@ const mcpHandler: ExportedHandler<Env> = {
 
     if (rawProps.upstreamTokenInvalid) {
       if (requestGrantId) {
-        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+        Sentry.metrics.count("app.oauth.grant_revoked", 1, {
           attributes: {
-            reason: "upstream_rejected",
-            client_family: clientFamily,
+            "app.oauth.grant_revoked.reason": "upstream_rejected",
+            "app.client.family": clientFamily,
           },
         });
       }
@@ -335,10 +335,10 @@ const mcpHandler: ExportedHandler<Env> = {
           });
           return;
         }
-        Sentry.metrics.count("mcp.oauth.grant_revoked", 1, {
+        Sentry.metrics.count("app.oauth.grant_revoked", 1, {
           attributes: {
-            reason: "upstream_rejected_in_use",
-            client_family: clientFamily,
+            "app.oauth.grant_revoked.reason": "upstream_rejected_in_use",
+            "app.client.family": clientFamily,
           },
         });
         ctx.waitUntil(

--- a/packages/mcp-cloudflare/src/server/logging.ts
+++ b/packages/mcp-cloudflare/src/server/logging.ts
@@ -15,8 +15,8 @@ export function createRequestLogger(
     logInfo(`${c.req.method} ${url.pathname}`, {
       loggerScope,
       extra: {
-        status: c.res.status,
-        duration_ms: Date.now() - start,
+        "http.response.status_code": c.res.status,
+        "app.request.duration_ms": Date.now() - start,
       },
     });
   };

--- a/packages/mcp-cloudflare/src/server/metrics.ts
+++ b/packages/mcp-cloudflare/src/server/metrics.ts
@@ -8,7 +8,7 @@ type TrackedRoute = {
   route: string;
 };
 
-const RESPONSE_METRIC_NAME = "mcp.server.response";
+const RESPONSE_METRIC_NAME = "app.server.response";
 const RESPONSE_REASON_HEADER = "x-sentry-response-reason";
 const RATE_LIMIT_SCOPE_HEADER = "x-sentry-rate-limit-scope";
 
@@ -92,7 +92,7 @@ function getMetricAttributes(
   return {
     "http.request.method": request.method,
     "http.route": trackedRoute.route,
-    "sentry.route.group": trackedRoute.group,
+    "app.route.group": trackedRoute.group,
   };
 }
 
@@ -166,15 +166,15 @@ export function recordResponseMetric(
 
   const responseAttributes: Record<string, string | number> = {
     "http.response.status_code": response.status,
-    "http.status_class": getStatusClass(response.status),
+    "app.response.status_class": getStatusClass(response.status),
   };
 
   if (options?.responseReason) {
-    responseAttributes["sentry.response.reason"] = options.responseReason;
+    responseAttributes["app.response.reason"] = options.responseReason;
   }
 
   if (options?.rateLimitScope) {
-    responseAttributes["sentry.rate_limit.scope"] = options.rateLimitScope;
+    responseAttributes["app.rate_limit.scope"] = options.rateLimitScope;
   }
 
   Sentry.metrics.count(RESPONSE_METRIC_NAME, 1, {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -448,9 +448,9 @@ function recordTokenExchangeOutcome(
   outcome: TokenExchangeOutcome,
   attributes?: Record<string, string>,
 ): void {
-  Sentry.metrics.count("mcp.oauth.token_exchange", 1, {
+  Sentry.metrics.count("app.oauth.token_exchange", 1, {
     attributes: {
-      outcome,
+      "app.oauth.token_exchange.outcome": outcome,
       ...attributes,
     },
   });
@@ -588,8 +588,8 @@ export async function tokenExchangeCallback(
     const remainingMs = expiresAt - Date.now();
     if (remainingMs > SAFE_WINDOW_MS) {
       recordTokenExchangeOutcome("cached_valid_local", {
-        grant_shape: "refreshable",
-        client_family: clientFamily,
+        "app.oauth.grant.shape": "refreshable",
+        "app.client.family": clientFamily,
       });
       return buildSuccessfulTokenExchangeResult(
         props,
@@ -609,14 +609,14 @@ export async function tokenExchangeCallback(
   // Metric attribute (not span attribute): Sentry.getActiveSpan() is
   // undefined inside tokenExchangeCallback.
   const outcomeAttributes: Record<string, string> = {
-    grant_shape: "refreshable",
-    client_family: clientFamily,
+    "app.oauth.grant.shape": "refreshable",
+    "app.client.family": clientFamily,
   };
   if (typeof status === "number") {
-    outcomeAttributes.probe_status = String(status);
+    outcomeAttributes["app.oauth.probe.status_code"] = String(status);
   }
   if (reason) {
-    outcomeAttributes.probe_reason = reason;
+    outcomeAttributes["app.oauth.probe.reason"] = reason;
   }
   switch (outcome) {
     case "cached_valid_probed": {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -324,9 +324,9 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // /oauth/callback is browser-navigated, so the User-Agent is the user's
   // browser, not the MCP client. Derive client family from the DCR-registered
   // client_name (resolved above).
-  Sentry.metrics.count("mcp.oauth.callback_completed", 1, {
+  Sentry.metrics.count("app.oauth.callback_completed", 1, {
     attributes: {
-      client_family: resolveClientFamilyFromName(registeredClientName),
+      "app.client.family": resolveClientFamilyFromName(registeredClientName),
     },
   });
 

--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -15,8 +15,8 @@ export default function getSentryConfig(env: Env): SentryConfig {
     beforeSend: sentryBeforeSend,
     initialScope: {
       tags: {
-        "mcp.server_version": LIB_VERSION,
-        "sentry.host": env.SENTRY_HOST,
+        "app.server.version": LIB_VERSION,
+        "app.upstream.host": env.SENTRY_HOST,
       },
     },
     ...(versionId ? { release: versionId } : {}),

--- a/packages/mcp-core/scripts/generate-otel-namespaces.ts
+++ b/packages/mcp-core/scripts/generate-otel-namespaces.ts
@@ -339,7 +339,7 @@ async function generateNamespaceFiles() {
       const existingJson = JSON.parse(existingContent);
 
       // Skip if this appears to be a custom namespace (not from OpenTelemetry)
-      if (existingJson.namespace === "mcp" || existingJson.custom === true) {
+      if (existingJson.custom === true) {
         console.log(`⏭️  Skipping custom namespace: ${namespace}`);
         skipped++;
         continue;
@@ -424,56 +424,43 @@ function generateNamespacesIndex(
   );
 }
 
-// Add MCP namespace as a custom one
+// Add MCP namespace from the current OpenTelemetry MCP draft.
 function generateMcpNamespace() {
   const mcpNamespace: JsonNamespace = {
     namespace: "mcp",
-    description:
-      "Model Context Protocol attributes for MCP tool calls and sessions",
+    description: "Model Context Protocol semantic convention attributes",
     attributes: {
-      "mcp.tool.name": {
-        description: "Tool name (e.g., find_issues, search_events)",
+      "mcp.method.name": {
+        description: "The name of the request or notification method.",
+        type: "string",
+        examples: ["initialize", "tools/call", "resources/read"],
+      },
+      "mcp.protocol.version": {
+        description: "The version of the Model Context Protocol used.",
+        type: "string",
+        examples: ["2025-06-18"],
+      },
+      "mcp.resource.uri": {
+        description: "The value of the resource URI.",
         type: "string",
         examples: [
-          "find_issues",
-          "search_events",
-          "get_issue_details",
-          "update_issue",
+          "postgres://database/customers/schema",
+          "file:///home/user/documents/report.pdf",
         ],
       },
       "mcp.session.id": {
-        description: "MCP session identifier",
+        description: "Identifies an MCP session.",
         type: "string",
-      },
-      "mcp.transport": {
-        description: "MCP transport protocol used",
-        type: "string",
-        examples: ["stdio", "http", "websocket"],
-      },
-      "mcp.request.id": {
-        description: "MCP request identifier",
-        type: "string",
-      },
-      "mcp.response.status": {
-        description: "MCP response status",
-        type: "string",
-        examples: ["success", "error"],
+        examples: ["191c4850af6c49e08843a3f6c80e5046"],
       },
     },
   };
 
   const outputPath = resolve(DATA_DIR, "mcp.json");
-  const content = JSON.stringify(
-    {
-      ...mcpNamespace,
-      custom: true, // Mark as custom so it doesn't get overwritten
-    },
-    null,
-    2,
-  );
+  const content = JSON.stringify(mcpNamespace, null, 2);
 
   writeFileSync(outputPath, content);
-  console.log("✅ Generated custom MCP namespace");
+  console.log("✅ Generated MCP namespace");
 }
 
 // Run the script

--- a/packages/mcp-core/src/internal/agents/tools/data/CLAUDE.md
+++ b/packages/mcp-core/src/internal/agents/tools/data/CLAUDE.md
@@ -42,10 +42,9 @@ The JSON files are imported directly in the TypeScript code and bundled by tsdow
 
 ### Custom Namespaces
 
-Some namespaces are maintained manually for attributes not yet in the OpenTelemetry specification:
-
-- **mcp.json** - Model Context Protocol attributes (custom)
-- Any file marked with `"custom": true` will be skipped during regeneration
+Namespaces are generated from OpenTelemetry semantic conventions by default.
+Files marked with `"custom": true` are reserved for manually maintained
+attributes and are skipped during regeneration.
 
 ## Usage
 
@@ -68,10 +67,7 @@ The `otel-semantics-lookup.ts` tool reads these JSON files to provide semantic g
 - **service** - Service identification (name, version, instance)
 - **error** - Error information (type, message, stack)
 - **user** - User identification (id, email, name)
-
-### Custom Namespaces
-
-- **mcp** - Model Context Protocol operations (tool calls, sessions)
+- **mcp** - Model Context Protocol attributes (methods, resources, sessions)
 
 ## Regeneration Process
 
@@ -89,14 +85,14 @@ data/
 ├── http.json              # HTTP attributes
 ├── rpc.json               # RPC attributes
 ├── messaging.json         # Messaging attributes
-├── mcp.json               # MCP attributes (custom)
+├── mcp.json               # MCP semantic convention attributes
 └── [other-namespaces].json
 ```
 
 ## Maintenance
 
 - **OpenTelemetry files**: Regenerate periodically to stay current with specifications
-- **Custom files**: Update manually as needed for new MCP or Sentry-specific attributes
+- **Custom files**: Update manually as needed for non-OpenTelemetry attributes
 - **Validation**: Ensure all files follow the expected JSON schema format
 
-The embedded AI agent uses these definitions to provide accurate semantic guidance when users query for things like "agent calls" (maps to gen_ai.*) vs "tool calls" (maps to mcp.*).
+The embedded AI agent uses these definitions to provide accurate semantic guidance when users query for things like "agent calls" or "tool calls" (maps to gen_ai.*) vs MCP protocol fields (maps to mcp.*).

--- a/packages/mcp-core/src/internal/agents/tools/data/__namespaces.json
+++ b/packages/mcp-core/src/internal/agents/tools/data/__namespaces.json
@@ -184,8 +184,7 @@
     },
     {
       "namespace": "mcp",
-      "description": "Model Context Protocol attributes for MCP tool calls and sessions",
-      "custom": true
+      "description": "Model Context Protocol semantic convention attributes"
     },
     {
       "namespace": "messaging",

--- a/packages/mcp-core/src/internal/agents/tools/data/mcp.json
+++ b/packages/mcp-core/src/internal/agents/tools/data/mcp.json
@@ -1,65 +1,29 @@
 {
   "namespace": "mcp",
-  "description": "Model Context Protocol attributes for MCP tool calls and sessions",
+  "description": "Model Context Protocol semantic convention attributes",
   "attributes": {
-    "mcp.tool.name": {
-      "description": "Tool name (e.g., search_issues, search_events)",
+    "mcp.method.name": {
+      "description": "The name of the request or notification method.",
+      "type": "string",
+      "examples": ["initialize", "tools/call", "resources/read"]
+    },
+    "mcp.protocol.version": {
+      "description": "The version of the Model Context Protocol used.",
+      "type": "string",
+      "examples": ["2025-06-18"]
+    },
+    "mcp.resource.uri": {
+      "description": "The value of the resource URI.",
       "type": "string",
       "examples": [
-        "search_issues",
-        "search_events",
-        "get_issue_details",
-        "update_issue"
+        "postgres://database/customers/schema",
+        "file:///home/user/documents/report.pdf"
       ]
     },
     "mcp.session.id": {
-      "description": "MCP session identifier",
-      "type": "string"
-    },
-    "mcp.transport": {
-      "description": "MCP transport protocol used",
+      "description": "Identifies an MCP session.",
       "type": "string",
-      "examples": ["stdio", "http", "websocket"]
-    },
-    "mcp.request.id": {
-      "description": "MCP request identifier",
-      "type": "string"
-    },
-    "mcp.response.status": {
-      "description": "MCP response status",
-      "type": "string",
-      "examples": ["success", "error"]
-    },
-    "mcp.client.name": {
-      "description": "Name of the MCP client application",
-      "type": "string",
-      "examples": [
-        "Cursor",
-        "Claude Code",
-        "VSCode MCP Extension",
-        "sentry-mcp-stdio"
-      ]
-    },
-    "mcp.client.version": {
-      "description": "Version of the MCP client application",
-      "type": "string",
-      "examples": ["0.16.0", "1.0.0", "2.3.1"]
-    },
-    "mcp.server.name": {
-      "description": "Name of the MCP server application",
-      "type": "string",
-      "examples": ["Sentry MCP Server", "GitHub MCP Server", "Slack MCP Server"]
-    },
-    "mcp.server.version": {
-      "description": "Version of the MCP server application",
-      "type": "string",
-      "examples": ["0.1.0", "1.2.3", "2.0.0"]
-    },
-    "mcp.protocol.version": {
-      "description": "MCP protocol version being used",
-      "type": "string",
-      "examples": ["2024-11-05", "1.0", "2.0"]
+      "examples": ["191c4850af6c49e08843a3f6c80e5046"]
     }
-  },
-  "custom": true
+  }
 }

--- a/packages/mcp-core/src/internal/agents/tools/otel-semantics.test.ts
+++ b/packages/mcp-core/src/internal/agents/tools/otel-semantics.test.ts
@@ -62,7 +62,7 @@ describe("otel-semantics-lookup", () => {
       expect(result).toContain("`http.response.status_code`");
     });
 
-    it("should show custom namespace note for mcp", async () => {
+    it("should return MCP semantic attributes", async () => {
       const result = await lookupOtelSemantics(
         "mcp",
         "spans",
@@ -70,7 +70,12 @@ describe("otel-semantics-lookup", () => {
         "test-org",
       );
 
-      expect(result).toContain("**Note:** This is a custom namespace");
+      expect(result).toContain("# OpenTelemetry Semantic Conventions: mcp");
+      expect(result).toContain("`mcp.method.name`");
+      expect(result).toContain("`mcp.protocol.version`");
+      expect(result).toContain("`mcp.resource.uri`");
+      expect(result).toContain("`mcp.session.id`");
+      expect(result).not.toContain("**Note:** This is a custom namespace");
     });
 
     it("should handle invalid namespace", async () => {

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -288,19 +288,19 @@ function configureServer({
         params: any,
         extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
       ) => {
-        // Get active span (mcp.server span) and attach more attributes to it
+        // Get the active MCP server span and attach request-scoped attributes.
         const activeSpan = getActiveSpan();
 
         if (activeSpan) {
           if (context.constraints.organizationSlug) {
             activeSpan.setAttribute(
-              "sentry-mcp.constraint-organization",
+              "app.constraint.organization_slug",
               context.constraints.organizationSlug,
             );
           }
           if (context.constraints.projectSlug) {
             activeSpan.setAttribute(
-              "sentry-mcp.constraint-project",
+              "app.constraint.project_slug",
               context.constraints.projectSlug,
             );
           }

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -475,7 +475,7 @@ export default defineTool({
       setTag("trace.span_id", resolved.spanId);
     }
 
-    getActiveSpan()?.setAttribute("sentry-mcp.resource-type", resolved.type);
+    getActiveSpan()?.setAttribute("app.resource.type", resolved.type);
 
     // Recognized but not yet fully supported types return guidance messages
     if (resolved.type === "monitor" || resolved.type === "release") {

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -1499,7 +1499,7 @@ describe("search_events", () => {
     mockGenerateText.mockResolvedValueOnce(
       mockAIResponse(
         "spans",
-        "has:mcp.tool.name AND has:user_agent.original",
+        "has:gen_ai.tool.name AND has:user_agent.original",
         ["user_agent.original", "count()"],
         undefined,
         "-count()",
@@ -1515,7 +1515,7 @@ describe("search_events", () => {
           const url = new URL(request.url);
           expect(url.searchParams.get("dataset")).toBe("spans");
           expect(url.searchParams.get("query")).toBe(
-            "has:mcp.tool.name AND has:user_agent.original",
+            "has:gen_ai.tool.name AND has:user_agent.original",
           );
           expect(url.searchParams.get("sort")).toBe("-count"); // API transforms count() to count
           expect(url.searchParams.get("statsPeriod")).toBe("24h");

--- a/packages/mcp-core/src/tools/search-events/config.ts
+++ b/packages/mcp-core/src/tools/search-events/config.ts
@@ -164,8 +164,8 @@ Performance Query Patterns (use duck typing):
 - Database: has:db.statement or has:db.system
 - HTTP/API calls: has:http.method or has:http.url
 - External Services: has:http.url (for outbound calls)
-- AI/LLM: has:gen_ai.system or has:gen_ai.request.model
-- MCP Tools: has:mcp.tool.name
+- AI/LLM: has:gen_ai.provider.name or has:gen_ai.request.model
+- MCP Tools: has:gen_ai.tool.name
 
 WHEN TO USE is_transaction:true (rare):
 - ONLY when you specifically need transaction boundaries (full request/response cycle)
@@ -323,14 +323,17 @@ export const DATASET_FIELDS = {
     // OpenTelemetry attribute namespaces for semantic queries
     // Use has:namespace.* to find spans with any attribute in that namespace
     // GenAI namespace (gen_ai.*) - for AI/LLM/Agent calls
-    "gen_ai.system": "AI system (e.g., anthropic, openai)",
+    "gen_ai.provider.name": "AI provider name (e.g., anthropic, openai)",
     "gen_ai.request.model": "Model name (e.g., claude-3-5-sonnet-20241022)",
     "gen_ai.operation.name": "Operation type (e.g., chat, completion)",
     "gen_ai.usage.input_tokens": "Number of input tokens (numeric)",
     "gen_ai.usage.output_tokens": "Number of output tokens (numeric)",
+    "gen_ai.tool.name": "Tool name (e.g., search_issues, search_events)",
 
-    // MCP namespace (mcp.*) - for Model Context Protocol tool calls
-    "mcp.tool.name": "Tool name (e.g., search_issues, search_events)",
+    // MCP namespace (mcp.*) - for Model Context Protocol semantics
+    "mcp.method.name": "MCP request or notification method",
+    "mcp.protocol.version": "MCP protocol version",
+    "mcp.resource.uri": "MCP resource URI",
     "mcp.session.id": "MCP session identifier",
 
     // Web Vitals measurements (frontend performance metrics)
@@ -581,8 +584,8 @@ export const DATASET_EXAMPLES: Record<
     {
       description: "top MCP tool calls by usage",
       output: {
-        query: "has:mcp.tool.name",
-        fields: ["mcp.tool.name", "count()"],
+        query: "has:gen_ai.tool.name",
+        fields: ["gen_ai.tool.name", "count()"],
         sort: "-count()",
       },
     },

--- a/packages/mcp-server-mocks/src/fixtures/trace-event.json
+++ b/packages/mcp-server-mocks/src/fixtures/trace-event.json
@@ -110,10 +110,10 @@
   "tags": [
     { "key": "environment", "value": "cloudflare" },
     { "key": "level", "value": "info" },
-    { "key": "mcp.server_version", "value": "0.17.1" },
+    { "key": "app.server.version", "value": "0.17.1" },
     { "key": "release", "value": "eece3c53-694c-4362-b599-95fc591a6cc7" },
     { "key": "runtime.name", "value": "cloudflare" },
-    { "key": "sentry.host", "value": "sentry.io" },
+    { "key": "app.upstream.host", "value": "sentry.io" },
     { "key": "transaction", "value": "POST /mcp" },
     { "key": "url", "value": "https://mcp.sentry.dev/mcp" },
     {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -260,12 +260,12 @@ async function main() {
     beforeSend: sentryBeforeSend,
     initialScope: {
       tags: {
-        "mcp.server_version": LIB_VERSION,
-        "mcp.transport": "stdio",
-        "mcp.agent_mode": cli.agent ? "true" : "false",
-        "mcp.experimental_mode": cli.experimental ? "true" : "false",
-        "sentry.host": cfg.sentryHost,
-        "mcp.mcp-url": cfg.mcpUrl,
+        "app.server.version": LIB_VERSION,
+        "app.transport": "stdio",
+        "app.server.mode.agent": cli.agent ? "true" : "false",
+        "app.server.mode.experimental": cli.experimental ? "true" : "false",
+        "app.upstream.host": cfg.sentryHost,
+        "app.url.full": cfg.mcpUrl,
       },
     },
     release: process.env.SENTRY_RELEASE,

--- a/packages/mcp-server/src/transports/stdio.ts
+++ b/packages/mcp-server/src/transports/stdio.ts
@@ -57,7 +57,7 @@ export async function startStdio(server: McpServer, context: ServerContext) {
       {
         name: "mcp.server/stdio",
         attributes: {
-          "mcp.transport": "stdio",
+          "app.transport": "stdio",
           "network.transport": "pipe",
           "service.version": LIB_VERSION,
         },

--- a/packages/mcp-test-client/src/agent.ts
+++ b/packages/mcp-test-client/src/agent.ts
@@ -57,7 +57,7 @@ export async function runAgent(
           "service.version": LIB_VERSION,
           "gen_ai.conversation.id": sessionId,
           "gen_ai.agent.name": "sentry-mcp-agent",
-          "gen_ai.system": "openai",
+          "gen_ai.provider.name": "openai",
           "gen_ai.request.model": model,
           "gen_ai.operation.name": "chat",
         },

--- a/packages/mcp-test-client/src/index.ts
+++ b/packages/mcp-test-client/src/index.ts
@@ -75,7 +75,7 @@ program
         initialScope: {
           tags: {
             "gen_ai.agent.name": "sentry-mcp-agent",
-            "gen_ai.system": "openai",
+            "gen_ai.provider.name": "openai",
           },
         },
         release: process.env.SENTRY_RELEASE,

--- a/packages/mcp-test-client/src/mcp-test-client-remote.ts
+++ b/packages/mcp-test-client/src/mcp-test-client-remote.ts
@@ -22,7 +22,7 @@ export async function connectToRemoteMCPServer(
       {
         name: "mcp.connect/http",
         attributes: {
-          "mcp.transport": "http",
+          "app.transport": "http",
           "gen_ai.conversation.id": sessionId,
           "service.version": LIB_VERSION,
         },

--- a/packages/mcp-test-client/src/mcp-test-client.ts
+++ b/packages/mcp-test-client/src/mcp-test-client.ts
@@ -19,7 +19,7 @@ export async function connectToMCPServer(
       {
         name: "mcp.connect/stdio",
         attributes: {
-          "mcp.transport": "stdio",
+          "app.transport": "stdio",
           "gen_ai.conversation.id": sessionId,
           "service.version": LIB_VERSION,
         },


### PR DESCRIPTION
Align Sentry MCP telemetry names with the current OpenTelemetry MCP semantic convention.

`mcp.*` is now reserved for documented MCP fields such as `mcp.method.name`, `mcp.protocol.version`, `mcp.resource.uri`, and `mcp.session.id`. Product-owned signals we still need for OAuth, local response metrics, route groups, resource dispatch, client family, stdio configuration, and test client GenAI tags use `app.*` or the matching existing OTel namespace.

This also adds `TELEMETRY.md` as the incident/runbook reference and updates the monitoring docs, OAuth sign-out playbook, semantic namespace data, trace fixture, and search-events guidance so examples match the emitted fields.

No telemetry-only unit tests were added. The only test change updates an existing semantic-registry expectation that still treated MCP as a custom namespace.