### PR TITLE
feat(mcp-core): Support comparison-aware snapshot image responses

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2915,7 +2915,7 @@ export class SentryApiService {
     let contentType = response.headers.get("content-type") ?? "";
     if (!contentType.startsWith("image/")) {
       const { detectImageMimeType } = await import("../internal/blob-utils.js");
-      contentType = (await detectImageMimeType(blob)) ?? "image/png";
+      contentType = (await detectImageMimeType(blob)) ?? contentType;
     }
     return { blob, contentType };
   }

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2912,10 +2912,12 @@ export class SentryApiService {
       );
     }
     const blob = await response.blob();
-    return {
-      blob,
-      contentType: response.headers.get("content-type") ?? "image/png",
-    };
+    let contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.startsWith("image/")) {
+      const { detectImageMimeType } = await import("../internal/blob-utils.js");
+      contentType = (await detectImageMimeType(blob)) ?? "image/png";
+    }
+    return { blob, contentType };
   }
 
   async getLatestBaseSnapshot({

--- a/packages/mcp-core/src/internal/blob-utils.test.ts
+++ b/packages/mcp-core/src/internal/blob-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { blobToBase64, detectImageMimeType } from "./blob-utils.js";
+
+describe("blob-utils", () => {
+  describe("blobToBase64", () => {
+    it("converts blob to base64 string", async () => {
+      const blob = new Blob([new Uint8Array([1, 2, 3])]);
+      const result = await blobToBase64(blob);
+      expect(result).toBe(Buffer.from([1, 2, 3]).toString("base64"));
+    });
+  });
+
+  describe("detectImageMimeType", () => {
+    it("detects PNG", async () => {
+      const png = new Blob([
+        new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      ]);
+      expect(await detectImageMimeType(png)).toBe("image/png");
+    });
+
+    it("detects JPEG", async () => {
+      const jpeg = new Blob([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])]);
+      expect(await detectImageMimeType(jpeg)).toBe("image/jpeg");
+    });
+
+    it("detects GIF", async () => {
+      const gif = new Blob([
+        new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]),
+      ]);
+      expect(await detectImageMimeType(gif)).toBe("image/gif");
+    });
+
+    it("detects WebP", async () => {
+      const webp = new Blob([
+        new Uint8Array([
+          0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42,
+          0x50,
+        ]),
+      ]);
+      expect(await detectImageMimeType(webp)).toBe("image/webp");
+    });
+
+    it("returns null for unknown format", async () => {
+      const unknown = new Blob([new Uint8Array([0x00, 0x01, 0x02, 0x03])]);
+      expect(await detectImageMimeType(unknown)).toBeNull();
+    });
+
+    it("returns null for empty blob", async () => {
+      const empty = new Blob([]);
+      expect(await detectImageMimeType(empty)).toBeNull();
+    });
+  });
+});

--- a/packages/mcp-core/src/internal/blob-utils.ts
+++ b/packages/mcp-core/src/internal/blob-utils.ts
@@ -1,3 +1,55 @@
 export async function blobToBase64(blob: Blob): Promise<string> {
   return Buffer.from(await blob.arrayBuffer()).toString("base64");
 }
+
+const MAGIC_SIGNATURES: { mime: string; offsets: [number, number][] }[] = [
+  {
+    mime: "image/png",
+    offsets: [
+      [0, 0x89],
+      [1, 0x50],
+      [2, 0x4e],
+      [3, 0x47],
+    ],
+  },
+  {
+    mime: "image/jpeg",
+    offsets: [
+      [0, 0xff],
+      [1, 0xd8],
+      [2, 0xff],
+    ],
+  },
+  {
+    mime: "image/gif",
+    offsets: [
+      [0, 0x47],
+      [1, 0x49],
+      [2, 0x46],
+      [3, 0x38],
+    ],
+  },
+  {
+    mime: "image/webp",
+    offsets: [
+      [0, 0x52],
+      [1, 0x49],
+      [2, 0x46],
+      [3, 0x46],
+      [8, 0x57],
+      [9, 0x45],
+      [10, 0x42],
+      [11, 0x50],
+    ],
+  },
+];
+
+export async function detectImageMimeType(blob: Blob): Promise<string | null> {
+  const header = new Uint8Array(await blob.slice(0, 12).arrayBuffer());
+  for (const { mime, offsets } of MAGIC_SIGNATURES) {
+    if (offsets.every(([offset, byte]) => header[offset] === byte)) {
+      return mime;
+    }
+  }
+  return null;
+}

--- a/packages/mcp-core/src/tools/get-snapshot-details.test.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-details.test.ts
@@ -121,12 +121,16 @@ const snapshotFixture = {
   unchanged: [],
 };
 
-const imageDetailFixture = {
+const headImageInfo = {
+  content_hash: "abc123",
   display_name: "login_screen.png",
   group: "auth",
   image_file_name: "snapshots-iphone-16/auth_login_screen.png",
   width: 1080,
   height: 1920,
+  description: null,
+  image_url:
+    "/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen.png/download/",
   context: {
     preview: {
       container_display_name: "Auth Login",
@@ -134,11 +138,75 @@ const imageDetailFixture = {
     },
     simulator: { device_name: "iPhone 16" },
   },
+};
+
+const baseImageInfo = {
+  content_hash: "def456",
+  display_name: "login_screen.png",
+  group: "auth",
+  image_file_name: "snapshots-iphone-16/auth_login_screen.png",
+  width: 1080,
+  height: 1920,
+  description: null,
   image_url:
-    "/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen.png/download/",
+    "/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen_base.png/download/",
+};
+
+const changedImageDetailFixture = {
+  image_file_name: "snapshots-iphone-16/auth_login_screen.png",
+  comparison_status: "changed",
+  head_image: headImageInfo,
+  base_image: baseImageInfo,
+  diff_image_url:
+    "/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen_diff.png/download/",
+  diff_percentage: 0.125,
+  previous_image_file_name: null,
+};
+
+const addedImageDetailFixture = {
+  image_file_name: "snapshots-iphone-16/auth_login_screen.png",
+  comparison_status: "added",
+  head_image: headImageInfo,
+  base_image: null,
+  diff_image_url: null,
+  diff_percentage: null,
+  previous_image_file_name: null,
+};
+
+const removedImageDetailFixture = {
+  image_file_name: "snapshots-iphone-16/auth_login_screen.png",
+  comparison_status: "removed",
+  head_image: null,
+  base_image: baseImageInfo,
+  diff_image_url: null,
+  diff_percentage: null,
+  previous_image_file_name: null,
+};
+
+const renamedImageDetailFixture = {
+  image_file_name: "snapshots-iphone-16/auth_login_screen.png",
+  comparison_status: "renamed",
+  head_image: headImageInfo,
+  base_image: {
+    ...baseImageInfo,
+    image_file_name: "snapshots-iphone-16/old_login.png",
+  },
+  diff_image_url: null,
+  diff_percentage: null,
+  previous_image_file_name: "snapshots-iphone-16/old_login.png",
 };
 
 const fakePng = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const fakeJpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+
+const IMAGE_DETAIL_PATH =
+  "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/login_screen.png/";
+const HEAD_DOWNLOAD_PATH =
+  "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen.png/download/";
+const BASE_DOWNLOAD_PATH =
+  "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen_base.png/download/";
+const DIFF_DOWNLOAD_PATH =
+  "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen_diff.png/download/";
 
 function setupSnapshotMock() {
   mswServer.use(
@@ -150,19 +218,47 @@ function setupSnapshotMock() {
   );
 }
 
-function setupImageMocks() {
+function setupChangedImageMocks() {
   mswServer.use(
     http.get(
-      "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/login_screen.png/",
-      () => HttpResponse.json(imageDetailFixture),
+      IMAGE_DETAIL_PATH,
+      () => HttpResponse.json(changedImageDetailFixture),
       { once: true },
     ),
     http.get(
-      "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen.png/download/",
+      HEAD_DOWNLOAD_PATH,
       () =>
-        new HttpResponse(fakePng, {
-          headers: { "content-type": "image/png" },
+        new HttpResponse(fakePng, { headers: { "content-type": "image/png" } }),
+      { once: true },
+    ),
+    http.get(
+      BASE_DOWNLOAD_PATH,
+      () =>
+        new HttpResponse(fakeJpeg, {
+          headers: { "content-type": "image/jpeg" },
         }),
+      { once: true },
+    ),
+    http.get(
+      DIFF_DOWNLOAD_PATH,
+      () =>
+        new HttpResponse(fakePng, { headers: { "content-type": "image/png" } }),
+      { once: true },
+    ),
+  );
+}
+
+function setupAddedImageMocks() {
+  mswServer.use(
+    http.get(
+      IMAGE_DETAIL_PATH,
+      () => HttpResponse.json(addedImageDetailFixture),
+      { once: true },
+    ),
+    http.get(
+      HEAD_DOWNLOAD_PATH,
+      () =>
+        new HttpResponse(fakePng, { headers: { "content-type": "image/png" } }),
       { once: true },
     ),
   );
@@ -376,8 +472,8 @@ describe("get_snapshot_details", () => {
     expect(text).toContain("`Dark mode` (Content View)");
   });
 
-  it("fetches image metadata and binary when selectedSnapshot is provided", async () => {
-    setupImageMocks();
+  it("returns head, base, and diff images for changed comparison", async () => {
+    setupChangedImageMocks();
     const result = await getSnapshotDetails.handler(
       {
         snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
@@ -393,32 +489,170 @@ describe("get_snapshot_details", () => {
     const imageParts = parts.filter(
       (p): p is ImageContent => p.type === "image",
     );
-    expect(textParts[0]!.text).toContain("login_screen.png");
+    expect(textParts[0]!.text).toContain("**Status**: changed");
+    expect(textParts[0]!.text).toContain("**Diff**: 12.5%");
     expect(textParts[0]!.text).toContain("**Group**: auth");
     expect(textParts[0]!.text).toContain("1080×1920");
-    expect(textParts[0]!.text).not.toContain("image_url");
-    expect(imageParts.length).toBe(1);
+    expect(textParts[0]!.text).toContain("**Container**: Auth Login");
+    expect(textParts[0]!.text).toContain("**Device**: iPhone 16");
+    expect(imageParts.length).toBe(3);
     expect(imageParts[0]!.mimeType).toBe("image/png");
-    expect(textParts[0]!.text).toMatchInlineSnapshot(`
-      "## login_screen.png
-
-      - **Display Name**: login_screen.png
-      - **Group**: auth
-      - **File**: \`snapshots-iphone-16/auth_login_screen.png\`
-      - **Dimensions**: 1080×1920
-      - **Container**: Auth Login
-      - **Device**: iPhone 16"
-    `);
+    expect(imageParts[1]!.mimeType).toBe("image/jpeg");
+    expect(imageParts[2]!.mimeType).toBe("image/png");
+    expect(textParts[1]!.text).toBe("### Head (current)");
+    expect(textParts[2]!.text).toBe("### Base (previous)");
+    expect(textParts[3]!.text).toBe("### Diff Mask");
   });
 
-  it("throws when selectedSnapshot image has no image_url", async () => {
+  it("returns only head image for added comparison", async () => {
+    setupAddedImageMocks();
+    const result = await getSnapshotDetails.handler(
+      {
+        snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
+        organizationSlug: null,
+        snapshotId: null,
+        selectedSnapshot: "login_screen.png",
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+    const parts = result as (TextContent | ImageContent)[];
+    const textParts = parts.filter((p): p is TextContent => p.type === "text");
+    const imageParts = parts.filter(
+      (p): p is ImageContent => p.type === "image",
+    );
+    expect(textParts[0]!.text).toContain("**Status**: added");
+    expect(textParts[0]!.text).not.toContain("**Diff**:");
+    expect(imageParts.length).toBe(1);
+    expect(imageParts[0]!.mimeType).toBe("image/png");
+    expect(textParts[1]!.text).toBe("### Head (current)");
+  });
+
+  it("returns only base image for removed comparison", async () => {
+    mswServer.use(
+      http.get(
+        IMAGE_DETAIL_PATH,
+        () => HttpResponse.json(removedImageDetailFixture),
+        { once: true },
+      ),
+      http.get(
+        BASE_DOWNLOAD_PATH,
+        () =>
+          new HttpResponse(fakePng, {
+            headers: { "content-type": "image/png" },
+          }),
+        { once: true },
+      ),
+    );
+    const result = await getSnapshotDetails.handler(
+      {
+        snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
+        organizationSlug: null,
+        snapshotId: null,
+        selectedSnapshot: "login_screen.png",
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+    const parts = result as (TextContent | ImageContent)[];
+    const imageParts = parts.filter(
+      (p): p is ImageContent => p.type === "image",
+    );
+    const textParts = parts.filter((p): p is TextContent => p.type === "text");
+    expect(textParts[0]!.text).toContain("**Status**: removed");
+    expect(imageParts.length).toBe(1);
+    expect(textParts[1]!.text).toBe("### Base (previous)");
+  });
+
+  it("shows previous_image_file_name for renamed images", async () => {
+    mswServer.use(
+      http.get(
+        IMAGE_DETAIL_PATH,
+        () => HttpResponse.json(renamedImageDetailFixture),
+        { once: true },
+      ),
+      http.get(
+        HEAD_DOWNLOAD_PATH,
+        () =>
+          new HttpResponse(fakePng, {
+            headers: { "content-type": "image/png" },
+          }),
+        { once: true },
+      ),
+      http.get(
+        BASE_DOWNLOAD_PATH,
+        () =>
+          new HttpResponse(fakePng, {
+            headers: { "content-type": "image/png" },
+          }),
+        { once: true },
+      ),
+    );
+    const result = await getSnapshotDetails.handler(
+      {
+        snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
+        organizationSlug: null,
+        snapshotId: null,
+        selectedSnapshot: "login_screen.png",
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+    const parts = result as (TextContent | ImageContent)[];
+    const textParts = parts.filter((p): p is TextContent => p.type === "text");
+    expect(textParts[0]!.text).toContain("**Status**: renamed");
+    expect(textParts[0]!.text).toContain(
+      "**Previous File**: `snapshots-iphone-16/old_login.png`",
+    );
+  });
+
+  it("detects image type from magic bytes when content-type is application/octet-stream", async () => {
+    mswServer.use(
+      http.get(
+        IMAGE_DETAIL_PATH,
+        () => HttpResponse.json(addedImageDetailFixture),
+        { once: true },
+      ),
+      http.get(
+        HEAD_DOWNLOAD_PATH,
+        () =>
+          new HttpResponse(fakePng, {
+            headers: { "content-type": "application/octet-stream" },
+          }),
+        { once: true },
+      ),
+    );
+    const result = await getSnapshotDetails.handler(
+      {
+        snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
+        organizationSlug: null,
+        snapshotId: null,
+        selectedSnapshot: "login_screen.png",
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+    const parts = result as (TextContent | ImageContent)[];
+    const imageParts = parts.filter(
+      (p): p is ImageContent => p.type === "image",
+    );
+    expect(imageParts.length).toBe(1);
+    expect(imageParts[0]!.mimeType).toBe("image/png");
+  });
+
+  it("throws when no image data is available", async () => {
     mswServer.use(
       http.get(
         "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/missing.png/",
         () =>
           HttpResponse.json({
-            display_name: "missing.png",
-            group: null,
+            image_file_name: "missing.png",
+            comparison_status: null,
+            head_image: null,
+            base_image: null,
+            diff_image_url: null,
+            diff_percentage: null,
+            previous_image_file_name: null,
           }),
         { once: true },
       ),
@@ -434,6 +668,6 @@ describe("get_snapshot_details", () => {
         },
         getServerContext(),
       ),
-    ).rejects.toThrow("No image_url returned");
+    ).rejects.toThrow("No image data returned");
   });
 });

--- a/packages/mcp-core/src/tools/get-snapshot-details.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-details.ts
@@ -25,6 +25,43 @@ interface SnapshotDiffPair {
   diff?: number | null;
 }
 
+interface SnapshotImageContext {
+  preview?: { container_display_name?: string; display_name?: string };
+  simulator?: { device_name?: string };
+  test_name?: string;
+}
+
+interface SnapshotImageInfo {
+  content_hash?: string;
+  display_name?: string | null;
+  group?: string | null;
+  image_file_name?: string;
+  width?: number;
+  height?: number;
+  description?: string | null;
+  image_url?: string;
+  context?: SnapshotImageContext;
+  [key: string]: unknown;
+}
+
+interface SnapshotImageDetailResponse {
+  image_file_name?: string;
+  comparison_status?:
+    | "added"
+    | "removed"
+    | "changed"
+    | "unchanged"
+    | "renamed"
+    | "errored"
+    | "skipped"
+    | null;
+  head_image?: SnapshotImageInfo | null;
+  base_image?: SnapshotImageInfo | null;
+  diff_image_url?: string | null;
+  diff_percentage?: number | null;
+  previous_image_file_name?: string | null;
+}
+
 function getImageDisplayName(img: SnapshotImageEntry): string {
   return img.display_name || img.image_file_name || "unknown";
 }
@@ -133,64 +170,110 @@ export default defineTool({
   },
 });
 
+function formatImageMetadata(img: SnapshotImageInfo): string[] {
+  const lines: string[] = [];
+  if (img.display_name) lines.push(`- **Display Name**: ${img.display_name}`);
+  if (img.group) lines.push(`- **Group**: ${img.group}`);
+  if (img.image_file_name) lines.push(`- **File**: \`${img.image_file_name}\``);
+  if (img.width || img.height)
+    lines.push(`- **Dimensions**: ${img.width}×${img.height}`);
+  if (img.description) lines.push(`- **Description**: ${img.description}`);
+  if (img.context?.preview?.container_display_name)
+    lines.push(
+      `- **Container**: ${img.context.preview.container_display_name}`,
+    );
+  if (img.context?.simulator?.device_name)
+    lines.push(`- **Device**: ${img.context.simulator.device_name}`);
+  if (img.context?.test_name)
+    lines.push(`- **Test**: ${img.context.test_name}`);
+  return lines;
+}
+
+async function fetchAndAppendImage(
+  apiService: ReturnType<typeof apiServiceFromContext>,
+  imageUrl: string,
+  label: string,
+  parts: (TextContent | ImageContent)[],
+): Promise<void> {
+  const { blob, contentType } = await apiService.fetchImageByUrl(imageUrl);
+  if (!contentType.startsWith("image/")) {
+    parts.push({
+      type: "text",
+      text: `(${label}: unexpected content type ${contentType})`,
+    });
+    return;
+  }
+  parts.push({ type: "text", text: `### ${label}` });
+  parts.push({
+    type: "image",
+    data: await blobToBase64(blob),
+    mimeType: contentType,
+  });
+}
+
 async function fetchSnapshotImage(
   apiService: ReturnType<typeof apiServiceFromContext>,
   organizationSlug: string,
   snapshotId: string,
   imageName: string,
 ): Promise<(TextContent | ImageContent)[]> {
-  const imageDetail = (await apiService.getSnapshotImageDetail({
+  const detail = (await apiService.getSnapshotImageDetail({
     organizationSlug,
     snapshotId,
     imageIdentifier: imageName,
-  })) as Record<string, unknown>;
+  })) as SnapshotImageDetailResponse;
 
-  const imageUrl = imageDetail.image_url as string | undefined;
-  if (!imageUrl) {
+  const headImage = detail.head_image;
+  const baseImage = detail.base_image;
+  const status = detail.comparison_status;
+
+  if (!headImage?.image_url && !baseImage?.image_url) {
     throw new UserInputError(
-      `No image_url returned for "${imageName}". The image may not exist in this snapshot.`,
+      `No image data returned for "${imageName}". The image may not exist in this snapshot.`,
     );
   }
 
-  const { image_url: _url, ...metadata } = imageDetail;
   const lines: string[] = [`## ${imageName}\n`];
-  if (metadata.display_name)
-    lines.push(`- **Display Name**: ${metadata.display_name}`);
-  if (metadata.group) lines.push(`- **Group**: ${metadata.group}`);
-  if (metadata.image_file_name)
-    lines.push(`- **File**: \`${metadata.image_file_name}\``);
-  if (metadata.width || metadata.height)
-    lines.push(`- **Dimensions**: ${metadata.width}×${metadata.height}`);
-  if (metadata.description)
-    lines.push(`- **Description**: ${metadata.description}`);
-  const context = metadata.context as Record<string, unknown> | undefined;
-  if (context) {
-    const preview = context.preview as Record<string, unknown> | undefined;
-    if (preview?.container_display_name)
-      lines.push(`- **Container**: ${preview.container_display_name}`);
-    const simulator = context.simulator as Record<string, unknown> | undefined;
-    if (simulator?.device_name)
-      lines.push(`- **Device**: ${simulator.device_name}`);
-    const test = context.test_name as string | undefined;
-    if (test) lines.push(`- **Test**: ${test}`);
-  }
+  if (status) lines.push(`- **Status**: ${status}`);
+  if (detail.diff_percentage != null)
+    lines.push(
+      `- **Diff**: ${Math.round(detail.diff_percentage * 10000) / 100}%`,
+    );
+  if (detail.previous_image_file_name)
+    lines.push(`- **Previous File**: \`${detail.previous_image_file_name}\``);
+
+  const primary = headImage ?? baseImage;
+  if (primary) lines.push(...formatImageMetadata(primary));
 
   const contentParts: (TextContent | ImageContent)[] = [
     { type: "text", text: lines.join("\n") },
   ];
 
-  const { blob, contentType } = await apiService.fetchImageByUrl(imageUrl);
-  if (!contentType.startsWith("image/")) {
-    contentParts.push({
-      type: "text",
-      text: `(Unexpected content type: ${contentType})`,
-    });
-  } else {
-    contentParts.push({
-      type: "image",
-      data: await blobToBase64(blob),
-      mimeType: contentType,
-    });
+  if (headImage?.image_url) {
+    await fetchAndAppendImage(
+      apiService,
+      headImage.image_url,
+      "Head (current)",
+      contentParts,
+    );
+  }
+
+  if (baseImage?.image_url && baseImage.image_url !== headImage?.image_url) {
+    await fetchAndAppendImage(
+      apiService,
+      baseImage.image_url,
+      "Base (previous)",
+      contentParts,
+    );
+  }
+
+  if (detail.diff_image_url) {
+    await fetchAndAppendImage(
+      apiService,
+      detail.diff_image_url,
+      "Diff Mask",
+      contentParts,
+    );
   }
 
   return contentParts;


### PR DESCRIPTION
Adapt snapshot image fetching to the new structured API response from
getsentry/sentry#115572. The image detail endpoint now returns a
comparison-aware envelope with `head_image`, `base_image`,
`diff_image_url`, `comparison_status`, and `diff_percentage` instead
of a flat object with a single `image_url`.

**What changed:**

- `get-snapshot-details` now returns up to 3 images as MCP `ImageContent`
  (head, base, diff mask), each with a labeled text header so LLMs know
  which is which
- Metadata text now includes comparison status, diff percentage, and
  previous file name for renamed images
- New `detectImageMimeType` utility reads magic bytes from blob data to
  determine the real image type when the API returns
  `application/octet-stream` — this was the root cause of LLMs being
  unable to view snapshot images
- `fetchImageByUrl` in the API client uses magic-byte detection as a
  fallback when content-type isn't an image type

**Why:**

Previously, when an LLM asked to view a snapshot image, it received only
text metadata and "(Unexpected content type: application/octet-stream)"
instead of the actual image. With this change, LLMs can visually inspect
head/base/diff images side by side and describe exactly what changed in a
snapshot comparison.

Refs getsentry/sentry#115572