### PR TITLE
feat(mcp-core): Enable preprod skill by default

### DIFF
--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -268,7 +268,7 @@
     "id": "preprod",
     "name": "Preprod Snapshots",
     "description": "Inspect visual regression snapshot tests from CI — view changed images and diff masks",
-    "defaultEnabled": false,
+    "defaultEnabled": true,
     "order": 6,
     "toolCount": 5,
     "tools": [

--- a/packages/mcp-core/src/skills.ts
+++ b/packages/mcp-core/src/skills.ts
@@ -66,7 +66,7 @@ export const SKILLS: Record<Skill, SkillDefinition> = {
     name: "Preprod Snapshots",
     description:
       "Inspect visual regression snapshot tests from CI — view changed images and diff masks",
-    defaultEnabled: false,
+    defaultEnabled: true,
     order: 6,
   },
 };


### PR DESCRIPTION
Enables the "Preprod Snapshots" skill by default in the OAuth consent screen.

Previously, only "Inspect Issues & Events" and "Seer" were default-enabled. Users had to manually scroll down and check "Preprod Snapshots" during OAuth authorization to get access to snapshot tools like `get_latest_base_snapshot`. Most users didn't realize this, causing the tool to appear unavailable even when routing was correct.