### PR TITLE
fix: Set app.client.family as Sentry attribute for Explore indexing

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -170,6 +170,7 @@ const wrappedOAuthProvider = {
     }
 
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
+    Sentry.getActiveSpan()?.setAttribute("app.client.family", clientFamily);
 
     // --- Phase 2: Let the OAuth library handle the request ---
     // We normalize any CORS headers it returns in the response handling below.

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -166,6 +166,8 @@ const mcpHandler: ExportedHandler<Env> = {
       userId,
     );
 
+    Sentry.getActiveSpan()?.setAttribute("app.client.family", clientFamily);
+
     // Parse and validate granted skills (primary authorization method)
     // Legacy tokens without grantedSkills are no longer supported
     if (!rawProps.grantedSkills) {


### PR DESCRIPTION
The \`app.client.family\` bucketing (claude-code, cursor, claude-desktop, etc.) was being set as an attribute on specific metrics but not on spans, making it unavailable for groupBy in Sentry Explore's trace view.

This adds \`Sentry.getActiveSpan()?.setAttribute("app.client.family", clientFamily)\` in both the root request handler (\`index.ts\`) and the MCP request handler (\`mcp-handler.ts\`), covering all request paths where a span is active.

Note: \`tokenExchangeCallback\` in \`oauth/helpers.ts\` does not do this because \`getActiveSpan()\` is \`undefined\` in that callback context — it intentionally uses metric attributes only.