### PR TITLE
docs: prefer env token examples for stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ team:write
 event:write
 ```
 
-Launch the transport:
+Launch the transport with your token in the environment:
 
 ```shell
-npx @sentry/mcp-server@latest --access-token=sentry-user-token
+SENTRY_ACCESS_TOKEN=sentry-user-token npx @sentry/mcp-server@latest
 ```
 
 Need to connect to a self-hosted deployment? Add <code>--host</code> (hostname
@@ -61,13 +61,13 @@ Some features (like Seer) may not be available on self-hosted instances. You can
 disable specific skills to prevent unsupported tools from being exposed:
 
 ```shell
-npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.example.com --disable-skills=seer
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server@latest --host=sentry.example.com --disable-skills=seer
 ```
 
 For self-hosted instances without TLS:
 
 ```shell
-npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.internal:9000 --insecure-http
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server@latest --host=sentry.internal:9000 --insecure-http
 ```
 
 #### Environment Variables
@@ -222,7 +222,7 @@ pnpm -w run cli --agent "who am I?"
 pnpm -w run cli --mcp-host=https://mcp.sentry.dev "query"
 
 # Test with local stdio mode (requires SENTRY_ACCESS_TOKEN)
-pnpm -w run cli --access-token=TOKEN "query"
+SENTRY_ACCESS_TOKEN=TOKEN pnpm -w run cli "query"
 ```
 
 Note: The CLI defaults to `http://localhost:5173`. Override with `--mcp-host` or set `MCP_URL` environment variable.

--- a/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
@@ -10,10 +10,10 @@ const orderedSkills = [...skillDefinitions].sort((a, b) => a.order - b.order);
 
 export default function StdioSetup() {
   const mcpStdioSnippet = `npx ${NPM_PACKAGE_NAME}@latest`;
+  const mcpStdioWithTokenSnippet = `SENTRY_ACCESS_TOKEN=sentry-user-token ${mcpStdioSnippet}`;
 
   const selfHostedHostExample = [
-    `${mcpStdioSnippet}`,
-    "--access-token=sentry-user-token",
+    `${mcpStdioWithTokenSnippet}`,
     "--host=sentry.example.com",
   ].join(" \\\n  ");
 
@@ -60,10 +60,7 @@ export default function StdioSetup() {
         </ul>
         <p>Now wire up that token to the MCP configuration:</p>
         <CodeSnippet
-          snippet={[
-            `${mcpStdioSnippet}`,
-            "--access-token=sentry-user-token",
-          ].join(" \\\n  ")}
+          snippet={mcpStdioWithTokenSnippet}
         />
         <div className="mt-6">
           <h4 className="text-base font-semibold text-slate-100">

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -29,19 +29,19 @@ You can limit which skills are granted using the `--skills` flag:
 
 ```shell
 # Default: ALL skills (inspect, docs, seer, triage, project-management)
-npx @sentry/mcp-server@latest --access-token=sentry-user-token
+SENTRY_ACCESS_TOKEN=sentry-user-token npx @sentry/mcp-server@latest
 
 # Limit to specific skills only
-npx @sentry/mcp-server@latest --access-token=TOKEN --skills=inspect,docs
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server@latest --skills=inspect,docs
 
 # Self-hosted Sentry
-npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.example.com
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server@latest --host=sentry.example.com
 
 # Override OpenAI endpoint for AI-powered tools (stdio only)
-npx @sentry/mcp-server@latest --access-token=TOKEN --openai-base-url=https://proxy.example.com/v1
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server@latest --openai-base-url=https://proxy.example.com/v1
 
 # Azure OpenAI / Azure-compatible deployment routing (stdio only)
-npx @sentry/mcp-server@latest --access-token=TOKEN --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server@latest --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
 ```
 
 For Azure OpenAI or Azure-compatible deployment proxies, use the dedicated
@@ -109,10 +109,10 @@ If you're currently using scopes:
 
 ```shell
 # OLD (deprecated)
-npx @sentry/mcp-server --access-token=TOKEN --scopes=org:read,event:write
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server --scopes=org:read,event:write
 
 # NEW (recommended)
-npx @sentry/mcp-server --access-token=TOKEN --skills=inspect,triage
+SENTRY_ACCESS_TOKEN=TOKEN npx @sentry/mcp-server --skills=inspect,triage
 ```
 
 The host configuration accepts two distinct formats:


### PR DESCRIPTION
## Summary
- update the main stdio examples to pass the Sentry token through `SENTRY_ACCESS_TOKEN`
- keep self-hosted and skill examples aligned with the existing environment-variable section
- update the website setup fragment and mcp-core README examples to match

Closes #959

## Validation
- `git diff --check`

No local dependency install or full test run; this is a docs/example-only change.
