### PR TITLE
fix(resource): Extract query params from AI conversation URLs

### DIFF
--- a/packages/mcp-core/src/internal/url-helpers.test.ts
+++ b/packages/mcp-core/src/internal/url-helpers.test.ts
@@ -241,7 +241,11 @@ describe("parseSentryUrl", () => {
       ).toMatchInlineSnapshot(`
         {
           "conversationId": "conv-123",
+          "end": undefined,
           "organizationSlug": "my-org",
+          "projectSlug": undefined,
+          "spanId": undefined,
+          "start": undefined,
           "type": "ai_conversation",
         }
       `);
@@ -255,7 +259,29 @@ describe("parseSentryUrl", () => {
       ).toMatchInlineSnapshot(`
         {
           "conversationId": "conv-123",
+          "end": undefined,
           "organizationSlug": "my-org",
+          "projectSlug": undefined,
+          "spanId": undefined,
+          "start": undefined,
+          "type": "ai_conversation",
+        }
+      `);
+    });
+
+    it("parses AI conversation URL with query params", () => {
+      expect(
+        parseSentryUrl(
+          "https://sentry.sentry.io/explore/conversations/slack%3AC07P2KGJGG0%3A1779498759.814569/?start=2026-05-23T00:23:27.667Z&end=2026-05-23T02:34:56.137Z&project=4510944073809921&spanId=459a11ae308afc7b",
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "conversationId": "slack:C07P2KGJGG0:1779498759.814569",
+          "end": "2026-05-23T02:34:56.137Z",
+          "organizationSlug": "sentry",
+          "projectSlug": "4510944073809921",
+          "spanId": "459a11ae308afc7b",
+          "start": "2026-05-23T00:23:27.667Z",
           "type": "ai_conversation",
         }
       `);

--- a/packages/mcp-core/src/internal/url-helpers.test.ts
+++ b/packages/mcp-core/src/internal/url-helpers.test.ts
@@ -170,7 +170,7 @@ describe("parseSentryUrl", () => {
           "organizationSlug": "my-org",
           "profileId": "cfe78a5c892d4a64a962d837673398d2",
           "profilerId": undefined,
-          "projectSlug": "my-project",
+          "projectSlugOrId": "my-project",
           "start": undefined,
           "type": "profile",
         }
@@ -188,7 +188,7 @@ describe("parseSentryUrl", () => {
           "organizationSlug": "my-org",
           "profileId": undefined,
           "profilerId": "abc123",
-          "projectSlug": "seer",
+          "projectSlugOrId": "seer",
           "start": undefined,
           "type": "profile",
         }
@@ -206,7 +206,7 @@ describe("parseSentryUrl", () => {
           "organizationSlug": "my-org",
           "profileId": undefined,
           "profilerId": "xyz789",
-          "projectSlug": "backend",
+          "projectSlugOrId": "backend",
           "start": "2024-01-01",
           "type": "profile",
         }
@@ -224,7 +224,7 @@ describe("parseSentryUrl", () => {
           "organizationSlug": "my-org",
           "profileId": "cfe78a5c892d4a64a962d837673398d2",
           "profilerId": undefined,
-          "projectSlug": "my-project",
+          "projectSlugOrId": "my-project",
           "start": undefined,
           "type": "profile",
         }
@@ -243,7 +243,7 @@ describe("parseSentryUrl", () => {
           "conversationId": "conv-123",
           "end": undefined,
           "organizationSlug": "my-org",
-          "projectSlug": undefined,
+          "projectSlugOrId": undefined,
           "spanId": undefined,
           "start": undefined,
           "type": "ai_conversation",
@@ -261,7 +261,7 @@ describe("parseSentryUrl", () => {
           "conversationId": "conv-123",
           "end": undefined,
           "organizationSlug": "my-org",
-          "projectSlug": undefined,
+          "projectSlugOrId": undefined,
           "spanId": undefined,
           "start": undefined,
           "type": "ai_conversation",
@@ -279,7 +279,7 @@ describe("parseSentryUrl", () => {
           "conversationId": "slack:C07P2KGJGG0:1779498759.814569",
           "end": "2026-05-23T02:34:56.137Z",
           "organizationSlug": "sentry",
-          "projectSlug": "4510944073809921",
+          "projectSlugOrId": "4510944073809921",
           "spanId": "459a11ae308afc7b",
           "start": "2026-05-23T00:23:27.667Z",
           "type": "ai_conversation",
@@ -376,7 +376,7 @@ describe("parseSentryUrl", () => {
         {
           "monitorSlug": "my-monitor",
           "organizationSlug": "my-org",
-          "projectSlug": "my-project",
+          "projectSlugOrId": "my-project",
           "type": "monitor",
         }
       `);

--- a/packages/mcp-core/src/internal/url-helpers.ts
+++ b/packages/mcp-core/src/internal/url-helpers.ts
@@ -42,8 +42,8 @@ export interface ParsedSentryUrl {
   spanId?: string;
   /** Event ID (for event URLs) */
   eventId?: string;
-  /** Project slug (for profile, monitor URLs) */
-  projectSlug?: string;
+  /** Project slug or numeric ID (for profile, monitor, and AI conversation URLs) */
+  projectSlugOrId?: string;
   /** Transaction profile ID from profile flamegraph URLs */
   profileId?: string;
   /** Profiler ID (for profile URLs, from query param) */
@@ -240,7 +240,7 @@ function identifyResource(
     return {
       type: "profile",
       organizationSlug,
-      projectSlug,
+      projectSlugOrId: projectSlug,
       profileId,
       profilerId,
       start,
@@ -270,7 +270,7 @@ function identifyResource(
       type: "ai_conversation",
       organizationSlug,
       conversationId: decodeURIComponent(conversationId),
-      projectSlug: project,
+      projectSlugOrId: project,
       spanId,
       start,
       end,
@@ -306,7 +306,7 @@ function identifyResource(
         return {
           type: "monitor",
           organizationSlug,
-          projectSlug: nextPart,
+          projectSlugOrId: nextPart,
           monitorSlug: afterNext,
         };
       }

--- a/packages/mcp-core/src/internal/url-helpers.ts
+++ b/packages/mcp-core/src/internal/url-helpers.ts
@@ -261,10 +261,19 @@ function identifyResource(
     "conversationId",
   );
   if (conversationId) {
+    const project = parsedUrl.searchParams.get("project") || undefined;
+    const spanId = parsedUrl.searchParams.get("spanId") || undefined;
+    const start = parsedUrl.searchParams.get("start") || undefined;
+    const end = parsedUrl.searchParams.get("end") || undefined;
+
     return {
       type: "ai_conversation",
       organizationSlug,
-      conversationId,
+      conversationId: decodeURIComponent(conversationId),
+      projectSlug: project,
+      spanId,
+      start,
+      end,
     };
   }
 

--- a/packages/mcp-core/src/tools/get-ai-conversation-details.ts
+++ b/packages/mcp-core/src/tools/get-ai-conversation-details.ts
@@ -464,14 +464,14 @@ export default defineTool({
     });
 
     let projectId: string | undefined;
-    if (params.project) {
-      projectId = params.project;
-    } else if (context.constraints.projectSlug) {
+    if (context.constraints.projectSlug) {
       const constrainedProject = await apiService.getProject({
         organizationSlug: params.organizationSlug,
         projectSlugOrId: context.constraints.projectSlug,
       });
       projectId = String(constrainedProject.id);
+    } else if (params.project) {
+      projectId = params.project;
     }
 
     const spans = await apiService.getAIConversation(

--- a/packages/mcp-core/src/tools/get-ai-conversation-details.ts
+++ b/packages/mcp-core/src/tools/get-ai-conversation-details.ts
@@ -443,6 +443,13 @@ export default defineTool({
       .string()
       .trim()
       .describe("The AI conversation ID from gen_ai.conversation.id."),
+    project: z
+      .string()
+      .trim()
+      .optional()
+      .describe(
+        "Numeric project ID to scope the query. Falls back to context constraint or all projects.",
+      ),
     regionUrl: ParamRegionUrl.optional(),
   },
 
@@ -455,17 +462,23 @@ export default defineTool({
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
     });
-    const constrainedProject = context.constraints.projectSlug
-      ? await apiService.getProject({
-          organizationSlug: params.organizationSlug,
-          projectSlugOrId: context.constraints.projectSlug,
-        })
-      : null;
+
+    let projectId: string | undefined;
+    if (params.project) {
+      projectId = params.project;
+    } else if (context.constraints.projectSlug) {
+      const constrainedProject = await apiService.getProject({
+        organizationSlug: params.organizationSlug,
+        projectSlugOrId: context.constraints.projectSlug,
+      });
+      projectId = String(constrainedProject.id);
+    }
+
     const spans = await apiService.getAIConversation(
       {
         organizationSlug: params.organizationSlug,
         conversationId: params.conversationId,
-        project: constrainedProject ? String(constrainedProject.id) : "-1",
+        project: projectId ?? "-1",
       },
       undefined,
     );

--- a/packages/mcp-core/src/tools/get-profile-details.ts
+++ b/packages/mcp-core/src/tools/get-profile-details.ts
@@ -50,7 +50,7 @@ function resolveProfileDetailsParams(params: {
     }
 
     const parsed = parseSentryUrl(params.profileUrl);
-    if (parsed.type !== "profile" || !parsed.projectSlug) {
+    if (parsed.type !== "profile" || !parsed.projectSlugOrId) {
       throw new UserInputError(
         "Invalid profile URL. URL must point to a Sentry profile resource.",
       );
@@ -67,7 +67,7 @@ function resolveProfileDetailsParams(params: {
         projectSlugOrId: resolveScopedProjectSlugOrId({
           resourceLabel: "Profile",
           scopedProjectSlugOrId: params.projectSlugOrId,
-          urlProjectSlug: parsed.projectSlug,
+          urlProjectSlug: parsed.projectSlugOrId,
         }),
         profileId: parsed.profileId,
       };
@@ -84,7 +84,7 @@ function resolveProfileDetailsParams(params: {
         projectSlugOrId: resolveScopedProjectSlugOrId({
           resourceLabel: "Profile",
           scopedProjectSlugOrId: params.projectSlugOrId,
-          urlProjectSlug: parsed.projectSlug,
+          urlProjectSlug: parsed.projectSlugOrId,
         }),
         profilerId: parsed.profilerId,
         start: parsed.start,

--- a/packages/mcp-core/src/tools/get-profile.ts
+++ b/packages/mcp-core/src/tools/get-profile.ts
@@ -47,11 +47,11 @@ function resolveProfileParams(params: {
         scopedOrganizationSlug: params.organizationSlug,
         urlOrganizationSlug: parsed.organizationSlug,
       }),
-      projectSlugOrId: parsed.projectSlug
+      projectSlugOrId: parsed.projectSlugOrId
         ? resolveScopedProjectSlugOrId({
             resourceLabel: "Profile",
             scopedProjectSlugOrId: params.projectSlugOrId,
-            urlProjectSlug: parsed.projectSlug,
+            urlProjectSlug: parsed.projectSlugOrId,
           })
         : (params.projectSlugOrId ?? undefined),
       transactionName: params.transactionName ?? undefined,

--- a/packages/mcp-core/src/tools/get-sentry-resource-resolve.test.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource-resolve.test.ts
@@ -227,7 +227,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "profile",
         organizationSlug: "my-org",
-        projectSlug: "my-project",
+        projectSlugOrId: "my-project",
         profileId: undefined,
         profilerId: undefined,
         start: undefined,
@@ -243,7 +243,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "profile",
         organizationSlug: "my-org",
-        projectSlug: "my-project",
+        projectSlugOrId: "my-project",
         profileId: undefined,
         profilerId: "abc123",
         start: undefined,
@@ -259,7 +259,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "profile",
         organizationSlug: "sentry",
-        projectSlug: "sentry",
+        projectSlugOrId: "sentry",
         profileId: "cfe78a5c892d4a64",
         profilerId: undefined,
         start: undefined,
@@ -275,7 +275,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "profile",
         organizationSlug: "my-org",
-        projectSlug: "my-project",
+        projectSlugOrId: "my-project",
         profileId: undefined,
         profilerId: undefined,
         start: undefined,
@@ -291,7 +291,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "profile",
         organizationSlug: "my-org",
-        projectSlug: "my-project",
+        projectSlugOrId: "my-project",
         profileId: undefined,
         profilerId: undefined,
         start: undefined,
@@ -307,7 +307,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "profile",
         organizationSlug: "sentry",
-        projectSlug: "sentry",
+        projectSlugOrId: "sentry",
         profileId: "cfe78a5c",
         profilerId: undefined,
         start: undefined,
@@ -372,7 +372,7 @@ describe("resolveResourceParams", () => {
       ).toEqual<ResolvedResourceParams>({
         type: "monitor",
         organizationSlug: "my-org",
-        projectSlug: "my-project",
+        projectSlugOrId: "my-project",
         monitorSlug: "my-monitor",
       });
     });

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -55,7 +55,7 @@ export interface ResolvedResourceParams {
   // AI conversation params
   conversationId?: string;
   // Profile params
-  projectSlug?: string;
+  projectSlugOrId?: string;
   profileId?: string;
   profilerId?: string;
   start?: string;
@@ -291,14 +291,14 @@ function resolveFromParsedUrl(
         type: "ai_conversation",
         organizationSlug,
         conversationId: parsed.conversationId,
-        projectSlug: parsed.projectSlug,
+        projectSlugOrId: parsed.projectSlugOrId,
         spanId: parsed.spanId,
         start: parsed.start,
         end: parsed.end,
       };
 
     case "profile":
-      if (!parsed.projectSlug) {
+      if (!parsed.projectSlugOrId) {
         throw new UserInputError(
           "Could not extract project slug from profile URL.",
         );
@@ -306,10 +306,10 @@ function resolveFromParsedUrl(
       return {
         type: "profile",
         organizationSlug,
-        projectSlug: resolveScopedProjectSlug({
+        projectSlugOrId: resolveScopedProjectSlug({
           resourceLabel: "Profile",
           scopedProjectSlug: params.projectSlug,
-          urlProjectSlug: parsed.projectSlug,
+          urlProjectSlug: parsed.projectSlugOrId,
         }),
         profileId: parsed.profileId,
         profilerId: parsed.profilerId,
@@ -335,11 +335,11 @@ function resolveFromParsedUrl(
         type: "monitor",
         organizationSlug,
         monitorSlug: parsed.monitorSlug,
-        projectSlug: parsed.projectSlug
+        projectSlugOrId: parsed.projectSlugOrId
           ? resolveScopedProjectSlug({
               resourceLabel: "Monitor",
               scopedProjectSlug: params.projectSlug,
-              urlProjectSlug: parsed.projectSlug,
+              urlProjectSlug: parsed.projectSlugOrId,
             })
           : undefined,
       };
@@ -393,9 +393,9 @@ function generateUnsupportedResourceMessage(
 
   switch (type) {
     case "monitor": {
-      // Include projectSlug in URL when present
-      const monitorPath = resolved.projectSlug
-        ? `${resolved.projectSlug}/${resolved.monitorSlug}`
+      // Include projectSlugOrId in URL when present
+      const monitorPath = resolved.projectSlugOrId
+        ? `${resolved.projectSlugOrId}/${resolved.monitorSlug}`
         : (resolved.monitorSlug ?? "");
       const monitorUrl = apiService.getMonitorUrl(
         organizationSlug,
@@ -406,7 +406,9 @@ function generateUnsupportedResourceMessage(
         "",
         `**Organization**: ${organizationSlug}`,
         `**Monitor**: ${resolved.monitorSlug}`,
-        resolved.projectSlug ? `**Project**: ${resolved.projectSlug}` : "",
+        resolved.projectSlugOrId
+          ? `**Project**: ${resolved.projectSlugOrId}`
+          : "",
         "",
         "Cron monitor support is coming soon. In the meantime:",
         "",
@@ -598,7 +600,7 @@ export default defineTool({
           {
             organizationSlug: resolved.organizationSlug,
             conversationId: resolved.conversationId!,
-            project: resolved.projectSlug,
+            project: resolved.projectSlugOrId,
             regionUrl: context.constraints.regionUrl ?? undefined,
           },
           context,
@@ -647,7 +649,7 @@ export default defineTool({
           {
             profileUrl: params.url,
             organizationSlug: resolved.organizationSlug,
-            projectSlugOrId: resolved.projectSlug,
+            projectSlugOrId: resolved.projectSlugOrId,
             profileId: resolved.profileId,
             profilerId: resolved.profilerId,
             start: resolved.start,

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -291,7 +291,7 @@ function resolveFromParsedUrl(
         type: "ai_conversation",
         organizationSlug,
         conversationId: parsed.conversationId,
-        projectSlug: parsed.projectSlug ?? params.projectSlug ?? undefined,
+        projectSlug: parsed.projectSlug,
         spanId: parsed.spanId,
         start: parsed.start,
         end: parsed.end,

--- a/packages/mcp-core/src/tools/get-sentry-resource.ts
+++ b/packages/mcp-core/src/tools/get-sentry-resource.ts
@@ -291,6 +291,10 @@ function resolveFromParsedUrl(
         type: "ai_conversation",
         organizationSlug,
         conversationId: parsed.conversationId,
+        projectSlug: parsed.projectSlug ?? params.projectSlug ?? undefined,
+        spanId: parsed.spanId,
+        start: parsed.start,
+        end: parsed.end,
       };
 
     case "profile":
@@ -594,6 +598,7 @@ export default defineTool({
           {
             organizationSlug: resolved.organizationSlug,
             conversationId: resolved.conversationId!,
+            project: resolved.projectSlug,
             regionUrl: context.constraints.regionUrl ?? undefined,
           },
           context,


### PR DESCRIPTION
## Summary
- Parse `project`, `spanId`, `start`, and `end` query params from AI conversation URLs (e.g. `https://sentry.sentry.io/explore/conversations/slack%3A.../?project=4510944073809921&spanId=...&start=...&end=...`)
- Thread the project ID through `get_sentry_resource` → `get_ai_conversation_details` so the Snuba query scopes to the correct project instead of scanning all projects (`-1`)
- Decode URL-encoded conversation IDs (e.g. `slack%3A...` → `slack:...`)
- Follows the existing pattern used by profile URLs for query param extraction

## Test plan
- [x] Added test for conversation URL with all query params (project, spanId, start, end)
- [x] Existing tests for conversation URLs without query params still pass (return `undefined` for optional fields, matching profile pattern)
- [x] All 1,413 tests pass (`pnpm run test --force`, 0 cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)