### PR TITLE
feat(cloudflare): Add Plausible analytics

### DIFF
--- a/packages/mcp-cloudflare/index.html
+++ b/packages/mcp-cloudflare/index.html
@@ -7,6 +7,7 @@
   <title>Sentry MCP</title>
   <link href="./src/client/index.css" rel="stylesheet" />
   <link rel="icon" href="/favicon.ico" />
+  <script defer data-domain="mcp.sentry.dev" src="https://plausible.io/js/script.js"></script>
   <!-- Primary Meta Tags -->
   <meta name="title" content="Sentry MCP" />
   <meta name="description" content="A Model Context Protocol implementation for interacting with Sentry." />


### PR DESCRIPTION
## Summary
- Adds Plausible analytics script to `mcp.sentry.dev` for privacy-friendly pageview tracking
- Single `<script defer>` tag in `index.html` — no bundle impact, no effect on page load

## Test plan
- [ ] Verify the script loads on the deployed site (check network tab for `plausible.io/js/script.js`)
- [ ] Confirm pageviews appear in the Plausible dashboard for `mcp.sentry.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)