### PR TITLE
feat(telemetry): Capture search helper result counts

### DIFF
--- a/packages/mcp-core/src/internal/agents/tools/dataset-fields.test.ts
+++ b/packages/mcp-core/src/internal/agents/tools/dataset-fields.test.ts
@@ -1,6 +1,6 @@
 import { mswServer } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { SentryApiService } from "../../../api-client";
 import {
   discoverDatasetFields,
@@ -14,7 +14,6 @@ describe("dataset-fields agent tool", () => {
   let apiService: SentryApiService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     apiService = new SentryApiService({
       accessToken: "test-token",
     });

--- a/packages/mcp-core/src/internal/agents/tools/dataset-fields.ts
+++ b/packages/mcp-core/src/internal/agents/tools/dataset-fields.ts
@@ -173,6 +173,7 @@ export function createDatasetFieldsTool(options: {
         projectId,
       });
     },
+    getResultCount: (result) => result.fields.length,
   });
 }
 

--- a/packages/mcp-core/src/internal/agents/tools/otel-semantics.ts
+++ b/packages/mcp-core/src/internal/agents/tools/otel-semantics.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import type { SentryApiService } from "../../../api-client";
-import { agentTool } from "./utils";
 import {
-  PUBLIC_EVENTS_DATASETS,
   type EventsDataset,
+  PUBLIC_EVENTS_DATASETS,
 } from "../../../utils/events-datasets";
+import { agentTool, recordAgentToolResultCount } from "./utils";
 
 // Import all JSON files directly
 import android from "./data/android.json";
@@ -213,6 +213,7 @@ export async function lookupOtelSemantics(
 
   // Get all attributes
   const attributes = Object.entries(data.attributes);
+  recordAgentToolResultCount(attributes.length);
 
   response += `## Attributes (${attributes.length} total)\n\n`;
 

--- a/packages/mcp-core/src/internal/agents/tools/utils.ts
+++ b/packages/mcp-core/src/internal/agents/tools/utils.ts
@@ -1,7 +1,8 @@
-import { tool, APICallError } from "ai";
+import { getActiveSpan } from "@sentry/core";
+import { APICallError, tool } from "ai";
 import { z } from "zod";
-import { UserInputError, LLMProviderError } from "../../../errors";
 import { ApiClientError, ApiServerError } from "../../../api-client";
+import { LLMProviderError, UserInputError } from "../../../errors";
 import { logIssue, logWarn } from "../../../telem/logging";
 
 /**
@@ -20,6 +21,29 @@ export type AgentToolResponse<T = unknown> = {
   error?: string;
   result?: T;
 };
+
+export function recordAgentToolResultCount(count: number | undefined) {
+  if (typeof count !== "number" || !Number.isFinite(count)) {
+    return;
+  }
+
+  try {
+    getActiveSpan()?.setAttribute("gen_ai.tool.call.result.count", count);
+  } catch {}
+}
+
+function recordExtractedAgentToolResultCount<TResult>(
+  result: TResult,
+  getResultCount?: (result: TResult) => number | undefined,
+) {
+  if (!getResultCount) {
+    return;
+  }
+
+  try {
+    recordAgentToolResultCount(getResultCount(result));
+  } catch {}
+}
 
 /**
  * Handles errors from agent tool execution and returns appropriate error messages.
@@ -149,6 +173,7 @@ export function agentTool<TParameters, TResult>(config: {
   description: string;
   parameters: z.ZodSchema<TParameters>;
   execute: (params: TParameters) => Promise<TResult>;
+  getResultCount?: (result: TResult) => number | undefined;
 }) {
   // Infer the result type from the execute function's return type
   type InferredResult = Awaited<ReturnType<typeof config.execute>>;
@@ -161,6 +186,7 @@ export function agentTool<TParameters, TResult>(config: {
     ): Promise<AgentToolResponse<InferredResult>> => {
       try {
         const result = await config.execute(input);
+        recordExtractedAgentToolResultCount(result, config.getResultCount);
         return { result };
       } catch (error) {
         return handleAgentToolError<InferredResult>(error);

--- a/packages/mcp-core/src/tools/catalog/search-docs.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-docs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import searchDocs from "./search-docs.js";
 
 describe("search_docs", () => {

--- a/packages/mcp-core/src/tools/catalog/search-docs.ts
+++ b/packages/mcp-core/src/tools/catalog/search-docs.ts
@@ -1,10 +1,11 @@
+import { getActiveSpan } from "@sentry/core";
 import { z } from "zod";
-import { defineTool } from "../../internal/tool-helpers/define";
-import { fetchWithTimeout } from "../../internal/fetch-utils";
 import { ApiError } from "../../api-client/index";
+import { fetchWithTimeout } from "../../internal/fetch-utils";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { ParamSentryGuide } from "../../schema";
 import type { ServerContext } from "../../types";
 import type { SearchResponse } from "../types";
-import { ParamSentryGuide } from "../../schema";
 
 export default defineTool({
   name: "search_docs",
@@ -107,6 +108,11 @@ export default defineTool({
       output += `**Error**: ${data.error}\n\n`;
       return output;
     }
+
+    getActiveSpan()?.setAttribute(
+      "gen_ai.tool.call.result.count",
+      data.results.length,
+    );
 
     // Display results
     if (data.results.length === 0) {

--- a/packages/mcp-core/src/tools/support/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.ts
@@ -5,15 +5,18 @@ import type {
   TraceItemAttributeValidationResult,
   TraceItemType,
 } from "../../../api-client";
-import { agentTool } from "../../../internal/agents/tools/utils";
+import {
+  agentTool,
+  recordAgentToolResultCount,
+} from "../../../internal/agents/tools/utils";
 import {
   formatUserGeoSummary,
   isPlainObject,
 } from "../../../internal/user-formatting";
 import {
-  normalizeEventsDataset,
-  PUBLIC_EVENTS_DATASETS,
   type EventsDataset,
+  PUBLIC_EVENTS_DATASETS,
+  normalizeEventsDataset,
 } from "../../../utils/events-datasets";
 
 // Type for flexible event data that can contain any fields
@@ -540,6 +543,7 @@ export function createDatasetAttributesTool(options: {
         ...DATASET_FIELDS[normalizedDataset],
         ...customAttributes,
       };
+      const fieldCount = Object.keys(allFields).length;
 
       const recommendedFields = RECOMMENDED_FIELDS[normalizedDataset];
 
@@ -553,15 +557,17 @@ export function createDatasetAttributesTool(options: {
         allFieldTypes[field] = "number";
       }
 
+      recordAgentToolResultCount(fieldCount);
+
       return `Dataset: ${dataset}
 ${formatValidationResults(validationResults)}
 
-Available Fields (${Object.keys(allFields).length} total):
+Available Fields (${fieldCount} total):
 ${Object.entries(allFields)
   .slice(0, 50) // Limit to first 50 to avoid overwhelming the agent
   .map(([key, desc]) => `- ${key}: ${desc}`)
   .join("\n")}
-${Object.keys(allFields).length > 50 ? `\n... and ${Object.keys(allFields).length - 50} more fields` : ""}
+${fieldCount > 50 ? `\n... and ${fieldCount - 50} more fields` : ""}
 
 Recommended Fields for ${dataset}:
 ${recommendedFields.basic.map((f) => `- ${f}`).join("\n")}

--- a/packages/mcp-core/src/tools/support/search-issue-events/utils.ts
+++ b/packages/mcp-core/src/tools/support/search-issue-events/utils.ts
@@ -1,12 +1,15 @@
 import { z } from "zod";
 import type { SentryApiService } from "../../../api-client";
-import { agentTool } from "../../../internal/agents/tools/utils";
 import { UserInputError } from "../../../errors";
+import {
+  agentTool,
+  recordAgentToolResultCount,
+} from "../../../internal/agents/tools/utils";
 import { resolveScopedOrganizationSlug } from "../../../internal/url-scope";
 import {
+  EXAMPLE_QUERIES,
   ISSUE_EVENT_TAGS,
   RECOMMENDED_FIELDS,
-  EXAMPLE_QUERIES,
 } from "./config";
 
 /**
@@ -49,9 +52,12 @@ export function createIssueEventFieldsTool(options: {
 
       // Combine with common known tags
       const allTags = { ...ISSUE_EVENT_TAGS, ...availableTags };
+      const tagCount = Object.keys(allTags).length;
+
+      recordAgentToolResultCount(tagCount);
 
       // Format the response
-      return `Available Tags and Fields (${Object.keys(allTags).length} total):
+      return `Available Tags and Fields (${tagCount} total):
 
 Common Tags:
 ${Object.entries(ISSUE_EVENT_TAGS)


### PR DESCRIPTION
Search telemetry now records result counts for embedded search helper tools, not just the final MCP search handlers. This makes field, tag, and attribute discovery calls show the same `gen_ai.tool.call.result.count` signal used by `search_issues` and `search_events`.

**Search Helper Telemetry**

The shared agent tool wrapper can now accept an opt-in result count extractor. Search-specific helpers wire in counts for dataset fields, dataset attributes, issue event fields, and OpenTelemetry semantic attributes.

**Documentation Search**

`search_docs` now records documentation result counts as a related consistency improvement.