### PR TITLE
feat(seer): Add referrer to autofix start request

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2853,6 +2853,7 @@ export class SentryApiService {
         body: JSON.stringify({
           event_id: eventId,
           instruction,
+          referrer: "api.mcp",
         }),
       },
       opts,

--- a/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.test.ts
+++ b/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.test.ts
@@ -392,6 +392,7 @@ describe("analyze_issue_with_seer", () => {
           expect(body).toEqual({
             event_id: undefined,
             instruction: "Focus on memory leaks",
+            referrer: "api.mcp",
           });
           return HttpResponse.json({
             run_id: 123,


### PR DESCRIPTION
Tags autofix runs triggered by the MCP server with a `referrer` of `api.mcp`, matching the `AutofixReferrer.MCP` value in the Sentry backend (`src/sentry/seer/autofix/constants.py`).

Agent transcript: https://claudescope.sentry.dev/share/jIOVMCaIoir7uFLy6krQP1b6De5yXFe0RprlaidOOwU