### PR TITLE
fix(search-events): Preserve structured trace searches

### DIFF
--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1097,6 +1097,138 @@ describe("API query builders", () => {
     });
   });
 
+  describe("trace item attributes", () => {
+    it("should list targeted attribute types with query filters", async () => {
+      const apiService = new SentryApiService({
+        host: "sentry.io",
+        accessToken: "test-token",
+      });
+      const urls: string[] = [];
+
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        urls.push(url);
+        const requestUrl = new URL(url);
+        const attributeType = requestUrl.searchParams.get("attributeType");
+        const body =
+          attributeType === "boolean"
+            ? [
+                {
+                  key: "tags[enabled,boolean]",
+                  name: "enabled",
+                  attributeType: "boolean",
+                },
+              ]
+            : [
+                {
+                  key: "tags[type]",
+                  name: "type",
+                  attributeType: "string",
+                },
+              ];
+
+        return Promise.resolve({
+          ok: true,
+          headers: {
+            get: (key: string) =>
+              key === "content-type" ? "application/json" : null,
+          },
+          json: () => Promise.resolve(body),
+        });
+      });
+
+      const result = await apiService.listTraceItemAttributes({
+        organizationSlug: "test-org",
+        itemType: "spans",
+        project: "123",
+        statsPeriod: "7d",
+        attributeTypes: ["string", "boolean"],
+        substringMatch: "tags[",
+        query: 'transaction:"VPN connections"',
+      });
+
+      expect(result).toEqual([
+        {
+          key: "tags[type]",
+          name: "type",
+          type: "string",
+        },
+        {
+          key: "tags[enabled,boolean]",
+          name: "enabled",
+          type: "boolean",
+        },
+      ]);
+      expect(urls).toHaveLength(2);
+      for (const url of urls) {
+        const params = new URL(url).searchParams;
+        expect(params.get("itemType")).toBe("spans");
+        expect(params.get("project")).toBe("123");
+        expect(params.get("statsPeriod")).toBe("7d");
+        expect(params.get("substringMatch")).toBe("tags[");
+        expect(params.get("query")).toBe('transaction:"VPN connections"');
+      }
+      expect(
+        urls.map((url) => new URL(url).searchParams.get("attributeType")),
+      ).toEqual(["string", "boolean"]);
+    });
+
+    it("should validate exact trace item attributes", async () => {
+      const apiService = new SentryApiService({
+        host: "sentry.io",
+        accessToken: "test-token",
+      });
+      let requestUrl: string | undefined;
+      let requestOptions: RequestInit | undefined;
+
+      globalThis.fetch = vi
+        .fn()
+        .mockImplementation((url: string, options: RequestInit) => {
+          requestUrl = url;
+          requestOptions = options;
+          return Promise.resolve({
+            ok: true,
+            headers: {
+              get: (key: string) =>
+                key === "content-type" ? "application/json" : null,
+            },
+            json: () =>
+              Promise.resolve({
+                attributes: {
+                  "tags[type]": { valid: true, type: "string" },
+                  "tags[missing]": {
+                    valid: false,
+                    error: "Unknown attribute: tags[missing]",
+                  },
+                },
+              }),
+          });
+        });
+
+      const result = await apiService.validateTraceItemAttributes({
+        organizationSlug: "test-org",
+        itemType: "spans",
+        attributes: ["tags[type]", "tags[missing]"],
+        project: "123",
+        statsPeriod: "7d",
+      });
+
+      expect(result).toEqual({
+        "tags[type]": { valid: true, type: "string" },
+        "tags[missing]": {
+          valid: false,
+          error: "Unknown attribute: tags[missing]",
+        },
+      });
+      expect(requestUrl).toContain(
+        "/api/0/organizations/test-org/trace-items/attributes/validate/?itemType=spans&project=123&statsPeriod=7d",
+      );
+      expect(requestOptions?.method).toBe("POST");
+      expect(JSON.parse(String(requestOptions?.body))).toEqual({
+        attributes: ["tags[type]", "tags[missing]"],
+      });
+    });
+  });
+
   describe("Web URL builders", () => {
     describe("buildDiscoverUrl", () => {
       it("should build correct URL for errors dataset on SaaS", () => {

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1116,6 +1116,7 @@ describe("API query builders", () => {
                   key: "tags[enabled,boolean]",
                   name: "enabled",
                   attributeType: "boolean",
+                  attributeSource: { source_type: "user" },
                 },
               ]
             : [
@@ -1123,6 +1124,10 @@ describe("API query builders", () => {
                   key: "tags[type]",
                   name: "type",
                   attributeType: "string",
+                  attributeSource: {
+                    source_type: "sentry",
+                    is_transformed_alias: true,
+                  },
                 },
               ];
 
@@ -1151,11 +1156,16 @@ describe("API query builders", () => {
           key: "tags[type]",
           name: "type",
           type: "string",
+          attributeSource: {
+            source_type: "sentry",
+            is_transformed_alias: true,
+          },
         },
         {
           key: "tags[enabled,boolean]",
           name: "enabled",
           type: "boolean",
+          attributeSource: { source_type: "user" },
         },
       ]);
       expect(urls).toHaveLength(2);

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -125,6 +125,69 @@ type RequestOptions = {
   host?: string;
 };
 
+export type TraceItemType = "spans" | "logs" | "tracemetrics";
+export type TraceItemAttributeType = "string" | "number" | "boolean";
+
+export type TraceItemAttribute = {
+  key: string;
+  name: string;
+  type: TraceItemAttributeType;
+  attributeSource?: unknown;
+  secondaryAliases?: string[];
+};
+
+export type TraceItemAttributeValidationResult = {
+  valid: boolean;
+  type?: TraceItemAttributeType;
+  error?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isTraceItemAttributeType(
+  value: unknown,
+): value is TraceItemAttributeType {
+  return value === "string" || value === "number" || value === "boolean";
+}
+
+function parseTraceItemAttributes(
+  body: unknown,
+  fallbackType: TraceItemAttributeType,
+): TraceItemAttribute[] {
+  if (!Array.isArray(body)) {
+    return [];
+  }
+
+  const attributes: TraceItemAttribute[] = [];
+  for (const value of body) {
+    if (!isRecord(value) || typeof value.key !== "string") {
+      continue;
+    }
+
+    const attribute: TraceItemAttribute = {
+      key: value.key,
+      name: typeof value.name === "string" ? value.name : value.key,
+      type: isTraceItemAttributeType(value.attributeType)
+        ? value.attributeType
+        : fallbackType,
+    };
+
+    if (value.attributeSource !== undefined) {
+      attribute.attributeSource = value.attributeSource;
+    }
+    if (Array.isArray(value.secondaryAliases)) {
+      attribute.secondaryAliases = value.secondaryAliases.filter(
+        (alias): alias is string => typeof alias === "string",
+      );
+    }
+    attributes.push(attribute);
+  }
+
+  return attributes;
+}
+
 /**
  * Sentry API client service for interacting with Sentry's REST API.
  *
@@ -1617,90 +1680,132 @@ export class SentryApiService {
       statsPeriod,
       start,
       end,
+      attributeTypes = ["string", "number"],
+      substringMatch,
+      query,
     }: {
       organizationSlug: string;
-      itemType?: "spans" | "logs" | "tracemetrics";
+      itemType?: TraceItemType;
+      project?: string;
+      statsPeriod?: string;
+      start?: string;
+      end?: string;
+      attributeTypes?: TraceItemAttributeType[];
+      substringMatch?: string;
+      query?: string;
+    },
+    opts?: RequestOptions,
+  ): Promise<TraceItemAttribute[]> {
+    const uniqueAttributeTypes = Array.from(new Set(attributeTypes));
+    const attributeResponses = await Promise.all(
+      uniqueAttributeTypes.map((attributeType) =>
+        this.fetchTraceItemAttributesByType(
+          organizationSlug,
+          itemType,
+          attributeType,
+          project,
+          statsPeriod,
+          start,
+          end,
+          substringMatch,
+          query,
+          opts,
+        ),
+      ),
+    );
+
+    return attributeResponses.flat();
+  }
+
+  async validateTraceItemAttributes(
+    {
+      organizationSlug,
+      itemType = "spans",
+      attributes,
+      project,
+      statsPeriod,
+      start,
+      end,
+    }: {
+      organizationSlug: string;
+      itemType?: TraceItemType;
+      attributes: string[];
       project?: string;
       statsPeriod?: string;
       start?: string;
       end?: string;
     },
     opts?: RequestOptions,
-  ): Promise<Array<{ key: string; name: string; type: "string" | "number" }>> {
-    // Fetch both string and number attributes
-    const [stringAttributes, numberAttributes] = await Promise.all([
-      this.fetchTraceItemAttributesByType(
-        organizationSlug,
-        itemType,
-        "string",
-        project,
-        statsPeriod,
-        start,
-        end,
-        opts,
-      ),
-      this.fetchTraceItemAttributesByType(
-        organizationSlug,
-        itemType,
-        "number",
-        project,
-        statsPeriod,
-        start,
-        end,
-        opts,
-      ),
-    ]);
+  ): Promise<Record<string, TraceItemAttributeValidationResult>> {
+    const queryParams = new URLSearchParams();
+    queryParams.set("itemType", itemType);
+    if (project) {
+      queryParams.set("project", project);
+    }
+    this.applyTimeParams(queryParams, statsPeriod, start, end);
 
-    // Combine attributes with explicit type information
-    const allAttributes: Array<{
-      key: string;
-      name: string;
-      type: "string" | "number";
-    }> = [];
+    const body = await this.requestJSON(
+      `/organizations/${organizationSlug}/trace-items/attributes/validate/?${queryParams.toString()}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ attributes }),
+      },
+      opts,
+    );
 
-    // Add string attributes
-    for (const attr of stringAttributes) {
-      allAttributes.push({
-        key: attr.key,
-        name: attr.name || attr.key,
-        type: "string",
-      });
+    if (!isRecord(body) || !isRecord(body.attributes)) {
+      return {};
     }
 
-    // Add number attributes
-    for (const attr of numberAttributes) {
-      allAttributes.push({
-        key: attr.key,
-        name: attr.name || attr.key,
-        type: "number",
-      });
+    const results: Record<string, TraceItemAttributeValidationResult> = {};
+    for (const [attribute, value] of Object.entries(body.attributes)) {
+      if (!isRecord(value) || typeof value.valid !== "boolean") {
+        continue;
+      }
+      const validationResult: TraceItemAttributeValidationResult = {
+        valid: value.valid,
+      };
+      if (isTraceItemAttributeType(value.type)) {
+        validationResult.type = value.type;
+      }
+      if (typeof value.error === "string") {
+        validationResult.error = value.error;
+      }
+      results[attribute] = validationResult;
     }
-
-    return allAttributes;
+    return results;
   }
 
   private async fetchTraceItemAttributesByType(
     organizationSlug: string,
-    itemType: "spans" | "logs" | "tracemetrics",
-    attributeType: "string" | "number",
+    itemType: TraceItemType,
+    attributeType: TraceItemAttributeType,
     project?: string,
     statsPeriod?: string,
     start?: string,
     end?: string,
+    substringMatch?: string,
+    query?: string,
     opts?: RequestOptions,
-  ): Promise<any> {
+  ): Promise<TraceItemAttribute[]> {
     const queryParams = new URLSearchParams();
     queryParams.set("itemType", itemType);
     queryParams.set("attributeType", attributeType);
     if (project) {
       queryParams.set("project", project);
     }
+    if (substringMatch) {
+      queryParams.set("substringMatch", substringMatch);
+    }
+    if (query) {
+      queryParams.set("query", query);
+    }
     this.applyTimeParams(queryParams, statsPeriod, start, end);
 
     const url = `/organizations/${organizationSlug}/trace-items/attributes/?${queryParams.toString()}`;
 
     const body = await this.requestJSON(url, undefined, opts);
-    return Array.isArray(body) ? body : [];
+    return parseTraceItemAttributes(body, attributeType);
   }
 
   /**

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -127,12 +127,18 @@ type RequestOptions = {
 
 export type TraceItemType = "spans" | "logs" | "tracemetrics";
 export type TraceItemAttributeType = "string" | "number" | "boolean";
+export type TraceItemAttributeSourceType = "sentry" | "user";
+
+export type TraceItemAttributeSource = {
+  source_type: TraceItemAttributeSourceType;
+  is_transformed_alias?: boolean;
+};
 
 export type TraceItemAttribute = {
   key: string;
   name: string;
   type: TraceItemAttributeType;
-  attributeSource?: unknown;
+  attributeSource?: TraceItemAttributeSource;
   secondaryAliases?: string[];
 };
 
@@ -150,6 +156,26 @@ function isTraceItemAttributeType(
   value: unknown,
 ): value is TraceItemAttributeType {
   return value === "string" || value === "number" || value === "boolean";
+}
+
+function isTraceItemAttributeSourceType(
+  value: unknown,
+): value is TraceItemAttributeSourceType {
+  return value === "sentry" || value === "user";
+}
+
+function parseTraceItemAttributeSource(
+  value: unknown,
+): TraceItemAttributeSource | undefined {
+  if (!isRecord(value) || !isTraceItemAttributeSourceType(value.source_type)) {
+    return undefined;
+  }
+
+  const source: TraceItemAttributeSource = { source_type: value.source_type };
+  if (typeof value.is_transformed_alias === "boolean") {
+    source.is_transformed_alias = value.is_transformed_alias;
+  }
+  return source;
 }
 
 function parseTraceItemAttributes(
@@ -174,8 +200,11 @@ function parseTraceItemAttributes(
         : fallbackType,
     };
 
-    if (value.attributeSource !== undefined) {
-      attribute.attributeSource = value.attributeSource;
+    const attributeSource = parseTraceItemAttributeSource(
+      value.attributeSource,
+    );
+    if (attributeSource) {
+      attribute.attributeSource = attributeSource;
     }
     if (Array.isArray(value.secondaryAliases)) {
       attribute.secondaryAliases = value.secondaryAliases.filter(

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -238,7 +238,7 @@ describe("search_events", () => {
 
   it("should append environment filters for structured trace searches", async () => {
     const query =
-      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+      'transaction:"VPN connections" message:"environment: prod" tags[type]:Unified tags[country]:CN';
     const fields = ["tags[type]", "count()"];
 
     mswServer.use(

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -165,6 +165,146 @@ describe("search_events", () => {
     expect(result).toContain("db.query");
   });
 
+  it("should execute complete structured search requests without agent rewriting", async () => {
+    const query =
+      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+    const fields = [
+      "tags[type]",
+      "tags[sequence]",
+      "span.status",
+      "tags[reason]",
+      "count()",
+    ];
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(query);
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+          expect(url.searchParams.get("sort")).toBe("-count");
+          expect(url.searchParams.get("statsPeriod")).toBe("7d");
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "tags[sequence]": "42",
+                "span.status": "ok",
+                "tags[reason]": "allowed",
+                "count()": 3,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: "-count()",
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).not.toHaveBeenCalled();
+    expect(result).toContain('"tags[type]": "Unified"');
+    expect(result).toContain(
+      '- Query: `transaction:"VPN connections" tags[type]:Unified tags[country]:CN`',
+    );
+    expect(result).toContain(
+      "- Fields: `tags[type]`, `tags[sequence]`, `span.status`, `tags[reason]`, `count()`",
+    );
+  });
+
+  it("should preserve structured query filters and explicit fields after agent repair", async () => {
+    const query =
+      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+    const fields = ["tags[type]", "tags[sequence]", "count()"];
+
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        'transaction:"VPN connections" tags[country]:CN',
+        ["span.status", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(query);
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+          expect(url.searchParams.get("sort")).toBe("-count");
+          expect(url.searchParams.get("statsPeriod")).toBe("7d");
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "tags[sequence]": "42",
+                "count()": 3,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: null,
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).toHaveBeenCalled();
+    expect(result).toContain('"tags[type]": "Unified"');
+    expect(result).toContain('"tags[sequence]": "42"');
+  });
+
   it("should handle metrics dataset queries", async () => {
     mockGenerateText.mockResolvedValueOnce(
       mockAIResponse(
@@ -226,6 +366,13 @@ describe("search_events", () => {
       "# Search Results for "slow request duration metrics"
 
       ⚠️ **IMPORTANT**: Display these metric aggregates as a data table with proper column alignment, grouping labels, and units.
+
+      ## Executed Search
+      - Dataset: \`metrics\`
+      - Query: \`(empty)\`
+      - Fields: \`transaction\`, \`p95(value,http.request.duration,distribution,millisecond)\`, \`count(value,http.request.duration,distribution,millisecond)\`
+      - Sort: \`-p95(value,http.request.duration,distribution,millisecond)\`
+      - Time range: Last 14d
 
       **View these results in Sentry**:
       https://test-org.sentry.io/explore/metrics/?statsPeriod=14d&metric=%7B%22metric%22%3A%7B%22name%22%3A%22http.request.duration%22%2C%22type%22%3A%22distribution%22%2C%22unit%22%3A%22millisecond%22%7D%2C%22query%22%3A%22%22%2C%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22p95%28value%2Chttp.request.duration%2Cdistribution%2Cmillisecond%29%22%5D%7D%2C%7B%22yAxes%22%3A%5B%22count%28value%2Chttp.request.duration%2Cdistribution%2Cmillisecond%29%22%5D%7D%2C%7B%22groupBy%22%3A%22transaction%22%7D%5D%2C%22aggregateSortBys%22%3A%5B%7B%22field%22%3A%22p95%28value%2Chttp.request.duration%2Cdistribution%2Cmillisecond%29%22%2C%22kind%22%3A%22desc%22%7D%5D%2C%22mode%22%3A%22aggregate%22%7D

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -555,6 +555,71 @@ describe("search_events", () => {
     expect(mockGenerateText).toHaveBeenCalled();
   });
 
+  it("should reject repaired structured trace queries with modified quoted filter values", async () => {
+    const query =
+      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+    const fields = ["tags[type]", "tags[sequence]", "count()"];
+
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        'transaction:"VPN adventures" connections" tags[type]:Unified tags[country]:CN has:span.status',
+        ["span.status", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(query);
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "tags[sequence]": "2",
+                "count()": 1,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: null,
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).toHaveBeenCalled();
+  });
+
   it("should handle metrics dataset queries", async () => {
     mockGenerateText.mockResolvedValueOnce(
       mockAIResponse(

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -425,6 +425,72 @@ describe("search_events", () => {
     expect(result).toContain('"tags[sequence]": "42"');
   });
 
+  it("should not duplicate environment filters after agent repair", async () => {
+    const query =
+      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+    const repairedQuery = `${query} environment:production has:span.status`;
+    const fields = ["tags[type]", "count()"];
+
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        repairedQuery,
+        ["span.status", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(repairedQuery);
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "count()": 3,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: null,
+        statsPeriod: "7d",
+        environment: "production",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).toHaveBeenCalled();
+  });
+
   it("should accept repaired structured trace queries that preserve the original filters", async () => {
     const query =
       'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -236,6 +236,62 @@ describe("search_events", () => {
     );
   });
 
+  it("should append environment filters for structured trace searches", async () => {
+    const query =
+      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+    const fields = ["tags[type]", "count()"];
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(
+            `${query} environment:production`,
+          );
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "count()": 3,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: "-count()",
+        statsPeriod: "7d",
+        environment: "production",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
   it("should preserve structured query filters and explicit fields after agent repair", async () => {
     const query =
       'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -491,6 +491,70 @@ describe("search_events", () => {
     expect(mockGenerateText).toHaveBeenCalled();
   });
 
+  it("should reject repaired structured trace queries with modified filter tokens", async () => {
+    const query = "tags[sequence]:2 tags[type]:Unified";
+    const fields = ["tags[type]", "tags[sequence]", "count()"];
+
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        "tags[sequence]:20 tags[type]:Unified has:span.status",
+        ["span.status", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(query);
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "tags[sequence]": "2",
+                "count()": 1,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: null,
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).toHaveBeenCalled();
+  });
+
   it("should handle metrics dataset queries", async () => {
     mockGenerateText.mockResolvedValueOnce(
       mockAIResponse(

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -425,6 +425,72 @@ describe("search_events", () => {
     expect(result).toContain('"tags[sequence]": "42"');
   });
 
+  it("should accept repaired structured trace queries that preserve the original filters", async () => {
+    const query =
+      'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';
+    const repairedQuery = `${query} has:span.status`;
+    const fields = ["tags[type]", "tags[sequence]", "count()"];
+
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        repairedQuery,
+        ["span.status", "count()"],
+        undefined,
+        "-count()",
+        { statsPeriod: "24h" },
+      ),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(repairedQuery);
+          expect(url.searchParams.getAll("field")).toEqual(fields);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "tags[type]": "Unified",
+                "tags[sequence]": "42",
+                "count()": 3,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields,
+        sort: null,
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).toHaveBeenCalled();
+  });
+
   it("should handle metrics dataset queries", async () => {
     mockGenerateText.mockResolvedValueOnce(
       mockAIResponse(

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -292,6 +292,70 @@ describe("search_events", () => {
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 
+  it("should repair trace queries with natural language colon patterns", async () => {
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "spans",
+        'span.op:"http.client"',
+        ["span.op", "span.duration"],
+        undefined,
+        "-span.duration",
+        { statsPeriod: "24h" },
+      ),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe('span.op:"http.client"');
+          expect(url.searchParams.getAll("field")).toEqual([
+            "span.op",
+            "span.duration",
+          ]);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "span.op": "http.client",
+                "span.duration": 123,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query:
+          "Find slow spans for http://example.com at 10:30. Note: failed requests",
+        dataset: "spans",
+        fields: ["span.op", "span.duration"],
+        sort: "-span.duration",
+        statsPeriod: "24h",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).toHaveBeenCalled();
+  });
+
   it("should preserve structured query filters and explicit fields after agent repair", async () => {
     const query =
       'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';

--- a/packages/mcp-core/src/tools/search-events/config.ts
+++ b/packages/mcp-core/src/tools/search-events/config.ts
@@ -28,8 +28,9 @@ Before constructing ANY query, you MUST verify field availability:
 2. This includes ALL fields: custom attributes, database fields, HTTP fields, AI fields, user fields, etc.
 3. Fields vary by project based on what data is being sent to Sentry
 4. Using an unverified field WILL cause your query to fail with "field not found" errors
-5. The datasetAttributes tool tells you EXACTLY which fields are available
-6. Replay fields vary by project too, so use replayFields before constructing replay queries
+5. For spans, logs, and metrics, datasetAttributes can validate exact field names with attributes and can list likely fields using substringMatch/query/attributeTypes
+6. A broad datasetAttributes listing is a discovery preview and may be truncated; do not treat absence from the preview as proof that a user-supplied field is invalid
+7. Replay fields vary by project too, so use replayFields before constructing replay queries
 
 TOOL USAGE GUIDELINES:
 1. Use datasetAttributes tool to discover available fields for your chosen dataset
@@ -37,6 +38,8 @@ TOOL USAGE GUIDELINES:
 3. Use otelSemantics tool when you need specific OpenTelemetry semantic convention attributes
 4. Use whoami tool when queries contain "me" references for user.id or user.email fields
 5. IMPORTANT: For ambiguous terms like "user agents", "browser", "client" - use the appropriate field discovery tool instead of guessing field names
+6. When the user already supplied Sentry search syntax for spans/logs/metrics, call datasetAttributes with exact attributes from the query or fields before dropping or renaming them
+7. Use datasetAttributes substringMatch, query, and attributeTypes for targeted lookup when broad field discovery is truncated
 
 CRITICAL - TOOL RESPONSE HANDLING:
 All tools return responses in this format: {error?: string, result?: data}

--- a/packages/mcp-core/src/tools/search-events/formatters.test.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { formatExecutedSearch } from "./formatters.js";
+
+describe("formatExecutedSearch", () => {
+  it("pads inline code values that start or end with backticks", () => {
+    const result = formatExecutedSearch({
+      dataset: "spans",
+      query: "`release`",
+      fields: ["tags[`weird`]", "`count()`", "count()`"],
+      sort: "-count()",
+    });
+
+    expect(result).toContain("- Query: `` `release` ``");
+    expect(result).toContain(
+      "- Fields: ``tags[`weird`]``, `` `count()` ``, `` count()` ``",
+    );
+    expect(result).toContain("- Sort: `-count()`");
+  });
+});

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -36,7 +36,10 @@ function formatInlineCode(value: string): string {
   const fenceLength =
     backtickRuns.reduce((max, run) => Math.max(max, run.length), 0) + 1;
   const fence = "`".repeat(fenceLength);
-  return `${fence}${value}${fence}`;
+  const needsPadding = value.startsWith("`") || value.endsWith("`");
+  return needsPadding
+    ? `${fence} ${value} ${fence}`
+    : `${fence}${value}${fence}`;
 }
 
 function formatExecutedTimeRange(timeRange?: SearchTimeRange): string {

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -32,7 +32,11 @@ export interface ExecutedSearch {
 }
 
 function formatInlineCode(value: string): string {
-  return `\`${value.replace(/`/g, "\\`")}\``;
+  const backtickRuns = value.match(/`+/g) ?? [];
+  const fenceLength =
+    backtickRuns.reduce((max, run) => Math.max(max, run.length), 0) + 1;
+  const fence = "`".repeat(fenceLength);
+  return `${fence}${value}${fence}`;
 }
 
 function formatExecutedTimeRange(timeRange?: SearchTimeRange): string {

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -17,6 +17,68 @@ export function formatExplanation(explanation: string): string {
   return `## How I interpreted your query\n\n${explanation}`;
 }
 
+interface SearchTimeRange {
+  statsPeriod?: string;
+  start?: string;
+  end?: string;
+}
+
+export interface ExecutedSearch {
+  dataset: string;
+  query: string;
+  fields?: string[];
+  sort?: string;
+  timeRange?: SearchTimeRange;
+}
+
+function formatInlineCode(value: string): string {
+  return `\`${value.replace(/`/g, "\\`")}\``;
+}
+
+function formatExecutedTimeRange(timeRange?: SearchTimeRange): string {
+  if (!timeRange) {
+    return "Last 14d";
+  }
+  if (timeRange.statsPeriod) {
+    return `Last ${timeRange.statsPeriod}`;
+  }
+  if (timeRange.start && timeRange.end) {
+    return `${timeRange.start} to ${timeRange.end}`;
+  }
+  return "Last 14d";
+}
+
+export function formatExecutedSearch(executedSearch?: ExecutedSearch): string {
+  if (!executedSearch) {
+    return "";
+  }
+
+  const fields =
+    executedSearch.fields === undefined
+      ? undefined
+      : executedSearch.fields.length > 0
+        ? executedSearch.fields.map(formatInlineCode).join(", ")
+        : "(none)";
+
+  const lines = [
+    "## Executed Search",
+    `- Dataset: ${formatInlineCode(executedSearch.dataset)}`,
+    `- Query: ${formatInlineCode(executedSearch.query || "(empty)")}`,
+  ];
+
+  if (fields !== undefined) {
+    lines.push(`- Fields: ${fields}`);
+  }
+  if (executedSearch.sort) {
+    lines.push(`- Sort: ${formatInlineCode(executedSearch.sort)}`);
+  }
+  lines.push(
+    `- Time range: ${formatExecutedTimeRange(executedSearch.timeRange)}`,
+  );
+
+  return `${lines.join("\n")}\n\n`;
+}
+
 /**
  * Common parameters for event formatters
  */
@@ -30,6 +92,7 @@ export interface FormatEventResultsParams {
   sentryQuery: string;
   fields: string[];
   explanation?: string;
+  executedSearch?: ExecutedSearch;
 }
 
 function formatUserFieldLines(
@@ -83,6 +146,8 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
     output += formatExplanation(explanation);
     output += `\n\n`;
   }
+
+  output += formatExecutedSearch(params.executedSearch);
 
   output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
@@ -216,6 +281,8 @@ export function formatLogResults(params: FormatEventResultsParams): string {
     output += formatExplanation(explanation);
     output += `\n\n`;
   }
+
+  output += formatExecutedSearch(params.executedSearch);
 
   output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
@@ -372,6 +439,8 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
     output += formatExplanation(explanation);
     output += `\n\n`;
   }
+
+  output += formatExecutedSearch(params.executedSearch);
 
   output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
@@ -559,6 +628,8 @@ export function formatProfileResults(params: FormatEventResultsParams): string {
     output += `\n\n`;
   }
 
+  output += formatExecutedSearch(params.executedSearch);
+
   output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
 
@@ -702,6 +773,8 @@ export function formatTraceMetricsResults(
     output += formatExplanation(explanation);
     output += `\n\n`;
   }
+
+  output += formatExecutedSearch(params.executedSearch);
 
   output += `**View these results in Sentry**:\n${explorerUrl}\n`;
   output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -129,6 +129,21 @@ function appendSearchFilter(query: string, filter?: string): string {
   return [trimmedQuery, filter].filter(Boolean).join(" ");
 }
 
+function tokenizeSearchQuery(query: string): string[] {
+  return query.split(/\s+/).filter(Boolean);
+}
+
+function containsSearchToken(query: string, token: string): boolean {
+  const escapedToken = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|\\s)${escapedToken}(?=\\s|$)`).test(query);
+}
+
+function preservesSearchTokens(originalQuery: string, repairedQuery: string) {
+  return tokenizeSearchQuery(originalQuery).every((token) =>
+    containsSearchToken(repairedQuery, token),
+  );
+}
+
 function choosePreservingRepairedQuery(params: {
   originalQuery: string;
   repairedQuery?: string | null;
@@ -140,7 +155,7 @@ function choosePreservingRepairedQuery(params: {
     return appendSearchFilter(originalQuery, params.filter);
   }
 
-  if (!originalQuery || repairedQuery.includes(originalQuery)) {
+  if (!originalQuery || preservesSearchTokens(originalQuery, repairedQuery)) {
     return appendSearchFilter(repairedQuery, params.filter);
   }
 

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -97,6 +97,38 @@ function hasFields(fields?: string[] | null): fields is string[] {
   return Array.isArray(fields) && fields.length > 0;
 }
 
+function formatSearchValue(value: string): string {
+  return /^[^\s"',[\]]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+function formatEnvironmentFilter(
+  environment?: string | string[] | null,
+): string | undefined {
+  if (!environment) {
+    return undefined;
+  }
+
+  const environments = Array.isArray(environment) ? environment : [environment];
+  if (environments.length === 0) {
+    return undefined;
+  }
+  if (environments.length === 1) {
+    const environmentValue = environments[0];
+    return environmentValue === undefined
+      ? undefined
+      : `environment:${formatSearchValue(environmentValue)}`;
+  }
+  return `environment:[${environments.map(formatSearchValue).join(",")}]`;
+}
+
+function appendSearchFilter(query: string, filter?: string): string {
+  const trimmedQuery = query.trim();
+  if (!filter || /\benvironment\s*:/.test(trimmedQuery)) {
+    return trimmedQuery;
+  }
+  return [trimmedQuery, filter].filter(Boolean).join(" ");
+}
+
 function buildSearchRepairPrompt(params: {
   query?: string;
   dataset: PublicEventsDataset | "replays";
@@ -242,11 +274,17 @@ export default defineTool({
     if (params.projectSlug) setTag("project.slug", params.projectSlug);
 
     const inputDataset = params.dataset ?? "errors";
+    const hasStructuredQuery = looksLikeSentrySearchSyntax(params.query);
+    const canApplyEnvironmentFilter =
+      inputDataset !== "replays" &&
+      isTraceItemDataset(inputDataset) &&
+      hasStructuredQuery;
 
     if (
       !hasAgentProvider() &&
       inputDataset !== "replays" &&
-      params.environment
+      params.environment &&
+      !canApplyEnvironmentFilter
     ) {
       throw new UserInputError(
         "The `environment` parameter is only supported for dataset='replays'. For other datasets, include environment filtering in the query string instead.",
@@ -271,7 +309,6 @@ export default defineTool({
     let environment: string | string[] | null | undefined = params.environment;
 
     const explicitSort = params.sort?.trim() || undefined;
-    const hasStructuredQuery = looksLikeSentrySearchSyntax(params.query);
     const hasExplicitDataset = params.dataset !== undefined;
     const hasExplicitFields = hasFields(params.fields);
     const hasExplicitSort = explicitSort !== undefined;
@@ -280,11 +317,14 @@ export default defineTool({
       hasExplicitDataset && isTraceItemDataset(inputDataset);
     const shouldTrustStructuredTraceSearch =
       hasStructuredQuery && hasExplicitTraceItemDataset;
+    const explicitStructuredTraceQuery = shouldTrustStructuredTraceSearch
+      ? appendSearchFilter(
+          params.query ?? "",
+          formatEnvironmentFilter(params.environment),
+        )
+      : (params.query ?? "");
     const canRunWithoutAgent =
-      shouldTrustStructuredTraceSearch &&
-      hasExplicitFields &&
-      hasExplicitSort &&
-      !(params.environment && inputDataset !== "replays");
+      shouldTrustStructuredTraceSearch && hasExplicitFields && hasExplicitSort;
 
     if (hasAgentProvider() && !canRunWithoutAgent) {
       const agentResult = await searchEventsAgent({
@@ -319,7 +359,7 @@ export default defineTool({
         ? inputDataset
         : parsed.dataset;
       sentryQuery = shouldTrustStructuredTraceSearch
-        ? (params.query ?? "")
+        ? explicitStructuredTraceQuery
         : parsed.query || "";
       sortParam =
         shouldTrustExplicitSearchParams && explicitSort
@@ -345,7 +385,9 @@ export default defineTool({
       }
     } else {
       dataset = inputDataset;
-      sentryQuery = params.query ?? "";
+      sentryQuery = shouldTrustStructuredTraceSearch
+        ? explicitStructuredTraceQuery
+        : (params.query ?? "");
       sortParam = explicitSort || defaultSortForDataset(dataset);
       timeParams = { statsPeriod: params.statsPeriod ?? "14d" };
       fields =

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -28,7 +28,7 @@ import {
   PUBLIC_EVENTS_DATASETS,
   type PublicEventsDataset,
 } from "../../utils/events-datasets";
-import { isAggregateQuery } from "./utils";
+import { isAggregateQuery, looksLikeSentrySearchSyntax } from "./utils";
 import {
   DEFAULT_REPLAY_SORT,
   DEFAULT_REPLAY_STATS_PERIOD,
@@ -38,6 +38,64 @@ import {
 
 const SEARCH_EVENTS_DATASETS = [...PUBLIC_EVENTS_DATASETS, "replays"] as const;
 const DEFAULT_EVENTS_SORT = "-timestamp";
+
+function defaultSortForDataset(dataset: PublicEventsDataset | "replays") {
+  return dataset === "replays" ? DEFAULT_REPLAY_SORT : DEFAULT_EVENTS_SORT;
+}
+
+function defaultFieldsForDataset(dataset: PublicEventsDataset): string[] {
+  return RECOMMENDED_FIELDS[normalizeEventsDataset(dataset)].basic;
+}
+
+function resolveEventFields({
+  dataset,
+  explicitFields,
+  agentFields,
+  trustExplicitFields,
+}: {
+  dataset: PublicEventsDataset;
+  explicitFields?: string[] | null;
+  agentFields?: string[];
+  trustExplicitFields: boolean;
+}): string[] {
+  if (trustExplicitFields && explicitFields && explicitFields.length > 0) {
+    return explicitFields;
+  }
+  if (agentFields && agentFields.length > 0) {
+    return agentFields;
+  }
+  return defaultFieldsForDataset(dataset);
+}
+
+function parseAgentTimeRange(
+  timeRange: unknown,
+): { statsPeriod?: string; start?: string; end?: string } | undefined {
+  if (typeof timeRange !== "object" || timeRange === null) {
+    return undefined;
+  }
+
+  if ("statsPeriod" in timeRange && typeof timeRange.statsPeriod === "string") {
+    return { statsPeriod: timeRange.statsPeriod };
+  }
+  if (
+    "start" in timeRange &&
+    "end" in timeRange &&
+    typeof timeRange.start === "string" &&
+    typeof timeRange.end === "string"
+  ) {
+    return { start: timeRange.start, end: timeRange.end };
+  }
+
+  return undefined;
+}
+
+function isTraceItemDataset(dataset: PublicEventsDataset | "replays"): boolean {
+  return dataset === "spans" || dataset === "logs" || dataset === "metrics";
+}
+
+function hasFields(fields?: string[] | null): fields is string[] {
+  return Array.isArray(fields) && fields.length > 0;
+}
 
 function buildSearchRepairPrompt(params: {
   query?: string;
@@ -51,6 +109,9 @@ function buildSearchRepairPrompt(params: {
     "Fix this Sentry event search request.",
     "The query may be natural language or already-valid Sentry search syntax.",
     "Preserve valid explicit parameters, but correct dataset, query syntax, fields, sort, and time range when they conflict or would fail.",
+    "If the user query already uses Sentry search syntax, treat its filters as authoritative unless validation proves a field is invalid.",
+    "For spans, logs, and metrics, use datasetAttributes exact attribute validation for explicit fields or query filters before dropping or renaming them.",
+    "A broad datasetAttributes result may be truncated, so absence from that preview does not prove an explicit field is invalid.",
     "For non-replay datasets, convert environment parameters into query filters. For replays, keep environment in the separate environment parameter.",
     "",
     `User query: ${params.query || "(empty)"}`,
@@ -209,7 +270,23 @@ export default defineTool({
     let explanation: string | undefined;
     let environment: string | string[] | null | undefined = params.environment;
 
-    if (hasAgentProvider()) {
+    const explicitSort = params.sort?.trim() || undefined;
+    const hasStructuredQuery = looksLikeSentrySearchSyntax(params.query);
+    const hasExplicitDataset = params.dataset !== undefined;
+    const hasExplicitFields = hasFields(params.fields);
+    const hasExplicitSort = explicitSort !== undefined;
+    const hasExplicitStatsPeriod = params.statsPeriod !== undefined;
+    const hasExplicitTraceItemDataset =
+      hasExplicitDataset && isTraceItemDataset(inputDataset);
+    const shouldTrustStructuredTraceSearch =
+      hasStructuredQuery && hasExplicitTraceItemDataset;
+    const canRunWithoutAgent =
+      shouldTrustStructuredTraceSearch &&
+      hasExplicitFields &&
+      hasExplicitSort &&
+      !(params.environment && inputDataset !== "replays");
+
+    if (hasAgentProvider() && !canRunWithoutAgent) {
       const agentResult = await searchEventsAgent({
         query: buildSearchRepairPrompt({
           query: params.query,
@@ -225,52 +302,56 @@ export default defineTool({
       });
 
       const parsed = agentResult.result;
+      const shouldTrustExplicitSearchParams =
+        shouldTrustStructuredTraceSearch ||
+        (hasStructuredQuery && parsed.dataset === inputDataset);
 
-      if (!parsed.sort?.trim()) {
+      if (
+        !parsed.sort?.trim() &&
+        !(shouldTrustExplicitSearchParams && hasExplicitSort)
+      ) {
         throw new UserInputError(
           `Search Events Agent response missing required 'sort' parameter. Received: ${JSON.stringify(parsed, null, 2)}. The agent must specify how to sort results (e.g., '-timestamp' for newest first).`,
         );
       }
 
-      dataset = parsed.dataset;
-      sentryQuery = parsed.query || "";
-      sortParam = parsed.sort.trim();
+      dataset = shouldTrustStructuredTraceSearch
+        ? inputDataset
+        : parsed.dataset;
+      sentryQuery = shouldTrustStructuredTraceSearch
+        ? (params.query ?? "")
+        : parsed.query || "";
+      sortParam =
+        shouldTrustExplicitSearchParams && explicitSort
+          ? explicitSort
+          : parsed.sort?.trim() || defaultSortForDataset(dataset);
       explanation = parsed.explanation;
-      environment = parsed.environment;
+      environment = params.environment ?? parsed.environment;
 
-      timeParams = {};
-      if (parsed.timeRange) {
-        if ("statsPeriod" in parsed.timeRange) {
-          timeParams.statsPeriod = parsed.timeRange.statsPeriod;
-        } else if ("start" in parsed.timeRange && "end" in parsed.timeRange) {
-          timeParams.start = parsed.timeRange.start;
-          timeParams.end = parsed.timeRange.end;
-        }
-      } else {
-        timeParams.statsPeriod = "14d";
-      }
+      timeParams =
+        shouldTrustExplicitSearchParams && hasExplicitStatsPeriod
+          ? { statsPeriod: params.statsPeriod }
+          : (parseAgentTimeRange(parsed.timeRange) ?? { statsPeriod: "14d" });
 
       if (dataset === "replays") {
         fields = [];
       } else {
-        const requestedFields = parsed.fields || [];
-        fields =
-          requestedFields.length > 0
-            ? requestedFields
-            : RECOMMENDED_FIELDS[normalizeEventsDataset(dataset)].basic;
+        fields = resolveEventFields({
+          dataset,
+          explicitFields: params.fields,
+          agentFields: parsed.fields,
+          trustExplicitFields: shouldTrustExplicitSearchParams,
+        });
       }
     } else {
       dataset = inputDataset;
       sentryQuery = params.query ?? "";
-      sortParam =
-        params.sort ||
-        (dataset === "replays" ? DEFAULT_REPLAY_SORT : DEFAULT_EVENTS_SORT);
+      sortParam = explicitSort || defaultSortForDataset(dataset);
       timeParams = { statsPeriod: params.statsPeriod ?? "14d" };
       fields =
         dataset === "replays"
           ? []
-          : (params.fields ??
-            RECOMMENDED_FIELDS[normalizeEventsDataset(dataset)].basic);
+          : (params.fields ?? defaultFieldsForDataset(dataset));
     }
 
     if (dataset === "replays") {
@@ -324,6 +405,13 @@ export default defineTool({
         environment,
         explanation,
         timeRange: replayTimeParams,
+        executedSearch: {
+          dataset,
+          query: sentryQuery,
+          fields: [],
+          sort: replaySort,
+          timeRange: replayTimeParams,
+        },
       });
     }
 
@@ -401,6 +489,13 @@ export default defineTool({
       sentryQuery,
       fields,
       explanation,
+      executedSearch: {
+        dataset,
+        query: sentryQuery,
+        fields,
+        sort: sortParam,
+        timeRange: timeParams,
+      },
     };
 
     switch (dataset) {

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -130,7 +130,54 @@ function appendSearchFilter(query: string, filter?: string): string {
 }
 
 function tokenizeSearchQuery(query: string): string[] {
-  return query.split(/\s+/).filter(Boolean);
+  const tokens: string[] = [];
+  let currentToken = "";
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const char of query) {
+    if (escaped) {
+      currentToken += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      currentToken += char;
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      currentToken += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      currentToken += char;
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (currentToken) {
+        tokens.push(currentToken);
+        currentToken = "";
+      }
+      continue;
+    }
+
+    currentToken += char;
+  }
+
+  if (currentToken) {
+    tokens.push(currentToken);
+  }
+
+  return tokens;
 }
 
 function containsSearchToken(query: string, token: string): boolean {

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -123,7 +123,7 @@ function formatEnvironmentFilter(
 
 function appendSearchFilter(query: string, filter?: string): string {
   const trimmedQuery = query.trim();
-  if (!filter || /\benvironment\s*:/.test(trimmedQuery)) {
+  if (!filter) {
     return trimmedQuery;
   }
   return [trimmedQuery, filter].filter(Boolean).join(" ");

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -126,6 +126,9 @@ function appendSearchFilter(query: string, filter?: string): string {
   if (!filter) {
     return trimmedQuery;
   }
+  if (tokenizeSearchQuery(trimmedQuery).includes(filter)) {
+    return trimmedQuery;
+  }
   return [trimmedQuery, filter].filter(Boolean).join(" ");
 }
 

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -129,6 +129,24 @@ function appendSearchFilter(query: string, filter?: string): string {
   return [trimmedQuery, filter].filter(Boolean).join(" ");
 }
 
+function choosePreservingRepairedQuery(params: {
+  originalQuery: string;
+  repairedQuery?: string | null;
+  filter?: string;
+}): string {
+  const originalQuery = params.originalQuery.trim();
+  const repairedQuery = params.repairedQuery?.trim();
+  if (!repairedQuery) {
+    return appendSearchFilter(originalQuery, params.filter);
+  }
+
+  if (!originalQuery || repairedQuery.includes(originalQuery)) {
+    return appendSearchFilter(repairedQuery, params.filter);
+  }
+
+  return appendSearchFilter(originalQuery, params.filter);
+}
+
 function buildSearchRepairPrompt(params: {
   query?: string;
   dataset: PublicEventsDataset | "replays";
@@ -317,11 +335,9 @@ export default defineTool({
       hasExplicitDataset && isTraceItemDataset(inputDataset);
     const shouldTrustStructuredTraceSearch =
       hasStructuredQuery && hasExplicitTraceItemDataset;
+    const environmentFilter = formatEnvironmentFilter(params.environment);
     const explicitStructuredTraceQuery = shouldTrustStructuredTraceSearch
-      ? appendSearchFilter(
-          params.query ?? "",
-          formatEnvironmentFilter(params.environment),
-        )
+      ? appendSearchFilter(params.query ?? "", environmentFilter)
       : (params.query ?? "");
     const canRunWithoutAgent =
       shouldTrustStructuredTraceSearch && hasExplicitFields && hasExplicitSort;
@@ -359,7 +375,11 @@ export default defineTool({
         ? inputDataset
         : parsed.dataset;
       sentryQuery = shouldTrustStructuredTraceSearch
-        ? explicitStructuredTraceQuery
+        ? choosePreservingRepairedQuery({
+            originalQuery: params.query ?? "",
+            repairedQuery: parsed.query,
+            filter: environmentFilter,
+          })
         : parsed.query || "";
       sortParam =
         shouldTrustExplicitSearchParams && explicitSort

--- a/packages/mcp-core/src/tools/search-events/replays.ts
+++ b/packages/mcp-core/src/tools/search-events/replays.ts
@@ -1,4 +1,5 @@
 import type { ReplayDetails, SentryApiService } from "../../api-client";
+import { formatExecutedSearch, type ExecutedSearch } from "./formatters";
 
 export const DEFAULT_REPLAY_SORT = "-started_at";
 export const DEFAULT_REPLAY_STATS_PERIOD = "14d";
@@ -56,6 +57,7 @@ export interface FormatReplayResultsParams {
   environment?: string | string[] | null;
   explanation?: string;
   timeRange?: ReplayTimeRange;
+  executedSearch?: ExecutedSearch;
 }
 
 export function isValidReplaySort(sort: string): boolean {
@@ -95,6 +97,8 @@ export function formatReplayResults(params: FormatReplayResultsParams): string {
       output += `## How I interpreted your query\n\n${explanation}\n\n`;
     }
   }
+
+  output += formatExecutedSearch(params.executedSearch);
 
   output += `**View these results in Sentry**:\n${searchUrl}\n`;
   output +=

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -5,6 +5,7 @@ import {
   fetchCustomAttributes,
   formatEventValue,
   formatKnownUserValue,
+  looksLikeSentrySearchSyntax,
 } from "./utils";
 import { SentryApiService } from "../../api-client";
 import * as logging from "../../telem/logging";
@@ -192,6 +193,19 @@ describe("formatEventValue", () => {
       const result = formatEventValue("abcdef", { maxLength: 3 });
       expect(result).toBe("abc");
     });
+  });
+});
+
+describe("search query helpers", () => {
+  it("should detect structured Sentry search syntax", () => {
+    expect(looksLikeSentrySearchSyntax("vpn connections from China")).toBe(
+      false,
+    );
+    expect(
+      looksLikeSentrySearchSyntax(
+        'transaction:"VPN connections" tags[type]:Unified tags[country]:CN',
+      ),
+    ).toBe(true);
   });
 });
 
@@ -463,6 +477,87 @@ describe("fetchCustomAttributes", () => {
           "metric.name": "string",
           "metric.type": "string",
           value: "number",
+        },
+      });
+    });
+
+    it("should pass targeted trace item attribute filters through to Sentry", async () => {
+      const requests: URLSearchParams[] = [];
+
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/test-org/trace-items/attributes/",
+          ({ request }) => {
+            const url = new URL(request.url);
+            requests.push(url.searchParams);
+
+            const attributeType = url.searchParams.get("attributeType");
+            if (attributeType === "string") {
+              return HttpResponse.json([
+                {
+                  key: "tags[type]",
+                  name: "type",
+                  attributeType: "string",
+                },
+              ]);
+            }
+            if (attributeType === "number") {
+              return HttpResponse.json([
+                {
+                  key: "tags[sequence,number]",
+                  name: "sequence",
+                  attributeType: "number",
+                },
+              ]);
+            }
+            if (attributeType === "boolean") {
+              return HttpResponse.json([
+                {
+                  key: "tags[enabled,boolean]",
+                  name: "enabled",
+                  attributeType: "boolean",
+                },
+              ]);
+            }
+            return HttpResponse.json([]);
+          },
+        ),
+      );
+
+      const result = await fetchCustomAttributes(
+        apiService,
+        "test-org",
+        "spans",
+        "123",
+        { statsPeriod: "7d" },
+        {
+          attributeTypes: ["string", "number", "boolean"],
+          substringMatch: "tags[",
+          query: 'transaction:"VPN connections"',
+        },
+      );
+
+      expect(requests).toHaveLength(3);
+      expect(
+        requests.map((params) => params.get("attributeType")).sort(),
+      ).toEqual(["boolean", "number", "string"]);
+      for (const params of requests) {
+        expect(params.get("itemType")).toBe("spans");
+        expect(params.get("project")).toBe("123");
+        expect(params.get("statsPeriod")).toBe("7d");
+        expect(params.get("substringMatch")).toBe("tags[");
+        expect(params.get("query")).toBe('transaction:"VPN connections"');
+      }
+      expect(result).toEqual({
+        attributes: {
+          "tags[type]": "type",
+          "tags[sequence,number]": "sequence",
+          "tags[enabled,boolean]": "enabled",
+        },
+        fieldTypes: {
+          "tags[type]": "string",
+          "tags[sequence,number]": "number",
+          "tags[enabled,boolean]": "boolean",
         },
       });
     });

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -206,6 +206,19 @@ describe("search query helpers", () => {
         'transaction:"VPN connections" tags[type]:Unified tags[country]:CN',
       ),
     ).toBe(true);
+    expect(looksLikeSentrySearchSyntax("span.op:http.client")).toBe(true);
+    expect(looksLikeSentrySearchSyntax("http.status_code:500")).toBe(true);
+    expect(looksLikeSentrySearchSyntax("customer:acme")).toBe(true);
+    expect(looksLikeSentrySearchSyntax('!transaction:"healthcheck"')).toBe(
+      true,
+    );
+  });
+
+  it("should ignore common natural language colon patterns", () => {
+    expect(looksLikeSentrySearchSyntax("open http://example.com")).toBe(false);
+    expect(looksLikeSentrySearchSyntax("started at 10:30")).toBe(false);
+    expect(looksLikeSentrySearchSyntax("Note: show slow spans")).toBe(false);
+    expect(looksLikeSentrySearchSyntax("ERROR: service is down")).toBe(false);
   });
 });
 

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import type { SentryApiService } from "../../api-client";
+import type {
+  SentryApiService,
+  TraceItemAttributeType,
+  TraceItemAttributeValidationResult,
+  TraceItemType,
+} from "../../api-client";
 import { agentTool } from "../../internal/agents/tools/utils";
 import {
   formatUserGeoSummary,
@@ -39,6 +44,14 @@ export function getNumberValue(
 // Helper to check if fields contain aggregate functions
 export function isAggregateQuery(fields: string[]): boolean {
   return fields.some((field) => field.includes("(") && field.includes(")"));
+}
+
+export function looksLikeSentrySearchSyntax(query?: string): boolean {
+  const trimmedQuery = query?.trim();
+  if (!trimmedQuery) {
+    return false;
+  }
+  return /(^|\s)!?[\w.[\],-]+\s*:/.test(trimmedQuery);
 }
 
 function isPrimitive(
@@ -267,13 +280,19 @@ export async function fetchCustomAttributes(
   dataset: EventsDataset,
   projectId?: string,
   timeParams?: { statsPeriod?: string; start?: string; end?: string },
+  options: {
+    attributeTypes?: TraceItemAttributeType[];
+    substringMatch?: string;
+    query?: string;
+  } = {},
 ): Promise<{
   attributes: Record<string, string>;
-  fieldTypes: Record<string, "string" | "number">;
+  fieldTypes: Record<string, TraceItemAttributeType>;
 }> {
   const customAttributes: Record<string, string> = {};
-  const fieldTypes: Record<string, "string" | "number"> = {};
+  const fieldTypes: Record<string, TraceItemAttributeType> = {};
   const normalizedDataset = normalizeEventsDataset(dataset);
+  const attributeTimeParams = timeParams ?? { statsPeriod: "14d" };
 
   if (normalizedDataset === "errors") {
     // TODO: For errors dataset, we currently need to use the old listTags API
@@ -282,7 +301,9 @@ export async function fetchCustomAttributes(
       organizationSlug,
       dataset: "events",
       project: projectId,
-      statsPeriod: "14d",
+      statsPeriod: attributeTimeParams.statsPeriod,
+      start: attributeTimeParams.start,
+      end: attributeTimeParams.end,
       useCache: true,
       useFlagsBackend: true,
     });
@@ -298,24 +319,28 @@ export async function fetchCustomAttributes(
     return { attributes: customAttributes, fieldTypes };
   } else {
     // For logs, spans, and trace metrics datasets, use the trace-items attributes endpoint
-    const itemType =
-      normalizedDataset === "logs"
-        ? "logs"
-        : normalizedDataset === "tracemetrics"
-          ? "tracemetrics"
-          : "spans";
+    const itemType = getTraceItemType(normalizedDataset);
+    if (!itemType) {
+      return { attributes: customAttributes, fieldTypes };
+    }
+
     const attributesResponse = await apiService.listTraceItemAttributes({
       organizationSlug,
       itemType,
       project: projectId,
-      statsPeriod: "14d",
+      statsPeriod: attributeTimeParams.statsPeriod,
+      start: attributeTimeParams.start,
+      end: attributeTimeParams.end,
+      attributeTypes: options.attributeTypes,
+      substringMatch: options.substringMatch,
+      query: options.query,
     });
 
     for (const attr of attributesResponse) {
       if (attr.key && !attr.key.startsWith("sentry:")) {
         customAttributes[attr.key] = attr.name || attr.key;
         // Track field type from the attribute response with validation
-        if (attr.type && (attr.type === "string" || attr.type === "number")) {
+        if (attr.type) {
           fieldTypes[attr.key] = attr.type;
         }
       }
@@ -323,6 +348,40 @@ export async function fetchCustomAttributes(
   }
 
   return { attributes: customAttributes, fieldTypes };
+}
+
+function getTraceItemType(dataset: EventsDataset): TraceItemType | null {
+  const normalizedDataset = normalizeEventsDataset(dataset);
+  if (normalizedDataset === "logs") {
+    return "logs";
+  }
+  if (normalizedDataset === "tracemetrics") {
+    return "tracemetrics";
+  }
+  if (normalizedDataset === "spans") {
+    return "spans";
+  }
+  return null;
+}
+
+function formatValidationResults(
+  validationResults: Record<string, TraceItemAttributeValidationResult>,
+): string {
+  const entries = Object.entries(validationResults);
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return `Validated Attributes:
+${entries
+  .map(([attribute, result]) => {
+    if (result.valid) {
+      return `- ${attribute}: valid${result.type ? ` (${result.type})` : ""}`;
+    }
+    return `- ${attribute}: invalid${result.error ? ` (${result.error})` : ""}`;
+  })
+  .join("\n")}
+`;
 }
 
 /**
@@ -335,15 +394,51 @@ export function createDatasetAttributesTool(options: {
   projectId?: string;
 }) {
   const { apiService, organizationSlug, projectId } = options;
+  const traceItemAttributeTypeSchema = z.enum(["string", "number", "boolean"]);
+
   return agentTool({
     description:
-      "Query available attributes and fields for a specific Sentry dataset to understand what data is available",
+      "Query, filter, and validate available attributes and fields for a specific Sentry dataset to understand what data is available",
     parameters: z.object({
       dataset: z
         .enum(PUBLIC_EVENTS_DATASETS)
         .describe("The dataset to query attributes for"),
+      substringMatch: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe("Optional substring to find matching attribute names"),
+      query: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          "Optional Sentry search query to list attributes available for that filtered result set",
+        ),
+      attributeTypes: z
+        .array(traceItemAttributeTypeSchema)
+        .min(1)
+        .optional()
+        .describe(
+          "Optional attribute types to list. Use ['string','number','boolean'] when unsure.",
+        ),
+      attributes: z
+        .array(z.string().trim().min(1))
+        .min(1)
+        .optional()
+        .describe(
+          "Optional exact attribute keys to validate, such as ['tags[type]', 'span.duration']",
+        ),
     }),
-    execute: async ({ dataset }) => {
+    execute: async ({
+      dataset,
+      substringMatch,
+      query,
+      attributeTypes,
+      attributes,
+    }) => {
       const {
         BASE_COMMON_FIELDS,
         DATASET_FIELDS,
@@ -357,12 +452,30 @@ export function createDatasetAttributesTool(options: {
       // UserInputError will be converted to error string for the AI agent
       // Other errors will bubble up to be captured by Sentry
       const normalizedDataset = normalizeEventsDataset(dataset);
+      const traceItemType = getTraceItemType(normalizedDataset);
+      const attributeTimeParams = { statsPeriod: "14d" };
+      const validationResults =
+        traceItemType && attributes?.length
+          ? await apiService.validateTraceItemAttributes({
+              organizationSlug,
+              itemType: traceItemType,
+              attributes,
+              project: projectId,
+              ...attributeTimeParams,
+            })
+          : {};
       const { attributes: customAttributes, fieldTypes } =
         await fetchCustomAttributes(
           apiService,
           organizationSlug,
           dataset,
           projectId,
+          attributeTimeParams,
+          {
+            attributeTypes,
+            substringMatch,
+            query,
+          },
         );
 
       // Combine all available fields
@@ -375,7 +488,9 @@ export function createDatasetAttributesTool(options: {
       const recommendedFields = RECOMMENDED_FIELDS[normalizedDataset];
 
       // Combine field types from both static config and dynamic API
-      const allFieldTypes = { ...fieldTypes };
+      const allFieldTypes: Record<string, TraceItemAttributeType> = {
+        ...fieldTypes,
+      };
       const staticNumericFields =
         NUMERIC_FIELDS[normalizedDataset] || new Set();
       for (const field of staticNumericFields) {
@@ -383,6 +498,7 @@ export function createDatasetAttributesTool(options: {
       }
 
       return `Dataset: ${dataset}
+${formatValidationResults(validationResults)}
 
 Available Fields (${Object.keys(allFields).length} total):
 ${Object.entries(allFields)

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -21,6 +21,38 @@ export type FlexibleEventData = Record<string, unknown>;
 
 const DEFAULT_MAX_VALUE_LENGTH = 200;
 const DEFAULT_MAX_ARRAY_ITEMS = 20;
+const SENTRY_SEARCH_TOKEN_PATTERN =
+  /(^|\s)!?([A-Za-z_][A-Za-z0-9_.[\],-]*):(?=\S)(?!\/\/)/g;
+const KNOWN_SENTRY_SEARCH_KEYS = new Set([
+  "browser",
+  "device",
+  "duration",
+  "environment",
+  "error.type",
+  "http.status_code",
+  "issue",
+  "level",
+  "message",
+  "os",
+  "project",
+  "release",
+  "severity",
+  "span.action",
+  "span.description",
+  "span.module",
+  "span.op",
+  "span.status",
+  "timestamp",
+  "trace",
+  "transaction",
+  "transaction.duration",
+  "transaction.op",
+  "url",
+  "user",
+  "user.email",
+  "user.id",
+  "user.username",
+]);
 
 // Helper to safely get a string value from event data
 export function getStringValue(
@@ -51,7 +83,31 @@ export function looksLikeSentrySearchSyntax(query?: string): boolean {
   if (!trimmedQuery) {
     return false;
   }
-  return /(^|\s)!?[\w.[\],-]+\s*:/.test(trimmedQuery);
+
+  for (const match of trimmedQuery.matchAll(SENTRY_SEARCH_TOKEN_PATTERN)) {
+    const key = match[2];
+    if (!key) {
+      continue;
+    }
+
+    if (/^tags\[[^\]]+\]$/.test(key)) {
+      return true;
+    }
+
+    if (key !== key.toLowerCase()) {
+      continue;
+    }
+
+    if (KNOWN_SENTRY_SEARCH_KEYS.has(key) || /[.[\],]/.test(key)) {
+      return true;
+    }
+
+    if (/^[a-z_][a-z0-9_-]*$/.test(key)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function isPrimitive(

--- a/packages/mcp-server-evals/src/evals/search-events-agent.eval.ts
+++ b/packages/mcp-server-evals/src/evals/search-events-agent.eval.ts
@@ -114,9 +114,6 @@ describeEval("search-events-agent", {
         expectedTools: [
           {
             name: "datasetAttributes",
-            arguments: {
-              dataset: "spans",
-            },
           },
         ],
         expected: {

--- a/packages/mcp-server-evals/src/evals/search-events-agent.eval.ts
+++ b/packages/mcp-server-evals/src/evals/search-events-agent.eval.ts
@@ -106,6 +106,38 @@ describeEval("search-events-agent", {
         },
       },
       {
+        // User-supplied Sentry syntax should remain authoritative. The agent
+        // can validate fields, but it should not rewrite or drop explicit
+        // filters/fields while translating the request.
+        input:
+          'In spans, search for transaction:"VPN connections" tags[type]:Unified tags[country]:CN over the last 7 days. Return tags[type], tags[sequence], and count(), sorted by count descending.',
+        expectedTools: [
+          {
+            name: "datasetAttributes",
+            arguments: {
+              dataset: "spans",
+            },
+          },
+        ],
+        expected: {
+          dataset: "spans",
+          query: (value: unknown) =>
+            typeof value === "string" &&
+            [
+              'transaction:"VPN connections"',
+              "tags[type]:Unified",
+              "tags[country]:CN",
+            ].every((token) => value.includes(token)),
+          fields: (value: unknown) =>
+            Array.isArray(value) &&
+            ["tags[type]", "tags[sequence]", "count()"].every((field) =>
+              value.includes(field),
+            ),
+          sort: "-count()",
+          timeRange: { statsPeriod: "7d" },
+        },
+      },
+      {
         // Query requiring equation field calculation
         input: "How many total tokens did we consume yesterday",
         expectedTools: [

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -825,6 +825,39 @@ export const restHandlers = buildHandlers([
     fetch: () => HttpResponse.json(tagsFixture),
   },
   {
+    method: "post",
+    path: "/api/0/organizations/sentry-mcp-evals/trace-items/attributes/validate/",
+    fetch: async ({ request }) => {
+      const body = (await request.json().catch(() => null)) as unknown;
+      const attributesValue =
+        typeof body === "object" && body !== null && "attributes" in body
+          ? body.attributes
+          : undefined;
+      const attributes = Array.isArray(attributesValue)
+        ? attributesValue.filter(
+            (attribute): attribute is string => typeof attribute === "string",
+          )
+        : [];
+
+      return HttpResponse.json({
+        attributes: Object.fromEntries(
+          attributes.map((attribute) => [
+            attribute,
+            {
+              valid: true,
+              type:
+                attribute.includes("sequence") ||
+                attribute.includes("count") ||
+                attribute.includes("duration")
+                  ? "number"
+                  : "string",
+            },
+          ]),
+        ),
+      });
+    },
+  },
+  {
     method: "get",
     path: "/api/0/organizations/sentry-mcp-evals/trace-items/attributes/",
     fetch: ({ request }) => {


### PR DESCRIPTION
Summary of changes from `main`:

- Preserve caller-provided structured trace-item searches in `search_events` for spans/logs/metrics. Complete explicit requests can execute directly, and partial requests that still invoke the embedded agent now keep the caller-provided query filters, fields, sort, and time range when those inputs are explicit and valid.
- Guard agent-repaired structured queries so they can add constraints but cannot silently replace user filters, including exact token checks and quoted-value handling. Non-replay environment params are appended as query filters instead of being dropped.
- Tighten Sentry search-syntax detection so URLs, time labels, and prose labels do not bypass the agent as false structured queries.
- Extend the Sentry API client and `datasetAttributes` tool with targeted trace-item attribute lookup, exact attribute validation, `attributeTypes`, substring/query filtering, and typed attribute-source parsing.
- Include executed search details in responses and add regression and eval coverage for custom tag fields, environment preservation, repaired query preservation, quoted values, attribute validation, and agent preservation of explicit Sentry search syntax.

Fixes #968