### PR TITLE
feat(telemetry): Track MCP mode adoption

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -38,21 +38,23 @@ the pivots and recipes below.
 | `app.rate_limit.scope` | local rate-limit scope | metrics | IP vs user rate limits |
 | `app.route.group` | coarse route family | metrics | `mcp`, `oauth`, `chat`, `search` |
 | `app.transport` | MCP transport | tags, spans | `http`, `sse`, or `stdio` |
+| `app.server.mode.agent` | agent-mode flag | metrics, spans, tags | `?agent=1` or stdio `--agent` adoption |
+| `app.server.mode.experimental` | experimental-mode flag | metrics, spans, tags | `?experimental=1` or stdio `--experimental` adoption |
 | `mcp.session.id` | MCP session identity | spans | session timeline |
 | `gen_ai.tool.name` | MCP tool being called | spans, issues | tool timeline |
 | `app.resource.type` | resolved Sentry resource type | spans | resource dispatch |
 | `app.constraint.organization_slug` | active organization constraint | spans | constrained session behavior |
 | `app.constraint.project_slug` | active project constraint | spans | constrained session behavior |
 | `gen_ai.tool.call.arguments.<key>` | effective tool arguments | spans | called tool input |
-| `app.client.family` | bucketed MCP client family | metrics | client-specific OAuth behavior |
+| `app.client.family` | bucketed MCP client family | metrics, spans | client-specific OAuth behavior |
 | `app.oauth.token_exchange.outcome` | OAuth refresh outcome | metrics | token refresh diagnosis |
 | `app.oauth.grant_revoked.reason` | wrapper grant revoke reason | metrics | sign-out diagnosis |
 | `app.consent.skill` | skill granted during approval | metrics | per-skill adoption |
 | `app.consent.skill.<skill>.granted` | skill granted on an MCP request | spans | tool behavior by enabled skills |
 | `app.oauth.probe.status_code` | upstream probe HTTP status | metrics | Sentry token validity probe result |
 | `app.oauth.probe.reason` | indeterminate probe bucket | metrics | upstream instability |
-| `app.upstream.host` | configured Sentry host | tags | host-specific behavior |
-| `app.server.version` | MCP server package version | tags | release/version behavior |
+| `app.upstream.host` | configured Sentry host | tags, spans | host-specific behavior |
+| `app.server.version` | MCP server package version | tags, spans | release/version behavior |
 | `app.utm_source` | sanitized in-product `utm_source` query param | spans | in-product attribution |
 | `app.referrer.family` | low-cardinality bucket of the `Referer` host | spans | external traffic attribution |
 | `gen_ai.provider.name` | GenAI provider | spans, tags | provider-specific model behavior |
@@ -81,8 +83,16 @@ HTTP response rates by route and status.
 
 ```text
 dataset=tracemetrics query='metric:app.server.response http.route:"<route>"'
-fields=timestamp,metric,http.request.method,http.route,http.response.status_code,app.response.status_class,app.route.group,value
+fields=timestamp,metric,http.request.method,http.route,http.response.status_code,app.response.status_class,app.route.group,app.client.family,app.server.mode.agent,app.server.mode.experimental,value
 aggregate=sum(value) by http.route,http.response.status_code
+```
+
+MCP mode adoption by client family.
+
+```text
+dataset=tracemetrics query='metric:app.server.response http.route:"/mcp/:organizationSlug?/:projectSlug?"'
+fields=timestamp,metric,app.client.family,app.server.mode.agent,app.server.mode.experimental,value
+aggregate=sum(value) by app.client.family,app.server.mode.agent,app.server.mode.experimental
 ```
 
 Local rate-limit volume and scope.
@@ -129,7 +139,7 @@ Tool execution timeline for a slow or failing tool.
 
 ```text
 dataset=spans query='gen_ai.tool.name:"<tool_name>" app.consent.skill.<skill>.granted:true'
-fields=timestamp,trace,span_id,span.op,span.duration,gen_ai.tool.name,app.constraint.organization_slug,app.constraint.project_slug,gen_ai.tool.call.arguments.organizationSlug,gen_ai.tool.call.arguments.projectSlugOrId,error.type
+fields=timestamp,trace,span_id,span.op,span.duration,gen_ai.tool.name,app.transport,app.client.family,app.server.mode.agent,app.server.mode.experimental,app.constraint.organization_slug,app.constraint.project_slug,gen_ai.tool.call.arguments.organizationSlug,gen_ai.tool.call.arguments.projectSlugOrId,error.type
 sort=-timestamp
 ```
 
@@ -172,7 +182,9 @@ Metrics: `app.server.response`
 Attributes: `http.request.method`, `http.route`,
 `http.response.status_code`, `app.response.status_class`,
 `app.route.group`, `app.response.reason`, `app.rate_limit.scope`,
-`app.request.duration_ms`
+`app.request.duration_ms`. MCP responses also include
+`app.client.family`, `app.server.mode.agent`, and
+`app.server.mode.experimental`.
 
 ### OAuth And Client Registration
 
@@ -255,10 +267,10 @@ Attributes: `gen_ai.provider.name`, `gen_ai.request.model`,
   full request bodies, or other high-cardinality or sensitive values.
 - Do not log secrets. Authorization headers and access tokens must remain
   scrubbed.
-- Update this document, `docs/monitoring.md`, and
-  `packages/mcp-core/src/internal/agents/tools/data/mcp.json` when adding or
-  renaming telemetry fields. Do not add unit tests solely to assert telemetry
-  attribute spelling.
+- Update this document, `docs/monitoring.md`, and the relevant semantic lookup
+  data file under `packages/mcp-core/src/internal/agents/tools/data/` when
+  adding or renaming telemetry fields. Do not add unit tests solely to assert
+  telemetry attribute spelling.
 
 ## References
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -154,10 +154,11 @@ These are Sentry MCP application attributes that are not part of the MCP semanti
 
 - `app.resource.type` - Resolved Sentry resource type for `get_sentry_resource`
 - `app.transport` - The product transport label (values: "http", "sse", "stdio")
+- `app.client.family` - Low-cardinality MCP client bucket derived from User-Agent or registered client name
 - `app.constraint.organization_slug` - Session organization constraint
 - `app.constraint.project_slug` - Session project constraint
-- `app.server.mode.agent` - Whether stdio started in agent mode
-- `app.server.mode.experimental` - Whether experimental tools are enabled
+- `app.server.mode.agent` - Whether agent mode is enabled for this MCP request or stdio session
+- `app.server.mode.experimental` - Whether experimental tools are enabled for this MCP request or stdio session
 - `app.consent.skill.<skill>.granted` - Per-skill boolean attributes for skills granted to the MCP request. Skill ids are normalized with `-` replaced by `_`
 - `app.upstream.host` - Upstream Sentry host configured for the server
 - `app.url.full` - MCP URL configured for stdio
@@ -262,6 +263,12 @@ Shared low-cardinality attributes:
 - `app.response.status_class` - Status family such as `2xx` or `4xx`
 - `app.route.group` - Coarse route family: `mcp`, `oauth`, `chat`, or `search`
 
+Additional attributes on MCP response metrics:
+
+- `app.client.family` - Bucketed MCP client User-Agent
+- `app.server.mode.agent` - `true` when the MCP URL includes `?agent=1`
+- `app.server.mode.experimental` - `true` when the MCP URL includes `?experimental=1`
+
 Optional local rate-limit attributes:
 
 - `app.response.reason` - `local_rate_limit`
@@ -271,6 +278,9 @@ Interpretation:
 
 - Use `sum(app.server.response)` grouped by `http.route` and
   `http.response.status_code` for response rates
+- Use `sum(app.server.response)` filtered to the MCP route and grouped by
+  `app.client.family`, `app.server.mode.agent`, and
+  `app.server.mode.experimental` for mode adoption
 - Use `sum(app.server.response)` filtered by
   `app.response.reason=local_rate_limit` to measure when we rate-limited the
   customer

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -6,6 +6,7 @@ import { resolveClientFamily } from "./lib/client-family";
 import sentryMcpHandler from "./lib/mcp-handler";
 import {
   type RateLimitScope,
+  annotateMcpRequestSpan,
   extractResponseMetricOptions,
   recordResponseMetric,
   stripResponseMetricHeaders,
@@ -92,6 +93,7 @@ function finalizeResponse(
     ? addCorsHeaders(responseWithoutMetricHeaders)
     : stripCorsHeaders(responseWithoutMetricHeaders);
 
+  annotateMcpRequestSpan(request, url);
   recordResponseMetric(request, finalized, {
     ...responseMetricOptions,
     ...options,

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -166,7 +166,14 @@ const mcpHandler: ExportedHandler<Env> = {
       userId,
     );
 
-    Sentry.getActiveSpan()?.setAttribute("app.client.family", clientFamily);
+    const activeSpan = Sentry.getActiveSpan();
+    activeSpan?.setAttribute("app.transport", "http");
+    activeSpan?.setAttribute("app.client.family", clientFamily);
+    activeSpan?.setAttribute("app.server.mode.agent", isAgentMode);
+    activeSpan?.setAttribute(
+      "app.server.mode.experimental",
+      isExperimentalMode,
+    );
 
     // Parse and validate granted skills (primary authorization method)
     // Legacy tokens without grantedSkills are no longer supported
@@ -257,7 +264,6 @@ const mcpHandler: ExportedHandler<Env> = {
       );
     }
 
-    const activeSpan = Sentry.getActiveSpan();
     for (const skill of Array.from(validSkills).sort()) {
       activeSpan?.setAttribute(getSkillGrantedAttributeName(skill), true);
     }

--- a/packages/mcp-cloudflare/src/server/metrics.ts
+++ b/packages/mcp-cloudflare/src/server/metrics.ts
@@ -81,6 +81,14 @@ function getBooleanAttribute(value: boolean): string {
   return value ? "true" : "false";
 }
 
+function getMcpRequestAttributes(request: Request, url: URL) {
+  return {
+    clientFamily: resolveClientFamily(request.headers.get("user-agent")),
+    agentMode: url.searchParams.get("agent") === "1",
+    experimentalMode: url.searchParams.get("experimental") === "1",
+  };
+}
+
 function getMetricAttributes(
   request: Request,
 ): Record<string, string | number> | null {
@@ -102,18 +110,43 @@ function getMetricAttributes(
   };
 
   if (trackedRoute.group === "mcp") {
-    attributes["app.client.family"] = resolveClientFamily(
-      request.headers.get("user-agent"),
-    );
+    const mcpAttributes = getMcpRequestAttributes(request, url);
+    attributes["app.client.family"] = mcpAttributes.clientFamily;
     attributes["app.server.mode.agent"] = getBooleanAttribute(
-      url.searchParams.get("agent") === "1",
+      mcpAttributes.agentMode,
     );
     attributes["app.server.mode.experimental"] = getBooleanAttribute(
-      url.searchParams.get("experimental") === "1",
+      mcpAttributes.experimentalMode,
     );
   }
 
   return attributes;
+}
+
+export function annotateMcpRequestSpan(request: Request, url: URL): void {
+  if (request.method === "OPTIONS") {
+    return;
+  }
+
+  const trackedRoute = classifyTrackedRoute(url.pathname);
+
+  if (trackedRoute?.group !== "mcp") {
+    return;
+  }
+
+  const activeSpan = Sentry.getActiveSpan();
+  if (!activeSpan) {
+    return;
+  }
+
+  const mcpAttributes = getMcpRequestAttributes(request, url);
+  activeSpan.setAttribute("app.transport", "http");
+  activeSpan.setAttribute("app.client.family", mcpAttributes.clientFamily);
+  activeSpan.setAttribute("app.server.mode.agent", mcpAttributes.agentMode);
+  activeSpan.setAttribute(
+    "app.server.mode.experimental",
+    mcpAttributes.experimentalMode,
+  );
 }
 
 export function annotateResponseMetric(

--- a/packages/mcp-cloudflare/src/server/metrics.ts
+++ b/packages/mcp-cloudflare/src/server/metrics.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
+import { resolveClientFamily } from "./lib/client-family";
 
 export type RateLimitScope = "ip" | "user";
 type ResponseReason = "local_rate_limit";
@@ -76,6 +77,10 @@ function getStatusClass(status: number): string {
   return `${Math.floor(status / 100)}xx`;
 }
 
+function getBooleanAttribute(value: boolean): string {
+  return value ? "true" : "false";
+}
+
 function getMetricAttributes(
   request: Request,
 ): Record<string, string | number> | null {
@@ -83,17 +88,32 @@ function getMetricAttributes(
     return null;
   }
 
-  const trackedRoute = classifyTrackedRoute(new URL(request.url).pathname);
+  const url = new URL(request.url);
+  const trackedRoute = classifyTrackedRoute(url.pathname);
 
   if (!trackedRoute) {
     return null;
   }
 
-  return {
+  const attributes: Record<string, string | number> = {
     "http.request.method": request.method,
     "http.route": trackedRoute.route,
     "app.route.group": trackedRoute.group,
   };
+
+  if (trackedRoute.group === "mcp") {
+    attributes["app.client.family"] = resolveClientFamily(
+      request.headers.get("user-agent"),
+    );
+    attributes["app.server.mode.agent"] = getBooleanAttribute(
+      url.searchParams.get("agent") === "1",
+    );
+    attributes["app.server.mode.experimental"] = getBooleanAttribute(
+      url.searchParams.get("experimental") === "1",
+    );
+  }
+
+  return attributes;
 }
 
 export function annotateResponseMetric(

--- a/packages/mcp-core/src/internal/agents/tools/data/app.json
+++ b/packages/mcp-core/src/internal/agents/tools/data/app.json
@@ -1,13 +1,109 @@
 {
   "namespace": "app",
-  "description": "Describes attributes related to client-side applications (e.g. web apps or mobile apps).\n",
+  "description": "Describes attributes related to client-side applications (e.g. web apps or mobile apps), plus Sentry MCP application-owned telemetry attributes.\n",
   "attributes": {
+    "app.client.family": {
+      "description": "Sentry MCP low-cardinality bucket for the MCP client family.",
+      "type": "string",
+      "note": "Resolved from the MCP client's User-Agent on direct MCP requests, or from the registered client name on browser-mediated OAuth endpoints.",
+      "examples": ["claude-code", "cursor", "codex", "unknown"]
+    },
+    "app.constraint.organization_slug": {
+      "description": "Sentry MCP organization slug constraint applied to the MCP session.",
+      "type": "string",
+      "examples": ["my-org"]
+    },
+    "app.constraint.project_slug": {
+      "description": "Sentry MCP project slug constraint applied to the MCP session.",
+      "type": "string",
+      "examples": ["backend"]
+    },
+    "app.consent.skill": {
+      "description": "Sentry MCP skill granted during OAuth approval.",
+      "type": "string",
+      "examples": ["inspect", "docs", "project-management"]
+    },
+    "app.consent.skill.<skill>.granted": {
+      "description": "Whether a normalized Sentry MCP skill was granted for a specific MCP request.",
+      "type": "boolean",
+      "note": "The dynamic <skill> segment uses the skill id with hyphens replaced by underscores.",
+      "examples": ["app.consent.skill.project_management.granted"]
+    },
     "app.installation.id": {
       "description": "A unique identifier representing the installation of an application on a specific device\n",
       "type": "string",
       "note": "Its value SHOULD persist across launches of the same application installation, including through application upgrades.\nIt SHOULD change if the application is uninstalled or if all applications of the vendor are uninstalled.\nAdditionally, users might be able to reset this value (e.g. by clearing application data).\nIf an app is installed multiple times on the same device (e.g. in different accounts on Android), each `app.installation.id` SHOULD have a different value.\nIf multiple OpenTelemetry SDKs are used within the same application, they SHOULD use the same value for `app.installation.id`.\nHardware IDs (e.g. serial number, IMEI, MAC address) MUST NOT be used as the `app.installation.id`.\n\nFor iOS, this value SHOULD be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/identifierforvendor).\n\nFor Android, examples of `app.installation.id` implementations include:\n\n- [Firebase Installation ID](https://firebase.google.com/docs/projects/manage-installations).\n- A globally unique UUID which is persisted across sessions in your application.\n- [App set ID](https://developer.android.com/identity/app-set-id).\n- [`Settings.getString(Settings.Secure.ANDROID_ID)`](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID).\n\nMore information about Android identifier best practices can be found [here](https://developer.android.com/training/articles/user-data-ids).\n",
       "stability": "development",
       "examples": ["2ab2916d-a51f-4ac8-80ee-45ac31a28092"]
+    },
+    "app.oauth.grant.shape": {
+      "description": "Shape of the Sentry MCP OAuth grant used during token exchange.",
+      "type": "string",
+      "examples": ["refreshable"]
+    },
+    "app.oauth.grant_revoked.reason": {
+      "description": "Reason a Sentry MCP OAuth wrapper grant was revoked.",
+      "type": "string",
+      "examples": [
+        "stale_props_no_refresh",
+        "upstream_rejected",
+        "upstream_rejected_in_use"
+      ]
+    },
+    "app.oauth.probe.reason": {
+      "description": "Sentry MCP bucket for an indeterminate upstream OAuth token probe.",
+      "type": "string",
+      "examples": ["rate_limit", "server_error", "unknown"]
+    },
+    "app.oauth.probe.status_code": {
+      "description": "HTTP status returned by the upstream Sentry token-validity probe.",
+      "type": "string",
+      "examples": ["200", "401", "429", "500"]
+    },
+    "app.oauth.token_exchange.outcome": {
+      "description": "Outcome bucket for a Sentry MCP OAuth token exchange or refresh.",
+      "type": "string",
+      "examples": [
+        "cached_valid_local",
+        "refreshed",
+        "upstream_rejected",
+        "verification_indeterminate"
+      ]
+    },
+    "app.rate_limit.scope": {
+      "description": "Scope of a Sentry MCP local rate-limit response.",
+      "type": "string",
+      "examples": ["ip", "user"]
+    },
+    "app.referrer.family": {
+      "description": "Sentry MCP low-cardinality bucket for the external referrer host.",
+      "type": "string",
+      "examples": ["sentry-docs", "github", "unknown"]
+    },
+    "app.request.duration_ms": {
+      "description": "Sentry MCP request duration in milliseconds.",
+      "type": "number",
+      "examples": ["42", "1250"]
+    },
+    "app.resource.type": {
+      "description": "Sentry MCP resource type resolved by get_sentry_resource.",
+      "type": "string",
+      "examples": ["issue", "event", "trace", "replay"]
+    },
+    "app.response.reason": {
+      "description": "Sentry MCP local response reason bucket.",
+      "type": "string",
+      "examples": ["local_rate_limit"]
+    },
+    "app.response.status_class": {
+      "description": "HTTP response status family for Sentry MCP response metrics.",
+      "type": "string",
+      "examples": ["2xx", "4xx", "5xx"]
+    },
+    "app.route.group": {
+      "description": "Sentry MCP coarse route family.",
+      "type": "string",
+      "examples": ["mcp", "oauth", "chat", "search"]
     },
     "app.screen.coordinate.x": {
       "description": "The x (horizontal) coordinate of a screen coordinate, in screen pixels.",
@@ -20,6 +116,44 @@
       "type": "number",
       "stability": "development",
       "examples": ["12", "99"]
+    },
+    "app.server.mode.agent": {
+      "description": "Whether Sentry MCP agent mode is enabled for the request or stdio session.",
+      "type": "boolean",
+      "note": "Metrics and tags record this as the low-cardinality string values `true` or `false`; spans record it as a boolean.",
+      "examples": [true, false]
+    },
+    "app.server.mode.experimental": {
+      "description": "Whether Sentry MCP experimental mode is enabled for the request or stdio session.",
+      "type": "boolean",
+      "note": "Metrics and tags record this as the low-cardinality string values `true` or `false`; spans record it as a boolean.",
+      "examples": [true, false]
+    },
+    "app.server.version": {
+      "description": "Sentry MCP server package version.",
+      "type": "string",
+      "examples": ["0.35.0"]
+    },
+    "app.transport": {
+      "description": "Sentry MCP product transport label.",
+      "type": "string",
+      "examples": ["http", "stdio"]
+    },
+    "app.upstream.host": {
+      "description": "Configured upstream Sentry host for Sentry MCP.",
+      "type": "string",
+      "examples": ["sentry.io"]
+    },
+    "app.url.full": {
+      "description": "Configured Sentry MCP URL for stdio telemetry.",
+      "type": "string",
+      "note": "Do not include credentials or access tokens in this URL.",
+      "examples": ["https://mcp.sentry.dev/mcp"]
+    },
+    "app.utm_source": {
+      "description": "Sanitized in-product utm_source query parameter for Sentry MCP attribution.",
+      "type": "string",
+      "examples": ["docs", "product"]
     },
     "app.widget.id": {
       "description": "An identifier that uniquely differentiates this widget from other widgets in the same application.\n",

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -31,18 +31,18 @@ import {
 import { isApiAuthenticationErrorDeep } from "./api-client";
 import { MCP_SERVER_NAME } from "./constants";
 import { formatErrorForUser } from "./internal/error-handling";
+import type { Skill } from "./skills";
 import { type LogIssueOptions, logIssue } from "./telem/logging";
-import tools from "./tools/index";
 import {
+  type RegisteredToolHandlerExtra,
+  type ToolRegistry,
   executeToolHandler,
   getFilteredInputSchema,
   getToolsForMcpRegistration,
   injectConstraintParams,
   resolveToolDescription,
-  type RegisteredToolHandlerExtra,
-  type ToolRegistry,
 } from "./tools/catalog-runtime/availability";
-import type { Skill } from "./skills";
+import tools from "./tools/index";
 import type { ServerContext } from "./types";
 import { LIB_VERSION } from "./version";
 
@@ -220,6 +220,17 @@ function configureServer({
         const activeSpan = getActiveSpan();
 
         if (activeSpan) {
+          activeSpan.setAttribute("app.server.mode.agent", agentMode);
+          activeSpan.setAttribute(
+            "app.server.mode.experimental",
+            experimentalMode,
+          );
+          if (context.transport) {
+            activeSpan.setAttribute("app.transport", context.transport);
+          }
+          if (context.clientFamily) {
+            activeSpan.setAttribute("app.client.family", context.clientFamily);
+          }
           if (context.constraints.organizationSlug) {
             activeSpan.setAttribute(
               "app.constraint.organization_slug",
@@ -254,8 +265,14 @@ function configureServer({
         if (context.clientId) {
           setTag("client.id", context.clientId);
         }
-        setTag("mode.agent", agentMode);
-        setTag("mode.experimental", experimentalMode);
+        if (context.clientFamily) {
+          setTag("app.client.family", context.clientFamily);
+        }
+        if (context.transport) {
+          setTag("app.transport", context.transport);
+        }
+        setTag("app.server.mode.agent", agentMode);
+        setTag("app.server.mode.experimental", experimentalMode);
 
         try {
           const rawParams =

--- a/packages/mcp-server/src/transports/stdio.ts
+++ b/packages/mcp-server/src/transports/stdio.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 /**
  * Standard I/O Transport for MCP Server.
  *
@@ -19,10 +20,31 @@
  * ```
  */
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import * as Sentry from "@sentry/node";
-import { LIB_VERSION } from "@sentry/mcp-core/version";
 import type { ServerContext } from "@sentry/mcp-core/types";
+import { LIB_VERSION } from "@sentry/mcp-core/version";
+import * as Sentry from "@sentry/node";
+
+function getStdioSpanAttributes(
+  context: ServerContext,
+): Record<string, string | boolean> {
+  const attributes: Record<string, string | boolean> = {
+    "app.transport": "stdio",
+    "app.server.version": LIB_VERSION,
+    "app.server.mode.agent": context.agentMode ?? false,
+    "app.server.mode.experimental": context.experimentalMode ?? false,
+    "network.transport": "pipe",
+    "service.version": LIB_VERSION,
+  };
+
+  if (context.sentryHost) {
+    attributes["app.upstream.host"] = context.sentryHost;
+  }
+  if (context.mcpUrl) {
+    attributes["app.url.full"] = context.mcpUrl;
+  }
+
+  return attributes;
+}
 
 /**
  * Starts the MCP server with stdio transport and telemetry.
@@ -56,11 +78,7 @@ export async function startStdio(server: McpServer, context: ServerContext) {
     return await Sentry.startSpan(
       {
         name: "mcp.server/stdio",
-        attributes: {
-          "app.transport": "stdio",
-          "network.transport": "pipe",
-          "service.version": LIB_VERSION,
-        },
+        attributes: getStdioSpanAttributes(context),
       },
       async () => {
         // Context already captured in tool handler closures during buildServer()


### PR DESCRIPTION
Track agent and experimental mode adoption across hosted MCP metrics, request spans, tool spans, and stdio spans. The new dimensions let us compare mode usage by low-cardinality client family without adding user-specific data.

**Mode Dimensions**

MCP response metrics now include `app.client.family`, `app.server.mode.agent`, and `app.server.mode.experimental` for MCP routes. HTTP and stdio spans use the same `app.*` names, and tool tags now use those names instead of the older `mode.*` tags.

**Telemetry Docs And Lookup Data**

Update `TELEMETRY.md`, `docs/monitoring.md`, and the embedded `app` semantic lookup data so operators and embedded agents can discover the fields and query recipes.