### PR TITLE
fix(search-events): Augment fields with sort column before API call

### DIFF
--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -426,12 +426,8 @@ describe("search_events", () => {
   });
 
   it("should include the sort field even when caller's explicit fields omit it", async () => {
-    // When the caller passes a structured Sentry-syntax query plus explicit
-    // fields that don't include the sort field, the embedded agent adds the
-    // sort field to satisfy its own refinement — but the handler trusts the
-    // caller's explicit fields verbatim and drops the agent's repair. Sentry
-    // then rejects the request with 400 "Cannot sort by a field that is not
-    // selected."
+    // Sentry rejects requests whose sort column isn't in the selected fields,
+    // so the handler must append the sort field before issuing the request.
     mockGenerateText.mockResolvedValueOnce(
       mockAIResponse(
         "errors",

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -425,6 +425,66 @@ describe("search_events", () => {
     expect(result).toContain('"tags[sequence]": "42"');
   });
 
+  it("should include the sort field even when caller's explicit fields omit it", async () => {
+    // When the caller passes a structured Sentry-syntax query plus explicit
+    // fields that don't include the sort field, the embedded agent adds the
+    // sort field to satisfy its own refinement — but the handler trusts the
+    // caller's explicit fields verbatim and drops the agent's repair. Sentry
+    // then rejects the request with 400 "Cannot sort by a field that is not
+    // selected."
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse(
+        "errors",
+        "level:error",
+        ["title", "issue", "message", "timestamp"],
+        undefined,
+        "-timestamp",
+      ),
+    );
+
+    let capturedFields: string[] | undefined;
+    let capturedSort: string | null | undefined;
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          capturedFields = url.searchParams.getAll("field");
+          capturedSort = url.searchParams.get("sort");
+          return HttpResponse.json({ data: [] });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query: "level:error",
+        dataset: "errors",
+        fields: ["title", "issue", "message"],
+        sort: "-timestamp",
+        statsPeriod: "14d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(capturedSort).toBe("-timestamp");
+    expect(capturedFields).toContain("timestamp");
+  });
+
   it("should not duplicate environment filters after agent repair", async () => {
     const query =
       'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -481,6 +481,107 @@ describe("search_events", () => {
     expect(capturedFields).toContain("timestamp");
   });
 
+  it("should not append a non-aggregate sort to aggregate fields", async () => {
+    // Adding a non-aggregate column to an aggregate query expands the
+    // GROUP BY and silently corrupts the result, so leave the request
+    // alone and let Sentry's 400 propagate.
+    let capturedFields: string[] | undefined;
+    let capturedSort: string | null | undefined;
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          capturedFields = url.searchParams.getAll("field");
+          capturedSort = url.searchParams.get("sort");
+          return HttpResponse.json({ data: [] });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query: 'span.op:"db.query"',
+        dataset: "spans",
+        fields: ["span.op", "count()"],
+        sort: "-timestamp",
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).not.toHaveBeenCalled();
+    expect(capturedSort).toBe("-timestamp");
+    expect(capturedFields).toEqual(["span.op", "count()"]);
+  });
+
+  it("should append an aggregate sort that isn't already in fields", async () => {
+    // Aggregate sort columns can safely be added to an aggregate query —
+    // Sentry treats them as additional aggregations, not GROUP BY columns.
+    let capturedFields: string[] | undefined;
+    let capturedSort: string | null | undefined;
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          capturedFields = url.searchParams.getAll("field");
+          capturedSort = url.searchParams.get("sort");
+          return HttpResponse.json({ data: [] });
+        },
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query: 'span.op:"db.query"',
+        dataset: "spans",
+        fields: ["span.op", "count()"],
+        sort: "-count_unique(user.id)",
+        statsPeriod: "7d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(mockGenerateText).not.toHaveBeenCalled();
+    // The API client normalizes aggregate sort params: count_unique(user.id)
+    // becomes count_unique_user_id. Fields keep their original form.
+    expect(capturedSort).toBe("-count_unique_user_id");
+    expect(capturedFields).toEqual([
+      "span.op",
+      "count()",
+      "count_unique(user.id)",
+    ]);
+  });
+
   it("should not duplicate environment filters after agent repair", async () => {
     const query =
       'transaction:"VPN connections" tags[type]:Unified tags[country]:CN';

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -542,6 +542,17 @@ export default defineTool({
       });
     }
 
+    // Sentry rejects the request if the sort column isn't in the selected
+    // fields. The embedded agent's schema enforces this, but the handler can
+    // recombine the caller's explicit fields with a default or explicit sort
+    // that the agent never saw — so re-check here.
+    const sortField = sortParam.startsWith("-")
+      ? sortParam.slice(1)
+      : sortParam;
+    if (sortField && !fields.includes(sortField)) {
+      fields = [...fields, sortField];
+    }
+
     const requestFields =
       isMetricsDataset(dataset) && !isAggregateQuery(fields)
         ? Array.from(

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -551,6 +551,11 @@ export default defineTool({
     // are aggregate: adding a non-aggregate column to an aggregate query
     // changes the GROUP BY and silently corrupts the result. Better to let
     // Sentry's 400 propagate so the caller can fix the request explicitly.
+    //
+    // Note: fields remain in function form (e.g. "count_unique(user.id)") and
+    // sortParam is also pre-normalization here. The API client normalizes
+    // aggregate sort params to underscore form (e.g. "count_unique_user_id")
+    // later, so an exact string match against fields is correct at this stage.
     const sortField = sortParam.startsWith("-")
       ? sortParam.slice(1)
       : sortParam;

--- a/packages/mcp-core/src/tools/search-events/handler.ts
+++ b/packages/mcp-core/src/tools/search-events/handler.ts
@@ -546,10 +546,20 @@ export default defineTool({
     // fields. The embedded agent's schema enforces this, but the handler can
     // recombine the caller's explicit fields with a default or explicit sort
     // that the agent never saw — so re-check here.
+    //
+    // Skip the augment when the sort is non-aggregate but the existing fields
+    // are aggregate: adding a non-aggregate column to an aggregate query
+    // changes the GROUP BY and silently corrupts the result. Better to let
+    // Sentry's 400 propagate so the caller can fix the request explicitly.
     const sortField = sortParam.startsWith("-")
       ? sortParam.slice(1)
       : sortParam;
-    if (sortField && !fields.includes(sortField)) {
+    const sortIsAggregate = sortField.includes("(") && sortField.includes(")");
+    if (
+      sortField &&
+      !fields.includes(sortField) &&
+      (sortIsAggregate || !isAggregateQuery(fields))
+    ) {
       fields = [...fields, sortField];
     }
 


### PR DESCRIPTION
## Summary

- `search_events` was occasionally sending Sentry a `sort=<col>` without `<col>` in `field=...`, producing a 400 "Cannot sort by a field that is not selected." 

- Adds a regression test that reproduces the failure (committed first, with the fix in the following commit).

Fixes BROWSE-526