### PR TITLE
chore(mcp-adoption-value-discovery): Adding docs traffic sources attrs

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,6 +53,8 @@ the pivots and recipes below.
 | `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
 | `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
 | `app.server.version` | MCP server package version | tags | release/version behavior |
+| `app.utm_source` | sanitized in-product `utm_source` query param (SPA `pageload`) | spans | in-product attribution |
+| `app.referrer.family` | low-cardinality bucket of the `Referer` host (SPA `pageload`) | spans | external traffic attribution |
 | `gen_ai.provider.name` | GenAI provider | spans, tags | provider-specific model behavior |
 | `gen_ai.request.model` | requested GenAI model | spans | model-specific behavior |
 | `user_agent.original` | original HTTP user agent | request data, spans | client identification |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,8 +53,8 @@ the pivots and recipes below.
 | `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
 | `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
 | `app.server.version` | MCP server package version | tags | release/version behavior |
-| `app.utm_source` | sanitized in-product `utm_source` query param (SPA `pageload`) | spans | in-product attribution |
-| `app.referrer.family` | low-cardinality bucket of the `Referer` host (SPA `pageload`) | spans | external traffic attribution |
+| `app.utm_source` | sanitized in-product `utm_source` query param | spans | in-product attribution |
+| `app.referrer.family` | low-cardinality bucket of the `Referer` host | spans | external traffic attribution |
 | `gen_ai.provider.name` | GenAI provider | spans, tags | provider-specific model behavior |
 | `gen_ai.request.model` | requested GenAI model | spans | model-specific behavior |
 | `user_agent.original` | original HTTP user agent | request data, spans | client identification |

--- a/packages/mcp-cloudflare/src/client/instrument.ts
+++ b/packages/mcp-cloudflare/src/client/instrument.ts
@@ -1,15 +1,14 @@
 import * as Sentry from "@sentry/react";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
-import { resolveAttribution } from "./utils";
+import { attributionBeforeSendSpan } from "./utils";
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   sendDefaultPii: true,
   tracesSampleRate: 1,
   beforeSend: sentryBeforeSend,
+  beforeSendSpan: attributionBeforeSendSpan,
   environment:
     import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.NODE_ENV,
   integrations: [Sentry.browserTracingIntegration()],
 });
-
-resolveAttribution();

--- a/packages/mcp-cloudflare/src/client/instrument.ts
+++ b/packages/mcp-cloudflare/src/client/instrument.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
+import { resolveAttribution } from "./utils";
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -8,4 +9,7 @@ Sentry.init({
   beforeSend: sentryBeforeSend,
   environment:
     import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.NODE_ENV,
+  integrations: [Sentry.browserTracingIntegration()],
 });
+
+resolveAttribution();

--- a/packages/mcp-cloudflare/src/client/instrument.ts
+++ b/packages/mcp-cloudflare/src/client/instrument.ts
@@ -1,14 +1,15 @@
 import * as Sentry from "@sentry/react";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
-import { attributionBeforeSendSpan } from "./utils";
+import { resolveAttribution } from "./utils";
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   sendDefaultPii: true,
   tracesSampleRate: 1,
   beforeSend: sentryBeforeSend,
-  beforeSendSpan: attributionBeforeSendSpan,
   environment:
     import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.NODE_ENV,
   integrations: [Sentry.browserTracingIntegration()],
 });
+
+resolveAttribution();

--- a/packages/mcp-cloudflare/src/client/utils/attribution.ts
+++ b/packages/mcp-cloudflare/src/client/utils/attribution.ts
@@ -1,4 +1,4 @@
-import type { spanToJSON } from "@sentry/react";
+import * as Sentry from "@sentry/react";
 
 export function resolveUtmSource(
   raw: string | null | undefined,
@@ -31,20 +31,15 @@ export function resolveReferrerFamily(
   return "other";
 }
 
-type SpanJSON = ReturnType<typeof spanToJSON>;
-
-export function attributionBeforeSendSpan(span: SpanJSON): SpanJSON {
-  if (span.op !== "pageload") return span;
+export function resolveAttribution(): void {
+  const span = Sentry.getActiveSpan();
+  if (!span) return;
 
   const utmSource = resolveUtmSource(
     new URLSearchParams(window.location.search).get("utm_source"),
   );
-  const referrerFamily = resolveReferrerFamily(document.referrer);
+  if (utmSource) span.setAttribute("app.utm_source", utmSource);
 
-  span.data = {
-    ...span.data,
-    ...(utmSource && { "app.utm_source": utmSource }),
-    ...(referrerFamily && { "app.referrer.family": referrerFamily }),
-  };
-  return span;
+  const referrerFamily = resolveReferrerFamily(document.referrer);
+  if (referrerFamily) span.setAttribute("app.referrer.family", referrerFamily);
 }

--- a/packages/mcp-cloudflare/src/client/utils/attribution.ts
+++ b/packages/mcp-cloudflare/src/client/utils/attribution.ts
@@ -1,0 +1,45 @@
+import * as Sentry from "@sentry/react";
+
+export function resolveUtmSource(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+  return raw === "sentry-mcp-settings-docs-btn" ? raw : "other";
+}
+
+const FAMILY_BY_HOST: Array<[RegExp, string]> = [
+  [/^docs\.sentry\.io$/, "sentry-docs"],
+  [/(^|\.)sentry\.io$/, "sentry"],
+  [/(^|\.)github\.com$/, "github"],
+  [/(^|\.)google\.[a-z.]+$/, "google"],
+];
+
+export function resolveReferrerFamily(
+  referer: string | null | undefined,
+): string | null {
+  if (!referer) return null;
+  let host: string;
+  try {
+    host = new URL(referer).hostname.toLowerCase();
+  } catch {
+    return "other";
+  }
+  if (host === "mcp.sentry.dev") return null;
+  for (const [pattern, family] of FAMILY_BY_HOST) {
+    if (pattern.test(host)) return family;
+  }
+  return "other";
+}
+
+export function resolveAttribution(): void {
+  const span = Sentry.getActiveSpan();
+  if (!span) return;
+
+  const utmSource = resolveUtmSource(
+    new URLSearchParams(window.location.search).get("utm_source"),
+  );
+  if (utmSource) span.setAttribute("app.utm_source", utmSource);
+
+  const referrerFamily = resolveReferrerFamily(document.referrer);
+  if (referrerFamily) span.setAttribute("app.referrer.family", referrerFamily);
+}

--- a/packages/mcp-cloudflare/src/client/utils/attribution.ts
+++ b/packages/mcp-cloudflare/src/client/utils/attribution.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/react";
+import type { SpanJSON } from "@sentry/react";
 
 export function resolveUtmSource(
   raw: string | null | undefined,
@@ -31,15 +31,18 @@ export function resolveReferrerFamily(
   return "other";
 }
 
-export function resolveAttribution(): void {
-  const span = Sentry.getActiveSpan();
-  if (!span) return;
+export function attributionBeforeSendSpan(span: SpanJSON): SpanJSON {
+  if (span.op !== "pageload") return span;
 
   const utmSource = resolveUtmSource(
     new URLSearchParams(window.location.search).get("utm_source"),
   );
-  if (utmSource) span.setAttribute("app.utm_source", utmSource);
-
   const referrerFamily = resolveReferrerFamily(document.referrer);
-  if (referrerFamily) span.setAttribute("app.referrer.family", referrerFamily);
+
+  span.data = {
+    ...span.data,
+    ...(utmSource && { "app.utm_source": utmSource }),
+    ...(referrerFamily && { "app.referrer.family": referrerFamily }),
+  };
+  return span;
 }

--- a/packages/mcp-cloudflare/src/client/utils/attribution.ts
+++ b/packages/mcp-cloudflare/src/client/utils/attribution.ts
@@ -1,4 +1,4 @@
-import type { SpanJSON } from "@sentry/react";
+import type { spanToJSON } from "@sentry/react";
 
 export function resolveUtmSource(
   raw: string | null | undefined,
@@ -30,6 +30,8 @@ export function resolveReferrerFamily(
   }
   return "other";
 }
+
+type SpanJSON = ReturnType<typeof spanToJSON>;
 
 export function attributionBeforeSendSpan(span: SpanJSON): SpanJSON {
   if (span.op !== "pageload") return span;

--- a/packages/mcp-cloudflare/src/client/utils/index.ts
+++ b/packages/mcp-cloudflare/src/client/utils/index.ts
@@ -1,2 +1,3 @@
+export * from "./attribution";
 export * from "./chat-error-handler";
 export * from "./cursor-deeplink";


### PR DESCRIPTION
Enables Sentry browser tracing on the SPA so we get pageload transactions for mcp.sentry.dev/ traffic. Added two attrs for traffic source tracking:

`app.utm_source `— sanitized in-product utm_source query param from window.location. Used to group by in-app sources as we surface mcp doc links more in Sentry. 

`app.referrer.family `— low-cardinality bucket of the Referer header host: google, github, sentry, sentry-docs, or other for now. Used to see where external traffic is arriving from.