### PR TITLE
feat(api-client): Send X-Sentry-MCP-Client-Family header on API requests

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -330,6 +330,7 @@ const mcpHandler: ExportedHandler<Env> = {
       userIpAddress,
       clientId,
       clientName,
+      clientFamily,
       accessToken,
       grantedSkills: validSkills,
       constraints,

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -518,6 +518,7 @@ describe("request headers", () => {
       accessToken: "test-token",
       clientId: "abc123",
       clientName: "Claude Code",
+      clientFamily: "claude-code",
     });
 
     await apiService.getAuthenticatedUser();
@@ -526,6 +527,9 @@ describe("request headers", () => {
       .calls[0];
     expect(requestInit.headers["X-Sentry-MCP-Client-Id"]).toBe("abc123");
     expect(requestInit.headers["X-Sentry-MCP-Client-Name"]).toBe("Claude Code");
+    expect(requestInit.headers["X-Sentry-MCP-Client-Family"]).toBe(
+      "claude-code",
+    );
   });
 
   it("should not send MCP client headers when clientId and clientName are not set", async () => {
@@ -554,6 +558,7 @@ describe("request headers", () => {
       .calls[0];
     expect(requestInit.headers["X-Sentry-MCP-Client-Id"]).toBeUndefined();
     expect(requestInit.headers["X-Sentry-MCP-Client-Name"]).toBeUndefined();
+    expect(requestInit.headers["X-Sentry-MCP-Client-Family"]).toBeUndefined();
   });
 });
 

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -288,6 +288,7 @@ export class SentryApiService {
   private accessToken: string | null;
   private clientId: string | null;
   private clientName: string | null;
+  private clientFamily: string | null;
   protected host: string;
   protected protocol: SentryProtocol;
   protected apiPrefix: string;
@@ -302,6 +303,7 @@ export class SentryApiService {
    * @param config.host Sentry hostname (e.g. "sentry.io", "sentry.example.com")
    * @param config.clientId DCR-registered OAuth client ID
    * @param config.clientName DCR-registered OAuth client name
+   * @param config.clientFamily Bucketed client family (e.g. "claude-code", "cursor")
    */
   constructor({
     accessToken = null,
@@ -309,16 +311,19 @@ export class SentryApiService {
     protocol = "https",
     clientId = null,
     clientName = null,
+    clientFamily = null,
   }: {
     accessToken?: string | null;
     host?: string;
     protocol?: SentryProtocol;
     clientId?: string | null;
     clientName?: string | null;
+    clientFamily?: string | null;
   }) {
     this.accessToken = accessToken;
     this.clientId = clientId;
     this.clientName = clientName;
+    this.clientFamily = clientFamily;
     this.host = host;
     this.protocol = protocol;
     this.apiPrefix = `${protocol}://${host}/api/0`;
@@ -422,6 +427,9 @@ export class SentryApiService {
     }
     if (this.clientName) {
       headers["X-Sentry-MCP-Client-Name"] = this.clientName;
+    }
+    if (this.clientFamily) {
+      headers["X-Sentry-MCP-Client-Family"] = this.clientFamily;
     }
 
     // Check if fetch is available, otherwise provide a helpful error message

--- a/packages/mcp-core/src/internal/tool-helpers/api.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/api.ts
@@ -34,6 +34,7 @@ export function apiServiceFromContext(
     accessToken: context.accessToken,
     clientId: context.clientId,
     clientName: context.clientName,
+    clientFamily: context.clientFamily,
   });
 }
 

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -48,6 +48,8 @@ export type ServerContext = {
   accessToken: string;
   /** DCR-registered client name (freeform, as provided during Dynamic Client Registration) */
   clientName?: string | null;
+  /** Bucketed client family (e.g. "claude-code", "cursor") resolved from User-Agent */
+  clientFamily?: string | null;
   openaiBaseUrl?: string;
   userId?: string | null;
   userIpAddress?: string | null;


### PR DESCRIPTION
Forward the bucketed `clientFamily` value (e.g. `claude-code`, `cursor`, `copilot`) as an `X-Sentry-MCP-Client-Family` HTTP header on all Sentry API requests. This lets the Sentry backend attribute API traffic to the originating MCP client.

**Plumbing path**

`clientFamily` is already resolved from User-Agent in the Cloudflare transport. This change threads it through `ServerContext` → `apiServiceFromContext` → `SentryApiService`, where it's emitted alongside the existing `X-Sentry-MCP-Client-Id` and `X-Sentry-MCP-Client-Name` headers. The stdio transport omits the field since no User-Agent is available; the header is simply not sent.