### PR TITLE
feat(telemetry): Enable mcp.session.id on MCP spans

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -374,6 +374,7 @@ const mcpHandler: ExportedHandler<Env> = {
     // Run MCP handler - context already captured in closures
     return createMcpHandler(server, {
       route: url.pathname,
+      sessionIdGenerator: () => crypto.randomUUID(),
     })(request, env, ctx);
   },
 };


### PR DESCRIPTION
## Summary

While exploring what our MCP can report for the [Issue Action Log project](https://linear.app/getsentry/project/track-actions-on-issues-by-agents-acf9340af3d5/overview), I noticed we have no way to correlate different tool calls within the same MCP session.

The Sentry SDK (`wrapMcpServerWithSentry`) already has code to read `transport.sessionId` and set `mcp.session.id` on all MCP spans — following the [OTel MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/). But it wasn't showing up in live data because the `WorkerTransport` created by `createMcpHandler` only sets `sessionId` when a `sessionIdGenerator` is provided, and we weren't passing one.

This PR passes `sessionIdGenerator: () => crypto.randomUUID()` so the transport assigns a session ID during initialization, and the SDK picks it up automatically for all subsequent spans in that session.

**One-line change.** No new types, no manual span attributes — just enabling the existing SDK mechanism.

## Open question

How much can we trust session boundaries to be meaningful? The session maps to a single MCP transport connection lifecycle — reconnections create new sessions, and long-lived connections may span unrelated conversations. But having the data lets us evaluate usefulness, and it's zero-cost since the SDK already has the instrumentation.

## Test plan
- [ ] Deploy and verify `mcp.session.id` appears on spans in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)