### PR TITLE
fix(snapshot): Encode selected image identifiers

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -3148,7 +3148,7 @@ export class SentryApiService {
     snapshotId: string;
     imageIdentifier: string;
   }): Promise<unknown> {
-    const path = `/organizations/${encodeURIComponent(organizationSlug)}/preprodartifacts/snapshots/${encodeURIComponent(snapshotId)}/images/${imageIdentifier}/`;
+    const path = `/organizations/${encodeURIComponent(organizationSlug)}/preprodartifacts/snapshots/${encodeURIComponent(snapshotId)}/images/${encodeURIComponent(imageIdentifier)}/`;
     return this.requestJSON(path);
   }
 

--- a/packages/mcp-core/src/tools/get-snapshot-details.test.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-details.test.ts
@@ -201,6 +201,9 @@ const fakeJpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
 
 const IMAGE_DETAIL_PATH =
   "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/login_screen.png/";
+const SLASH_IMAGE_IDENTIFIER =
+  "snapshots-iphone-17e/test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png";
+const SLASH_IMAGE_DETAIL_PATH = `https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/${encodeURIComponent(SLASH_IMAGE_IDENTIFIER)}/`;
 const HEAD_DOWNLOAD_PATH =
   "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/images/auth_login_screen.png/download/";
 const BASE_DOWNLOAD_PATH =
@@ -526,6 +529,51 @@ describe("get_snapshot_details", () => {
     expect(imageParts.length).toBe(1);
     expect(imageParts[0]!.mimeType).toBe("image/png");
     expect(textParts[1]!.text).toBe("### Head (current)");
+  });
+
+  it("encodes slash-containing selected image identifiers as one path segment", async () => {
+    const slashImageDetailFixture = {
+      ...addedImageDetailFixture,
+      image_file_name: SLASH_IMAGE_IDENTIFIER,
+      head_image: {
+        ...headImageInfo,
+        image_file_name: SLASH_IMAGE_IDENTIFIER,
+      },
+    };
+
+    mswServer.use(
+      http.get(
+        SLASH_IMAGE_DETAIL_PATH,
+        () => HttpResponse.json(slashImageDetailFixture),
+        { once: true },
+      ),
+      http.get(
+        HEAD_DOWNLOAD_PATH,
+        () =>
+          new HttpResponse(fakePng, {
+            headers: { "content-type": "image/png" },
+          }),
+        { once: true },
+      ),
+    );
+
+    const result = await getSnapshotDetails.handler(
+      {
+        snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
+        organizationSlug: null,
+        snapshotId: null,
+        selectedSnapshot: SLASH_IMAGE_IDENTIFIER,
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+
+    const parts = result as (TextContent | ImageContent)[];
+    const textParts = parts.filter((p): p is TextContent => p.type === "text");
+    expect(textParts[0]!.text).toContain(`## ${SLASH_IMAGE_IDENTIFIER}`);
+    expect(textParts[0]!.text).toContain(
+      `- **File**: \`${SLASH_IMAGE_IDENTIFIER}\``,
+    );
   });
 
   it("returns only base image for removed comparison", async () => {


### PR DESCRIPTION
Encode selected snapshot image identifiers before sending them to the preprod image-detail endpoint. Snapshot image names can contain slash-like prefixes, but the API treats the whole value as a single identifier, not as URL path segments.

**Business Rule**

`selectedSnapshot` and image file names are opaque image identifiers. A value like `snapshots-iphone-17e/test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png` must be encoded into one path segment when calling the image-detail endpoint.

**Behavior**

This keeps URL-mode reads working for path-like snapshot image names without changing how callers provide the identifier. The selected image value remains human-readable in MCP input and output; only the outbound Sentry API path is encoded.

**Coverage**

Adds regression coverage for slash-containing selected image names so future refactors do not accidentally split them into multiple API path segments.

Co-Authored-By: Codex CLI <noreply@openai.com>