### PR TITLE
chore(mcp-adoption-value-discovery): Adding auth consent metrics

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -178,6 +178,7 @@ Users report sign-outs, refresh loops, DCR churn, or callback/register
 imbalance.
 
 Metrics: `app.oauth.token_exchange`, `app.oauth.grant_revoked`,
+`app.oauth.consent_prompted`, `app.oauth.consent_granted`,
 `app.oauth.callback_completed`, `app.consent.skill_granted`,
 `app.oauth.register`
 

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -162,13 +162,7 @@ export default new Hono<{ Bindings: Env }>()
     // }
 
     const client = await c.env.OAUTH_PROVIDER.lookupClient(clientId);
-    Sentry.metrics.count("app.oauth.consent_prompted", 1, {
-      attributes: {
-        "app.client.family": resolveClientFamilyFromName(client?.clientName),
-      },
-    });
-
-    return await renderApprovalDialog(c.req.raw, {
+    const response = await renderApprovalDialog(c.req.raw, {
       client,
       server: {
         name: "Sentry MCP",
@@ -178,6 +172,14 @@ export default new Hono<{ Bindings: Env }>()
       state: { oauthReqInfo: oauthReqInfoWithResource },
       cookieSecret: c.env.COOKIE_SECRET,
     });
+
+    Sentry.metrics.count("app.oauth.consent_prompted", 1, {
+      attributes: {
+        "app.client.family": resolveClientFamilyFromName(client?.clientName),
+      },
+    });
+
+    return response;
   })
 
   /**

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono";
+import * as Sentry from "@sentry/cloudflare";
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
 import {
   renderApprovalDialog,
   parseRedirectApproval,
 } from "../../lib/approval-dialog";
+import { resolveClientFamilyFromName } from "../../lib/client-family";
 import type { Env } from "../../types";
 import { SENTRY_AUTH_URL } from "../constants";
 import {
@@ -159,8 +161,15 @@ export default new Hono<{ Bindings: Env }>()
     //   return redirectToUpstream(c.env, c.req.raw, oauthReqInfo);
     // }
 
+    const client = await c.env.OAUTH_PROVIDER.lookupClient(clientId);
+    Sentry.metrics.count("app.oauth.consent_prompted", 1, {
+      attributes: {
+        "app.client.family": resolveClientFamilyFromName(client?.clientName),
+      },
+    });
+
     return await renderApprovalDialog(c.req.raw, {
-      client: await c.env.OAUTH_PROVIDER.lookupClient(clientId),
+      client,
       server: {
         name: "Sentry MCP",
       },
@@ -202,9 +211,9 @@ export default new Hono<{ Bindings: Env }>()
       skills,
     };
 
-    // Validate redirectUri first to prevent open redirects from error responses
+    let client = null;
     try {
-      const client = await c.env.OAUTH_PROVIDER.lookupClient(
+      client = await c.env.OAUTH_PROVIDER.lookupClient(
         oauthReqWithSkills.clientId,
       );
       const uriIsAllowed =
@@ -258,6 +267,12 @@ export default new Hono<{ Bindings: Env }>()
       exp: now + 10 * 60 * 1000,
     };
     const signedState = await signState(payload, c.env.COOKIE_SECRET);
+
+    Sentry.metrics.count("app.oauth.consent_granted", 1, {
+      attributes: {
+        "app.client.family": resolveClientFamilyFromName(client?.clientName),
+      },
+    });
 
     return redirectToUpstream(
       c.env,

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -211,6 +211,7 @@ export default new Hono<{ Bindings: Env }>()
       skills,
     };
 
+    // Validate redirectUri first to prevent open redirects from error responses
     let client = null;
     try {
       client = await c.env.OAUTH_PROVIDER.lookupClient(


### PR DESCRIPTION
The existing `app.oauth.register` metric tracks DCR (Dynamic Client Registration) registrations, which fire on every fresh client_id — re-triggered on cold starts, reinstalls, and any client that doesn't persist DCR state. That makes it more of a client-behavior signal than a user-adoption one: the count reflects how each IDE manages its OAuth state, not whether a human meant to install or sign in.

This PR adds two new counters on /oauth/authorize:

`app.oauth.consent_prompted` — fires when the consent page renders (GET /oauth/authorize)
`app.oauth.consent_granted` — fires when the user clicks Approve and validation passes (POST /oauth/authorize)
Paired with the existing `app.oauth.callback_completed`, these form a three-stage funnel — prompted → granted → completed — that's a much better proxy for user drop-off. The gap between prompted and granted is users bailing at the consent screen; the gap between granted and completed is users bailing at upstream Sentry login. All three carry app.client.family, so we can split per-IDE.