### PR TITLE
feat(metadata): Publish complete tool metadata

### DIFF
--- a/packages/mcp-cloudflare/src/server/routes/__tests__/mcp-discovery.test.ts
+++ b/packages/mcp-cloudflare/src/server/routes/__tests__/mcp-discovery.test.ts
@@ -23,7 +23,7 @@ describe("/.mcp discovery routes", () => {
     });
   });
 
-  it("GET /.mcp/tools.json should return tool definitions", async () => {
+  it("GET /.mcp/tools.json should return direct and catalog tool definitions", async () => {
     const res = await app.request(
       "/.mcp/tools.json",
       {
@@ -37,16 +37,39 @@ describe("/.mcp discovery routes", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toContain("application/json");
 
-    const json = (await res.json()) as Array<{ name: string }>;
+    const json = (await res.json()) as Array<{
+      name: string;
+      inputSchema: unknown;
+      skills: string[];
+      surface: "direct" | "catalog";
+    }>;
     expect(Array.isArray(json)).toBe(true);
     expect(json.length).toBeGreaterThan(0);
 
-    // Verify tool structure
-    const toolNames = json.map((t) => t.name);
-    expect(toolNames).toContain("find_organizations");
-    expect(toolNames).toContain("get_sentry_resource");
-    expect(toolNames).not.toContain("get_issue_details");
-    expect(toolNames).not.toContain("get_trace_details");
-    expect(toolNames).toContain("search_events");
+    const toolsByName = new Map(json.map((tool) => [tool.name, tool]));
+    expect(toolsByName.get("find_organizations")).toEqual(
+      expect.objectContaining({
+        inputSchema: expect.any(Object),
+        surface: "direct",
+      }),
+    );
+    expect(toolsByName.get("search_events")).toEqual(
+      expect.objectContaining({
+        surface: "direct",
+      }),
+    );
+    expect(toolsByName.get("get_issue_details")).toEqual(
+      expect.objectContaining({
+        inputSchema: expect.any(Object),
+        skills: expect.arrayContaining(["inspect"]),
+        surface: "catalog",
+      }),
+    );
+    expect(toolsByName.get("get_trace_details")).toEqual(
+      expect.objectContaining({
+        skills: expect.arrayContaining(["inspect"]),
+        surface: "catalog",
+      }),
+    );
   });
 });

--- a/packages/mcp-core/scripts/generate-definitions.ts
+++ b/packages/mcp-core/scripts/generate-definitions.ts
@@ -79,11 +79,19 @@ type DefinitionTool = {
   hideInExperimentalMode?: boolean;
 };
 
+type ToolSurface = "direct" | "catalog";
+
 function isSkillDefinitionTool(tool: DefinitionTool): boolean {
   return (
     !surfacesModule.isWrapperToolName(tool.name) &&
     !surfacesModule.isCatalogInfrastructureToolName(tool.name)
   );
+}
+
+function toolNamesFromEntries(
+  entries: Array<[string, DefinitionTool]>,
+): ReadonlySet<string> {
+  return new Set(entries.flatMap(([toolKey, tool]) => [toolKey, tool.name]));
 }
 
 // Tools
@@ -99,29 +107,55 @@ function generateToolDefinitions({
     throw new Error("Failed to import tools from src/tools/index.ts");
   }
 
-  const defs = Object.entries(toolsDefault).map(([key, tool]) => {
-    if (!tool || typeof tool !== "object")
-      throw new Error(`Invalid tool: ${key}`);
-    const t = tool as DefinitionTool;
-    if (!surfacesModule.isTopLevelToolName(t.name, experimentalMode)) {
-      return null;
-    }
-    if (!toolTypesModule.isToolVisibleInMode(t, experimentalMode)) {
+  const visibleEntries = Object.entries(toolsDefault).flatMap(
+    ([key, tool]): Array<[string, DefinitionTool]> => {
+      if (!tool || typeof tool !== "object") {
+        throw new Error(`Invalid tool: ${key}`);
+      }
+      const t = tool as DefinitionTool;
+      if (
+        surfacesModule.isWrapperToolName(t.name) ||
+        !toolTypesModule.isToolVisibleInMode(t, experimentalMode)
+      ) {
+        return [];
+      }
+      return [[key, t]];
+    },
+  );
+  const directEntries = visibleEntries.filter(([, tool]) =>
+    surfacesModule.isTopLevelToolName(tool.name, experimentalMode),
+  );
+  const availableToolNames = toolNamesFromEntries(visibleEntries);
+  const directToolNames = toolNamesFromEntries(directEntries);
+
+  const defs = visibleEntries.map(([, t]) => {
+    const isDirect = directToolNames.has(t.name);
+    const isCatalog =
+      isSkillDefinitionTool(t) &&
+      Array.isArray(t.skills) &&
+      t.skills.length > 0;
+    if (!isDirect && !isCatalog) {
       return null;
     }
     if (!Array.isArray(t.requiredScopes)) {
       throw new Error(`Tool '${t.name}' is missing requiredScopes array`);
     }
     const jsonSchema = zodFieldMapToJsonSchema(t.inputSchema || {});
+    const surface: ToolSurface = isDirect ? "direct" : "catalog";
     return {
       name: t.name,
       description: toolTypesModule.resolveDescription(t.description, {
         experimentalMode,
+        availableToolNames,
+        directToolNames,
       }),
       // Export full JSON Schema under inputSchema for external docs
       inputSchema: jsonSchema,
       // Preserve tool access requirements for UIs/docs
       requiredScopes: t.requiredScopes,
+      // Preserve skill catalog membership and call surface for UIs/docs.
+      skills: t.skills,
+      surface,
     };
   });
   return defs.filter(isNonNull).sort(byName);
@@ -323,8 +357,12 @@ async function main() {
 
     // Sync allowedTools in agent frontmatter with the direct MCP surface for
     // each plugin's MCP mode.
-    const toolNames = tools.map((t) => t.name);
-    const experimentalToolNames = experimentalTools.map((t) => t.name);
+    const directTools = tools.filter((tool) => tool.surface === "direct");
+    const experimentalDirectTools = experimentalTools.filter(
+      (tool) => tool.surface === "direct",
+    );
+    const toolNames = directTools.map((t) => t.name);
+    const experimentalToolNames = experimentalDirectTools.map((t) => t.name);
 
     let agentsSynced = 0;
     for (const agentConfig of agentConfigs()) {
@@ -338,7 +376,7 @@ async function main() {
     }
 
     console.log(
-      `✅ Generated: tools(${tools.length}), experimentalTools(${experimentalTools.length}), skills(${skills.length}), agents(${agentsSynced})`,
+      `✅ Generated: tools(${tools.length}), directTools(${directTools.length}), experimentalTools(${experimentalTools.length}), experimentalDirectTools(${experimentalDirectTools.length}), skills(${skills.length}), agents(${agentsSynced})`,
     );
   } catch (error) {
     const err = error as Error;

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -39,7 +39,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": []
+    "requiredScopes": [],
+    "skills": ["seer"],
+    "surface": "direct"
   },
   {
     "name": "create_dsn",
@@ -77,7 +79,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:write"]
+    "requiredScopes": ["project:write"],
+    "skills": ["project-management"],
+    "surface": "direct"
   },
   {
     "name": "create_project",
@@ -140,7 +144,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:write", "team:read", "org:read"]
+    "requiredScopes": ["project:write", "team:read", "org:read"],
+    "skills": ["project-management"],
+    "surface": "direct"
   },
   {
     "name": "create_team",
@@ -174,7 +180,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["team:write"]
+    "requiredScopes": ["team:write"],
+    "skills": ["project-management"],
+    "surface": "direct"
   },
   {
     "name": "find_dsns",
@@ -208,7 +216,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:read"]
+    "requiredScopes": ["project:read"],
+    "skills": ["project-management"],
+    "surface": "direct"
   },
   {
     "name": "find_organizations",
@@ -233,7 +243,16 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["org:read"]
+    "requiredScopes": ["org:read"],
+    "skills": [
+      "inspect",
+      "seer",
+      "docs",
+      "triage",
+      "project-management",
+      "preprod"
+    ],
+    "surface": "direct"
   },
   {
     "name": "find_projects",
@@ -276,7 +295,16 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:read"]
+    "requiredScopes": ["project:read"],
+    "skills": [
+      "inspect",
+      "seer",
+      "docs",
+      "triage",
+      "project-management",
+      "preprod"
+    ],
+    "surface": "direct"
   },
   {
     "name": "find_releases",
@@ -332,7 +360,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:read"]
+    "requiredScopes": ["project:read"],
+    "skills": ["inspect"],
+    "surface": "direct"
   },
   {
     "name": "find_teams",
@@ -375,7 +405,40 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["team:read"]
+    "requiredScopes": ["team:read"],
+    "skills": ["inspect", "triage", "project-management"],
+    "surface": "direct"
+  },
+  {
+    "name": "get_ai_conversation_details",
+    "description": "Fetch all spans for an AI conversation by its gen_ai.conversation.id.\n\nA conversation is a set of spans sharing the same gen_ai.conversation.id. To discover conversation IDs, use search_events with dataset='spans' and query='has:gen_ai.conversation.id'.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "conversationId": {
+          "type": "string",
+          "description": "The AI conversation ID from gen_ai.conversation.id."
+        },
+        "project": {
+          "type": "string",
+          "description": "Numeric project ID to scope the query. Falls back to context constraint or all projects."
+        },
+        "regionUrl": {
+          "type": "string",
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+        }
+      },
+      "required": ["organizationSlug", "conversationId"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read", "project:read"],
+    "skills": ["inspect", "triage", "seer"],
+    "surface": "catalog"
   },
   {
     "name": "get_doc",
@@ -392,7 +455,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": []
+    "requiredScopes": [],
+    "skills": ["docs"],
+    "surface": "direct"
   },
   {
     "name": "get_event_attachment",
@@ -443,7 +508,53 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect"],
+    "surface": "direct"
+  },
+  {
+    "name": "get_issue_details",
+    "description": "Get detailed information about a specific Sentry issue by ID.\n\nUSE THIS TOOL WHEN USERS:\n- Provide a specific issue ID (e.g., 'CLOUDFLARE-MCP-41', 'PROJECT-123')\n- Ask to 'explain [ISSUE-ID]', 'tell me about [ISSUE-ID]'\n- Want details/stacktrace/analysis for a known issue\n- Provide a Sentry issue URL\n\nDO NOT USE for:\n- General searching or listing issues (use search_issues)\n\nTRIGGER PATTERNS:\n- 'Explain ISSUE-123' → use get_issue_details\n- 'Tell me about PROJECT-456' → use get_issue_details\n- 'What happened in [issue URL]' → use get_issue_details\n\n<examples>\n### With Sentry URL (recommended - simplest approach)\n```\nget_issue_details(issueUrl='https://sentry.sentry.io/issues/6916805731/?project=4509062593708032&query=is%3Aunresolved')\n```\n\n### With issue ID and organization\n```\nget_issue_details(organizationSlug='my-organization', issueId='CLOUDFLARE-MCP-41')\n```\n\n### With event ID and organization\n```\nget_issue_details(organizationSlug='my-organization', eventId='c49541c747cb4d8aa3efb70ca5aba243')\n```\n</examples>\n\n<hints>\n- **IMPORTANT**: If user provides a Sentry URL, pass the ENTIRE URL to issueUrl parameter unchanged\n- When using issueUrl, all other parameters are automatically extracted - don't provide them separately\n- If using issueId (not URL), then organizationSlug is required\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "issueId": {
+          "type": "string",
+          "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+        },
+        "eventId": {
+          "type": "string",
+          "description": "The ID of the event."
+        },
+        "issueUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect", "triage", "seer"],
+    "surface": "catalog"
   },
   {
     "name": "get_issue_tag_values",
@@ -487,7 +598,136 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect"],
+    "surface": "direct"
+  },
+  {
+    "name": "get_latest_base_snapshot",
+    "description": "Get the latest UI screenshots/images for an app from the preprod snapshot system.\n\nThis is the primary tool for retrieving app screenshots — not search_events or search_issues.\n\nUse this tool when you need to:\n- Get screenshots, screens, golden images, or reference images for an app\n- Find what the current UI looks like (latest screenshots from the main/default branch)\n- List available snapshots or browse images before requesting specific ones\n- Look up dark mode, light mode, or other variant screenshots\n- Understand what baseline images exist when investigating snapshot test or visual regression CI failures\n\nThe appId parameter is the app identifier (e.g. 'sentry-frontend', 'com.emergetools.hackernews').\nReturns compact image metadata (display_name, image_file_name, group, description) for every image.\n\n<examples>\n### Get the latest screenshots for an app\n\n```\nget_latest_base_snapshot(organizationSlug=\"sentry\", appId=\"sentry-frontend\", project=\"frontend\")\n```\n\n### Get the latest screenshots for a specific branch\n\n```\nget_latest_base_snapshot(organizationSlug=\"sentry\", appId=\"sentry-frontend\", project=\"frontend\", branch=\"main\")\n```\n</examples>\n\n<hints>\n- The response includes compact metadata per image. Scan the list to find images matching what you need (e.g. filter by group or name containing 'button').\n- To view a specific image, use get_sentry_resource(url='<snapshot_url>?selectedSnapshot=<image_file_name>').\n- If you need to investigate a specific snapshot comparison, use get_sentry_resource with the snapshot URL.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "appId": {
+          "type": "string",
+          "description": "The app identifier (e.g. 'sentry-frontend', 'com.emergetools.hackernews'). Required."
+        },
+        "branch": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Filter by git branch (e.g. 'main'). Omit to use the app's default branch."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Filter by git branch (e.g. 'main'). Omit to use the app's default branch.",
+          "default": null
+        },
+        "project": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Project slug or numeric ID for scoping (e.g. 'frontend')."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Project slug or numeric ID for scoping (e.g. 'frontend').",
+          "default": null
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        }
+      },
+      "required": ["organizationSlug", "appId"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["project:read"],
+    "skills": ["preprod"],
+    "surface": "catalog"
+  },
+  {
+    "name": "get_profile",
+    "description": "Analyze CPU profiling data to identify performance bottlenecks and detect regressions.\n\nUSE THIS TOOL WHEN:\n- User asks why a specific endpoint/transaction is slow\n- User wants to understand where CPU time is spent\n- User asks about performance bottlenecks\n- User wants to compare performance between time periods\n- User shares a Sentry profile URL\n\nRETURNS:\n- Hot paths (call stacks consuming the most CPU time)\n- Performance percentiles (p75, p95, p99) for each function\n- User code vs library code breakdown\n- Actionable recommendations for optimization\n- Regression analysis when comparing periods\n\n<examples>\n### Analyze from URL (with transaction name)\n```\nget_profile(\n  profileUrl='https://my-org.sentry.io/explore/profiling/profile/backend/flamegraph/?profilerId=abc123',\n  transactionName='/api/users'\n)\n```\n\n### Analyze by transaction name\n```\nget_profile(\n  organizationSlug='my-org',\n  transactionName='/api/users',\n  projectSlugOrId='backend'\n)\n```\n\n### Compare performance between periods\n```\nget_profile(\n  organizationSlug='my-org',\n  transactionName='/api/users',\n  projectSlugOrId='backend',\n  statsPeriod='7d',\n  compareAgainstPeriod='14d'\n)\n```\n</examples>\n\n<hints>\n- Use `focusOnUserCode: true` (default) to filter out library code\n- High p99 relative to p75 indicates inconsistent performance\n- Use compareAgainstPeriod to detect regressions over time\n- Transaction names are case-sensitive\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "profileUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Sentry profile URL. If provided, organization and project are extracted from URL. transactionName is still required."
+        },
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "projectSlugOrId": {
+          "type": ["string", "number"],
+          "description": "Project slug or numeric ID"
+        },
+        "transactionName": {
+          "type": "string",
+          "description": "Transaction name (e.g., '/api/users', 'POST /graphql')"
+        },
+        "statsPeriod": {
+          "type": "string",
+          "default": "7d",
+          "description": "Time period: '1h', '24h', '7d', '14d', '30d' (default: '7d')"
+        },
+        "compareAgainstPeriod": {
+          "type": "string",
+          "description": "Compare against this baseline period (e.g., '14d', '30d'). Enables regression detection."
+        },
+        "focusOnUserCode": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show only user code (is_application: true). Set to false to include library code."
+        },
+        "maxHotPaths": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "default": 10,
+          "description": "Number of hot paths to display (1-20, default: 10)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect"],
+    "surface": "catalog"
   },
   {
     "name": "get_profile_details",
@@ -546,7 +786,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect"],
+    "surface": "direct"
   },
   {
     "name": "get_replay_details",
@@ -583,7 +825,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["org:read", "project:read", "event:read"]
+    "requiredScopes": ["org:read", "project:read", "event:read"],
+    "skills": ["inspect"],
+    "surface": "direct"
   },
   {
     "name": "get_sentry_resource",
@@ -623,7 +867,141 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read", "project:read"]
+    "requiredScopes": ["event:read", "project:read"],
+    "skills": ["inspect", "triage", "seer", "preprod"],
+    "surface": "direct"
+  },
+  {
+    "name": "get_snapshot",
+    "description": "Get a preprod snapshot comparison summary, including metadata, counts, and changed image sections.\n\nUse this tool when you need to:\n- Investigate a failed snapshot test from CI\n- Review what changed in a specific preprod snapshot\n- Browse snapshot image file names before viewing a specific image\n\nPass organizationSlug and snapshotId. Use get_sentry_resource for snapshot URLs.\nCompact output is returned by default. Set showUnmodified=true to list unchanged and skipped images separately.\n\n<examples>\n### Browse a snapshot\n\n```\nget_snapshot(organizationSlug=\"sentry\", snapshotId=\"231949\")\n```\n\n### Include unchanged and skipped images\n\n```\nget_snapshot(organizationSlug=\"sentry\", snapshotId=\"231949\", showUnmodified=true)\n```\n</examples>\n\n<hints>\n- Use the Sentry tool `get_sentry_resource(resourceType='snapshotImage', organizationSlug='<organization_slug>', resourceId='<snapshot_id>:<image_file_name>')` to view a specific image preview.\n- Use get_sentry_resource when starting from a Sentry snapshot URL.\n- The diff percent field shows what percentage of pixels changed (0-100).\n- showUnmodified=true is useful when a diff snapshot has no changed image sections.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "snapshotId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The numeric snapshot artifact ID."
+        },
+        "showUnmodified": {
+          "type": "boolean",
+          "description": "When true, include unchanged and skipped image sections. This can substantially increase response size and token usage for large snapshots.",
+          "default": false
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        }
+      },
+      "required": ["organizationSlug", "snapshotId"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["project:read"],
+    "skills": ["preprod"],
+    "surface": "catalog"
+  },
+  {
+    "name": "get_snapshot_image",
+    "description": "Get metadata and image content for one image in a preprod snapshot.\n\nUse this tool when you need to:\n- View the current, previous, or diff image for a snapshot entry\n- Inspect metadata and context for a specific snapshot image\n- Fetch full-resolution image bytes when preview images are insufficient; full-resolution images can substantially increase response size and token usage\n\nPass organizationSlug, snapshotId, and imageIdentifier. Use get_sentry_resource for snapshot URLs.\nPreview images are returned by default; set imageResolution=full for original bytes when needed, but expect higher response size and token usage.\n\n<examples>\n### View a preview image\n\n```\nget_snapshot_image(organizationSlug=\"sentry\", snapshotId=\"231949\", imageIdentifier=\"login_screen.png\")\n```\n\n### Fetch original full-resolution bytes\n\n```\nget_snapshot_image(organizationSlug=\"sentry\", snapshotId=\"231949\", imageIdentifier=\"login_screen.png\", imageResolution=\"full\")\n```\n</examples>\n\n<hints>\n- Use get_snapshot first if you need to discover available image file names.\n- Use get_sentry_resource when starting from a Sentry snapshot URL.\n- imageIdentifier values may include slashes; pass the full image_file_name exactly as shown by get_snapshot.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "snapshotId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The numeric snapshot artifact ID."
+        },
+        "imageIdentifier": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The snapshot image file name or identifier to fetch."
+        },
+        "imageResolution": {
+          "type": "string",
+          "enum": ["preview", "full"],
+          "description": "Return locally generated previews or original full-resolution bytes. Full-resolution images can substantially increase response size and token usage.",
+          "default": "preview"
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        }
+      },
+      "required": ["organizationSlug", "snapshotId", "imageIdentifier"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["project:read"],
+    "skills": ["preprod"],
+    "surface": "catalog"
+  },
+  {
+    "name": "get_trace_details",
+    "description": "Get detailed information about a specific Sentry trace by ID.\n\nUSE THIS TOOL WHEN USERS:\n- Provide a specific trace ID (e.g., 'a4d1aae7216b47ff8117cf4e09ce9d0a')\n- Ask to 'show me trace [TRACE-ID]', 'explain trace [TRACE-ID]'\n- Want high-level overview and link to view trace details in Sentry\n- Need trace statistics and span breakdown\n- Want an overview first, then a guided pivot into additional spans or events\n\nDO NOT USE for:\n- General searching for traces (use search_events with trace queries)\n- Complete span enumeration or branch-by-branch reconstruction (use search_events scoped to the trace)\n\nTRIGGER PATTERNS:\n- 'Show me trace abc123' → use get_trace_details\n- 'Explain trace a4d1aae7216b47ff8117cf4e09ce9d0a' → use get_trace_details\n- 'What is trace [trace-id]' → use get_trace_details\n\n<examples>\n### Get trace overview\n```\nget_trace_details(organizationSlug='my-organization', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\n```\n\n### Focus a single span\n```\nget_trace_details(organizationSlug='my-organization', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a', spanId='aa8e7f3384ef4ff5')\n```\n</examples>\n\n<hints>\n- Trace IDs are 32-character hexadecimal strings\n- This returns a condensed trace overview, not a full span dump\n- Provide `spanId` to focus on a single span within the trace\n- If the response says it shows a subset of spans, use search_events to inspect the rest of the trace\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "traceId": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{32}$",
+          "description": "The trace ID. e.g. `a4d1aae7216b47ff8117cf4e09ce9d0a`"
+        },
+        "spanId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The span ID within a trace. Use this with a trace resource to focus on a specific span."
+        }
+      },
+      "required": ["organizationSlug", "traceId"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect"],
+    "surface": "catalog"
   },
   {
     "name": "search_docs",
@@ -790,7 +1168,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": []
+    "requiredScopes": [],
+    "skills": ["docs"],
+    "surface": "direct"
   },
   {
     "name": "search_events",
@@ -907,7 +1287,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect", "triage", "seer"],
+    "surface": "direct"
   },
   {
     "name": "search_issue_events",
@@ -991,7 +1373,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect", "triage"],
+    "surface": "direct"
   },
   {
     "name": "search_issues",
@@ -1056,7 +1440,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:read"]
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect", "triage", "seer"],
+    "surface": "direct"
   },
   {
     "name": "update_issue",
@@ -1151,7 +1537,9 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["event:write"]
+    "requiredScopes": ["event:write"],
+    "skills": ["triage"],
+    "surface": "direct"
   },
   {
     "name": "update_project",
@@ -1237,12 +1625,23 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:write"]
+    "requiredScopes": ["project:write"],
+    "skills": ["project-management"],
+    "surface": "direct"
   },
   {
     "name": "whoami",
     "description": "Identify the authenticated user in Sentry.\n\nUse this tool when you need to:\n- Get the user's name and email address.",
     "inputSchema": {},
-    "requiredScopes": []
+    "requiredScopes": [],
+    "skills": [
+      "inspect",
+      "seer",
+      "docs",
+      "triage",
+      "project-management",
+      "preprod"
+    ],
+    "surface": "direct"
   }
 ]

--- a/packages/mcp-core/src/toolDefinitions.ts
+++ b/packages/mcp-core/src/toolDefinitions.ts
@@ -1,7 +1,10 @@
 import toolDefinitionsData from "./toolDefinitions.json";
 import type { Scope } from "./permissions";
+import type { Skill } from "./skills";
 
 // Tool definition for UI/external consumption
+export type ToolDefinitionSurface = "direct" | "catalog";
+
 export interface ToolDefinition {
   name: string;
   description: string;
@@ -9,8 +12,20 @@ export interface ToolDefinition {
   inputSchema: unknown;
   // Sentry API scopes required to use the tool
   requiredScopes: Scope[];
+  // User-facing skill catalog memberships
+  skills: Skill[];
+  // Whether this tool is exposed directly or through the catalog.
+  surface: ToolDefinitionSurface;
 }
 
 const toolDefinitions = toolDefinitionsData as ToolDefinition[];
+
+export const directToolDefinitions = toolDefinitions.filter(
+  (tool) => tool.surface === "direct",
+);
+
+export const catalogToolDefinitions = toolDefinitions.filter(
+  (tool) => tool.surface === "catalog",
+);
 
 export default toolDefinitions;

--- a/packages/mcp-core/src/tools/catalog/support/api-formatting.ts
+++ b/packages/mcp-core/src/tools/catalog/support/api-formatting.ts
@@ -1,0 +1,86 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function formatId(value: string | number | undefined | null): string {
+  return value === undefined || value === null ? "unknown" : String(value);
+}
+
+export function formatDate(value: string | undefined | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toISOString();
+}
+
+export function formatActor(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (!isRecord(value)) {
+    return "unknown";
+  }
+
+  const name = value.name;
+  if (typeof name === "string" && name.trim()) {
+    return name;
+  }
+
+  const email = value.email;
+  if (typeof email === "string" && email.trim()) {
+    return email;
+  }
+
+  const username = value.username;
+  if (typeof username === "string" && username.trim()) {
+    return username;
+  }
+
+  return formatId(
+    typeof value.id === "string" || typeof value.id === "number"
+      ? value.id
+      : undefined,
+  );
+}
+
+export function formatUnknown(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "unknown";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+export function readString(
+  value: Record<string, unknown> | undefined | null,
+  key: string,
+): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const field = value[key];
+  return typeof field === "string" && field.trim() ? field : null;
+}
+
+export function compactLines(lines: Array<string | null | undefined | false>) {
+  return lines.filter(
+    (line): line is string =>
+      line !== null && line !== undefined && line !== false,
+  );
+}

--- a/packages/mcp-core/src/tools/catalog/support/project-constraints.test.ts
+++ b/packages/mcp-core/src/tools/catalog/support/project-constraints.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { UserInputError } from "../../../errors";
+import {
+  assertProjectConstraintEvidence,
+  assertProjectListContainsConstraint,
+  assertProjectRefWithinConstraint,
+} from "./project-constraints";
+
+describe("project constraint helpers", () => {
+  describe("assertProjectRefWithinConstraint", () => {
+    it("allows missing project evidence without a scoped project", () => {
+      expect(() =>
+        assertProjectRefWithinConstraint({
+          resourceLabel: "Release",
+          scopedProjectSlug: null,
+          project: null,
+        }),
+      ).not.toThrow();
+    });
+
+    it("accepts a matching project slug", () => {
+      expect(() =>
+        assertProjectRefWithinConstraint({
+          resourceLabel: "Release",
+          scopedProjectSlug: "frontend",
+          project: { slug: "frontend" },
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects a different project slug", () => {
+      expect(() =>
+        assertProjectRefWithinConstraint({
+          resourceLabel: "Release",
+          scopedProjectSlug: "frontend",
+          project: { slug: "backend" },
+        }),
+      ).toThrow(UserInputError);
+    });
+
+    it("does not treat a display name as slug evidence", () => {
+      const project = { slug: null, name: "frontend" };
+
+      expect(() =>
+        assertProjectRefWithinConstraint({
+          resourceLabel: "Release",
+          scopedProjectSlug: "frontend",
+          project,
+        }),
+      ).toThrow(UserInputError);
+    });
+  });
+
+  describe("assertProjectListContainsConstraint", () => {
+    it("accepts a list containing the scoped project slug", () => {
+      expect(() =>
+        assertProjectListContainsConstraint({
+          resourceLabel: "Release",
+          scopedProjectSlug: "frontend",
+          projects: [{ slug: "backend" }, { slug: "frontend" }],
+        }),
+      ).not.toThrow();
+    });
+
+    it("does not treat display names as slug evidence", () => {
+      const projects = [{ slug: null, name: "frontend" }];
+
+      expect(() =>
+        assertProjectListContainsConstraint({
+          resourceLabel: "Release",
+          scopedProjectSlug: "frontend",
+          projects,
+        }),
+      ).toThrow(UserInputError);
+    });
+  });
+
+  describe("assertProjectConstraintEvidence", () => {
+    it("allows missing evidence without a scoped project", () => {
+      expect(() =>
+        assertProjectConstraintEvidence({
+          resourceLabel: "Release",
+          scopedProjectSlug: null,
+          hasEvidence: false,
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects missing evidence with a scoped project", () => {
+      expect(() =>
+        assertProjectConstraintEvidence({
+          resourceLabel: "Release",
+          scopedProjectSlug: "frontend",
+          hasEvidence: false,
+        }),
+      ).toThrow(UserInputError);
+    });
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/support/project-constraints.ts
+++ b/packages/mcp-core/src/tools/catalog/support/project-constraints.ts
@@ -2,7 +2,6 @@ import { UserInputError } from "../../../errors";
 
 type ProjectRef = {
   slug?: string | null;
-  name?: string | null;
 };
 
 function projectConstraintError(resourceLabel: string, projectSlug: string) {
@@ -11,8 +10,8 @@ function projectConstraintError(resourceLabel: string, projectSlug: string) {
   );
 }
 
-function projectLabel(project: ProjectRef | null | undefined): string | null {
-  return project?.slug ?? project?.name ?? null;
+function projectSlug(project: ProjectRef | null | undefined): string | null {
+  return project?.slug ?? null;
 }
 
 export function assertProjectRefWithinConstraint({
@@ -28,7 +27,7 @@ export function assertProjectRefWithinConstraint({
     return;
   }
 
-  if (projectLabel(project) !== scopedProjectSlug) {
+  if (projectSlug(project) !== scopedProjectSlug) {
     throw projectConstraintError(resourceLabel, scopedProjectSlug);
   }
 }
@@ -47,7 +46,7 @@ export function assertProjectListContainsConstraint({
   }
 
   const hasMatchingProject =
-    projects?.some((project) => projectLabel(project) === scopedProjectSlug) ??
+    projects?.some((project) => projectSlug(project) === scopedProjectSlug) ??
     false;
 
   if (!hasMatchingProject) {

--- a/packages/mcp-core/src/tools/catalog/support/project-constraints.ts
+++ b/packages/mcp-core/src/tools/catalog/support/project-constraints.ts
@@ -1,0 +1,72 @@
+import { UserInputError } from "../../../errors";
+
+type ProjectRef = {
+  slug?: string | null;
+  name?: string | null;
+};
+
+function projectConstraintError(resourceLabel: string, projectSlug: string) {
+  return new UserInputError(
+    `${resourceLabel} is outside the active project constraint. Expected project "${projectSlug}".`,
+  );
+}
+
+function projectLabel(project: ProjectRef | null | undefined): string | null {
+  return project?.slug ?? project?.name ?? null;
+}
+
+export function assertProjectRefWithinConstraint({
+  resourceLabel,
+  scopedProjectSlug,
+  project,
+}: {
+  resourceLabel: string;
+  scopedProjectSlug?: string | null;
+  project?: ProjectRef | null;
+}): void {
+  if (!scopedProjectSlug) {
+    return;
+  }
+
+  if (projectLabel(project) !== scopedProjectSlug) {
+    throw projectConstraintError(resourceLabel, scopedProjectSlug);
+  }
+}
+
+export function assertProjectListContainsConstraint({
+  resourceLabel,
+  scopedProjectSlug,
+  projects,
+}: {
+  resourceLabel: string;
+  scopedProjectSlug?: string | null;
+  projects?: ProjectRef[] | null;
+}): void {
+  if (!scopedProjectSlug) {
+    return;
+  }
+
+  const hasMatchingProject =
+    projects?.some((project) => projectLabel(project) === scopedProjectSlug) ??
+    false;
+
+  if (!hasMatchingProject) {
+    throw projectConstraintError(resourceLabel, scopedProjectSlug);
+  }
+}
+
+export function assertProjectConstraintEvidence({
+  resourceLabel,
+  scopedProjectSlug,
+  hasEvidence,
+}: {
+  resourceLabel: string;
+  scopedProjectSlug?: string | null;
+  hasEvidence: boolean;
+}): void {
+  if (!scopedProjectSlug || hasEvidence) {
+    return;
+  }
+
+  throw projectConstraintError(resourceLabel, scopedProjectSlug);
+}


### PR DESCRIPTION
Publish all user-visible Sentry MCP tools through the existing /.mcp/tools.json metadata route so catalog-only tools can be discovered without adding another public endpoint. Each generated tool now includes surface and skills metadata to distinguish direct MCP calls from catalog-executed tools.

**Tool Catalog**

The @sentry/mcp-core/toolDefinitions artifact now includes both direct and catalog tools, with named exports for directToolDefinitions and catalogToolDefinitions when consumers need the split.

**Agent Configuration**

Definition generation still syncs plugin allowedTools from direct tools only, so catalog-only entries are not advertised as direct MCP calls.

**Catalog Foundation**

Add shared formatting and project-constraint helpers for follow-up Sentry API tool branches.