### PR TITLE
fix(telemetry): Capture GenAI tool argument attributes

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -43,6 +43,7 @@ the pivots and recipes below.
 | `app.resource.type` | resolved Sentry resource type | spans | resource dispatch |
 | `app.constraint.organization_slug` | active organization constraint | spans | constrained session behavior |
 | `app.constraint.project_slug` | active project constraint | spans | constrained session behavior |
+| `gen_ai.tool.call.arguments.<key>` | effective tool arguments | spans | called tool input |
 | `app.client.family` | bucketed MCP client family | metrics | client-specific OAuth behavior |
 | `app.oauth.token_exchange.outcome` | OAuth refresh outcome | metrics | token refresh diagnosis |
 | `app.oauth.grant_revoked.reason` | wrapper grant revoke reason | metrics | sign-out diagnosis |
@@ -116,7 +117,7 @@ Tool execution timeline for a slow or failing tool.
 
 ```text
 dataset=spans query='gen_ai.tool.name:"<tool_name>"'
-fields=timestamp,trace,span_id,span.op,span.duration,gen_ai.tool.name,app.constraint.organization_slug,app.constraint.project_slug,error.type
+fields=timestamp,trace,span_id,span.op,span.duration,gen_ai.tool.name,app.constraint.organization_slug,app.constraint.project_slug,gen_ai.tool.call.arguments.organizationSlug,gen_ai.tool.call.arguments.projectSlugOrId,error.type
 sort=-timestamp
 ```
 
@@ -230,6 +231,8 @@ Attributes: `gen_ai.provider.name`, `gen_ai.request.model`,
 - `app.*` fields are Sentry MCP application-owned attributes for product
   concepts that are not part of the MCP semantic convention, such as OAuth
   outcomes, route groups, constraints, and local response reasons.
+- `gen_ai.tool.call.arguments.<key>` intentionally extends GenAI semconv with
+  per-key tool arguments after constraints.
 - Keep metric attributes low-cardinality. Avoid raw URLs, tokens, prompts,
   full request bodies, or other high-cardinality or sensitive values.
 - Do not log secrets. Authorization headers and access tokens must remain

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -133,7 +133,7 @@ process.on("uncaughtException", (error) => {
 Sentry follows OpenTelemetry semantic conventions for consistent observability.
 
 ### MCP Attributes (Model Context Protocol)
-Based on the current [OpenTelemetry MCP conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/), keep `mcp.*` limited to the documented MCP semantic attributes:
+Based on the current [OpenTelemetry MCP conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/), the standard MCP semantic attributes are:
 
 - `mcp.method.name` - The name of the request or notification method (e.g., "notifications/cancelled", "initialize", "tools/call")
 - `mcp.protocol.version` - The MCP protocol version (e.g., "2025-06-18")
@@ -147,6 +147,7 @@ Current MCP spans also use related OpenTelemetry attributes outside the `mcp.*` 
 - `jsonrpc.request.id` - The JSON-RPC request ID
 - `rpc.response.status_code` - The JSON-RPC response status or error code
 - `network.transport` - Transport protocol (`pipe` for stdio, `tcp` or `quic` for HTTP)
+- `gen_ai.tool.call.arguments.<key>` - Per-key effective tool arguments after constraints
 
 ### Application-Owned Attributes
 These are Sentry MCP application attributes that are not part of the MCP semantic convention:

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -26,6 +26,7 @@ import type {
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
+  type SpanAttributeValue,
   getActiveSpan,
   setTag,
   setUser,
@@ -333,7 +334,21 @@ function configureServer({
           const paramsWithConstraints = {
             ...params,
             ...applicableConstraints,
-          };
+          } as Record<string, unknown>;
+
+          if (activeSpan) {
+            // Intentional GenAI semconv extension: per-key attrs like http.request.header.<key>.
+            for (const [key, value] of Object.entries(paramsWithConstraints)) {
+              const attributeValue =
+                value == null || typeof value === "object"
+                  ? JSON.stringify(value)
+                  : value;
+              activeSpan.setAttribute(
+                `gen_ai.tool.call.arguments.${key}`,
+                attributeValue as SpanAttributeValue | undefined,
+              );
+            }
+          }
 
           const output = await tool.handler(paramsWithConstraints, context);
 


### PR DESCRIPTION
Capture effective MCP tool arguments after constraint injection as per-key GenAI tool-call argument attributes.

This intentionally extends the GenAI convention with dynamic attributes like `gen_ai.tool.call.arguments.organizationSlug`, matching the flat `<namespace>.<key>` style used by attributes such as `http.request.header.<key>`.

Refs getsentry/sentry#115485