### PR TITLE
fix: Use correct CF options type

### DIFF
--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -1,11 +1,10 @@
 import type { Env } from "./types";
 import { LIB_VERSION } from "@sentry/mcp-core/version";
 import * as Sentry from "@sentry/cloudflare";
+import type { CloudflareOptions } from "@sentry/cloudflare";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 
-type SentryConfig = ReturnType<Parameters<typeof Sentry.withSentry>[0]>;
-
-export default function getSentryConfig(env: Env): SentryConfig {
+export default function getSentryConfig(env: Env): CloudflareOptions {
   const versionId = env.CF_VERSION_METADATA?.id;
 
   return {
@@ -33,7 +32,7 @@ export default function getSentryConfig(env: Env): SentryConfig {
   };
 }
 
-getSentryConfig.partial = (config: Partial<SentryConfig>) => {
+getSentryConfig.partial = (config: Partial<CloudflareOptions>) => {
   return (env: Env) => {
     const defaultConfig = getSentryConfig(env);
     return {


### PR DESCRIPTION
The `Sentry` config is a little unreliable, as it also returns `undefined`. There were build errors when using the previous version at least locally.