### PR TITLE
feat(telemetry): Add mcp.session.id for cross-call correlation

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -310,6 +310,15 @@ const mcpHandler: ExportedHandler<Env> = {
 
     const constraints = verification.constraints;
 
+    // Extract MCP session ID from the protocol layer for cross-call correlation.
+    // Streamable HTTP: mcp-session-id header (absent on initialize, present after).
+    // SSE: sessionId query parameter.
+    // Absent on the initialize request — left undefined rather than fabricating one.
+    const sessionId =
+      request.headers.get("mcp-session-id") ||
+      url.searchParams.get("sessionId") ||
+      undefined;
+
     // Build complete ServerContext from OAuth props + verified constraints.
     // Latched so use_sentry's multi-tool runs revoke at most once per request.
     let upstreamUnauthorizedHandled = false;
@@ -325,6 +334,7 @@ const mcpHandler: ExportedHandler<Env> = {
       agentMode: isAgentMode,
       experimentalMode: isExperimentalMode,
       transport: "http",
+      sessionId,
       onUpstreamUnauthorized: () => {
         if (upstreamUnauthorizedHandled) return;
         upstreamUnauthorizedHandled = true;

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { setUser } from "@sentry/core";
+import { setUser, getActiveSpan } from "@sentry/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildServer } from "./server";
 import type { ToolConfig } from "./tools/types";
@@ -110,6 +110,93 @@ describe("buildServer", () => {
         id: "user-123",
         ip_address: "192.0.2.1",
       });
+    });
+
+    it("sets session ID as span attribute for tool calls", async () => {
+      const mockSpan = {
+        setAttribute: vi.fn(),
+        setStatus: vi.fn(),
+        recordException: vi.fn(),
+      };
+      vi.mocked(getActiveSpan).mockReturnValue(
+        mockSpan as unknown as ReturnType<typeof getActiveSpan>,
+      );
+
+      const server = buildServer({
+        context: {
+          ...baseContext,
+          userId: "user-123",
+          sessionId: "test-session-abc",
+        },
+        tools: {
+          example_tool: createMockTool("example_tool", {
+            annotations: { readOnlyHint: true },
+          }),
+        },
+      });
+      const registeredTools = (
+        server as unknown as {
+          _registeredTools: Record<
+            string,
+            {
+              handler: (
+                params: Record<string, unknown>,
+                extra: unknown,
+              ) => Promise<unknown>;
+            }
+          >;
+        }
+      )._registeredTools;
+
+      await registeredTools.example_tool?.handler({}, {});
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        "mcp.session.id",
+        "test-session-abc",
+      );
+    });
+
+    it("does not set session ID span attribute when sessionId is absent", async () => {
+      const mockSpan = {
+        setAttribute: vi.fn(),
+        setStatus: vi.fn(),
+        recordException: vi.fn(),
+      };
+      vi.mocked(getActiveSpan).mockReturnValue(
+        mockSpan as unknown as ReturnType<typeof getActiveSpan>,
+      );
+
+      const server = buildServer({
+        context: {
+          ...baseContext,
+          userId: "user-123",
+        },
+        tools: {
+          example_tool: createMockTool("example_tool", {
+            annotations: { readOnlyHint: true },
+          }),
+        },
+      });
+      const registeredTools = (
+        server as unknown as {
+          _registeredTools: Record<
+            string,
+            {
+              handler: (
+                params: Record<string, unknown>,
+                extra: unknown,
+              ) => Promise<unknown>;
+            }
+          >;
+        }
+      )._registeredTools;
+
+      await registeredTools.example_tool?.handler({}, {});
+
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+        "mcp.session.id",
+        expect.anything(),
+      );
     });
   });
 

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -307,6 +307,10 @@ function configureServer({
           }
         }
 
+        if (activeSpan && context.sessionId) {
+          activeSpan.setAttribute("mcp.session.id", context.sessionId);
+        }
+
         if (context.userId) {
           const user = {
             id: context.userId,

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -50,6 +50,8 @@ export type ServerContext = {
   userId?: string | null;
   userIpAddress?: string | null;
   clientId?: string;
+  /** Unique identifier for this MCP session, used for cross-call correlation in telemetry */
+  sessionId?: string;
   /** Primary authorization method - granted skills for tool access control */
   grantedSkills?: Set<Skill> | ReadonlySet<Skill>;
   // URL-based session constraints


### PR DESCRIPTION
## Summary

As part of exploring what our MCP can report for the [Issue Action Log project](https://linear.app/getsentry/project/track-actions-on-issues-by-agents-acf9340af3d5/overview), I noticed we have no way to correlate different tool calls within the same MCP session. Each tool call produces an independent span with no shared session identifier.

After researching industry patterns, it turns out the [OTel MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/) define `mcp.session.id` as a recommended span attribute for exactly this purpose. For HTTP/SSE transports, the MCP protocol already manages session IDs (`mcp-session-id` header / `sessionId` query param) — we just weren't capturing them.

This PR extracts the protocol-level session ID in the Cloudflare handler and sets it as an `mcp.session.id` span attribute on every tool call.

**Scope:**
- HTTP/SSE transports only — stdio is excluded because the MCP protocol has no session concept over stdio (the process IS the session, which is too coarse to be useful)
- Span attribute only, no Sentry tag (avoids high-cardinality indexing cost with no current consumer)
- `undefined` on the `initialize` request (no fabricated IDs)

**Open question:** How much can we trust clients to provide meaningful session boundaries? The session ID maps to transport connection lifecycle, not necessarily to "one user investigation." Reconnections create new sessions, and long-lived connections may span unrelated conversations. However, it's protocol-managed (not client-discretionary), and having the data lets us evaluate its usefulness.

## Test plan
- [x] Unit tests for session ID span attribute presence/absence
- [x] `pnpm run lint` passes
- [x] `pnpm --filter @sentry/mcp-core run test` passes (933/933, 2 pre-existing failures in unrelated OpenAI integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)