### PR TITLE
feat(oauth): Track granted skills in telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -47,6 +47,8 @@ the pivots and recipes below.
 | `app.client.family` | bucketed MCP client family | metrics | client-specific OAuth behavior |
 | `app.oauth.token_exchange.outcome` | OAuth refresh outcome | metrics | token refresh diagnosis |
 | `app.oauth.grant_revoked.reason` | wrapper grant revoke reason | metrics | sign-out diagnosis |
+| `app.oauth.skill` | OAuth skill granted during approval | metrics | per-skill adoption |
+| `app.oauth.skill.<skill>.granted` | skill granted on an MCP request | spans | tool behavior by enabled skills |
 | `app.oauth.probe.status_code` | upstream probe HTTP status | metrics | Sentry token validity probe result |
 | `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
 | `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
@@ -113,13 +115,24 @@ fields=timestamp,metric,app.client.family,value
 aggregate=sum(value) by metric,app.client.family
 ```
 
+OAuth skill adoption by client family.
+
+```text
+dataset=metrics query='metric:app.oauth.skill_granted'
+fields=timestamp,metric,app.oauth.skill,app.client.family,value
+aggregate=sum(value) by app.oauth.skill,app.client.family
+```
+
 Tool execution timeline for a slow or failing tool.
 
 ```text
-dataset=spans query='gen_ai.tool.name:"<tool_name>"'
+dataset=spans query='gen_ai.tool.name:"<tool_name>" app.oauth.skill.<skill>.granted:true'
 fields=timestamp,trace,span_id,span.op,span.duration,gen_ai.tool.name,app.constraint.organization_slug,app.constraint.project_slug,gen_ai.tool.call.arguments.organizationSlug,gen_ai.tool.call.arguments.projectSlugOrId,error.type
 sort=-timestamp
 ```
+
+Use the skill id with `-` replaced by `_` in span attribute keys, such as
+`app.oauth.skill.project_management.granted`.
 
 Resource dispatch behavior for `get_sentry_resource`.
 
@@ -165,11 +178,13 @@ Users report sign-outs, refresh loops, DCR churn, or callback/register
 imbalance.
 
 Metrics: `app.oauth.token_exchange`, `app.oauth.grant_revoked`,
-`app.oauth.callback_completed`, `app.oauth.register`
+`app.oauth.callback_completed`, `app.oauth.skill_granted`,
+`app.oauth.register`
 
 Attributes: `app.oauth.token_exchange.outcome`, `app.oauth.grant.shape`,
 `app.oauth.probe.status_code`, `app.oauth.probe.reason`,
-`app.oauth.grant_revoked.reason`, `app.client.family`, `user.id`
+`app.oauth.grant_revoked.reason`, `app.oauth.skill`,
+`app.client.family`, `user.id`
 
 ### MCP Tool Execution
 
@@ -180,7 +195,7 @@ Spans: tool call spans and downstream Sentry API spans
 
 Attributes: `gen_ai.tool.name`, `mcp.session.id`,
 `app.constraint.organization_slug`, `app.constraint.project_slug`,
-`app.transport`, `user.id`
+`app.oauth.skill.<skill>.granted`, `app.transport`, `user.id`
 
 ### Resource Resolution
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -158,6 +158,7 @@ These are Sentry MCP application attributes that are not part of the MCP semanti
 - `app.constraint.project_slug` - Session project constraint
 - `app.server.mode.agent` - Whether stdio started in agent mode
 - `app.server.mode.experimental` - Whether experimental tools are enabled
+- `app.oauth.skill.<skill>.granted` - Per-skill boolean attributes for skills granted to the MCP request. Skill ids are normalized with `-` replaced by `_`
 - `app.upstream.host` - Upstream Sentry host configured for the server
 - `app.url.full` - MCP URL configured for stdio
 

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -34,6 +34,10 @@ type OAuthExecutionContext = ExecutionContext & {
   props?: Record<string, unknown>;
 };
 
+function getSkillGrantedAttributeName(skill: string): string {
+  return `app.oauth.skill.${skill.replaceAll("-", "_")}.granted`;
+}
+
 function escapeAuthenticateHeaderValue(value: string): string {
   return value
     .replaceAll("\\", "\\\\")
@@ -248,6 +252,11 @@ const mcpHandler: ExportedHandler<Env> = {
         "Authorization failed: No valid skills were granted. Please re-authorize and select at least one permission.",
         { status: 400 },
       );
+    }
+
+    const activeSpan = Sentry.getActiveSpan();
+    for (const skill of Array.from(validSkills).sort()) {
+      activeSpan?.setAttribute(getSkillGrantedAttributeName(skill), true);
     }
 
     const rateLimitResult = await checkRateLimit(

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -324,11 +324,20 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
   // /oauth/callback is browser-navigated, so the User-Agent is the user's
   // browser, not the MCP client. Derive client family from the DCR-registered
   // client_name (resolved above).
+  const clientFamily = resolveClientFamilyFromName(registeredClientName);
   Sentry.metrics.count("app.oauth.callback_completed", 1, {
     attributes: {
-      "app.client.family": resolveClientFamilyFromName(registeredClientName),
+      "app.client.family": clientFamily,
     },
   });
+  for (const skill of grantedSkills) {
+    Sentry.metrics.count("app.oauth.skill_granted", 1, {
+      attributes: {
+        "app.oauth.skill": skill,
+        "app.client.family": clientFamily,
+      },
+    });
+  }
 
   // Use manual redirect instead of Response.redirect() to allow middleware to add headers
   return c.redirect(redirectTo);

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -50,6 +50,10 @@ import {
 import type { ProjectCapabilities, ServerContext } from "./types";
 import { LIB_VERSION } from "./version";
 
+function getSkillGrantedAttributeName(skill: Skill): string {
+  return `app.oauth.skill.${skill.replaceAll("-", "_")}.granted`;
+}
+
 /**
  * Creates and configures a complete MCP server with Sentry instrumentation.
  *
@@ -179,6 +183,9 @@ function configureServer({
   const grantedSkills: Set<Skill> | undefined = context.grantedSkills
     ? new Set<Skill>(context.grantedSkills)
     : undefined;
+  const grantedSkillIds = grantedSkills
+    ? Array.from(grantedSkills).sort()
+    : undefined;
 
   server.server.onerror = (error) => {
     const transportLogOptions: LogIssueOptions = {
@@ -304,6 +311,14 @@ function configureServer({
               "app.constraint.project_slug",
               context.constraints.projectSlug,
             );
+          }
+          if (grantedSkillIds?.length) {
+            for (const skill of grantedSkillIds) {
+              activeSpan.setAttribute(
+                getSkillGrantedAttributeName(skill),
+                true,
+              );
+            }
           }
         }
 


### PR DESCRIPTION
Track OAuth skill adoption and request context for granted MCP skills.

A completed OAuth callback now emits `app.oauth.skill_granted` once for each granted skill with scalar attributes `app.oauth.skill` and `app.client.family`. This answers queries like "how many users enable X skill" without encoding whole skill combinations.

MCP request and tool telemetry now includes scalar boolean span attributes in the form `app.oauth.skill.<skill>.granted:true`. Skill ids are normalized for field names, so `project-management` is recorded as `app.oauth.skill.project_management.granted`. This keeps the custom authorization concept out of the `mcp.*` semantic-convention namespace while keeping Sentry span search queryable by individual skill.

The patch intentionally avoids response metric plumbing, hidden response headers, and string-array span attributes. Request-volume-by-skill can come later if it proves useful.

Fixes #979