### PR TITLE
ci(deploy): wire VITE_SENTRY_DSN into the build env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,8 @@ jobs:
         run: pnpm -w run build
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: production
 
       - name: Deploy to Canary Worker
         id: deploy_canary


### PR DESCRIPTION
The SPA's Sentry.init() reads `import.meta.env.VITE_SENTRY_DSN`, which Vite inlines at build time. The deploy workflow never exported this variable, so every production bundle has shipped with `dsn: undefined` (minified to `void 0` in the bundle). Suspecting this is silently breaking SPA telemetry 

This wires `secrets.VITE_SENTRY_DSN` and a hardcoded `VITE_SENTRY_ENVIRONMENT=production` into the Build step. Both keys are already declared in turbo.json's globalPassThroughEnv and documented in TELEMETRY.md as required build-time vars.

I have already assigned VITE_SENTRY_DSN: {dsn from project settings} as a secret to the sentry-mcp repo using gh cli