### PR TITLE
fix(snapshot): Render host-aware URLs in tool output

### DIFF
--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -61,6 +61,36 @@ describe("getIssueUrl", () => {
   });
 });
 
+describe("getPreprodSnapshotUrl", () => {
+  it("should work with sentry.io", () => {
+    const apiService = new SentryApiService({ host: "sentry.io" });
+    const result = apiService.getPreprodSnapshotUrl("sentry", "12");
+    expect(result).toEqual("https://sentry.sentry.io/preprod/snapshots/12/");
+  });
+  it("should work with self-hosted", () => {
+    const apiService = new SentryApiService({ host: "sentry.example.com" });
+    const result = apiService.getPreprodSnapshotUrl("sentry", "12");
+    expect(result).toEqual(
+      "https://sentry.example.com/organizations/sentry/preprod/snapshots/12/",
+    );
+  });
+  it("should respect HTTP protocol for self-hosted", () => {
+    const apiService = new SentryApiService({
+      host: "localhost:8000",
+      protocol: "http",
+    });
+    const result = apiService.getPreprodSnapshotUrl("sentry", "12");
+    expect(result).toEqual(
+      "http://localhost:8000/organizations/sentry/preprod/snapshots/12/",
+    );
+  });
+  it("should use sentry.io (not regional) for SaaS web URL", () => {
+    const apiService = new SentryApiService({ host: "us.sentry.io" });
+    const result = apiService.getPreprodSnapshotUrl("sentry", "12");
+    expect(result).toEqual("https://sentry.sentry.io/preprod/snapshots/12/");
+  });
+});
+
 describe("getTraceUrl", () => {
   it("should work with sentry.io", () => {
     const apiService = new SentryApiService({ host: "sentry.io" });

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -4,6 +4,7 @@ import {
   getAIConversationUrl as getAIConversationUrlUtil,
   getIssueUrl as getIssueUrlUtil,
   getMonitorUrl as getMonitorUrlUtil,
+  getPreprodSnapshotUrl as getPreprodSnapshotUrlUtil,
   getProfileUrl as getProfileUrlUtil,
   getProfilingExplorerUrl,
   getReleaseUrl as getReleaseUrlUtil,
@@ -3120,6 +3121,15 @@ export class SentryApiService {
     }
 
     return response.chunks[0];
+  }
+
+  getPreprodSnapshotUrl(organizationSlug: string, snapshotId: string): string {
+    return getPreprodSnapshotUrlUtil(
+      this.host,
+      organizationSlug,
+      snapshotId,
+      this.protocol,
+    );
   }
 
   async getSnapshotDetails({

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -508,13 +508,13 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "Project slug or numeric ID for scoping (e.g. 'frontend'). Required when Sentry cannot infer the project from appId alone."
+              "description": "Project slug or numeric ID for scoping (e.g. 'frontend')."
             },
             {
               "type": "null"
             }
           ],
-          "description": "Project slug or numeric ID for scoping (e.g. 'frontend'). Required when Sentry cannot infer the project from appId alone.",
+          "description": "Project slug or numeric ID for scoping (e.g. 'frontend').",
           "default": null
         },
         "regionUrl": {

--- a/packages/mcp-core/src/tools/get-latest-base-snapshot.ts
+++ b/packages/mcp-core/src/tools/get-latest-base-snapshot.ts
@@ -65,9 +65,7 @@ export default defineTool({
     project: z
       .string()
       .trim()
-      .describe(
-        "Project slug or numeric ID for scoping (e.g. 'frontend'). Required when Sentry cannot infer the project from appId alone.",
-      )
+      .describe("Project slug or numeric ID for scoping (e.g. 'frontend').")
       .nullable()
       .default(null),
     regionUrl: ParamRegionUrl.nullable().default(null),
@@ -104,7 +102,7 @@ export default defineTool({
     const vcsInfo = data.vcs_info as Record<string, unknown> | undefined;
 
     const snapshotUrl = snapshotId
-      ? `https://${params.organizationSlug}.sentry.io/preprod/snapshots/${snapshotId}/`
+      ? apiService.getPreprodSnapshotUrl(params.organizationSlug, snapshotId)
       : null;
 
     const sections: string[] = [];

--- a/packages/mcp-core/src/tools/get-snapshot-image.test.ts
+++ b/packages/mcp-core/src/tools/get-snapshot-image.test.ts
@@ -150,6 +150,9 @@ describe("get_snapshot_image", () => {
     const { textParts, imageParts } = splitParts(result);
 
     expect(textParts[0]!.text).toContain("## login_screen.png");
+    expect(textParts[0]!.text).toContain(
+      "- **URL**: https://sentry.sentry.io/preprod/snapshots/231949/?selectedSnapshot=login_screen.png",
+    );
     expect(textParts[0]!.text).toContain("**Status**: changed");
     expect(textParts[0]!.text).toContain("**Diff**: 12.5%");
     expect(textParts[0]!.text).toContain("**Image Resolution**: preview");

--- a/packages/mcp-core/src/tools/snapshot-handlers.ts
+++ b/packages/mcp-core/src/tools/snapshot-handlers.ts
@@ -167,7 +167,13 @@ export async function fetchSnapshotImage(
     );
   }
 
+  const snapshotUrl = `${apiService.getPreprodSnapshotUrl(
+    organizationSlug,
+    snapshotId,
+  )}?selectedSnapshot=${encodeURIComponent(imageIdentifier)}`;
+
   const lines: string[] = [`## ${imageIdentifier}\n`];
+  lines.push(`- **URL**: ${snapshotUrl}`);
   if (status) lines.push(`- **Status**: ${status}`);
   if (detail.diff_percentage != null)
     lines.push(
@@ -282,7 +288,7 @@ export async function fetchSnapshotSummary(
 
   const resolvedSnapshotUrl =
     sourceUrlForDisplay ||
-    `https://${organizationSlug}.sentry.io/preprod/snapshots/${snapshotId}/`;
+    apiService.getPreprodSnapshotUrl(organizationSlug, snapshotId);
 
   const sections: string[] = [];
 

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -5,6 +5,7 @@ import {
   validateOpenAiBaseUrlThrows,
   getIssueUrl,
   getIssuesSearchUrl,
+  getPreprodSnapshotUrl,
   getReplaysSearchUrl,
   getReplayUrl,
   getTraceUrl,
@@ -158,6 +159,37 @@ describe("url-utils", () => {
       );
       expect(result).toBe(
         "http://sentry.internal:9000/organizations/myorg/issues/PROJ-123",
+      );
+    });
+  });
+
+  describe("getPreprodSnapshotUrl", () => {
+    it("should handle regional URLs correctly for SaaS", () => {
+      const result = getPreprodSnapshotUrl("us.sentry.io", "myorg", "12");
+      expect(result).toBe("https://myorg.sentry.io/preprod/snapshots/12/");
+    });
+
+    it("should handle standard sentry.io correctly", () => {
+      const result = getPreprodSnapshotUrl("sentry.io", "myorg", "12");
+      expect(result).toBe("https://myorg.sentry.io/preprod/snapshots/12/");
+    });
+
+    it("should handle self-hosted correctly", () => {
+      const result = getPreprodSnapshotUrl("sentry.example.com", "myorg", "12");
+      expect(result).toBe(
+        "https://sentry.example.com/organizations/myorg/preprod/snapshots/12/",
+      );
+    });
+
+    it("should support HTTP for self-hosted snapshot URLs when requested", () => {
+      const result = getPreprodSnapshotUrl(
+        "sentry.internal:9000",
+        "myorg",
+        "12",
+        "http",
+      );
+      expect(result).toBe(
+        "http://sentry.internal:9000/organizations/myorg/preprod/snapshots/12/",
       );
     });
   });

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -344,6 +344,27 @@ export function getIssueUrl(
 }
 
 /**
+ * Generates a Sentry preprod snapshot URL.
+ * @param host The Sentry host (may include regional subdomain for API access)
+ * @param organizationSlug Organization identifier
+ * @param snapshotId Preprod snapshot artifact ID
+ * @returns The complete snapshot URL
+ */
+export function getPreprodSnapshotUrl(
+  host: string,
+  organizationSlug: string,
+  snapshotId: string,
+  protocol: SentryProtocol = "https",
+): string {
+  return getSentryWebBaseUrl(
+    host,
+    organizationSlug,
+    `/preprod/snapshots/${snapshotId}/`,
+    protocol,
+  );
+}
+
+/**
  * Generates a Sentry cron monitor URL.
  * @param host The Sentry host (may include regional subdomain for API access)
  * @param organizationSlug Organization identifier


### PR DESCRIPTION
## Summary

Snapshot tool URLs in `get_snapshot`, `get_latest_base_snapshot`, and `get_snapshot_image` were hardcoded to the SaaS subdomain shape (`https://<org>.sentry.io/preprod/snapshots/<id>/`), so self-hosted Sentry instances (and the ngrok-fronted dev setup) rendered URLs that 404'd — those instances use the path-based shape `https://<host>/organizations/<org>/preprod/snapshots/<id>/`.

- Add `SentryApiService.getPreprodSnapshotUrl(orgSlug, snapshotId)` following the existing `buildDiscoverUrl` pattern: subdomain for SaaS, path-based for self-hosted, respects `protocol`.
- Pull `get_snapshot`, `get_latest_base_snapshot`, and `get_snapshot_image` through the helper.
- `get_snapshot_image` now renders a `- **URL**: …?selectedSnapshot=<encoded id>` deep-link line at the top of the response. Callers can pivot to the Sentry UI or feed the URL straight back into `get_sentry_resource` without string-building it themselves.
- Trim `get_latest_base_snapshot`'s `project` arg description — the previous *"Required when Sentry cannot infer the project from appId alone"* wording overstated the constraint and didn't match runtime behavior. Regenerate `toolDefinitions.json` to match.

## Test plan

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] `pnpm --filter @sentry/mcp-core test` — 1013 passed, 4 skipped (added 4 new unit tests on `getPreprodSnapshotUrl` covering SaaS, self-hosted, HTTP protocol, and regional `us.sentry.io` → `sentry.sentry.io` web URL; added `get_snapshot_image` URL-line assertion)
- [x] Verified live via MCP Inspector against a dev Sentry on ngrok: `get_snapshot` and `get_snapshot_image` now render `https://<host>/organizations/<org>/preprod/snapshots/…` URLs that open correctly in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)