### PR TITLE
refactor(snapshot): Drop dead code in split snapshot tools

### DIFF
--- a/packages/mcp-core/src/tools/get-snapshot-image.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-image.ts
@@ -5,10 +5,7 @@ import { apiServiceFromContext } from "../internal/tool-helpers/api";
 import type { ServerContext } from "../types";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../schema";
 import { UserInputError } from "../errors";
-import {
-  fetchSnapshotImage,
-  type SnapshotImageResolution,
-} from "./snapshot-handlers";
+import { fetchSnapshotImage } from "./snapshot-handlers";
 
 export default defineTool({
   name: "get_snapshot_image",
@@ -87,7 +84,7 @@ export default defineTool({
       params.organizationSlug,
       params.snapshotId,
       params.imageIdentifier,
-      params.imageResolution as SnapshotImageResolution,
+      params.imageResolution,
       { nextSteps: "snapshot-tools" },
     );
   },

--- a/packages/mcp-core/src/tools/snapshot-formatting.ts
+++ b/packages/mcp-core/src/tools/snapshot-formatting.ts
@@ -54,16 +54,7 @@ export function renderSnapshotImageTreeSection(
 }
 
 export function renderSnapshotImageContext(context: unknown): string[] {
-  if (!isPlainObject(context)) {
-    return [];
-  }
-
-  const contextLines = renderContextObject(context, 0);
-  if (contextLines.length === 0) {
-    return [];
-  }
-
-  return contextLines;
+  return isPlainObject(context) ? renderContextObject(context, 0) : [];
 }
 
 function createBranch(label: string): TreeBranch {

--- a/packages/mcp-core/src/tools/snapshot-handlers.ts
+++ b/packages/mcp-core/src/tools/snapshot-handlers.ts
@@ -228,15 +228,11 @@ function isSnapshotDiffPair(
 
 function entryToTreeItem(
   entry: SnapshotDiffPair | SnapshotImageEntry,
-  details: string[] = [],
 ): SnapshotImageTreeItem {
   if (isSnapshotDiffPair(entry)) {
-    const image: SnapshotImageEntry =
-      entry.head_image ?? entry.base_image ?? {};
-    return { image, details };
+    return { image: entry.head_image ?? entry.base_image ?? {} };
   }
-
-  return { image: entry, details };
+  return { image: entry };
 }
 
 function renderTreeSections(


### PR DESCRIPTION
## Summary

Small cleanups in the snapshot tool split from #997. No behavior change.

- Remove unused `details` parameter from `entryToTreeItem`; no caller passed it and the empty array was attached to every returned item.
- Drop redundant `SnapshotImageResolution` cast in `get_snapshot_image`; Zod already infers the equivalent literal union.
- Collapse `renderSnapshotImageContext` guard ladder into a single ternary; `renderContextObject` already returns `[]` for empty input.

## Test plan

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] Snapshot-related vitest suites pass (80 tests across `get-snapshot`, `get-snapshot-image`, `get-sentry-resource`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)