### PR TITLE
feat(snapshot): Condense snapshot summaries

### DIFF
--- a/packages/mcp-core/src/tools/get-latest-base-snapshot.test.ts
+++ b/packages/mcp-core/src/tools/get-latest-base-snapshot.test.ts
@@ -64,8 +64,8 @@ describe("get_latest_base_snapshot", () => {
     expect(text).toContain("com.emergetools.hackernews");
     expect(text).toContain("**Snapshot ID**: 232800");
     expect(text).toContain("**Total Images**: 2");
-    expect(text).toContain("`Home Screen` (Main)");
-    expect(text).toContain("`Settings` (Settings)");
+    expect(text).toContain("main_home_screen.png — Home Screen — Main");
+    expect(text).toContain("settings_page.png — Settings — Settings");
     expect(text).toContain("**App Name**: HackerNews");
     expect(text).toContain("**Platform**: ios");
     expect(text).toContain("**Branch**: main (`abc123de`)");
@@ -84,13 +84,71 @@ describe("get_latest_base_snapshot", () => {
 
       ## Images
 
-      - \`Home Screen\` (Main) — file: \`snapshots-iphone/main_home_screen.png\`
-      - \`Settings\` (Settings) — file: \`snapshots-iphone/settings_page.png\`
+      **Snapshot Images:**
+      └── snapshots-iphone/
+          ├── main_home_screen.png — Home Screen — Main
+          └── settings_page.png — Settings — Settings
 
       ## Next Steps
 
       - To view a specific image, use \`get_sentry_resource(url="https://sentry.sentry.io/preprod/snapshots/232800/?selectedSnapshot=<image_file_name>")\`"
     `);
+  });
+
+  it("groups large latest-base image lists by shared path prefixes", async () => {
+    const largeLatestBaseFixture = {
+      ...latestBaseFixture,
+      images: [
+        {
+          display_name: "Kenya",
+          group: "FeaturedProductCard",
+          image_file_name:
+            "snapshots-iphone-17e/test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png",
+        },
+        {
+          display_name: "Ethiopia",
+          group: "FeaturedProductCard",
+          image_file_name:
+            "snapshots-iphone-17e/test_CoffeeProductCards.swift_FeaturedProductCard_Ethiopia.png",
+        },
+        {
+          display_name: "Kenya",
+          group: "FeaturedProductCard",
+          image_file_name:
+            "snapshots-iphone-17-pro-max/test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png",
+        },
+      ],
+    };
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/latest-base/",
+        () => HttpResponse.json(largeLatestBaseFixture),
+        { once: true },
+      ),
+    );
+
+    const result = await getLatestBaseSnapshot.handler(
+      {
+        organizationSlug: "sentry",
+        appId: "com.emergetools.hackernews",
+        branch: null,
+        project: null,
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+    const text = result as string;
+
+    expect(text).toContain("**Total Images**: 3");
+    expect(text).toContain("├── snapshots-iphone-17e/");
+    expect(text).toContain("└── snapshots-iphone-17-pro-max/");
+    expect(text).toContain(
+      "test_CoffeeProductCards.swift_FeaturedProductCard_Ethiopia.png — Ethiopia — FeaturedProductCard",
+    );
+    expect(text).toContain(
+      "test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png — Kenya — FeaturedProductCard",
+    );
   });
 
   it("passes branch filter to endpoint", async () => {

--- a/packages/mcp-core/src/tools/get-latest-base-snapshot.test.ts
+++ b/packages/mcp-core/src/tools/get-latest-base-snapshot.test.ts
@@ -65,7 +65,7 @@ describe("get_latest_base_snapshot", () => {
     expect(text).toContain("**Snapshot ID**: 232800");
     expect(text).toContain("**Total Images**: 2");
     expect(text).toContain("main_home_screen.png — Home Screen — Main");
-    expect(text).toContain("settings_page.png — Settings — Settings");
+    expect(text).toContain("settings_page.png — Settings");
     expect(text).toContain("**App Name**: HackerNews");
     expect(text).toContain("**Platform**: ios");
     expect(text).toContain("**Branch**: main (`abc123de`)");
@@ -87,7 +87,7 @@ describe("get_latest_base_snapshot", () => {
       **Snapshot Images:**
       └── snapshots-iphone/
           ├── main_home_screen.png — Home Screen — Main
-          └── settings_page.png — Settings — Settings
+          └── settings_page.png — Settings
 
       ## Next Steps
 

--- a/packages/mcp-core/src/tools/get-latest-base-snapshot.ts
+++ b/packages/mcp-core/src/tools/get-latest-base-snapshot.ts
@@ -4,6 +4,7 @@ import { defineTool } from "../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../internal/tool-helpers/api";
 import type { ServerContext } from "../types";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../schema";
+import { renderSnapshotImageTreeSection } from "./snapshot-formatting";
 
 export default defineTool({
   name: "get_latest_base_snapshot",
@@ -122,15 +123,12 @@ export default defineTool({
 
     if (images.length > 0) {
       sections.push("\n## Images\n");
-      for (const img of images) {
-        const name = img.display_name || img.image_file_name || "unknown";
-        const group = img.group ? ` (${img.group})` : "";
-        const file =
-          img.image_file_name && img.image_file_name !== img.display_name
-            ? ` — file: \`${img.image_file_name}\``
-            : "";
-        sections.push(`- \`${name}\`${group}${file}`);
-      }
+      sections.push(
+        ...renderSnapshotImageTreeSection(
+          "Snapshot Images",
+          images.map((image) => ({ image })),
+        ),
+      );
     }
 
     sections.push(

--- a/packages/mcp-core/src/tools/get-snapshot-details.test.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-details.test.ts
@@ -291,15 +291,17 @@ describe("get_snapshot_details", () => {
     expect(text).toContain("**PR**: #789");
     expect(text).toContain("**Approval**: requires_approval");
     expect(text).toContain(
-      "`login_screen.png` (auth) — file: `snapshots-iphone-16/auth_login_screen.png` — 12.5% diff",
+      "auth_login_screen.png — 12.5% diff — login_screen.png — auth",
     );
     expect(text).toContain(
-      "`dashboard.png` (main) — file: `snapshots-iphone-16/main_dashboard.png` — 2.1% diff",
+      "main_dashboard.png — 2.1% diff — dashboard.png — main",
     );
     expect(text).toContain("**Added:**");
-    expect(text).toContain("`new_modal.png` (dialogs)");
+    expect(text).toContain("dialogs_new_modal.png — new_modal.png — dialogs");
     expect(text).toContain("**Renamed:**");
-    expect(text).toContain("`preferences_page.png` → `settings_page.png`");
+    expect(text).toContain(
+      "settings_page.png — previous: preferences_page.png — settings",
+    );
     expect(text).toContain("get_sentry_resource");
     expect(text).toMatchInlineSnapshot(`
       "# Snapshot 231949 in **sentry**
@@ -310,7 +312,7 @@ describe("get_snapshot_details", () => {
       - **Type**: diff
       - **State**: visible
       - **Project ID**: 12345
-      - **Images**: 4 total (2 changed, 1 added, 0 removed, 1 renamed, 10 unchanged, 0 errored)
+      - **Images**: 4 total (2 changed, 1 added, 0 removed, 1 renamed, 10 unchanged, 0 errored, 0 skipped)
 
       ## VCS Info
 
@@ -324,21 +326,17 @@ describe("get_snapshot_details", () => {
       ## Changes
 
       **Changed:**
-      - \`login_screen.png\` (auth) — file: \`snapshots-iphone-16/auth_login_screen.png\` — 12.5% diff
-      - \`dashboard.png\` (main) — file: \`snapshots-iphone-16/main_dashboard.png\` — 2.1% diff
+      └── snapshots-iphone-16/
+          ├── auth_login_screen.png — 12.5% diff — login_screen.png — auth
+          └── main_dashboard.png — 2.1% diff — dashboard.png — main
 
       **Added:**
-      - \`new_modal.png\` (dialogs) — file: \`snapshots-iphone-16/dialogs_new_modal.png\`
+      └── snapshots-iphone-16/
+          └── dialogs_new_modal.png — new_modal.png — dialogs
 
       **Renamed:**
-      - \`preferences_page.png\` → \`settings_page.png\`
-
-      ## All Images
-
-      - \`login_screen.png\` (auth) — file: \`snapshots-iphone-16/auth_login_screen.png\`
-      - \`dashboard.png\` (main) — file: \`snapshots-iphone-16/main_dashboard.png\`
-      - \`new_modal.png\` (dialogs) — file: \`snapshots-iphone-16/dialogs_new_modal.png\`
-      - \`settings_page.png\` (settings) — file: \`snapshots-iphone-16/settings_page.png\`
+      └── snapshots-iphone-16/
+          └── settings_page.png — previous: preferences_page.png — settings
 
       ## Next Steps
 
@@ -472,7 +470,134 @@ describe("get_snapshot_details", () => {
     );
     const text = result as string;
     expect(text).toContain("**Type**: solo");
-    expect(text).toContain("`Dark mode` (Content View)");
+    expect(text).toContain(
+      "Content_View_Dark_mode.png — Dark mode — Content View",
+    );
+  });
+
+  it("groups large diff summaries without listing unchanged details", async () => {
+    const largeFixture = {
+      ...snapshotFixture,
+      changed_count: 3,
+      added_count: 1,
+      removed_count: 1,
+      renamed_count: 1,
+      unchanged_count: 42,
+      errored_count: 1,
+      skipped_count: 2,
+      images: [
+        ...snapshotFixture.images,
+        {
+          display_name: "unchanged_detail.png",
+          group: "unchanged",
+          image_file_name: "snapshots-iphone-17e/unchanged_detail.png",
+        },
+      ],
+      changed: [
+        {
+          head_image: {
+            display_name: "Kenya",
+            group: "FeaturedProductCard",
+            image_file_name:
+              "snapshots-iphone-17e/test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png",
+          },
+          diff: 0.2605,
+        },
+        {
+          head_image: {
+            display_name: "Ethiopia",
+            group: "FeaturedProductCard",
+            image_file_name:
+              "snapshots-iphone-17e/test_CoffeeProductCards.swift_FeaturedProductCard_Ethiopia.png",
+          },
+          diff: 0.2341,
+        },
+        {
+          head_image: {
+            display_name: "Kenya",
+            group: "FeaturedProductCard",
+            image_file_name:
+              "snapshots-iphone-17-pro-max/test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png",
+          },
+          diff: 0.234,
+        },
+      ],
+      added: [
+        {
+          display_name: "New Cart",
+          group: "Cart",
+          image_file_name: "snapshots-iphone-17e/test_Cart.swift_NewCart.png",
+        },
+      ],
+      removed: [
+        {
+          display_name: "Old Cart",
+          group: "Cart",
+          image_file_name: "snapshots-iphone-17e/test_Cart.swift_OldCart.png",
+        },
+      ],
+      renamed: [
+        {
+          head_image: {
+            display_name: "Settings",
+            group: "Settings",
+            image_file_name:
+              "snapshots-iphone-17e/test_Settings.swift_Settings.png",
+          },
+          base_image: {
+            display_name: "Preferences",
+            group: "Settings",
+            image_file_name:
+              "snapshots-iphone-17e/test_Settings.swift_Preferences.png",
+          },
+        },
+      ],
+      errored: [
+        {
+          head_image: {
+            display_name: "Error State",
+            group: "Errors",
+            image_file_name:
+              "snapshots-iphone-17e/test_Error.swift_ErrorState.png",
+          },
+        },
+      ],
+    };
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry/preprodartifacts/snapshots/231949/",
+        () => HttpResponse.json(largeFixture),
+        { once: true },
+      ),
+    );
+
+    const result = await getSnapshotDetails.handler(
+      {
+        snapshotUrl: "https://sentry.sentry.io/preprod/snapshots/231949/",
+        organizationSlug: null,
+        snapshotId: null,
+        selectedSnapshot: null,
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+    const text = result as string;
+
+    expect(text).toContain(
+      "3 changed, 1 added, 1 removed, 1 renamed, 42 unchanged, 1 errored, 2 skipped",
+    );
+    expect(text).toContain("└── snapshots-iphone-17-pro-max/");
+    expect(text).toContain("├── snapshots-iphone-17e/");
+    expect(text).toContain(
+      "test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png — 26.05% diff — Kenya — FeaturedProductCard",
+    );
+    expect(text).toContain("**Added:**");
+    expect(text).toContain("**Removed:**");
+    expect(text).toContain("**Renamed:**");
+    expect(text).toContain("**Errored:**");
+    expect(text).not.toContain("## All Images");
+    expect(text).not.toContain("unchanged_detail.png");
   });
 
   it("returns head, base, and diff images for changed comparison", async () => {

--- a/packages/mcp-core/src/tools/get-snapshot-details.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-details.ts
@@ -11,13 +11,13 @@ import { UserInputError } from "../errors";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../schema";
 import { resolveSnapshotParams } from "../internal/url-helpers";
 import { blobToBase64 } from "../internal/blob-utils";
-
-interface SnapshotImageEntry {
-  display_name?: string | null;
-  group?: string | null;
-  image_file_name?: string;
-  [key: string]: unknown;
-}
+import {
+  formatSnapshotDiffPercent,
+  getSnapshotImageDisplayName,
+  renderSnapshotImageTreeSection,
+  type SnapshotImageEntry,
+  type SnapshotImageTreeItem,
+} from "./snapshot-formatting";
 
 interface SnapshotDiffPair {
   base_image?: SnapshotImageEntry;
@@ -60,20 +60,6 @@ interface SnapshotImageDetailResponse {
   diff_image_url?: string | null;
   diff_percentage?: number | null;
   previous_image_file_name?: string | null;
-}
-
-function getImageDisplayName(img: SnapshotImageEntry): string {
-  return img.display_name || img.image_file_name || "unknown";
-}
-
-function formatImageLine(img: SnapshotImageEntry): string {
-  const name = getImageDisplayName(img);
-  const group = img.group ? ` (${img.group})` : "";
-  const file =
-    img.image_file_name && img.image_file_name !== img.display_name
-      ? ` — file: \`${img.image_file_name}\``
-      : "";
-  return `- \`${name}\`${group}${file}`;
 }
 
 export default defineTool({
@@ -170,6 +156,15 @@ export default defineTool({
   },
 });
 
+function countField(
+  data: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number {
+  const value = data[key];
+  return typeof value === "number" ? value : fallback;
+}
+
 function formatImageMetadata(img: SnapshotImageInfo): string[] {
   const lines: string[] = [];
   if (img.display_name) lines.push(`- **Display Name**: ${img.display_name}`);
@@ -237,7 +232,7 @@ async function fetchSnapshotImage(
   if (status) lines.push(`- **Status**: ${status}`);
   if (detail.diff_percentage != null)
     lines.push(
-      `- **Diff**: ${Math.round(detail.diff_percentage * 10000) / 100}%`,
+      `- **Diff**: ${formatSnapshotDiffPercent(detail.diff_percentage)}`,
     );
   if (detail.previous_image_file_name)
     lines.push(`- **Previous File**: \`${detail.previous_image_file_name}\``);
@@ -319,14 +314,16 @@ async function fetchSnapshotSummary(
     sections.push(`- **Project ID**: ${data.project_id}`);
   }
 
-  const changedCount = (data.changed_count as number) ?? changed.length;
-  const addedCount = (data.added_count as number) ?? added.length;
-  const removedCount = (data.removed_count as number) ?? removed.length;
-  const renamedCount = (data.renamed_count as number) ?? renamed.length;
-  const unchangedCount = (data.unchanged_count as number) ?? 0;
-  const erroredCount = (data.errored_count as number) ?? errored.length;
+  const totalCount = countField(data, "total_count", allImages.length);
+  const changedCount = countField(data, "changed_count", changed.length);
+  const addedCount = countField(data, "added_count", added.length);
+  const removedCount = countField(data, "removed_count", removed.length);
+  const renamedCount = countField(data, "renamed_count", renamed.length);
+  const unchangedCount = countField(data, "unchanged_count", 0);
+  const erroredCount = countField(data, "errored_count", errored.length);
+  const skippedCount = countField(data, "skipped_count", 0);
   sections.push(
-    `- **Images**: ${allImages.length} total (${changedCount} changed, ${addedCount} added, ${removedCount} removed, ${renamedCount} renamed, ${unchangedCount} unchanged, ${erroredCount} errored)`,
+    `- **Images**: ${totalCount} total (${changedCount} changed, ${addedCount} added, ${removedCount} removed, ${renamedCount} renamed, ${unchangedCount} unchanged, ${erroredCount} errored, ${skippedCount} skipped)`,
   );
 
   if (vcsInfo) {
@@ -359,53 +356,56 @@ async function fetchSnapshotSummary(
   if (hasDiffs) {
     sections.push("\n## Changes\n");
 
-    if (changed.length > 0) {
-      sections.push("**Changed:**");
-      for (const pair of changed) {
-        const img = pair.head_image ?? {};
-        const name = getImageDisplayName(img);
-        const group = img.group ? ` (${img.group})` : "";
-        const file =
-          img.image_file_name && img.image_file_name !== img.display_name
-            ? ` — file: \`${img.image_file_name}\``
-            : "";
-        const diff =
-          pair.diff != null
-            ? ` — ${Math.round(pair.diff * 10000) / 100}% diff`
-            : "";
-        sections.push(`- \`${name}\`${group}${file}${diff}`);
-      }
-    }
+    const sortedChanged = changed
+      .slice()
+      .sort((left, right) => (right.diff ?? -1) - (left.diff ?? -1));
 
-    if (added.length > 0) {
-      sections.push("\n**Added:**");
-      for (const img of added) sections.push(formatImageLine(img));
-    }
+    const diffSections: Array<{
+      title: string;
+      items: SnapshotImageTreeItem[];
+    }> = [
+      {
+        title: "Changed",
+        items: sortedChanged.map((pair) => ({
+          image: pair.head_image ?? {},
+          details:
+            pair.diff != null
+              ? [`${formatSnapshotDiffPercent(pair.diff)} diff`]
+              : [],
+        })),
+      },
+      { title: "Added", items: added.map((image) => ({ image })) },
+      { title: "Removed", items: removed.map((image) => ({ image })) },
+      {
+        title: "Renamed",
+        items: renamed.map((pair) => ({
+          image: pair.head_image ?? {},
+          details: [
+            `previous: ${getSnapshotImageDisplayName(pair.base_image ?? {})}`,
+          ],
+        })),
+      },
+      {
+        title: "Errored",
+        items: errored.map((pair) => ({ image: pair.head_image ?? {} })),
+      },
+    ];
 
-    if (removed.length > 0) {
-      sections.push("\n**Removed:**");
-      for (const img of removed) sections.push(formatImageLine(img));
+    const renderedDiffs = diffSections
+      .map(({ title, items }) => renderSnapshotImageTreeSection(title, items))
+      .filter((lines) => lines.length > 0);
+    for (const [index, lines] of renderedDiffs.entries()) {
+      if (index > 0) sections.push("");
+      sections.push(...lines);
     }
-
-    if (renamed.length > 0) {
-      sections.push("\n**Renamed:**");
-      for (const pair of renamed) {
-        const newName = getImageDisplayName(pair.head_image ?? {});
-        const oldName = getImageDisplayName(pair.base_image ?? {});
-        sections.push(`- \`${oldName}\` → \`${newName}\``);
-      }
-    }
-
-    if (errored.length > 0) {
-      sections.push("\n**Errored:**");
-      for (const pair of errored)
-        sections.push(formatImageLine(pair.head_image ?? {}));
-    }
-  }
-
-  if (allImages.length > 0) {
-    sections.push("\n## All Images\n");
-    for (const img of allImages) sections.push(formatImageLine(img));
+  } else if (allImages.length > 0) {
+    sections.push("\n## Images\n");
+    sections.push(
+      ...renderSnapshotImageTreeSection(
+        "Snapshot Images",
+        allImages.map((image) => ({ image })),
+      ),
+    );
   }
 
   sections.push(

--- a/packages/mcp-core/src/tools/snapshot-formatting.ts
+++ b/packages/mcp-core/src/tools/snapshot-formatting.ts
@@ -96,7 +96,7 @@ function formatLeafLabel(
   if (displayName !== leafName && displayName !== img.image_file_name) {
     suffixes.push(displayName);
   }
-  if (img.group) {
+  if (img.group && String(img.group) !== displayName) {
     suffixes.push(String(img.group));
   }
 

--- a/packages/mcp-core/src/tools/snapshot-formatting.ts
+++ b/packages/mcp-core/src/tools/snapshot-formatting.ts
@@ -1,0 +1,131 @@
+export interface SnapshotImageEntry {
+  display_name?: string | null;
+  group?: string | null;
+  image_file_name?: string;
+  [key: string]: unknown;
+}
+
+export interface SnapshotImageTreeItem {
+  image: SnapshotImageEntry;
+  details?: string[];
+}
+
+interface TreeBranch {
+  kind: "branch";
+  label: string;
+  children: Map<string, TreeBranch>;
+  leaves: TreeLeaf[];
+}
+
+interface TreeLeaf {
+  kind: "leaf";
+  label: string;
+}
+
+type TreeEntry = TreeBranch | TreeLeaf;
+
+export function getSnapshotImageDisplayName(img: SnapshotImageEntry): string {
+  return img.display_name || img.image_file_name || "unknown";
+}
+
+export function formatSnapshotDiffPercent(diff: number): string {
+  return `${Math.round(diff * 10000) / 100}%`;
+}
+
+export function renderSnapshotImageTreeSection(
+  title: string,
+  items: SnapshotImageTreeItem[],
+): string[] {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const root = createBranch("");
+  for (const item of items) {
+    addItemToBranch(root, item);
+  }
+
+  const lines = [`**${title}:**`];
+  const entries = collectChildEntries(root);
+  for (const [index, entry] of entries.entries()) {
+    lines.push(renderEntry(entry, "", index === entries.length - 1));
+  }
+  return lines;
+}
+
+function createBranch(label: string): TreeBranch {
+  return { kind: "branch", label, children: new Map(), leaves: [] };
+}
+
+function addItemToBranch(root: TreeBranch, item: SnapshotImageTreeItem): void {
+  const identifier = getSnapshotImageIdentifier(item.image);
+  const segments = identifier.split("/").filter(Boolean);
+  const pathSegments = segments.length > 0 ? segments : [identifier];
+  const leafName = pathSegments[pathSegments.length - 1] ?? identifier;
+
+  let node = root;
+  for (const segment of pathSegments.slice(0, -1)) {
+    let child = node.children.get(segment);
+    if (!child) {
+      child = createBranch(`${segment}/`);
+      node.children.set(segment, child);
+    }
+    node = child;
+  }
+
+  node.leaves.push({
+    kind: "leaf",
+    label: formatLeafLabel(leafName, item.image, item.details ?? []),
+  });
+}
+
+function getSnapshotImageIdentifier(img: SnapshotImageEntry): string {
+  return img.image_file_name || getSnapshotImageDisplayName(img);
+}
+
+function formatLeafLabel(
+  leafName: string,
+  img: SnapshotImageEntry,
+  details: string[],
+): string {
+  const displayName = getSnapshotImageDisplayName(img);
+  const suffixes = [...details];
+
+  // Only surface the display name when it adds information beyond the
+  // file name (leaf) and isn't already the image_file_name.
+  if (displayName !== leafName && displayName !== img.image_file_name) {
+    suffixes.push(displayName);
+  }
+  if (img.group) {
+    suffixes.push(String(img.group));
+  }
+
+  return suffixes.length > 0
+    ? `${leafName} — ${suffixes.join(" — ")}`
+    : leafName;
+}
+
+function collectChildEntries(branch: TreeBranch): TreeEntry[] {
+  return [...branch.children.values(), ...branch.leaves];
+}
+
+function renderEntry(
+  entry: TreeEntry,
+  prefix: string,
+  isLast: boolean,
+): string {
+  const connector = isLast ? "└── " : "├── ";
+
+  if (entry.kind === "leaf") {
+    return `${prefix}${connector}${entry.label}`;
+  }
+
+  const childPrefix = `${prefix}${isLast ? "    " : "│   "}`;
+  const children = collectChildEntries(entry);
+  const lines = [`${prefix}${connector}${entry.label}`];
+
+  for (const [index, child] of children.entries()) {
+    lines.push(renderEntry(child, childPrefix, index === children.length - 1));
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
Condense snapshot summaries so large preprod diffs remain usable in MCP contexts. Image identifiers are rendered as grouped ASCII trees to avoid repeating the same path-like prefixes across every row.

**Summary Rules**

Snapshot summaries always include the URL, comparison type, state, project ID, VCS info when available, and total image counts. Counts include changed, added, removed, renamed, unchanged, errored, and skipped images.

**Change Listing Rules**

Changed images are listed in full because they are the primary review surface. They are sorted by descending diff percentage when a diff is available. Added, removed, renamed, and errored images are also surfaced in grouped sections. Unchanged image identifiers are intentionally omitted from diff summaries to save tokens; they are represented by the unchanged count.

**Tree Format**

Image names are split on `/` only for display grouping. The underlying image identifier is unchanged and remains the exact value agents should pass to `selectedSnapshot` when requesting a specific image.

Example response:

```markdown
# Snapshot 55 in **sentry**

## Summary

- **URL**: https://cameroncooke.ngrok.io/organizations/sentry/preprod/snapshots/55/
- **Type**: diff
- **State**: 1
- **Project ID**: 1
- **Images**: 297 total (75 changed, 0 added, 0 removed, 0 renamed, 222 unchanged, 0 errored, 0 skipped)

## VCS Info

- **Head**: change_assets (`ba23cfc0`)
- **Base**: main (`880a0088`)
- **PR**: #3

## Changes

**Changed:**
├── snapshots-iphone-17e/
│   ├── test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png — 26.05% diff — FeaturedProductCard / Kenya — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_FeaturedProductCard_Ethiopia.png — 23.41% diff — FeaturedProductCard / Ethiopia — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_ProductGridSection_Two_by_Two.png — 17% diff — ProductGridSection / Two by Two — test/CoffeeProductCards.swift
│   ├── test_CoffeeWidgets.swift_RatingSummaryWidget_4.6_Stars.png — 14.46% diff — RatingSummaryWidget / 4.6 Stars — test/CoffeeWidgets.swift
│   ├── test_CoffeeWidgets.swift_RatingSummaryWidget_3.2_Stars.png — 14.3% diff — RatingSummaryWidget / 3.2 Stars — test/CoffeeWidgets.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_Ready.png — 11.62% diff — LoyaltyCard / Ready — test/CoffeeCards.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_Empty.png — 11.6% diff — LoyaltyCard / Empty — test/CoffeeCards.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_Almost_There.png — 11.51% diff — LoyaltyCard / Almost There — test/CoffeeCards.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_In_Progress.png — 11.51% diff — LoyaltyCard / In Progress — test/CoffeeCards.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_Preorder.png — 1.3% diff — CoffeeProductCard / Preorder — test/CoffeeProductCards.swift
│   ├── test_CoffeeBadges.swift_StockPill_Preorder.png — 1.08% diff — StockPill / Preorder — test/CoffeeBadges.swift
│   ├── test_CoffeeProductCards.swift_ProductDetailHeader_Huila_Sale.png — 0.72% diff — ProductDetailHeader / Huila Sale — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_Sold_Out_Dark.png — 0.64% diff — CoffeeProductCard / Sold Out Dark — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_ProductDetailHeader_Sumatra_Sold_Out.png — 0.62% diff — ProductDetailHeader / Sumatra Sold Out — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_ProductDetailHeader_Yirgacheffe.png — 0.62% diff — ProductDetailHeader / Yirgacheffe — test/CoffeeProductCards.swift
│   ├── test_CoffeeBadges.swift_StockPill_Low_Stock.png — 0.6% diff — StockPill / Low Stock — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_StockPill_Sold_Out.png — 0.53% diff — StockPill / Sold Out — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_StockPill_In_Stock.png — 0.51% diff — StockPill / In Stock — test/CoffeeBadges.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_On_Sale_Low_Stock.png — 0.23% diff — CoffeeProductCard / On Sale Low Stock — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_Light_Roast_Regular.png — 0.08% diff — CoffeeProductCard / Light Roast Regular — test/CoffeeProductCards.swift
│   ├── test_CoffeeBadges.swift_DiscountBadge_50_Percent.png — 0.03% diff — DiscountBadge / 50 Percent — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_DiscountBadge_25_Percent.png — 0.03% diff — DiscountBadge / 25 Percent — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_DiscountBadge_10_Percent.png — 0.03% diff — DiscountBadge / 10 Percent — test/CoffeeBadges.swift
│   ├── test_ContentView.swift_line-137.png — 0.02% diff — At line #137 — test/ContentView.swift
│   └── test_CoffeeButtons.swift_AddToCartButton_Adding.png — 0.02% diff — AddToCartButton / Adding — test/CoffeeButtons.swift
├── snapshots-iphone-17-pro-max/
│   ├── test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png — 23.4% diff — FeaturedProductCard / Kenya — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_FeaturedProductCard_Ethiopia.png — 21.04% diff — FeaturedProductCard / Ethiopia — test/CoffeeProductCards.swift
│   ├── test_CoffeeWidgets.swift_RatingSummaryWidget_4.6_Stars.png — 13.05% diff — RatingSummaryWidget / 4.6 Stars — test/CoffeeWidgets.swift
│   ├── test_CoffeeWidgets.swift_RatingSummaryWidget_3.2_Stars.png — 12.95% diff — RatingSummaryWidget / 3.2 Stars — test/CoffeeWidgets.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_Ready.png — 9.74% diff — LoyaltyCard / Ready — test/CoffeeCards.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_Empty.png — 9.74% diff — LoyaltyCard / Empty — test/CoffeeCards.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_Almost_There.png — 9.67% diff — LoyaltyCard / Almost There — test/CoffeeCards.swift
│   ├── test_CoffeeCards.swift_LoyaltyCard_In_Progress.png — 9.67% diff — LoyaltyCard / In Progress — test/CoffeeCards.swift
│   ├── test_CoffeeProductCards.swift_ProductGridSection_Two_by_Two.png — 4.05% diff — ProductGridSection / Two by Two — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_Preorder.png — 1.02% diff — CoffeeProductCard / Preorder — test/CoffeeProductCards.swift
│   ├── test_CoffeeBadges.swift_StockPill_Preorder.png — 0.84% diff — StockPill / Preorder — test/CoffeeBadges.swift
│   ├── test_CoffeeProductCards.swift_ProductDetailHeader_Huila_Sale.png — 0.56% diff — ProductDetailHeader / Huila Sale — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_Sold_Out_Dark.png — 0.5% diff — CoffeeProductCard / Sold Out Dark — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_ProductDetailHeader_Sumatra_Sold_Out.png — 0.49% diff — ProductDetailHeader / Sumatra Sold Out — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_ProductDetailHeader_Yirgacheffe.png — 0.48% diff — ProductDetailHeader / Yirgacheffe — test/CoffeeProductCards.swift
│   ├── test_CoffeeBadges.swift_StockPill_Low_Stock.png — 0.47% diff — StockPill / Low Stock — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_StockPill_Sold_Out.png — 0.41% diff — StockPill / Sold Out — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_StockPill_In_Stock.png — 0.4% diff — StockPill / In Stock — test/CoffeeBadges.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_On_Sale_Low_Stock.png — 0.18% diff — CoffeeProductCard / On Sale Low Stock — test/CoffeeProductCards.swift
│   ├── test_CoffeeProductCards.swift_CoffeeProductCard_Light_Roast_Regular.png — 0.06% diff — CoffeeProductCard / Light Roast Regular — test/CoffeeProductCards.swift
│   ├── test_CoffeeBadges.swift_DiscountBadge_50_Percent.png — 0.03% diff — DiscountBadge / 50 Percent — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_DiscountBadge_25_Percent.png — 0.03% diff — DiscountBadge / 25 Percent — test/CoffeeBadges.swift
│   ├── test_CoffeeBadges.swift_DiscountBadge_10_Percent.png — 0.03% diff — DiscountBadge / 10 Percent — test/CoffeeBadges.swift
│   ├── test_ContentView.swift_line-137.png — 0.01% diff — At line #137 — test/ContentView.swift
│   └── test_CoffeeButtons.swift_AddToCartButton_Adding.png — 0.01% diff — AddToCartButton / Adding — test/CoffeeButtons.swift
└── snapshots-ipad-air-11-inch-m4/
    ├── test_CoffeeProductCards.swift_FeaturedProductCard_Kenya.png — 19.93% diff — FeaturedProductCard / Kenya — test/CoffeeProductCards.swift
    ├── test_CoffeeProductCards.swift_FeaturedProductCard_Ethiopia.png — 17.87% diff — FeaturedProductCard / Ethiopia — test/CoffeeProductCards.swift
    ├── test_CoffeeWidgets.swift_RatingSummaryWidget_4.6_Stars.png — 11.28% diff — RatingSummaryWidget / 4.6 Stars — test/CoffeeWidgets.swift
    ├── test_CoffeeWidgets.swift_RatingSummaryWidget_3.2_Stars.png — 11.25% diff — RatingSummaryWidget / 3.2 Stars — test/CoffeeWidgets.swift
    ├── test_CoffeeCards.swift_LoyaltyCard_Empty.png — 7.53% diff — LoyaltyCard / Empty — test/CoffeeCards.swift
    ├── test_CoffeeCards.swift_LoyaltyCard_Ready.png — 7.49% diff — LoyaltyCard / Ready — test/CoffeeCards.swift
    ├── test_CoffeeCards.swift_LoyaltyCard_In_Progress.png — 7.48% diff — LoyaltyCard / In Progress — test/CoffeeCards.swift
    ├── test_CoffeeCards.swift_LoyaltyCard_Almost_There.png — 7.46% diff — LoyaltyCard / Almost There — test/CoffeeCards.swift
    ├── test_CoffeeProductCards.swift_ProductGridSection_Two_by_Two.png — 0.62% diff — ProductGridSection / Two by Two — test/CoffeeProductCards.swift
    ├── test_CoffeeProductCards.swift_CoffeeProductCard_Preorder.png — 0.42% diff — CoffeeProductCard / Preorder — test/CoffeeProductCards.swift
    ├── test_CoffeeBadges.swift_StockPill_Preorder.png — 0.36% diff — StockPill / Preorder — test/CoffeeBadges.swift
    ├── test_CoffeeProductCards.swift_ProductDetailHeader_Huila_Sale.png — 0.24% diff — ProductDetailHeader / Huila Sale — test/CoffeeProductCards.swift
    ├── test_CoffeeProductCards.swift_CoffeeProductCard_Sold_Out_Dark.png — 0.21% diff — CoffeeProductCard / Sold Out Dark — test/CoffeeProductCards.swift
    ├── test_CoffeeProductCards.swift_ProductDetailHeader_Sumatra_Sold_Out.png — 0.2% diff — ProductDetailHeader / Sumatra Sold Out — test/CoffeeProductCards.swift
    ├── test_CoffeeProductCards.swift_ProductDetailHeader_Yirgacheffe.png — 0.2% diff — ProductDetailHeader / Yirgacheffe — test/CoffeeProductCards.swift
    ├── test_CoffeeBadges.swift_StockPill_Low_Stock.png — 0.2% diff — StockPill / Low Stock — test/CoffeeBadges.swift
    ├── test_CoffeeBadges.swift_StockPill_Sold_Out.png — 0.17% diff — StockPill / Sold Out — test/CoffeeBadges.swift
    ├── test_CoffeeBadges.swift_StockPill_In_Stock.png — 0.17% diff — StockPill / In Stock — test/CoffeeBadges.swift
    ├── test_CoffeeProductCards.swift_CoffeeProductCard_On_Sale_Low_Stock.png — 0.08% diff — CoffeeProductCard / On Sale Low Stock — test/CoffeeProductCards.swift
    ├── test_CoffeeProductCards.swift_CoffeeProductCard_Light_Roast_Regular.png — 0.02% diff — CoffeeProductCard / Light Roast Regular — test/CoffeeProductCards.swift
    ├── test_CoffeeBadges.swift_DiscountBadge_50_Percent.png — 0.01% diff — DiscountBadge / 50 Percent — test/CoffeeBadges.swift
    ├── test_CoffeeBadges.swift_DiscountBadge_25_Percent.png — 0.01% diff — DiscountBadge / 25 Percent — test/CoffeeBadges.swift
    ├── test_CoffeeBadges.swift_DiscountBadge_10_Percent.png — 0.01% diff — DiscountBadge / 10 Percent — test/CoffeeBadges.swift
    ├── test_ContentView.swift_line-137.png — 0.01% diff — At line #137 — test/ContentView.swift
    └── test_CoffeeButtons.swift_AddToCartButton_Adding.png — 0.01% diff — AddToCartButton / Adding — test/CoffeeButtons.swift

## Next Steps

- To view a specific image preview, use `get_sentry_resource(url="https://cameroncooke.ngrok.io/organizations/sentry/preprod/snapshots/55/?selectedSnapshot=<image_file_name>")`
- To fetch original full-resolution image bytes, append `&imageResolution=full` to the selected-image URL
```

## Tokens usage:



### Before

<img width="789" height="239" alt="Screenshot 2026-05-19 at 15 42 26" src="https://github.com/user-attachments/assets/305504e7-87f9-41cf-bdd2-7ddef2223c72" />

### After

<img width="789" height="239" alt="Screenshot 2026-05-19 at 15 39 02" src="https://github.com/user-attachments/assets/6fe32893-9d30-4e0c-9136-39cc2501d60a" />

Co-Authored-By: Codex CLI <noreply@openai.com>