### PR TITLE
perf(search-events): Skip attribute API lookup for built-in fields

### DIFF
--- a/packages/mcp-core/src/tools/search-events/config.ts
+++ b/packages/mcp-core/src/tools/search-events/config.ts
@@ -28,7 +28,7 @@ Before constructing ANY query, you MUST verify field availability:
 2. This includes ALL fields: custom attributes, database fields, HTTP fields, AI fields, user fields, etc.
 3. Fields vary by project based on what data is being sent to Sentry
 4. Using an unverified field WILL cause your query to fail with "field not found" errors
-5. For spans, logs, and metrics, datasetAttributes lists fields and supports substringMatch/query/attributeTypes for targeted lookup; pass the exact field name as substringMatch to confirm whether it exists
+5. For spans, logs, and metrics, datasetAttributes lists fields and supports substringMatch/query/attributeTypes for targeted lookup. Fields shown under "Built-in Fields" are already confirmed — do NOT re-check them with substringMatch. Reserve substringMatch for suspected custom attributes (e.g. tags[...]) that are not in the built-in list; pass the exact name to confirm whether it exists
 6. A broad datasetAttributes listing is a discovery preview and may be truncated; if a user-supplied field is missing from the preview, look it up explicitly with substringMatch before discarding it
 7. Replay fields vary by project too, so use replayFields before constructing replay queries
 
@@ -38,7 +38,7 @@ TOOL USAGE GUIDELINES:
 3. Use otelSemantics tool when you need specific OpenTelemetry semantic convention attributes
 4. Use whoami tool when queries contain "me" references for user.id or user.email fields
 5. IMPORTANT: For ambiguous terms like "user agents", "browser", "client" - use the appropriate field discovery tool instead of guessing field names
-6. When the user already supplied Sentry search syntax for spans/logs/metrics, look up each explicit field name with datasetAttributes substringMatch before dropping or renaming it
+6. When the user already supplied Sentry search syntax for spans/logs/metrics, look up each explicit field that is NOT in the built-in list with datasetAttributes substringMatch before dropping or renaming it
 7. Use datasetAttributes substringMatch, query, and attributeTypes for targeted lookup when broad field discovery is truncated
 
 CRITICAL - TOOL RESPONSE HANDLING:

--- a/packages/mcp-core/src/tools/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.test.ts
@@ -669,4 +669,37 @@ describe("createDatasetAttributesTool — should not depend on the private valid
     // some incidental slot like Field Types or Example Queries.
     expect(result).toMatch(/Custom Attributes[^\n]*:\s*\n- tags\[foo\]/);
   });
+
+  // Built-in fields are known from static config. Verifying one (the prompt
+  // tells the agent to pass an exact field name as substringMatch) must not
+  // hit the trace-items attributes endpoint — that network round-trip is pure
+  // overhead and, repeated per built-in field, is what bloated discovery-heavy
+  // agent turns into multi-second failures.
+  it("verifies a built-in field from static config without calling the attributes endpoint", async () => {
+    const attributesCalls = vi.fn();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/trace-items/attributes/",
+        () => {
+          attributesCalls();
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    const executeOptions = { toolCallId: "test", messages: [] } as any;
+    // span.duration is a built-in span field (and a known numeric field).
+    const response = await tool.execute!(
+      { dataset: "spans", substringMatch: "span.duration" },
+      executeOptions,
+    );
+
+    expect(attributesCalls).not.toHaveBeenCalled();
+    expect(response).toHaveProperty("result");
+    const result = (response as { result: string }).result;
+    // The field is confirmed as built-in, and the custom-attribute lookup is
+    // explicitly reported as skipped rather than silently empty.
+    expect(result).toContain("span.duration");
+    expect(result).toMatch(/skipped — "span\.duration" is a built-in field/);
+  });
 });

--- a/packages/mcp-core/src/tools/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/search-events/utils.ts
@@ -471,30 +471,52 @@ export function createDatasetAttributesTool(options: {
         DATASET_EXAMPLES,
       } = await import("./config");
 
-      // Get custom attributes for this dataset
-      // IMPORTANT: Let ALL errors bubble up to wrapAgentToolExecute
-      // UserInputError will be converted to error string for the AI agent
-      // Other errors will bubble up to be captured by Sentry
       const normalizedDataset = normalizeEventsDataset(dataset);
       const attributeTimeParams = { statsPeriod: "14d" };
-      const { attributes: customAttributes, fieldTypes } =
-        await fetchCustomAttributes(
-          apiService,
-          organizationSlug,
-          dataset,
-          projectId,
-          attributeTimeParams,
-          {
-            attributeTypes,
-            substringMatch,
-            query,
-          },
-        );
 
       const staticFields = {
         ...BASE_COMMON_FIELDS,
         ...DATASET_FIELDS[normalizedDataset],
       };
+      const staticNumericFields =
+        NUMERIC_FIELDS[normalizedDataset] || new Set<string>();
+
+      // Built-in fields are known from static config, so verifying one needs
+      // no API call. When the agent passes an exact built-in name as
+      // substringMatch (the field-existence check the prompt encourages), skip
+      // the trace-items attributes lookup entirely — the field is already
+      // confirmed, and a custom-attribute scan would only add a network
+      // round-trip per field, bloating discovery-heavy agent turns.
+      const builtInFieldNames = new Set([
+        ...Object.keys(staticFields),
+        ...staticNumericFields,
+      ]);
+      const matchedBuiltInField =
+        substringMatch != null && builtInFieldNames.has(substringMatch)
+          ? substringMatch
+          : null;
+
+      // Get custom attributes for this dataset
+      // IMPORTANT: Let ALL errors bubble up to wrapAgentToolExecute
+      // UserInputError will be converted to error string for the AI agent
+      // Other errors will bubble up to be captured by Sentry
+      const { attributes: customAttributes, fieldTypes } = matchedBuiltInField
+        ? {
+            attributes: {} as Record<string, string>,
+            fieldTypes: {} as Record<string, TraceItemAttributeType>,
+          }
+        : await fetchCustomAttributes(
+            apiService,
+            organizationSlug,
+            dataset,
+            projectId,
+            attributeTimeParams,
+            {
+              attributeTypes,
+              substringMatch,
+              query,
+            },
+          );
 
       const recommendedFields = RECOMMENDED_FIELDS[normalizedDataset];
 
@@ -502,8 +524,6 @@ export function createDatasetAttributesTool(options: {
       const allFieldTypes: Record<string, TraceItemAttributeType> = {
         ...fieldTypes,
       };
-      const staticNumericFields =
-        NUMERIC_FIELDS[normalizedDataset] || new Set();
       for (const field of staticNumericFields) {
         allFieldTypes[field] = "number";
       }
@@ -512,14 +532,19 @@ export function createDatasetAttributesTool(options: {
       const staticEntries = Object.entries(staticFields);
       const STATIC_LIMIT = 50;
 
+      const customAttributesSection = matchedBuiltInField
+        ? `Custom Attributes:\n(skipped — "${matchedBuiltInField}" is a built-in field for this dataset, so no custom-attribute lookup was needed)`
+        : `Custom Attributes (${customEntries.length}${substringMatch ? ` matching "${substringMatch}"` : ""}):\n${
+            customEntries.length === 0
+              ? "(none returned by Sentry for this query — the attribute may not exist within the time window)"
+              : customEntries
+                  .map(([key, desc]) => `- ${key}: ${desc}`)
+                  .join("\n")
+          }`;
+
       return `Dataset: ${dataset}
 
-Custom Attributes (${customEntries.length}${substringMatch ? ` matching "${substringMatch}"` : ""}):
-${
-  customEntries.length === 0
-    ? "(none returned by Sentry for this query — the attribute may not exist within the time window)"
-    : customEntries.map(([key, desc]) => `- ${key}: ${desc}`).join("\n")
-}
+${customAttributesSection}
 
 Built-in Fields (${staticEntries.length} total):
 ${staticEntries


### PR DESCRIPTION
## Summary

`datasetAttributes` (the embedded-agent tool inside `search_events`) verified every explicit field by calling the trace-items attributes endpoint — even for **built-in fields** like `span.duration` or `http.method` that are already enumerated in static config. The prompt encourages the agent to confirm each explicit field via `substringMatch`, so a single agent turn could stack up a dozen-plus sequential attribute lookups.

That redundant network fan-out lengthened discovery-heavy turns enough to occasionally tip a `search_events` call into an `AI_NoOutputGeneratedError` (the agent exhausting its time/step budget before producing output).

## What changed

- **Tool short-circuit (`utils.ts`):** build a `Set` of known built-in field names (`BASE_COMMON_FIELDS` ∪ `DATASET_FIELDS[dataset]` ∪ `NUMERIC_FIELDS[dataset]`). If `substringMatch` exactly matches a built-in, skip `fetchCustomAttributes` entirely — the field is already confirmed from config, no GET to `/trace-items/attributes/`. Own-keys-only `Set.has` is used (the match target is untrusted input, so prototype-chain checks like `in` are avoided).
- The output's Custom Attributes section now reports the skip explicitly instead of rendering a misleading empty result.
- **Prompt guidance (`config.ts`):** tell the agent that fields in the "Built-in Fields" listing are pre-confirmed, and reserve `substringMatch` for suspected custom attributes (`tags[...]`) not already in that list.

## Effect

Built-in field checks now resolve in-memory with zero network round-trips; only genuine custom-attribute lookups still hit the API. This is the path that no-ops the validate-endpoint dependency removed in #1017 — same field-discovery flow, far fewer calls.

## Test plan

- [x] New regression test: verifying a built-in field (`span.duration`) makes **no** call to the attributes endpoint and reports it as built-in.
- [x] Existing search-events tests still pass (38), incl. the custom-attribute (`tags[...]`) discovery and static-field-cap guards.
- [x] `pnpm run tsc` and `pnpm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)