### PR TITLE
fix(tools): Soften result steering language

### DIFF
--- a/docs/adding-tools.md
+++ b/docs/adding-tools.md
@@ -149,9 +149,9 @@ async handler(params, context: ServerContext) {
   // 6. Format data
   output += formatYourData(data);
 
-  // 7. Add next steps
-  output += "\n\n# Using this information\n\n";
-  output += "- Next tool to use: `related_tool(param='...')`\n";
+  // 7. Add response notes
+  output += "\n\n## Response Notes\n\n";
+  output += "- Please tell the user the resource ID.\n";
 
   return output;
 }
@@ -162,7 +162,7 @@ async handler(params, context: ServerContext) {
 See [common-patterns.md](common-patterns.md#response-formatting) for:
 - Markdown structure
 - ID/URL formatting
-- Next steps guidance
+- Response notes guidance
 
 ## Step 3: Add Tests
 

--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -49,6 +49,16 @@ export type ToolParams<T> = z.infer<typeof toolDefinitions[T].parameters>;
 
 ## Response Formatting
 
+Tool descriptions and parameter `.describe()` text are trusted steering surfaces. It is fine for those descriptions to tell the model when to call a tool, which parameters to preserve, or what follow-up behavior is expected.
+
+Tool result text can include light, scoped steering when it helps the assistant present or use the result correctly. MCP clients still treat result text like external data, so keep this steering narrow:
+
+- OK: `Please tell the user the DSN.`
+- OK: `**Suggested presentation:** A compact table works well for these aggregate results.`
+- OK: `**Dashboard URL:** https://example.sentry.io/issues/`
+- Avoid: `IMPORTANT`, `MUST`, `CRITICAL`, `Display these...`, or `# Using this information` in handler output.
+- Avoid: instructions that override assistant behavior beyond this result.
+
 ### Markdown Structure
 
 ```typescript
@@ -64,9 +74,10 @@ if (data.length === 0) {
 output += "## Section\n";
 output += formatData(data);
 
-// Add usage instructions
-output += "\n\n# Using this information\n\n";
-output += "- Next steps...\n";
+// Add response notes
+output += "\n\n## Response Notes\n\n";
+output += "- Please tell the user the project slug.\n";
+output += "- Dashboard URL: https://example.sentry.io/issues/\n";
 ```
 
 ### Multi-Content Resources

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -1934,18 +1934,18 @@ export function formatIssueOutput({
       ? event.contexts.trace.trace_id
       : undefined;
 
-  output += "# Using this information\n\n";
-  output += `- You can reference the IssueID in commit messages (e.g. \`Fixes ${issue.shortId}\`) to automatically close the issue when the commit is merged.\n`;
+  output += "## Response Notes\n\n";
+  output += `- Commit message issue reference: \`Fixes ${issue.shortId}\` automatically closes the issue when the commit is merged.\n`;
   output +=
-    "- The stacktrace includes both first-party application code as well as third-party code, its important to triage to first-party code.\n";
-  output += `- To search for specific occurrences or filter events within this issue, use \`search_issue_events(organizationSlug='${organizationSlug}', issueId='${issue.shortId}', query='your query')\`\n`;
+    "- The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.\n";
+  output += `- Issue event search: \`search_issue_events(organizationSlug='${organizationSlug}', issueId='${issue.shortId}', query='your query')\`\n`;
   if (traceId) {
-    output += `- To inspect the full distributed trace and span tree for this event, use \`get_sentry_resource(resourceType='trace', organizationSlug='${organizationSlug}', resourceId='${traceId}')\`\n`;
-    output += `- To search related spans, use \`search_events(organizationSlug='${organizationSlug}', dataset='spans', query='trace:${traceId}')\`\n`;
-    output += `- To search related logs, use \`search_events(organizationSlug='${organizationSlug}', dataset='logs', query='trace:${traceId}')\`\n`;
+    output += `- Full distributed trace and span tree: \`get_sentry_resource(resourceType='trace', organizationSlug='${organizationSlug}', resourceId='${traceId}')\`\n`;
+    output += `- Related span search: \`search_events(organizationSlug='${organizationSlug}', dataset='spans', query='trace:${traceId}')\`\n`;
+    output += `- Related log search: \`search_events(organizationSlug='${organizationSlug}', dataset='logs', query='trace:${traceId}')\`\n`;
   }
   if (experimentalMode) {
-    output += `- To see the trail of events leading up to this error, use \`get_sentry_resource(url='${apiService.getIssueUrl(organizationSlug, issue.shortId)}', resourceType='breadcrumbs')\`\n`;
+    output += `- Breadcrumb trail leading up to this error: \`get_sentry_resource(url='${apiService.getIssueUrl(organizationSlug, issue.shortId)}', resourceType='breadcrumbs')\`\n`;
   }
   return output;
 }

--- a/packages/mcp-core/src/tools/create-dsn.test.ts
+++ b/packages/mcp-core/src/tools/create-dsn.test.ts
@@ -25,9 +25,10 @@ describe("create_dsn", () => {
       **DSN**: https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945
       **Name**: Default
 
-      # Using this information
+      ## Response Notes
 
-      - The \`SENTRY_DSN\` value is a URL that you can use to initialize Sentry's SDKs.
+      - Please tell the user the DSN.
+      - The \`SENTRY_DSN\` value is a URL used to initialize Sentry SDKs.
       "
     `);
   });

--- a/packages/mcp-core/src/tools/create-dsn.ts
+++ b/packages/mcp-core/src/tools/create-dsn.ts
@@ -68,9 +68,10 @@ export default defineTool({
     let output = `# New DSN in **${organizationSlug}/${params.projectSlug}**\n\n`;
     output += `**DSN**: ${clientKey.dsn.public}\n`;
     output += `**Name**: ${clientKey.name}\n\n`;
-    output += "# Using this information\n\n";
+    output += "## Response Notes\n\n";
+    output += "- Please tell the user the DSN.\n";
     output +=
-      "- The `SENTRY_DSN` value is a URL that you can use to initialize Sentry's SDKs.\n";
+      "- The `SENTRY_DSN` value is a URL used to initialize Sentry SDKs.\n";
     return output;
   },
 });

--- a/packages/mcp-core/src/tools/create-project.test.ts
+++ b/packages/mcp-core/src/tools/create-project.test.ts
@@ -27,10 +27,10 @@ describe("create_project", () => {
       **Name**: cloudflare-mcp
       **SENTRY_DSN**: https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the **SENTRY_DSN** value to initialize Sentry's SDKs.
-      - You should always inform the user of the **SENTRY_DSN** and Project Slug values.
+      - Please tell the user the project slug and **SENTRY_DSN**.
+      - The **SENTRY_DSN** value is used to initialize Sentry SDKs.
       "
     `);
   });

--- a/packages/mcp-core/src/tools/create-project.ts
+++ b/packages/mcp-core/src/tools/create-project.ts
@@ -92,9 +92,9 @@ export default defineTool({
     } else {
       output += "**SENTRY_DSN**: There was an error fetching this value.\n\n";
     }
-    output += "# Using this information\n\n";
-    output += `- You can reference the **SENTRY_DSN** value to initialize Sentry's SDKs.\n`;
-    output += `- You should always inform the user of the **SENTRY_DSN** and Project Slug values.\n`;
+    output += "## Response Notes\n\n";
+    output += `- Please tell the user the project slug and **SENTRY_DSN**.\n`;
+    output += `- The **SENTRY_DSN** value is used to initialize Sentry SDKs.\n`;
     return output;
   },
 });

--- a/packages/mcp-core/src/tools/create-team.test.ts
+++ b/packages/mcp-core/src/tools/create-team.test.ts
@@ -23,9 +23,10 @@ describe("create_team", () => {
       **ID**: 4509109078196224
       **Slug**: the-goats
       **Name**: the-goats
-      # Using this information
 
-      - You should always inform the user of the Team Slug value.
+      ## Response Notes
+
+      - Please tell the user the team slug.
       "
     `);
   });

--- a/packages/mcp-core/src/tools/create-team.ts
+++ b/packages/mcp-core/src/tools/create-team.ts
@@ -56,8 +56,8 @@ export default defineTool({
     output += `**ID**: ${team.id}\n`;
     output += `**Slug**: ${team.slug}\n`;
     output += `**Name**: ${team.name}\n`;
-    output += "# Using this information\n\n";
-    output += `- You should always inform the user of the Team Slug value.\n`;
+    output += "\n## Response Notes\n\n";
+    output += `- Please tell the user the team slug.\n`;
     return output;
   },
 });

--- a/packages/mcp-core/src/tools/find-dsns.test.ts
+++ b/packages/mcp-core/src/tools/find-dsns.test.ts
@@ -25,9 +25,10 @@ describe("find_dsns", () => {
       **ID**: d20df0a1ab5031c7f3c7edca9c02814d
       **DSN**: https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945
 
-      # Using this information
+      ## Response Notes
 
-      - The \`SENTRY_DSN\` value is a URL that you can use to initialize Sentry's SDKs.
+      - Please tell the user the DSN.
+      - The \`SENTRY_DSN\` value is a URL used to initialize Sentry SDKs.
       "
     `);
   });

--- a/packages/mcp-core/src/tools/find-dsns.ts
+++ b/packages/mcp-core/src/tools/find-dsns.ts
@@ -56,9 +56,10 @@ export default defineTool({
       output += `**ID**: ${clientKey.id}\n`;
       output += `**DSN**: ${clientKey.dsn.public}\n\n`;
     }
-    output += "# Using this information\n\n";
+    output += "## Response Notes\n\n";
+    output += "- Please tell the user the DSN.\n";
     output +=
-      "- The `SENTRY_DSN` value is a URL that you can use to initialize Sentry's SDKs.\n";
+      "- The `SENTRY_DSN` value is a URL used to initialize Sentry SDKs.\n";
     return output;
   },
 });

--- a/packages/mcp-core/src/tools/find-organizations.test.ts
+++ b/packages/mcp-core/src/tools/find-organizations.test.ts
@@ -21,11 +21,10 @@ describe("find_organizations", () => {
       **Web URL:** https://sentry.io/sentry-mcp-evals
       **Region URL:** https://us.sentry.io
 
-      # Using this information
+      ## Response Notes
 
-      - The organization's name is the identifier for the organization, and is used in many tools for \`organizationSlug\`.
-      - If a tool supports passing in the \`regionUrl\`, you MUST pass in the correct value shown above for each organization.
-      - For Sentry's Cloud Service (sentry.io), always use the regionUrl to ensure requests go to the correct region.
+      - The organization slug is used as \`organizationSlug\` in other tools.
+      - The Region URL shown above is the \`regionUrl\` value for later tools that accept it. This keeps Sentry Cloud requests on the correct region.
       "
     `);
   });

--- a/packages/mcp-core/src/tools/find-organizations.ts
+++ b/packages/mcp-core/src/tools/find-organizations.ts
@@ -63,19 +63,17 @@ export default defineTool({
       output += `\n\n---\n\n**Note:** Showing ${RESULT_LIMIT} results (maximum). There may be more organizations available. Use the \`query\` parameter to search for specific organizations.`;
     }
 
-    output += "\n\n# Using this information\n\n";
-    output += `- The organization's name is the identifier for the organization, and is used in many tools for \`organizationSlug\`.\n`;
+    output += "\n\n## Response Notes\n\n";
+    output += `- The organization slug is used as \`organizationSlug\` in other tools.\n`;
 
     const hasValidRegionUrls = organizations.some((org) =>
       org.links?.regionUrl?.trim(),
     );
 
     if (hasValidRegionUrls) {
-      output += `- If a tool supports passing in the \`regionUrl\`, you MUST pass in the correct value shown above for each organization.\n`;
-      output += `- For Sentry's Cloud Service (sentry.io), always use the regionUrl to ensure requests go to the correct region.\n`;
+      output += `- The Region URL shown above is the \`regionUrl\` value for later tools that accept it. This keeps Sentry Cloud requests on the correct region.\n`;
     } else {
-      output += `- This appears to be a self-hosted Sentry installation. You can omit the \`regionUrl\` parameter when using other tools.\n`;
-      output += `- For self-hosted Sentry, the regionUrl is typically empty and not needed for API calls.\n`;
+      output += `- This appears to be a self-hosted Sentry installation. The \`regionUrl\` parameter can be omitted in other tools.\n`;
     }
 
     return output;

--- a/packages/mcp-core/src/tools/find-releases.test.ts
+++ b/packages/mcp-core/src/tools/find-releases.test.ts
@@ -29,10 +29,10 @@ describe("find_releases", () => {
       **New Issues**: 0
       **Projects**: cloudflare-mcp
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the Release version in commit messages or documentation.
-      - You can search for issues in a specific release using the \`find_errors()\` tool with the query \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
+      - Release versions can be referenced in commit messages or documentation.
+      - Release filter syntax for issue searches: \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
       "
     `);
   });
@@ -64,10 +64,10 @@ describe("find_releases", () => {
       **New Issues**: 0
       **Projects**: cloudflare-mcp
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the Release version in commit messages or documentation.
-      - You can search for issues in a specific release using the \`find_errors()\` tool with the query \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
+      - Release versions can be referenced in commit messages or documentation.
+      - Release filter syntax for issue searches: \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
       "
     `);
   });

--- a/packages/mcp-core/src/tools/find-releases.ts
+++ b/packages/mcp-core/src/tools/find-releases.ts
@@ -138,9 +138,10 @@ export default defineTool({
       })
       .join("\n\n");
     output += "\n\n";
-    output += "# Using this information\n\n";
-    output += `- You can reference the Release version in commit messages or documentation.\n`;
-    output += `- You can search for issues in a specific release using the \`find_errors()\` tool with the query \`release:${releases.length ? releases[0]!.shortVersion : "VERSION"}\`.\n`;
+    output += "## Response Notes\n\n";
+    output +=
+      "- Release versions can be referenced in commit messages or documentation.\n";
+    output += `- Release filter syntax for issue searches: \`release:${releases.length ? releases[0]!.shortVersion : "VERSION"}\`.\n`;
     return output;
   },
 });

--- a/packages/mcp-core/src/tools/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-details.test.ts
@@ -253,14 +253,14 @@ describe("get_issue_details", () => {
       client_sample_rate: 1
       sampled: true
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the IssueID in commit messages (e.g. \`Fixes CLOUDFLARE-MCP-41\`) to automatically close the issue when the commit is merged.
-      - The stacktrace includes both first-party application code as well as third-party code, its important to triage to first-party code.
-      - To search for specific occurrences or filter events within this issue, use \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', query='your query')\`
-      - To inspect the full distributed trace and span tree for this event, use \`get_sentry_resource(resourceType='trace', organizationSlug='sentry-mcp-evals', resourceId='3032af8bcdfe4423b937fc5c041d5d82')\`
-      - To search related spans, use \`search_events(organizationSlug='sentry-mcp-evals', dataset='spans', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
-      - To search related logs, use \`search_events(organizationSlug='sentry-mcp-evals', dataset='logs', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Commit message issue reference: \`Fixes CLOUDFLARE-MCP-41\` automatically closes the issue when the commit is merged.
+      - The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.
+      - Issue event search: \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', query='your query')\`
+      - Full distributed trace and span tree: \`get_sentry_resource(resourceType='trace', organizationSlug='sentry-mcp-evals', resourceId='3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Related span search: \`search_events(organizationSlug='sentry-mcp-evals', dataset='spans', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Related log search: \`search_events(organizationSlug='sentry-mcp-evals', dataset='logs', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
       "
     `);
   });
@@ -512,14 +512,14 @@ describe("get_issue_details", () => {
       client_sample_rate: 1
       sampled: true
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the IssueID in commit messages (e.g. \`Fixes CLOUDFLARE-MCP-41\`) to automatically close the issue when the commit is merged.
-      - The stacktrace includes both first-party application code as well as third-party code, its important to triage to first-party code.
-      - To search for specific occurrences or filter events within this issue, use \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', query='your query')\`
-      - To inspect the full distributed trace and span tree for this event, use \`get_sentry_resource(resourceType='trace', organizationSlug='sentry-mcp-evals', resourceId='3032af8bcdfe4423b937fc5c041d5d82')\`
-      - To search related spans, use \`search_events(organizationSlug='sentry-mcp-evals', dataset='spans', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
-      - To search related logs, use \`search_events(organizationSlug='sentry-mcp-evals', dataset='logs', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Commit message issue reference: \`Fixes CLOUDFLARE-MCP-41\` automatically closes the issue when the commit is merged.
+      - The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.
+      - Issue event search: \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', query='your query')\`
+      - Full distributed trace and span tree: \`get_sentry_resource(resourceType='trace', organizationSlug='sentry-mcp-evals', resourceId='3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Related span search: \`search_events(organizationSlug='sentry-mcp-evals', dataset='spans', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Related log search: \`search_events(organizationSlug='sentry-mcp-evals', dataset='logs', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
       "
     `);
   });
@@ -797,14 +797,14 @@ describe("get_issue_details", () => {
       client_sample_rate: 1
       sampled: true
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the IssueID in commit messages (e.g. \`Fixes CLOUDFLARE-MCP-41\`) to automatically close the issue when the commit is merged.
-      - The stacktrace includes both first-party application code as well as third-party code, its important to triage to first-party code.
-      - To search for specific occurrences or filter events within this issue, use \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', query='your query')\`
-      - To inspect the full distributed trace and span tree for this event, use \`get_sentry_resource(resourceType='trace', organizationSlug='sentry-mcp-evals', resourceId='3032af8bcdfe4423b937fc5c041d5d82')\`
-      - To search related spans, use \`search_events(organizationSlug='sentry-mcp-evals', dataset='spans', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
-      - To search related logs, use \`search_events(organizationSlug='sentry-mcp-evals', dataset='logs', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Commit message issue reference: \`Fixes CLOUDFLARE-MCP-41\` automatically closes the issue when the commit is merged.
+      - The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.
+      - Issue event search: \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='CLOUDFLARE-MCP-41', query='your query')\`
+      - Full distributed trace and span tree: \`get_sentry_resource(resourceType='trace', organizationSlug='sentry-mcp-evals', resourceId='3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Related span search: \`search_events(organizationSlug='sentry-mcp-evals', dataset='spans', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
+      - Related log search: \`search_events(organizationSlug='sentry-mcp-evals', dataset='logs', query='trace:3032af8bcdfe4423b937fc5c041d5d82')\`
       "
     `);
   });
@@ -1440,11 +1440,11 @@ describe("get_issue_details", () => {
       **level**: info
       **transaction**: POST /oauth/token
 
-      # Using this information
+      ## Response Notes
 
-      - You can reference the IssueID in commit messages (e.g. \`Fixes MCP-SERVER-EQE\`) to automatically close the issue when the commit is merged.
-      - The stacktrace includes both first-party application code as well as third-party code, its important to triage to first-party code.
-      - To search for specific occurrences or filter events within this issue, use \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='MCP-SERVER-EQE', query='your query')\`
+      - Commit message issue reference: \`Fixes MCP-SERVER-EQE\` automatically closes the issue when the commit is merged.
+      - The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.
+      - Issue event search: \`search_issue_events(organizationSlug='sentry-mcp-evals', issueId='MCP-SERVER-EQE', query='your query')\`
       "
     `);
   });

--- a/packages/mcp-core/src/tools/get-issue-tag-values.test.ts
+++ b/packages/mcp-core/src/tools/get-issue-tag-values.test.ts
@@ -36,10 +36,10 @@ describe("get_issue_tag_values", () => {
 
       *Showing top 5 of 156 unique values*
 
-      ## Using this information
+      ## Response Notes
 
-      - Use \`get_sentry_resource(resourceType='issue', organizationSlug='sentry-mcp-evals', resourceId='CLOUDFLARE-MCP-41')\` to see the full issue details
-      - Try other tag keys like: url, browser, environment, release, os, device, user
+      - Full issue details: \`get_sentry_resource(resourceType='issue', organizationSlug='sentry-mcp-evals', resourceId='CLOUDFLARE-MCP-41')\`
+      - Other common tag keys: url, browser, environment, release, os, device, user
       "
     `);
   });

--- a/packages/mcp-core/src/tools/get-issue-tag-values.ts
+++ b/packages/mcp-core/src/tools/get-issue-tag-values.ts
@@ -183,10 +183,10 @@ export default defineTool({
       output += `\n*Showing top ${shownCount} of ${tagValues.totalValues} unique values*\n`;
     }
 
-    // Add usage hints
-    output += "\n## Using this information\n\n";
-    output += `- Use \`get_sentry_resource(resourceType='issue', organizationSlug='${orgSlug}', resourceId='${parsedIssueId}')\` to see the full issue details\n`;
-    output += `- Try other tag keys like: url, browser, environment, release, os, device, user\n`;
+    // Add lightweight follow-up hints
+    output += "\n## Response Notes\n\n";
+    output += `- Full issue details: \`get_sentry_resource(resourceType='issue', organizationSlug='${orgSlug}', resourceId='${parsedIssueId}')\`\n`;
+    output += `- Other common tag keys: url, browser, environment, release, os, device, user\n`;
 
     return output;
   },

--- a/packages/mcp-core/src/tools/search-events.test.ts
+++ b/packages/mcp-core/src/tools/search-events.test.ts
@@ -903,7 +903,7 @@ describe("search_events", () => {
     expect(result).toMatchInlineSnapshot(`
       "# Search Results for "slow request duration metrics"
 
-      ⚠️ **IMPORTANT**: Display these metric aggregates as a data table with proper column alignment, grouping labels, and units.
+      **Suggested presentation:** A compact table with grouping labels and units works well for these metric aggregates.
 
       ## Executed Search
       - Dataset: \`metrics\`
@@ -914,7 +914,7 @@ describe("search_events", () => {
 
       **View these results in Sentry**:
       https://test-org.sentry.io/explore/metrics/?statsPeriod=14d&metric=%7B%22metric%22%3A%7B%22name%22%3A%22http.request.duration%22%2C%22type%22%3A%22distribution%22%2C%22unit%22%3A%22millisecond%22%7D%2C%22query%22%3A%22%22%2C%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22p95%28value%2Chttp.request.duration%2Cdistribution%2Cmillisecond%29%22%5D%7D%2C%7B%22yAxes%22%3A%5B%22count%28value%2Chttp.request.duration%2Cdistribution%2Cmillisecond%29%22%5D%7D%2C%7B%22groupBy%22%3A%22transaction%22%7D%5D%2C%22aggregateSortBys%22%3A%5B%7B%22field%22%3A%22p95%28value%2Chttp.request.duration%2Cdistribution%2Cmillisecond%29%22%2C%22kind%22%3A%22desc%22%7D%5D%2C%22mode%22%3A%22aggregate%22%7D
-      _Please share this link with the user to view the search results in their Sentry dashboard._
+      Please tell the user this dashboard link is available if they want to open the results in Sentry.
 
       Found 1 aggregate result:
 

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -86,6 +86,14 @@ export function formatExecutedSearch(executedSearch?: ExecutedSearch): string {
   return `${lines.join("\n")}\n\n`;
 }
 
+function formatSearchPresentationHint(hint: string): string {
+  return `**Suggested presentation:** ${hint}\n\n`;
+}
+
+function formatSentryDashboardLink(url: string): string {
+  return `**View these results in Sentry**:\n${url}\nPlease tell the user this dashboard link is available if they want to open the results in Sentry.\n\n`;
+}
+
 /**
  * Common parameters for event formatters
  */
@@ -144,9 +152,13 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
 
   // Check if this is an aggregate query and adjust display instructions
   if (isAggregateQuery(fields)) {
-    output += `⚠️ **IMPORTANT**: Display these aggregate results as a data table with proper column alignment and formatting.\n\n`;
+    output += formatSearchPresentationHint(
+      "A compact table works well for these aggregate results.",
+    );
   } else {
-    output += `⚠️ **IMPORTANT**: Display these errors as highlighted alert cards with color-coded severity levels and clickable Event IDs.\n\n`;
+    output += formatSearchPresentationHint(
+      "Useful details to surface include severity, event IDs, and links.",
+    );
   }
 
   if (includeExplanation && explanation) {
@@ -156,8 +168,7 @@ export function formatErrorResults(params: FormatEventResultsParams): string {
 
   output += formatExecutedSearch(params.executedSearch);
 
-  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
-  output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
+  output += formatSentryDashboardLink(explorerUrl);
 
   if (eventData.length === 0) {
     logInfo(`No error events found for query: ${inputQuery}`, {
@@ -279,9 +290,13 @@ export function formatLogResults(params: FormatEventResultsParams): string {
 
   // Check if this is an aggregate query and adjust display instructions
   if (isAggregateQuery(fields)) {
-    output += `⚠️ **IMPORTANT**: Display these aggregate results as a data table with proper column alignment and formatting.\n\n`;
+    output += formatSearchPresentationHint(
+      "A compact table works well for these aggregate results.",
+    );
   } else {
-    output += `⚠️ **IMPORTANT**: Display these logs in console format with monospace font, color-coded severity (🔴 ERROR, 🟡 WARN, 🔵 INFO), and preserve timestamps.\n\n`;
+    output += formatSearchPresentationHint(
+      "Console-style formatting works well for these logs, with timestamps preserved.",
+    );
   }
 
   if (includeExplanation && explanation) {
@@ -291,8 +306,7 @@ export function formatLogResults(params: FormatEventResultsParams): string {
 
   output += formatExecutedSearch(params.executedSearch);
 
-  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
-  output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
+  output += formatSentryDashboardLink(explorerUrl);
 
   if (eventData.length === 0) {
     logInfo(`No log events found for query: ${inputQuery}`, {
@@ -437,9 +451,13 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
 
   // Check if this is an aggregate query and adjust display instructions
   if (isAggregateQuery(fields)) {
-    output += `⚠️ **IMPORTANT**: Display these aggregate results as a data table with proper column alignment and formatting.\n\n`;
+    output += formatSearchPresentationHint(
+      "A compact table works well for these aggregate results.",
+    );
   } else {
-    output += `⚠️ **IMPORTANT**: Display these traces as a performance timeline with duration bars and hierarchical span relationships.\n\n`;
+    output += formatSearchPresentationHint(
+      "A timeline works well for these traces, with durations and parent-child span relationships visible.",
+    );
   }
 
   if (includeExplanation && explanation) {
@@ -449,8 +467,7 @@ export function formatSpanResults(params: FormatEventResultsParams): string {
 
   output += formatExecutedSearch(params.executedSearch);
 
-  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
-  output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
+  output += formatSentryDashboardLink(explorerUrl);
 
   if (eventData.length === 0) {
     logInfo(`No span events found for query: ${inputQuery}`, {
@@ -625,9 +642,13 @@ export function formatProfileResults(params: FormatEventResultsParams): string {
   let output = `# Search Results for "${inputQuery}"\n\n`;
 
   if (isAggregateQuery(fields)) {
-    output += `⚠️ **IMPORTANT**: Display these profile aggregates as a data table with proper column alignment and readable duration units.\n\n`;
+    output += formatSearchPresentationHint(
+      "A compact table with readable duration units works well for these profile aggregates.",
+    );
   } else {
-    output += `⚠️ **IMPORTANT**: Display these profiles as concise cards, highlighting the profile identifier, transaction, duration, release, and trace context.\n\n`;
+    output += formatSearchPresentationHint(
+      "Concise summaries work well for these profiles, highlighting profile ID, transaction, duration, release, and trace context.",
+    );
   }
 
   if (includeExplanation && explanation) {
@@ -637,8 +658,7 @@ export function formatProfileResults(params: FormatEventResultsParams): string {
 
   output += formatExecutedSearch(params.executedSearch);
 
-  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
-  output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
+  output += formatSentryDashboardLink(explorerUrl);
 
   if (eventData.length === 0) {
     logInfo(`No profile events found for query: ${inputQuery}`, {
@@ -771,9 +791,13 @@ export function formatTraceMetricsResults(
   let output = `# Search Results for "${inputQuery}"\n\n`;
 
   if (isAggregateQuery(fields)) {
-    output += `⚠️ **IMPORTANT**: Display these metric aggregates as a data table with proper column alignment, grouping labels, and units.\n\n`;
+    output += formatSearchPresentationHint(
+      "A compact table with grouping labels and units works well for these metric aggregates.",
+    );
   } else {
-    output += `⚠️ **IMPORTANT**: Display these as metric samples, highlighting the metric name, type, value, and trace context.\n\n`;
+    output += formatSearchPresentationHint(
+      "Concise summaries work well for these metric samples, highlighting metric name, type, value, and trace context.",
+    );
   }
 
   if (includeExplanation && explanation) {
@@ -783,8 +807,7 @@ export function formatTraceMetricsResults(
 
   output += formatExecutedSearch(params.executedSearch);
 
-  output += `**View these results in Sentry**:\n${explorerUrl}\n`;
-  output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
+  output += formatSentryDashboardLink(explorerUrl);
 
   if (eventData.length === 0) {
     logInfo(`No trace metric events found for query: ${inputQuery}`, {

--- a/packages/mcp-core/src/tools/search-events/formatters.ts
+++ b/packages/mcp-core/src/tools/search-events/formatters.ts
@@ -86,11 +86,11 @@ export function formatExecutedSearch(executedSearch?: ExecutedSearch): string {
   return `${lines.join("\n")}\n\n`;
 }
 
-function formatSearchPresentationHint(hint: string): string {
+export function formatSearchPresentationHint(hint: string): string {
   return `**Suggested presentation:** ${hint}\n\n`;
 }
 
-function formatSentryDashboardLink(url: string): string {
+export function formatSentryDashboardLink(url: string): string {
   return `**View these results in Sentry**:\n${url}\nPlease tell the user this dashboard link is available if they want to open the results in Sentry.\n\n`;
 }
 

--- a/packages/mcp-core/src/tools/search-events/replays.ts
+++ b/packages/mcp-core/src/tools/search-events/replays.ts
@@ -81,7 +81,7 @@ export function formatReplayResults(params: FormatReplayResultsParams): string {
 
   let output = `# Search Results for "${inputQuery}"\n\n`;
   output +=
-    "⚠️ **IMPORTANT**: Display these replays as cards or rows with clickable Replay IDs, user context, duration, click/error counts, and page URLs.\n\n";
+    "**Suggested presentation:** Cards or rows work well for these replays, with replay IDs, user context, duration, click/error counts, and page URLs visible.\n\n";
 
   if (includeExplanation) {
     output += "## Query Translation\n";
@@ -102,7 +102,7 @@ export function formatReplayResults(params: FormatReplayResultsParams): string {
 
   output += `**View these results in Sentry**:\n${searchUrl}\n`;
   output +=
-    "_Please share this link with the user to view the search results in their Sentry dashboard._\n\n";
+    "Please tell the user this dashboard link is available if they want to open the results in Sentry.\n\n";
 
   if (replays.length === 0) {
     output += "No replays found matching your search criteria.\n\n";

--- a/packages/mcp-core/src/tools/search-events/replays.ts
+++ b/packages/mcp-core/src/tools/search-events/replays.ts
@@ -1,5 +1,10 @@
 import type { ReplayDetails, SentryApiService } from "../../api-client";
-import { formatExecutedSearch, type ExecutedSearch } from "./formatters";
+import {
+  type ExecutedSearch,
+  formatExecutedSearch,
+  formatSearchPresentationHint,
+  formatSentryDashboardLink,
+} from "./formatters";
 
 export const DEFAULT_REPLAY_SORT = "-started_at";
 export const DEFAULT_REPLAY_STATS_PERIOD = "14d";
@@ -80,8 +85,9 @@ export function formatReplayResults(params: FormatReplayResultsParams): string {
   } = params;
 
   let output = `# Search Results for "${inputQuery}"\n\n`;
-  output +=
-    "**Suggested presentation:** Cards or rows work well for these replays, with replay IDs, user context, duration, click/error counts, and page URLs visible.\n\n";
+  output += formatSearchPresentationHint(
+    "Cards or rows work well for these replays, with replay IDs, user context, duration, click/error counts, and page URLs visible.",
+  );
 
   if (includeExplanation) {
     output += "## Query Translation\n";
@@ -100,9 +106,7 @@ export function formatReplayResults(params: FormatReplayResultsParams): string {
 
   output += formatExecutedSearch(params.executedSearch);
 
-  output += `**View these results in Sentry**:\n${searchUrl}\n`;
-  output +=
-    "Please tell the user this dashboard link is available if they want to open the results in Sentry.\n\n";
+  output += formatSentryDashboardLink(searchUrl);
 
   if (replays.length === 0) {
     output += "No replays found matching your search criteria.\n\n";

--- a/packages/mcp-core/src/tools/search-issues/formatters.test.ts
+++ b/packages/mcp-core/src/tools/search-issues/formatters.test.ts
@@ -244,11 +244,11 @@ describe("formatIssueResults", () => {
       expect(result).toMatchInlineSnapshot(`
         "# Search Results for "show me user feedback"
 
-        ⚠️ **IMPORTANT**: Display these issues as highlighted cards with status indicators, assignee info, and clickable Issue IDs.
+        **Suggested presentation:** Cards work well for these issues, with status, assignee, and issue ID links visible.
 
         **View these results in Sentry**:
         https://test-org.sentry.io/issues/
-        _Please share this link with the user to view the search results in their Sentry dashboard._
+        Please tell the user this dashboard link is available if they want to open the results in Sentry.
 
         Found **1** issue:
 

--- a/packages/mcp-core/src/tools/search-issues/formatters.ts
+++ b/packages/mcp-core/src/tools/search-issues/formatters.ts
@@ -60,8 +60,8 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
       output += "**\n\n";
     }
 
-    // Add display instructions for UI
-    output += `⚠️ **IMPORTANT**: Display these issues as highlighted cards with status indicators, assignee info, and clickable Issue IDs.\n\n`;
+    // Add lightweight presentation guidance for clients that can render rich results.
+    output += `**Suggested presentation:** Cards work well for these issues, with status, assignee, and issue ID links visible.\n\n`;
   }
 
   if (issues.length === 0) {
@@ -87,9 +87,9 @@ export function formatIssueResults(params: FormatIssueResultsParams): string {
     resolvedProtocol,
   );
 
-  // Add view link with emoji and guidance text (like search_events)
+  // Add view link with lightweight guidance text (like search_events)
   output += `**View these results in Sentry**:\n${searchUrl}\n`;
-  output += `_Please share this link with the user to view the search results in their Sentry dashboard._\n\n`;
+  output += `Please tell the user this dashboard link is available if they want to open the results in Sentry.\n\n`;
 
   output += `Found **${issues.length}** issue${issues.length === 1 ? "" : "s"}:\n\n`;
 

--- a/packages/mcp-core/src/tools/search-issues/handler.ts
+++ b/packages/mcp-core/src/tools/search-issues/handler.ts
@@ -171,7 +171,7 @@ export default defineTool({
 
     if (params.includeExplanation && explanation) {
       output += `# Search Results for "${params.query}"\n\n`;
-      output += `⚠️ **IMPORTANT**: Display these issues as highlighted cards with status indicators, assignee info, and clickable Issue IDs.\n\n`;
+      output += `**Suggested presentation:** Cards work well for these issues, with status, assignee, and issue ID links visible.\n\n`;
 
       output += `## Query Translation\n`;
       output += `Input query: "${params.query}"\n`;

--- a/packages/mcp-core/src/tools/update-issue.test.ts
+++ b/packages/mcp-core/src/tools/update-issue.test.ts
@@ -52,10 +52,10 @@ describe("update_issue", () => {
       **Status**: resolved
       **Assigned To**: Jane Developer
 
-      # Using this information
+      ## Response Notes
 
-      - The issue has been successfully updated in Sentry
-      - You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
+      - The issue has been updated in Sentry.
+      - Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
       - The issue is now marked as resolved and will no longer generate alerts
       "
     `);
@@ -88,10 +88,10 @@ describe("update_issue", () => {
       **Status**: unresolved
       **Assigned To**: john.doe
 
-      # Using this information
+      ## Response Notes
 
-      - The issue has been successfully updated in Sentry
-      - You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
+      - The issue has been updated in Sentry.
+      - Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
       "
     `);
   });
@@ -197,10 +197,10 @@ describe("update_issue", () => {
       **Status**: resolved
       **Assigned To**: me
 
-      # Using this information
+      ## Response Notes
 
-      - The issue has been successfully updated in Sentry
-      - You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
+      - The issue has been updated in Sentry.
+      - Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
       - The issue is now marked as resolved and will no longer generate alerts
       "
     `);
@@ -335,10 +335,10 @@ describe("update_issue", () => {
       **Ignore Behavior**: Until escalating
       **Assigned To**: Jane Developer
 
-      # Using this information
+      ## Response Notes
 
-      - The issue has been successfully updated in Sentry
-      - You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
+      - The issue has been updated in Sentry.
+      - Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
       - The issue is now ignored until it escalates
       "
     `);
@@ -393,10 +393,10 @@ describe("update_issue", () => {
       **Ignore Behavior**: Until it occurs 100 times in 60 minutes
       **Assigned To**: Jane Developer
 
-      # Using this information
+      ## Response Notes
 
-      - The issue has been successfully updated in Sentry
-      - You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
+      - The issue has been updated in Sentry.
+      - Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="sentry-mcp-evals", resourceId="CLOUDFLARE-MCP-41")\`
       - The issue is now ignored until it occurs 100 times in 60 minutes
       "
     `);

--- a/packages/mcp-core/src/tools/update-issue.ts
+++ b/packages/mcp-core/src/tools/update-issue.ts
@@ -330,9 +330,9 @@ function buildNoChangesOutput(params: {
   }
   output += `**Assigned To**: ${formatAssignedTo(issue.assignedTo ?? null)}\n`;
 
-  output += "\n# Using this information\n\n";
-  output += "- The issue already matched the requested state\n";
-  output += `- You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="${organizationSlug}", resourceId="${issue.shortId}")\`\n`;
+  output += "\n## Response Notes\n\n";
+  output += "- The issue already matched the requested state.\n";
+  output += `- Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="${organizationSlug}", resourceId="${issue.shortId}")\`\n`;
 
   return output;
 }
@@ -851,9 +851,9 @@ export default defineTool({
     const currentAssignee = formatAssignedTo(updatedIssue.assignedTo ?? null);
     output += `**Assigned To**: ${currentAssignee}\n`;
 
-    output += "\n# Using this information\n\n";
-    output += `- The issue has been successfully updated in Sentry\n`;
-    output += `- You can view the issue details using: \`get_sentry_resource(resourceType="issue", organizationSlug="${orgSlug}", resourceId="${updatedIssue.shortId}")\`\n`;
+    output += "\n## Response Notes\n\n";
+    output += `- The issue has been updated in Sentry.\n`;
+    output += `- Full issue details: \`get_sentry_resource(resourceType="issue", organizationSlug="${orgSlug}", resourceId="${updatedIssue.shortId}")\`\n`;
 
     if (statusChanged && updatedStatusDisplay === "resolved") {
       output += `- The issue is now marked as resolved and will no longer generate alerts\n`;

--- a/packages/mcp-core/src/tools/update-project.test.ts
+++ b/packages/mcp-core/src/tools/update-project.test.ts
@@ -33,9 +33,9 @@ describe("update_project", () => {
       - Updated name to "New Project Name"
       - Updated platform to "python"
 
-      # Using this information
+      ## Response Notes
 
-      - The project is now accessible at slug: \`cloudflare-mcp\`
+      - Project slug for later requests: \`cloudflare-mcp\`
       "
     `);
   });
@@ -70,10 +70,10 @@ describe("update_project", () => {
       ## Updates Applied
       - Updated team assignment to "backend-team"
 
-      # Using this information
+      ## Response Notes
 
-      - The project is now accessible at slug: \`cloudflare-mcp\`
-      - The project is now assigned to the \`backend-team\` team
+      - Project slug for later requests: \`cloudflare-mcp\`
+      - Team assignment: \`backend-team\`
       "
     `);
   });

--- a/packages/mcp-core/src/tools/update-project.ts
+++ b/packages/mcp-core/src/tools/update-project.ts
@@ -164,10 +164,10 @@ export default defineTool({
       output += `\n`;
     }
 
-    output += "\n# Using this information\n\n";
-    output += `- The project is now accessible at slug: \`${project.slug}\`\n`;
+    output += "\n## Response Notes\n\n";
+    output += `- Project slug for later requests: \`${project.slug}\`\n`;
     if (params.teamSlug) {
-      output += `- The project is now assigned to the \`${params.teamSlug}\` team\n`;
+      output += `- Team assignment: \`${params.teamSlug}\`\n`;
     }
     return output;
   },


### PR DESCRIPTION
Replace the strongest assistant-facing phrasing in tool result content with scoped response notes and mild presentation guidance. This keeps result steering for values like DSNs, dashboard URLs, and suggested layouts while avoiding result text that looks like a prompt-injection directive to MCP clients.

**Result Text**

Search/event responses no longer emit warning-style display directives or italicized share-link commands. Create/update/find outputs use `## Response Notes` with local, polite guidance or factual references.

**Authoring Guidance**

The docs now clarify that tool descriptions and parameter docs may steer directly, while tool result steering should stay narrow and avoid terms like `IMPORTANT`, `MUST`, `CRITICAL`, `Display these...`, and `# Using this information`.

Fixes GH-1019