### PR TITLE
feat(issues): Add activity and note tools

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -33,6 +33,9 @@ import {
   ProjectSchema,
   RepositoryListSchema,
   ReleaseListSchema,
+  IssueActivityListResponseSchema,
+  IssueCommentListSchema,
+  IssueCommentSchema,
   IssueListSchema,
   IssueSchema,
   IssueTagValuesSchema,
@@ -72,6 +75,9 @@ import type {
   EventAttachment,
   EventAttachmentList,
   Issue,
+  IssueActivityList,
+  IssueComment,
+  IssueCommentList,
   IssueList,
   IssueTagValues,
   ExternalIssueList,
@@ -2484,8 +2490,8 @@ export class SentryApiService {
       text: string;
     },
     opts?: RequestOptions,
-  ): Promise<void> {
-    await this.requestJSON(
+  ): Promise<IssueComment> {
+    const body = await this.requestJSON(
       `/organizations/${organizationSlug}/issues/${issueId}/notes/`,
       {
         method: "POST",
@@ -2493,6 +2499,51 @@ export class SentryApiService {
       },
       opts,
     );
+    return IssueCommentSchema.parse(body);
+  }
+
+  async getIssueActivity(
+    {
+      organizationSlug,
+      issueId,
+    }: {
+      organizationSlug: string;
+      issueId: string;
+    },
+    opts?: RequestOptions,
+  ): Promise<IssueActivityList> {
+    const body = await this.requestJSON(
+      `/organizations/${organizationSlug}/issues/${issueId}/activities/`,
+      undefined,
+      opts,
+    );
+    return IssueActivityListResponseSchema.parse(body).activity;
+  }
+
+  async listIssueComments(
+    {
+      organizationSlug,
+      issueId,
+      limit,
+    }: {
+      organizationSlug: string;
+      issueId: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<IssueCommentList> {
+    const searchQuery = new URLSearchParams();
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
+    }
+
+    const path = `/organizations/${organizationSlug}/issues/${issueId}/notes/`;
+    const body = await this.requestJSON(
+      searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
+      undefined,
+      opts,
+    );
+    return IssueCommentListSchema.parse(body);
   }
 
   // TODO: Sentry is not yet exposing a reasonable API to fetch trace data

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -325,6 +325,39 @@ export const ReleaseSchema = z.object({
 
 export const ReleaseListSchema = z.array(ReleaseSchema);
 
+const ApiResourceIdSchema = z.union([z.string(), z.number()]);
+
+const ApiActorSchema = z
+  .object({
+    id: ApiResourceIdSchema.optional(),
+    name: z.string().nullable().optional(),
+    email: z.string().nullable().optional(),
+    username: z.string().nullable().optional(),
+    type: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const IssueActivitySchema = z
+  .object({
+    id: ApiResourceIdSchema,
+    type: z.string().nullable().optional(),
+    dateCreated: z.string().datetime().nullable().optional(),
+    user: ApiActorSchema.nullable().optional(),
+    sentry_app: z.record(z.string(), z.unknown()).nullable().optional(),
+    data: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .passthrough();
+
+export const IssueActivityListResponseSchema = z.object({
+  activity: z.array(IssueActivitySchema),
+});
+
+export const IssueCommentSchema = IssueActivitySchema.extend({
+  type: z.string().nullable().optional(),
+});
+
+export const IssueCommentListSchema = z.array(IssueCommentSchema);
+
 /**
  * Organization tag lists are backed by `TagKeySerializerResponse`, which only
  * guarantees `key` and `name`. Count fields are backend-dependent and may come

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -60,6 +60,10 @@ import type {
   FlamegraphProfileSchema,
   FlamegraphSchema,
   GenericEventSchema,
+  IssueActivityListResponseSchema,
+  IssueActivitySchema,
+  IssueCommentListSchema,
+  IssueCommentSchema,
   IssueListSchema,
   IssueSchema,
   IssueTagValuesSchema,
@@ -98,6 +102,8 @@ export type Project = z.infer<typeof ProjectSchema>;
 export type ClientKey = z.infer<typeof ClientKeySchema>;
 export type Release = z.infer<typeof ReleaseSchema>;
 export type Issue = z.infer<typeof IssueSchema>;
+export type IssueActivity = z.infer<typeof IssueActivitySchema>;
+export type IssueComment = z.infer<typeof IssueCommentSchema>;
 
 // Individual event types
 export type ErrorEvent = z.infer<typeof ErrorEventSchema>;
@@ -131,6 +137,10 @@ export type TeamList = z.infer<typeof TeamListSchema>;
 export type ProjectList = z.infer<typeof ProjectListSchema>;
 export type ReleaseList = z.infer<typeof ReleaseListSchema>;
 export type IssueList = z.infer<typeof IssueListSchema>;
+export type IssueActivityList = z.infer<
+  typeof IssueActivityListResponseSchema
+>["activity"];
+export type IssueCommentList = z.infer<typeof IssueCommentListSchema>;
 export type EventAttachmentList = z.infer<typeof EventAttachmentListSchema>;
 export type TagList = z.infer<typeof TagListSchema>;
 export type ClientKeyList = z.infer<typeof ClientKeyListSchema>;

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Search for errors, analyze traces, and explore event details",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 17,
+    "toolCount": 18,
     "tools": [
       {
         "name": "find_organizations",
@@ -35,6 +35,11 @@
       {
         "name": "get_event_attachment",
         "description": "Download attachments from a Sentry event.\n\nUse this tool when you need to:\n- Download files attached to a specific event\n- Access screenshots, log files, or other attachments uploaded with an error report\n- Retrieve attachment metadata and download URLs\n\n<examples>\n### Download a specific attachment by ID\n\n```\nget_event_attachment(organizationSlug='my-organization', projectSlug='my-project', eventId='c49541c747cb4d8aa3efb70ca5aba243', attachmentId='12345')\n```\n\n### List all attachments for an event\n\n```\nget_event_attachment(organizationSlug='my-organization', projectSlug='my-project', eventId='c49541c747cb4d8aa3efb70ca5aba243')\n```\n\n</examples>\n\n<hints>\n- If `attachmentId` is provided, the specific attachment will be downloaded as an embedded resource\n- If `attachmentId` is omitted, all attachments for the event will be listed with download information\n- The `projectSlug` is required to identify which project the event belongs to\n</hints>",
+        "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "get_issue_activity",
+        "description": "Get the activity feed and comments for a Sentry issue.\n\nUse this tool when you need to:\n- Review prior comments before triaging an issue\n- Understand who resolved, ignored, assigned, or commented on an issue\n- See recent issue activity that is not included in `get_issue_details`\n\n<examples>\nget_issue_activity(organizationSlug='my-organization', issueId='PROJECT-123')\nget_issue_activity(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/')\n</examples>",
         "requiredScopes": ["event:read"]
       },
       {
@@ -190,8 +195,13 @@
     "description": "Resolve, assign, and update issues",
     "defaultEnabled": false,
     "order": 4,
-    "toolCount": 11,
+    "toolCount": 13,
     "tools": [
+      {
+        "name": "add_issue_note",
+        "description": "Add a human-visible comment to a Sentry issue's activity feed.\n\nUse this tool when the user explicitly asks to leave a note/comment, or when a triage workflow needs to record a user-approved explanation.\n\n<examples>\nadd_issue_note(organizationSlug='my-organization', issueId='PROJECT-123', text='Investigating with the payments team.')\nadd_issue_note(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/', text='Resolved by deploy 1.2.3.')\n</examples>\n\n<hints>\n- This mutates visible Sentry issue state by posting a comment.\n- Do not use this for private scratch notes, secrets, credentials, or unapproved content.\n</hints>",
+        "requiredScopes": ["event:write"]
+      },
       {
         "name": "find_organizations",
         "description": "Find organizations that the user has access to in Sentry.\n\nUse this tool when you need to:\n- View organizations in Sentry\n- Find an organization's slug to aid other tool requests\n- Search for specific organizations by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
@@ -211,6 +221,11 @@
         "name": "get_ai_conversation_details",
         "description": "Fetch all spans for an AI conversation by its gen_ai.conversation.id.\n\nA conversation is a set of spans sharing the same gen_ai.conversation.id. To discover conversation IDs, use search_events with dataset='spans' and query='has:gen_ai.conversation.id'.",
         "requiredScopes": ["event:read", "project:read"]
+      },
+      {
+        "name": "get_issue_activity",
+        "description": "Get the activity feed and comments for a Sentry issue.\n\nUse this tool when you need to:\n- Review prior comments before triaging an issue\n- Understand who resolved, ignored, assigned, or commented on an issue\n- See recent issue activity that is not included in `get_issue_details`\n\n<examples>\nget_issue_activity(organizationSlug='my-organization', issueId='PROJECT-123')\nget_issue_activity(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/')\n</examples>",
+        "requiredScopes": ["event:read"]
       },
       {
         "name": "get_issue_details",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -1,5 +1,52 @@
 [
   {
+    "name": "add_issue_note",
+    "description": "Add a human-visible comment to a Sentry issue's activity feed.\n\nUse this tool when the user explicitly asks to leave a note/comment, or when a triage workflow needs to record a user-approved explanation.\n\n<examples>\nadd_issue_note(organizationSlug='my-organization', issueId='PROJECT-123', text='Investigating with the payments team.')\nadd_issue_note(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/', text='Resolved by deploy 1.2.3.')\n</examples>\n\n<hints>\n- This mutates visible Sentry issue state by posting a comment.\n- Do not use this for private scratch notes, secrets, credentials, or unapproved content.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "issueId": {
+          "type": "string",
+          "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+        },
+        "issueUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43"
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "description": "The exact comment text to add to the issue."
+        }
+      },
+      "required": ["text"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:write"],
+    "skills": ["triage"],
+    "surface": "catalog"
+  },
+  {
     "name": "analyze_issue_with_seer",
     "description": "Use Seer to analyze production errors and get detailed root cause analysis with specific code fixes.\n\nUse this tool when:\n- The user explicitly asks for root cause analysis, Seer analysis, or help fixing/debugging an issue\n- You are unable to accurately determine the root cause from the issue details alone\n\nDo NOT call this tool as an automatic follow-up to get_sentry_resource.\n\nWhat this tool provides:\n- Root cause analysis with code-level explanations\n- Specific file locations and line numbers where errors occur\n- Concrete code fixes you can apply\n- Step-by-step implementation guidance\n\nThis tool automatically:\n1. Checks if analysis already exists (instant results)\n2. Starts new AI analysis if needed (~2-5 minutes)\n3. Returns complete fix recommendations\n\n<examples>\n### User: \"Run Seer on this issue\"\n\n```\nanalyze_issue_with_seer(issueUrl='https://my-org.sentry.io/issues/PROJECT-1Z43')\n```\n\n### User: \"Analyze this issue and suggest a fix\"\n\n```\nanalyze_issue_with_seer(organizationSlug='my-organization', issueId='ERROR-456')\n```\n</examples>\n\n<hints>\n- Only use when the user explicitly requests analysis or you cannot determine the root cause from issue details alone\n- If the user provides an issueUrl, extract it and use that parameter alone\n- The analysis includes actual code snippets and fixes, not just error descriptions\n- Results are cached - subsequent calls return instantly\n</hints>",
     "inputSchema": {
@@ -511,6 +558,56 @@
     "requiredScopes": ["event:read"],
     "skills": ["inspect"],
     "surface": "direct"
+  },
+  {
+    "name": "get_issue_activity",
+    "description": "Get the activity feed and comments for a Sentry issue.\n\nUse this tool when you need to:\n- Review prior comments before triaging an issue\n- Understand who resolved, ignored, assigned, or commented on an issue\n- See recent issue activity that is not included in `get_issue_details`\n\n<examples>\nget_issue_activity(organizationSlug='my-organization', issueId='PROJECT-123')\nget_issue_activity(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/')\n</examples>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "issueId": {
+          "type": "string",
+          "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+        },
+        "issueUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the issue. e.g. https://my-organization.sentry.io/issues/PROJECT-1Z43"
+        },
+        "includeComments": {
+          "type": "boolean",
+          "default": true
+        },
+        "limit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 100,
+          "default": 25
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect", "triage"],
+    "surface": "catalog"
   },
   {
     "name": "get_issue_details",

--- a/packages/mcp-core/src/tools/catalog/add-issue-note.test.ts
+++ b/packages/mcp-core/src/tools/catalog/add-issue-note.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import addIssueNote from "./add-issue-note.js";
+
+const context = {
+  constraints: {
+    organizationSlug: null,
+  },
+  accessToken: "access-token",
+  userId: "1",
+};
+
+describe("add_issue_note", () => {
+  it("serializes the created note", async () => {
+    const result = await addIssueNote.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        issueId: "CLOUDFLARE-MCP-41",
+        text: "Investigating with the payments team.",
+      },
+      context,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Added Note to Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**
+
+      **Comment ID**: 12345
+      **Type**: note
+      **Author**: Test User
+      **Created**: 2025-04-14T12:34:56.000Z
+      **Text**: Investigating with the payments team.
+
+      ## Response Notes
+
+      - The note is visible in the issue activity feed."
+    `);
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/add-issue-note.ts
+++ b/packages/mcp-core/src/tools/catalog/add-issue-note.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import {
+  ensureIssueWithinProjectConstraint,
+  parseIssueParams,
+} from "../../internal/tool-helpers/issue";
+import type { IssueComment } from "../../api-client/types";
+import type { ServerContext } from "../../types";
+import {
+  ParamIssueShortId,
+  ParamIssueUrl,
+  ParamOrganizationSlug,
+  ParamRegionUrl,
+} from "../../schema";
+import {
+  formatActor,
+  formatDate,
+  formatId,
+  readString,
+} from "./support/api-formatting";
+
+function formatComment(comment: IssueComment): string {
+  const actor = comment.user ? formatActor(comment.user) : "current user";
+  const text = comment.data ? readString(comment.data, "text") : null;
+
+  return [
+    `**Comment ID**: ${formatId(comment.id)}`,
+    `**Type**: ${comment.type ?? "note"}`,
+    `**Author**: ${actor}`,
+    formatDate(comment.dateCreated)
+      ? `**Created**: ${formatDate(comment.dateCreated)}`
+      : null,
+    text ? `**Text**: ${text}` : null,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+export default defineTool({
+  name: "add_issue_note",
+  skills: ["triage"],
+  requiredScopes: ["event:write"],
+  description: [
+    "Add a human-visible comment to a Sentry issue's activity feed.",
+    "",
+    "Use this tool when the user explicitly asks to leave a note/comment, or when a triage workflow needs to record a user-approved explanation.",
+    "",
+    "<examples>",
+    "add_issue_note(organizationSlug='my-organization', issueId='PROJECT-123', text='Investigating with the payments team.')",
+    "add_issue_note(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/', text='Resolved by deploy 1.2.3.')",
+    "</examples>",
+    "",
+    "<hints>",
+    "- This mutates visible Sentry issue state by posting a comment.",
+    "- Do not use this for private scratch notes, secrets, credentials, or unapproved content.",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug.optional(),
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    issueId: ParamIssueShortId.optional(),
+    issueUrl: ParamIssueUrl.optional(),
+    text: z
+      .string()
+      .trim()
+      .min(1)
+      .max(4096)
+      .describe("The exact comment text to add to the issue."),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const parsed = parseIssueParams({
+      issueUrl: params.issueUrl,
+      issueId: params.issueId,
+      organizationSlug:
+        params.organizationSlug ?? context.constraints.organizationSlug,
+    });
+
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? context.constraints.regionUrl ?? undefined,
+    });
+    setTag("organization.slug", parsed.organizationSlug);
+    setTag("issue.id", parsed.issueId);
+
+    await ensureIssueWithinProjectConstraint({
+      apiService,
+      organizationSlug: parsed.organizationSlug,
+      issueId: parsed.issueId,
+      projectSlug: context.constraints.projectSlug,
+    });
+
+    const comment = await apiService.createIssueComment({
+      organizationSlug: parsed.organizationSlug,
+      issueId: parsed.issueId,
+      text: params.text,
+    });
+
+    return [
+      `# Added Note to Issue ${parsed.issueId} in **${parsed.organizationSlug}**`,
+      "",
+      formatComment(comment),
+      "",
+      "## Response Notes",
+      "",
+      "- The note is visible in the issue activity feed.",
+    ].join("\n");
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/get-issue-activity.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-activity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import getIssueActivity from "./get-issue-activity.js";
+
+const context = {
+  constraints: {
+    organizationSlug: null,
+  },
+  accessToken: "access-token",
+  userId: "1",
+};
+
+describe("get_issue_activity", () => {
+  it("serializes issue activity and comments", async () => {
+    const result = await getIssueActivity.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        issueId: "CLOUDFLARE-MCP-41",
+        includeComments: true,
+        limit: 25,
+      },
+      context,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Activity for Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**
+
+      ## Activity
+
+      - 2025-04-10T22:55:22.411Z: auto_set_ongoing by system (4633815464)
+        - Data: {"after_days":7}
+      - 2025-04-14T12:00:00.000Z: note by Jane Developer (4633816000)
+        - Investigating after the latest deploy.
+
+      ## Comments
+
+      - 2025-04-14T12:00:00.000Z: note by Jane Developer (4633816000)
+        - Investigating after the latest deploy.
+
+      ## Response Notes
+
+      - Use \`add_issue_note\` to add a new human-visible issue comment.
+      "
+    `);
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/get-issue-activity.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-activity.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import {
+  ensureIssueWithinProjectConstraint,
+  parseIssueParams,
+} from "../../internal/tool-helpers/issue";
+import type { IssueActivity, IssueComment } from "../../api-client/types";
+import type { ServerContext } from "../../types";
+import {
+  ParamIssueShortId,
+  ParamIssueUrl,
+  ParamOrganizationSlug,
+  ParamRegionUrl,
+} from "../../schema";
+import {
+  formatActor,
+  formatDate,
+  formatId,
+  formatUnknown,
+  isRecord,
+  readString,
+} from "./support/api-formatting";
+
+function getActivityText(
+  activity: IssueActivity | IssueComment,
+): string | null {
+  const data = activity.data;
+  if (!data) {
+    return null;
+  }
+
+  return (
+    readString(data, "text") ??
+    readString(data, "message") ??
+    readString(data, "reason") ??
+    readString(data, "description")
+  );
+}
+
+function formatActivity(activity: IssueActivity | IssueComment): string {
+  const actor = activity.user ? formatActor(activity.user) : "system";
+  const date = formatDate(activity.dateCreated) ?? "unknown time";
+  const text = getActivityText(activity);
+  const details =
+    !text && isRecord(activity.data) && Object.keys(activity.data).length > 0
+      ? `\n  - Data: ${formatUnknown(activity.data)}`
+      : "";
+  return `- ${date}: ${activity.type ?? "activity"} by ${actor} (${formatId(activity.id)})${text ? `\n  - ${text}` : ""}${details}`;
+}
+
+export default defineTool({
+  name: "get_issue_activity",
+  skills: ["inspect", "triage"],
+  requiredScopes: ["event:read"],
+  description: [
+    "Get the activity feed and comments for a Sentry issue.",
+    "",
+    "Use this tool when you need to:",
+    "- Review prior comments before triaging an issue",
+    "- Understand who resolved, ignored, assigned, or commented on an issue",
+    "- See recent issue activity that is not included in `get_issue_details`",
+    "",
+    "<examples>",
+    "get_issue_activity(organizationSlug='my-organization', issueId='PROJECT-123')",
+    "get_issue_activity(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/')",
+    "</examples>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug.optional(),
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    issueId: ParamIssueShortId.optional(),
+    issueUrl: ParamIssueUrl.optional(),
+    includeComments: z.boolean().default(true),
+    limit: z.number().int().positive().max(100).default(25),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const parsed = parseIssueParams({
+      issueUrl: params.issueUrl,
+      issueId: params.issueId,
+      organizationSlug:
+        params.organizationSlug ?? context.constraints.organizationSlug,
+    });
+
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? context.constraints.regionUrl ?? undefined,
+    });
+    setTag("organization.slug", parsed.organizationSlug);
+    setTag("issue.id", parsed.issueId);
+
+    await ensureIssueWithinProjectConstraint({
+      apiService,
+      organizationSlug: parsed.organizationSlug,
+      issueId: parsed.issueId,
+      projectSlug: context.constraints.projectSlug,
+    });
+
+    const [activity, comments] = await Promise.all([
+      apiService.getIssueActivity({
+        organizationSlug: parsed.organizationSlug,
+        issueId: parsed.issueId,
+      }),
+      params.includeComments
+        ? apiService.listIssueComments({
+            organizationSlug: parsed.organizationSlug,
+            issueId: parsed.issueId,
+            limit: params.limit,
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const output = [
+      `# Activity for Issue ${parsed.issueId} in **${parsed.organizationSlug}**`,
+      "",
+      "## Activity",
+      "",
+      activity.length === 0
+        ? "No activity found."
+        : activity.slice(0, params.limit).map(formatActivity).join("\n"),
+    ];
+
+    if (params.includeComments) {
+      output.push("", "## Comments", "");
+      output.push(
+        comments.length === 0
+          ? "No comments found."
+          : comments.slice(0, params.limit).map(formatActivity).join("\n"),
+      );
+    }
+
+    output.push("", "## Response Notes", "");
+    output.push(
+      "- Use `add_issue_note` to add a new human-visible issue comment.",
+    );
+
+    return `${output.join("\n")}\n`;
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/index.ts
+++ b/packages/mcp-core/src/tools/catalog/index.ts
@@ -4,6 +4,7 @@ import findTeams from "./find-teams";
 import findProjects from "./find-projects";
 import findReleases from "./find-releases";
 import getIssueDetails from "./get-issue-details";
+import getIssueActivity from "./get-issue-activity";
 import getIssueTagValues from "./get-issue-tag-values";
 import getTraceDetails from "./get-trace-details";
 import getReplayDetails from "./get-replay-details";
@@ -27,6 +28,7 @@ import getSnapshot from "./get-snapshot";
 import getSnapshotImage from "./get-snapshot-image";
 import getLatestBaseSnapshot from "./get-latest-base-snapshot";
 import getAIConversationDetails from "./get-ai-conversation-details";
+import addIssueNote from "./add-issue-note";
 import type { ToolConfig } from "../types";
 
 /**
@@ -45,6 +47,7 @@ const catalogTools = {
   find_projects: findProjects,
   find_releases: findReleases,
   get_issue_details: getIssueDetails,
+  get_issue_activity: getIssueActivity,
   get_issue_tag_values: getIssueTagValues,
   get_trace_details: getTraceDetails,
   get_replay_details: getReplayDetails,
@@ -68,6 +71,7 @@ const catalogTools = {
   get_snapshot_image: getSnapshotImage,
   get_latest_base_snapshot: getLatestBaseSnapshot,
   get_ai_conversation_details: getAIConversationDetails,
+  add_issue_note: addIssueNote,
 } as const satisfies Record<string, ToolConfig<any>>;
 
 export default catalogTools;

--- a/packages/mcp-core/src/tools/catalog/update-issue.ts
+++ b/packages/mcp-core/src/tools/catalog/update-issue.ts
@@ -574,7 +574,7 @@ async function tryPostReasonComment(
       organizationSlug: string;
       issueId: string;
       text: string;
-    }) => Promise<void>;
+    }) => Promise<unknown>;
   },
   organizationSlug: string,
   issueId: string,

--- a/packages/mcp-server-mocks/src/fixtures/issue-activity.json
+++ b/packages/mcp-server-mocks/src/fixtures/issue-activity.json
@@ -1,0 +1,28 @@
+{
+  "activity": [
+    {
+      "id": "4633815464",
+      "user": null,
+      "sentry_app": null,
+      "type": "auto_set_ongoing",
+      "data": {
+        "after_days": 7
+      },
+      "dateCreated": "2025-04-10T22:55:22.411Z"
+    },
+    {
+      "id": "4633816000",
+      "user": {
+        "id": "12345",
+        "name": "Jane Developer",
+        "email": "jane@example.com"
+      },
+      "sentry_app": null,
+      "type": "note",
+      "data": {
+        "text": "Investigating after the latest deploy."
+      },
+      "dateCreated": "2025-04-14T12:00:00.000Z"
+    }
+  ]
+}

--- a/packages/mcp-server-mocks/src/fixtures/issue-comments.json
+++ b/packages/mcp-server-mocks/src/fixtures/issue-comments.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "4633816000",
+    "user": {
+      "id": "12345",
+      "name": "Jane Developer",
+      "email": "jane@example.com"
+    },
+    "sentry_app": null,
+    "type": "note",
+    "data": {
+      "text": "Investigating after the latest deploy."
+    },
+    "dateCreated": "2025-04-14T12:00:00.000Z"
+  }
+]

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -71,6 +71,12 @@ import profileChunkFixture from "./fixtures/profile-chunk.json" with {
 import issueTagValuesFixture from "./fixtures/issue-tag-values.json" with {
   type: "json",
 };
+import issueActivityFixture from "./fixtures/issue-activity.json" with {
+  type: "json",
+};
+import issueCommentsFixture from "./fixtures/issue-comments.json" with {
+  type: "json",
+};
 import issueFixture from "./fixtures/issue.json" with { type: "json" };
 import issueNullCulpritFixture from "./fixtures/issue-null-culprit.json" with {
   type: "json",
@@ -1031,6 +1037,16 @@ export const restHandlers = buildHandlers([
     },
   },
   {
+    method: "get",
+    path: "/api/0/organizations/:org/issues/:issueId/activities/",
+    fetch: () => HttpResponse.json(issueActivityFixture),
+  },
+  {
+    method: "get",
+    path: "/api/0/organizations/:org/issues/:issueId/notes/",
+    fetch: () => HttpResponse.json(issueCommentsFixture),
+  },
+  {
     method: "post",
     path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/teams/:teamSlug/",
     fetch: async ({ request, params }) => {
@@ -1052,9 +1068,13 @@ export const restHandlers = buildHandlers([
       const body = (await request.json()) as { text: string };
       return HttpResponse.json({
         id: "12345",
-        text: body.text,
+        user: userFixture,
+        sentry_app: null,
         type: "note",
-        dateCreated: new Date().toISOString(),
+        data: {
+          text: body.text,
+        },
+        dateCreated: "2025-04-14T12:34:56.000Z",
       });
     },
   },


### PR DESCRIPTION
Add catalog-only tools for reading issue activity/comments and posting user-approved notes to the issue activity feed. These tools reuse existing issue URL/ID parsing and project constraint checks while keeping the direct MCP tool surface unchanged.

**Issue Activity**

`get_issue_activity` reads the upstream group activities endpoint and optionally the notes endpoint, formats recent activity/comments, and points users to `add_issue_note` when they want to leave a visible comment.

**Issue Notes**

`add_issue_note` posts to the upstream issue notes endpoint and returns the created comment payload. The API client parses the serialized activity shape returned by Sentry, with mocks and fixtures matching the confirmed upstream schema.