### PR TITLE
chore(evals): unblock ToolPredictionScorer

### DIFF
--- a/packages/mcp-server-evals/src/evals/utils/toolPredictionScorer.ts
+++ b/packages/mcp-server-evals/src/evals/utils/toolPredictionScorer.ts
@@ -19,12 +19,7 @@ async function getAvailableTools(): Promise<string[]> {
   // Use pnpm exec to run the binary from the workspace
   const transport = new Experimental_StdioMCPTransport({
     command: "pnpm",
-    args: [
-      "exec",
-      "sentry-mcp",
-      "--access-token=mocked-access-token",
-      "--all-scopes",
-    ],
+    args: ["exec", "sentry-mcp", "--access-token=mocked-access-token"],
     env: {
       ...process.env,
       SENTRY_ACCESS_TOKEN: "mocked-access-token",
@@ -73,7 +68,12 @@ const predictionSchema = z.object({
     .array(
       z.object({
         name: z.string(),
-        arguments: z.record(z.any()).optional().default({}),
+        // Serialize arguments as a JSON string so the schema stays compatible
+        // with OpenAI's strict response_format (z.record(z.any()) emits
+        // `additionalProperties` without a `type`, which the API rejects).
+        argumentsJson: z
+          .string()
+          .describe("JSON-encoded tool arguments, e.g. '{}' for none."),
       }),
     )
     .describe("What tools the AI would likely call"),


### PR DESCRIPTION
## Summary
Two unrelated bugs were both blocking the entire eval suite — every eval currently crashes with \`MCPClientError: Connection closed\` before any scoring runs. Both are fixed here.

1. **Stale CLI flag.** \`toolPredictionScorer\` spawns \`pnpm exec sentry-mcp\` with \`--access-token=mocked-access-token --all-scopes\`. \`--all-scopes\` was removed in #668 ("remove legacy grantedScopes in favor of grantedSkills"), so the spawned binary prints its usage banner and exits, surfacing as a closed-stdio error. Drop the flag.
2. **OpenAI strict response_format rejection.** The prediction schema uses \`arguments: z.record(z.any()).optional().default({})\`. zod-to-JSON-Schema emits this as \`additionalProperties: {}\` (no \`type\` key), which OpenAI's strict structured-output endpoint refuses with \`AI_APICallError: Invalid schema for response_format 'response': … schema must have a 'type' key\`. Verified this also fails on the latest \`@ai-sdk/openai@3.0.63\` + \`ai@6.0.182\`, so it's not a stale-dep issue. Encode arguments as a JSON string instead.

With both fixed, the eval suite runs end-to-end again (verified locally — autofix.eval.ts cases score 1.00 against the current main).

## Test plan
- [x] \`pnpm run tsc\`
- [x] \`pnpm run lint\`
- [x] \`pnpm run test\` — all 1341 tests pass
- [x] \`pnpm vitest run autofix.eval.ts\` with \`OPENAI_API_KEY\` set — both cases score 1.00

## Notes for reviewers
- \`predictedTools[*].arguments\` was already only read for the rationale/metadata field in the scorer's return value, so renaming to \`argumentsJson\` doesn't break scoring.
- First in a stack of three. Subsequent PRs do the Sentry-side autofix migration to explorer-mode endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/HYSozfr18sU5lMEbTaUO5UX2YmVyaBdNoueQpOS6xJQ