### PR TITLE
feat(mcp-core): Forward DCR client identity to Sentry API

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -157,6 +157,7 @@ const mcpHandler: ExportedHandler<Env> = {
     const userId = rawProps.id as string;
     const accessToken = rawProps.accessToken as string;
     const clientId = rawProps.clientId as string;
+    const clientName = rawProps.clientName;
     const sentryHost = env.SENTRY_HOST || "sentry.io";
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
     const requestGrantId = getRequestGrantId(request);
@@ -326,7 +327,7 @@ const mcpHandler: ExportedHandler<Env> = {
       userId,
       userIpAddress,
       clientId,
-      clientFamily,
+      clientName,
       accessToken,
       grantedSkills: validSkills,
       constraints,

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -326,6 +326,7 @@ const mcpHandler: ExportedHandler<Env> = {
       userId,
       userIpAddress,
       clientId,
+      clientFamily,
       accessToken,
       grantedSkills: validSkills,
       constraints,

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -307,6 +307,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       // unnecessary upstream refresh calls when still valid
       accessTokenExpiresAt,
       clientId: oauthReqInfo.clientId,
+      clientName: registeredClientName,
       scope: oauthReqInfo.scope.join(" "),
       // Scopes derived from skills - for backward compatibility with old MCP clients
       // that don't support grantedSkills and only understand grantedScopes

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -20,6 +20,7 @@ export type WorkerProps = {
   accessTokenExpiresAt?: number; // Cached validity deadline; extended on successful probe.
   upstreamTokenInvalid?: boolean;
   clientId: string;
+  clientName?: string;
   scope: string;
   /**
    * @deprecated grantedScopes is deprecated and will be removed on Jan 1, 2026.

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -457,6 +457,76 @@ describe("network error handling", () => {
   });
 });
 
+describe("request headers", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("should send MCP client headers when clientId and clientName are set", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "1",
+          name: "Test User",
+          email: "test@example.com",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+      clientId: "abc123",
+      clientName: "Claude Code",
+    });
+
+    await apiService.getAuthenticatedUser();
+
+    const [, requestInit] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(requestInit.headers["X-Sentry-MCP-Client-Id"]).toBe("abc123");
+    expect(requestInit.headers["X-Sentry-MCP-Client-Name"]).toBe("Claude Code");
+  });
+
+  it("should not send MCP client headers when clientId and clientName are not set", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "1",
+          name: "Test User",
+          email: "test@example.com",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+    });
+
+    await apiService.getAuthenticatedUser();
+
+    const [, requestInit] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(requestInit.headers["X-Sentry-MCP-Client-Id"]).toBeUndefined();
+    expect(requestInit.headers["X-Sentry-MCP-Client-Name"]).toBeUndefined();
+  });
+});
+
 describe("listOrganizations", () => {
   let originalFetch: typeof globalThis.fetch;
 

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -263,7 +263,8 @@ function parseTraceItemAttributes(
  */
 export class SentryApiService {
   private accessToken: string | null;
-  private clientFamily: string | null;
+  private clientId: string | null;
+  private clientName: string | null;
   protected host: string;
   protected protocol: SentryProtocol;
   protected apiPrefix: string;
@@ -276,21 +277,25 @@ export class SentryApiService {
    * @param config Configuration object
    * @param config.accessToken OAuth access token for authentication (optional for some endpoints)
    * @param config.host Sentry hostname (e.g. "sentry.io", "sentry.example.com")
-   * @param config.clientFamily Resolved AI agent family (e.g. "claude-code", "cursor")
+   * @param config.clientId DCR-registered OAuth client ID
+   * @param config.clientName DCR-registered OAuth client name
    */
   constructor({
     accessToken = null,
     host = "sentry.io",
     protocol = "https",
-    clientFamily = null,
+    clientId = null,
+    clientName = null,
   }: {
     accessToken?: string | null;
     host?: string;
     protocol?: SentryProtocol;
-    clientFamily?: string | null;
+    clientId?: string | null;
+    clientName?: string | null;
   }) {
     this.accessToken = accessToken;
-    this.clientFamily = clientFamily;
+    this.clientId = clientId;
+    this.clientName = clientName;
     this.host = host;
     this.protocol = protocol;
     this.apiPrefix = `${protocol}://${host}/api/0`;
@@ -389,8 +394,11 @@ export class SentryApiService {
     if (this.accessToken) {
       headers.Authorization = `Bearer ${this.accessToken}`;
     }
-    if (this.clientFamily) {
-      headers["X-Sentry-Client-Family"] = this.clientFamily;
+    if (this.clientId) {
+      headers["X-Sentry-MCP-Client-Id"] = this.clientId;
+    }
+    if (this.clientName) {
+      headers["X-Sentry-MCP-Client-Name"] = this.clientName;
     }
 
     // Check if fetch is available, otherwise provide a helpful error message

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -263,6 +263,7 @@ function parseTraceItemAttributes(
  */
 export class SentryApiService {
   private accessToken: string | null;
+  private clientFamily: string | null;
   protected host: string;
   protected protocol: SentryProtocol;
   protected apiPrefix: string;
@@ -275,17 +276,21 @@ export class SentryApiService {
    * @param config Configuration object
    * @param config.accessToken OAuth access token for authentication (optional for some endpoints)
    * @param config.host Sentry hostname (e.g. "sentry.io", "sentry.example.com")
+   * @param config.clientFamily Resolved AI agent family (e.g. "claude-code", "cursor")
    */
   constructor({
     accessToken = null,
     host = "sentry.io",
     protocol = "https",
+    clientFamily = null,
   }: {
     accessToken?: string | null;
     host?: string;
     protocol?: SentryProtocol;
+    clientFamily?: string | null;
   }) {
     this.accessToken = accessToken;
+    this.clientFamily = clientFamily;
     this.host = host;
     this.protocol = protocol;
     this.apiPrefix = `${protocol}://${host}/api/0`;
@@ -383,6 +388,9 @@ export class SentryApiService {
     };
     if (this.accessToken) {
       headers.Authorization = `Bearer ${this.accessToken}`;
+    }
+    if (this.clientFamily) {
+      headers["X-Sentry-Client-Family"] = this.clientFamily;
     }
 
     // Check if fetch is available, otherwise provide a helpful error message

--- a/packages/mcp-core/src/internal/tool-helpers/api.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.ts
@@ -32,6 +32,7 @@ export function apiServiceFromContext(
     host,
     protocol: context.sentryProtocol,
     accessToken: context.accessToken,
+    clientFamily: context.clientFamily,
   });
 }
 

--- a/packages/mcp-core/src/internal/tool-helpers/api.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.ts
@@ -32,7 +32,8 @@ export function apiServiceFromContext(
     host,
     protocol: context.sentryProtocol,
     accessToken: context.accessToken,
-    clientFamily: context.clientFamily,
+    clientId: context.clientId,
+    clientName: context.clientName,
   });
 }
 

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -46,6 +46,8 @@ export type ServerContext = {
   sentryProtocol?: SentryProtocol;
   mcpUrl?: string;
   accessToken: string;
+  /** Resolved AI agent family (e.g. "claude-code", "cursor") from the MCP client's User-Agent */
+  clientFamily?: string | null;
   openaiBaseUrl?: string;
   userId?: string | null;
   userIpAddress?: string | null;

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -46,8 +46,8 @@ export type ServerContext = {
   sentryProtocol?: SentryProtocol;
   mcpUrl?: string;
   accessToken: string;
-  /** Resolved AI agent family (e.g. "claude-code", "cursor") from the MCP client's User-Agent */
-  clientFamily?: string | null;
+  /** DCR-registered client name (freeform, as provided during Dynamic Client Registration) */
+  clientName?: string | null;
   openaiBaseUrl?: string;
   userId?: string | null;
   userIpAddress?: string | null;


### PR DESCRIPTION
## Summary
- Forward DCR-registered `client_id` and `client_name` as `X-Sentry-MCP-Client-Id` and `X-Sentry-MCP-Client-Name` headers on upstream API requests
- Persist `clientName` from OAuth callback into WorkerProps so it's available per-request
- Enables Sentry to identify which MCP client (e.g. Claude Code, Cursor) made a given API call — not possible today since all MCP traffic uses the same OAuth app

## Test plan
- [ ] Verify `X-Sentry-MCP-Client-Id` and `X-Sentry-MCP-Client-Name` headers appear on outgoing API requests
- [ ] Verify no headers sent when values are null/undefined (e.g. stdio transport)
- [ ] Verify existing tokens without `clientName` in props still work (backward compat)