### PR TITLE
chore(mcp-adoption-value-discovery): Adding docs traffic sources attrs

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,8 +53,8 @@ the pivots and recipes below.
 | `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
 | `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
 | `app.server.version` | MCP server package version | tags | release/version behavior |
-| `app.utm_source` | sanitized `utm_source` query param (e.g. `sentry-mcp-settings-docs-btn`) | spans | in-product attribution |
-| `app.referrer.family` | bucketed `Referer` host (`google`, `github`, `sentry`, `sentry-docs`, `other`) | spans | external traffic attribution |
+| `app.utm_source` | in-product `utm_source` query param | spans | in-product attribution |
+| `app.referrer.family` | low-cardinality bucket of the `Referer` host | spans | external traffic attribution |
 | `gen_ai.provider.name` | GenAI provider | spans, tags | provider-specific model behavior |
 | `gen_ai.request.model` | requested GenAI model | spans | model-specific behavior |
 | `user_agent.original` | original HTTP user agent | request data, spans | client identification |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,6 +53,8 @@ the pivots and recipes below.
 | `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
 | `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
 | `app.server.version` | MCP server package version | tags | release/version behavior |
+| `app.utm_source` | sanitized `utm_source` query param (e.g. `sentry-mcp-settings-docs-btn`) | spans | in-product attribution |
+| `app.referrer.family` | bucketed `Referer` host (`google`, `github`, `sentry`, `sentry-docs`, `other`) | spans | external traffic attribution |
 | `gen_ai.provider.name` | GenAI provider | spans, tags | provider-specific model behavior |
 | `gen_ai.request.model` | requested GenAI model | spans | model-specific behavior |
 | `user_agent.original` | original HTTP user agent | request data, spans | client identification |

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -1,8 +1,11 @@
 import { logIssue } from "@sentry/mcp-core/telem/logging";
+import * as Sentry from "@sentry/cloudflare";
 import { type Context, Hono } from "hono";
 import { csrf } from "hono/csrf";
 import { secureHeaders } from "hono/secure-headers";
 import { createScopedAuthorizationServerMetadataResponse } from "./authorization-server-metadata";
+import { resolveReferrerFamily } from "./lib/referer";
+import { sanitizeUtmSource } from "./lib/utm";
 import { createRequestLogger } from "./logging";
 import sentryOauth from "./oauth";
 import { createProtectedResourceMetadataResponse } from "./protected-resource-metadata";
@@ -118,6 +121,23 @@ const app = new Hono<{
       },
     }),
   )
+  .use("*", async (c, next) => {
+    const span = Sentry.getActiveSpan();
+
+    const utmSource = sanitizeUtmSource(
+      new URL(c.req.url).searchParams.get("utm_source"),
+    );
+    if (utmSource) {
+      span?.setAttribute("app.utm_source", utmSource);
+    }
+
+    const referrerFamily = resolveReferrerFamily(c.req.header("referer"));
+    if (referrerFamily) {
+      span?.setAttribute("app.referrer.family", referrerFamily);
+    }
+
+    await next();
+  })
   // Content-negotiated homepage: serve markdown to agents, SPA to browsers
   .get("/", async (c, next) => {
     const accept = c.req.header("Accept") ?? "";

--- a/packages/mcp-cloudflare/src/server/app.ts
+++ b/packages/mcp-cloudflare/src/server/app.ts
@@ -5,7 +5,7 @@ import { csrf } from "hono/csrf";
 import { secureHeaders } from "hono/secure-headers";
 import { createScopedAuthorizationServerMetadataResponse } from "./authorization-server-metadata";
 import { resolveReferrerFamily } from "./lib/referer";
-import { sanitizeUtmSource } from "./lib/utm";
+import { resolveUtmSource } from "./lib/utm";
 import { createRequestLogger } from "./logging";
 import sentryOauth from "./oauth";
 import { createProtectedResourceMetadataResponse } from "./protected-resource-metadata";
@@ -124,7 +124,7 @@ const app = new Hono<{
   .use("*", async (c, next) => {
     const span = Sentry.getActiveSpan();
 
-    const utmSource = sanitizeUtmSource(
+    const utmSource = resolveUtmSource(
       new URL(c.req.url).searchParams.get("utm_source"),
     );
     if (utmSource) {

--- a/packages/mcp-cloudflare/src/server/lib/referer.ts
+++ b/packages/mcp-cloudflare/src/server/lib/referer.ts
@@ -1,0 +1,26 @@
+// Buckets the `Referer` header host into a low-cardinality "family" for
+// span attribution. Unknown hosts collapse to "other"; missing/same-origin
+// referers return null so they're not stamped on the span.
+const FAMILY_BY_HOST: Array<[RegExp, string]> = [
+  [/^docs\.sentry\.io$/, "sentry-docs"],
+  [/(^|\.)sentry\.io$/, "sentry"],
+  [/(^|\.)github\.com$/, "github"],
+  [/(^|\.)google\.[a-z.]+$/, "google"],
+];
+
+export function resolveReferrerFamily(
+  referer: string | null | undefined,
+): string | null {
+  if (!referer) return null;
+  let host: string;
+  try {
+    host = new URL(referer).hostname.toLowerCase();
+  } catch {
+    return "other";
+  }
+  if (host === "mcp.sentry.dev") return null;
+  for (const [pattern, family] of FAMILY_BY_HOST) {
+    if (pattern.test(host)) return family;
+  }
+  return "other";
+}

--- a/packages/mcp-cloudflare/src/server/lib/utm.ts
+++ b/packages/mcp-cloudflare/src/server/lib/utm.ts
@@ -1,4 +1,4 @@
-export function sanitizeUtmSource(
+export function resolveUtmSource(
   raw: string | null | undefined,
 ): string | null {
   if (!raw) return null;

--- a/packages/mcp-cloudflare/src/server/lib/utm.ts
+++ b/packages/mcp-cloudflare/src/server/lib/utm.ts
@@ -1,0 +1,7 @@
+export function sanitizeUtmSource(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+  // Exact-match to keep cardinality bounded
+  return raw === "sentry-mcp-settings-docs-btn" ? raw : "other";
+}


### PR DESCRIPTION
Adds two attributes:

`app.utm_source` — set when the user clicks a CTA we placed in-app. 

`app.referrer.family` — set from the request's Referer header, bucketed into google / github / sentry / sentry-docs / other for  now. 