### PR TITLE
feat(releases): Add release details tool

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -15,6 +15,7 @@ import {
   isSentryHost,
   type TraceMetricIdentifier,
 } from "../utils/url-utils";
+import { isNumericId } from "../utils/slug-validation";
 import {
   isMetricsDataset,
   isProfilesDataset,
@@ -1667,29 +1668,24 @@ export class SentryApiService {
     {
       organizationSlug,
       releaseVersion,
-      projectSlug,
-      projectId,
+      projectSlugOrId,
       includeHealth,
     }: {
       organizationSlug: string;
       releaseVersion: string;
-      projectSlug?: string;
-      projectId?: string;
+      projectSlugOrId?: string;
       includeHealth?: boolean;
     },
     opts?: RequestOptions,
   ): Promise<ReleaseDetails> {
     const searchQuery = new URLSearchParams();
-    if (projectId) {
-      searchQuery.set("project", projectId);
-    }
     if (includeHealth) {
       searchQuery.set("health", "1");
     }
 
     const encodedVersion = encodeURIComponent(releaseVersion);
-    const path = projectSlug
-      ? `/projects/${organizationSlug}/${projectSlug}/releases/${encodedVersion}/`
+    const path = projectSlugOrId
+      ? `/projects/${organizationSlug}/${projectSlugOrId}/releases/${encodedVersion}/`
       : `/organizations/${organizationSlug}/releases/${encodedVersion}/`;
     const body = await this.requestJSON(
       searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
@@ -1703,19 +1699,22 @@ export class SentryApiService {
     {
       organizationSlug,
       releaseVersion,
-      projectSlug,
+      projectSlugOrId,
       limit,
     }: {
       organizationSlug: string;
       releaseVersion: string;
-      projectSlug?: string;
+      projectSlugOrId?: string;
       limit?: number;
     },
     opts?: RequestOptions,
   ): Promise<DeployList> {
     const searchQuery = new URLSearchParams();
-    if (projectSlug) {
-      searchQuery.set("projectSlug", projectSlug);
+    if (projectSlugOrId) {
+      searchQuery.set(
+        isNumericId(projectSlugOrId) ? "project" : "projectSlug",
+        projectSlugOrId,
+      );
     }
     if (limit !== undefined) {
       searchQuery.set("per_page", String(limit));
@@ -1735,12 +1734,12 @@ export class SentryApiService {
     {
       organizationSlug,
       releaseVersion,
-      projectSlug,
+      projectSlugOrId,
       limit,
     }: {
       organizationSlug: string;
       releaseVersion: string;
-      projectSlug?: string;
+      projectSlugOrId?: string;
       limit?: number;
     },
     opts?: RequestOptions,
@@ -1751,8 +1750,8 @@ export class SentryApiService {
     }
 
     const encodedVersion = encodeURIComponent(releaseVersion);
-    const path = projectSlug
-      ? `/projects/${organizationSlug}/${projectSlug}/releases/${encodedVersion}/commits/`
+    const path = projectSlugOrId
+      ? `/projects/${organizationSlug}/${projectSlugOrId}/releases/${encodedVersion}/commits/`
       : `/organizations/${organizationSlug}/releases/${encodedVersion}/commits/`;
     const body = await this.requestJSON(
       searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -1746,15 +1746,14 @@ export class SentryApiService {
     opts?: RequestOptions,
   ): Promise<CommitList> {
     const searchQuery = new URLSearchParams();
-    if (projectSlug) {
-      searchQuery.set("projectSlug", projectSlug);
-    }
     if (limit !== undefined) {
       searchQuery.set("per_page", String(limit));
     }
 
     const encodedVersion = encodeURIComponent(releaseVersion);
-    const path = `/organizations/${organizationSlug}/releases/${encodedVersion}/commits/`;
+    const path = projectSlug
+      ? `/projects/${organizationSlug}/${projectSlug}/releases/${encodedVersion}/commits/`
+      : `/organizations/${organizationSlug}/releases/${encodedVersion}/commits/`;
     const body = await this.requestJSON(
       searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
       undefined,

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -31,7 +31,10 @@ import {
   ProjectListSchema,
   ProjectRepoLinkSchema,
   ProjectSchema,
+  CommitListSchema,
+  DeployListSchema,
   RepositoryListSchema,
+  ReleaseDetailsSchema,
   ReleaseListSchema,
   IssueActivityListResponseSchema,
   IssueCommentListSchema,
@@ -81,9 +84,12 @@ import type {
   IssueList,
   IssueTagValues,
   ExternalIssueList,
+  CommitList,
+  DeployList,
   OrganizationList,
   Project,
   ProjectList,
+  ReleaseDetails,
   ReleaseList,
   TagList,
   Team,
@@ -1655,6 +1661,106 @@ export class SentryApiService {
       opts,
     );
     return ReleaseListSchema.parse(body);
+  }
+
+  async getReleaseDetails(
+    {
+      organizationSlug,
+      releaseVersion,
+      projectSlug,
+      projectId,
+      includeHealth,
+    }: {
+      organizationSlug: string;
+      releaseVersion: string;
+      projectSlug?: string;
+      projectId?: string;
+      includeHealth?: boolean;
+    },
+    opts?: RequestOptions,
+  ): Promise<ReleaseDetails> {
+    const searchQuery = new URLSearchParams();
+    if (projectId) {
+      searchQuery.set("project", projectId);
+    }
+    if (includeHealth) {
+      searchQuery.set("health", "1");
+    }
+
+    const encodedVersion = encodeURIComponent(releaseVersion);
+    const path = projectSlug
+      ? `/projects/${organizationSlug}/${projectSlug}/releases/${encodedVersion}/`
+      : `/organizations/${organizationSlug}/releases/${encodedVersion}/`;
+    const body = await this.requestJSON(
+      searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
+      undefined,
+      opts,
+    );
+    return ReleaseDetailsSchema.parse(body);
+  }
+
+  async listReleaseDeploys(
+    {
+      organizationSlug,
+      releaseVersion,
+      projectSlug,
+      limit,
+    }: {
+      organizationSlug: string;
+      releaseVersion: string;
+      projectSlug?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<DeployList> {
+    const searchQuery = new URLSearchParams();
+    if (projectSlug) {
+      searchQuery.set("projectSlug", projectSlug);
+    }
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
+    }
+
+    const encodedVersion = encodeURIComponent(releaseVersion);
+    const path = `/organizations/${organizationSlug}/releases/${encodedVersion}/deploys/`;
+    const body = await this.requestJSON(
+      searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
+      undefined,
+      opts,
+    );
+    return DeployListSchema.parse(body);
+  }
+
+  async listReleaseCommits(
+    {
+      organizationSlug,
+      releaseVersion,
+      projectSlug,
+      limit,
+    }: {
+      organizationSlug: string;
+      releaseVersion: string;
+      projectSlug?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<CommitList> {
+    const searchQuery = new URLSearchParams();
+    if (projectSlug) {
+      searchQuery.set("projectSlug", projectSlug);
+    }
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
+    }
+
+    const encodedVersion = encodeURIComponent(releaseVersion);
+    const path = `/organizations/${organizationSlug}/releases/${encodedVersion}/commits/`;
+    const body = await this.requestJSON(
+      searchQuery.toString() ? `${path}?${searchQuery.toString()}` : path,
+      undefined,
+      opts,
+    );
+    return CommitListSchema.parse(body);
   }
 
   /**

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -337,6 +337,58 @@ const ApiActorSchema = z
   })
   .passthrough();
 
+export const ReleaseDetailsSchema = ReleaseSchema.extend({
+  adoptionStages: z.unknown().optional(),
+  authors: z.array(ApiActorSchema).optional(),
+  commitCount: z.number().optional(),
+  currentProjectMeta: z.record(z.string(), z.unknown()).optional(),
+  deployCount: z.number().optional(),
+  lastDeploy: ReleaseSchema.shape.lastDeploy.optional(),
+  newGroups: z.number().optional(),
+  owner: ApiActorSchema.nullable().optional(),
+  projects: z.array(ReleaseProjectSchema).optional(),
+  refs: z.array(z.record(z.string(), z.unknown())).optional(),
+})
+  .partial()
+  .extend({
+    id: ApiResourceIdSchema,
+    version: z.string(),
+  })
+  .passthrough();
+
+export const DeploySchema = z
+  .object({
+    id: ApiResourceIdSchema,
+    environment: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    dateStarted: z.string().datetime().nullable().optional(),
+    dateFinished: z.string().datetime().nullable().optional(),
+  })
+  .passthrough();
+
+export const DeployListSchema = z.array(DeploySchema);
+
+export const CommitSchema = z
+  .object({
+    id: ApiResourceIdSchema,
+    message: z.string().nullable().optional(),
+    dateCreated: z.string().datetime().nullable().optional(),
+    pullRequest: z.record(z.string(), z.unknown()).nullable().optional(),
+    suspectCommitType: z.string().optional(),
+    author: ApiActorSchema.nullable().optional(),
+    repository: z
+      .object({
+        name: z.string().nullable().optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
+export const CommitListSchema = z.array(CommitSchema);
+
 export const IssueActivitySchema = z
   .object({
     id: ApiResourceIdSchema,

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -47,7 +47,11 @@ import type {
   AutofixRunStateSchema,
   ClientKeyListSchema,
   ClientKeySchema,
+  CommitListSchema,
+  CommitSchema,
   DefaultEventSchema,
+  DeployListSchema,
+  DeploySchema,
   ErrorEventSchema,
   EventAttachmentListSchema,
   EventAttachmentSchema,
@@ -75,6 +79,7 @@ import type {
   ProfileFrameSchema,
   ProjectListSchema,
   ProjectSchema,
+  ReleaseDetailsSchema,
   ReleaseListSchema,
   ReleaseSchema,
   ReplayDetailsSchema,
@@ -101,6 +106,9 @@ export type Team = z.infer<typeof TeamSchema>;
 export type Project = z.infer<typeof ProjectSchema>;
 export type ClientKey = z.infer<typeof ClientKeySchema>;
 export type Release = z.infer<typeof ReleaseSchema>;
+export type ReleaseDetails = z.infer<typeof ReleaseDetailsSchema>;
+export type Deploy = z.infer<typeof DeploySchema>;
+export type Commit = z.infer<typeof CommitSchema>;
 export type Issue = z.infer<typeof IssueSchema>;
 export type IssueActivity = z.infer<typeof IssueActivitySchema>;
 export type IssueComment = z.infer<typeof IssueCommentSchema>;
@@ -136,6 +144,8 @@ export type OrganizationList = z.infer<typeof OrganizationListSchema>;
 export type TeamList = z.infer<typeof TeamListSchema>;
 export type ProjectList = z.infer<typeof ProjectListSchema>;
 export type ReleaseList = z.infer<typeof ReleaseListSchema>;
+export type DeployList = z.infer<typeof DeployListSchema>;
+export type CommitList = z.infer<typeof CommitListSchema>;
 export type IssueList = z.infer<typeof IssueListSchema>;
 export type IssueActivityList = z.infer<
   typeof IssueActivityListResponseSchema

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -65,7 +65,7 @@
       {
         "name": "get_release_details",
         "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project ID is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')\n</examples>",
-        "requiredScopes": ["project:releases"]
+        "requiredScopes": ["project:read"]
       },
       {
         "name": "get_replay_details",

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -64,7 +64,7 @@
       },
       {
         "name": "get_release_details",
-        "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project ID is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')\n</examples>",
+        "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- Scope a release lookup to a specific project\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', projectSlugOrId='backend')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectSlugOrId='backend')\n</examples>",
         "requiredScopes": ["project:read"]
       },
       {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Search for errors, analyze traces, and explore event details",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 18,
+    "toolCount": 19,
     "tools": [
       {
         "name": "find_organizations",
@@ -61,6 +61,11 @@
         "name": "get_profile_details",
         "description": "Inspect a specific Sentry profile in detail.\n\nUSE THIS TOOL WHEN:\n- User shares a transaction profile URL and wants the details\n- User has a profile ID and wants a concise summary plus raw sample structure\n- User needs to inspect a continuous profile session by profiler ID and time range\n\nRETURNS:\n- Transaction profile summary with profile URL, transaction, trace, release, and runtime details\n- Sample structure summaries such as frame count, sample count, stacks, and thread breakdown\n- Top frames by occurrence for a quick hotspot overview\n\nNOTE: This tool supports two profile modes.\n- Transaction profiles: pass `profileUrl` or `organizationSlug` + `projectSlugOrId` + `profileId`\n- Continuous profiles: pass `profileUrl` or `organizationSlug` + `projectSlugOrId` + `profilerId` + `start` + `end`\n\n<examples>\n### Transaction profile URL\n```\nget_profile_details(\n  profileUrl='https://my-org.sentry.io/explore/profiling/profile/backend/cfe78a5c892d4a64a962d837673398d2/flamegraph/'\n)\n```\n\n### Transaction profile by ID\n```\nget_profile_details(\n  organizationSlug='my-org',\n  projectSlugOrId='backend',\n  profileId='cfe78a5c892d4a64a962d837673398d2'\n)\n```\n\n### Continuous profile by session\n```\nget_profile_details(\n  organizationSlug='my-org',\n  projectSlugOrId='backend',\n  profilerId='041bde57b9844e36b8b7e5734efae5f7',\n  start='2024-01-01T00:00:00Z',\n  end='2024-01-01T01:00:00Z'\n)\n```\n</examples>",
         "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "get_release_details",
+        "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project ID is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')\n</examples>",
+        "requiredScopes": ["project:releases"]
       },
       {
         "name": "get_replay_details",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -951,7 +951,7 @@
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
-    "requiredScopes": ["project:releases"],
+    "requiredScopes": ["project:read"],
     "skills": ["inspect"],
     "surface": "catalog"
   },

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -888,6 +888,74 @@
     "surface": "direct"
   },
   {
+    "name": "get_release_details",
+    "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project ID is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')\n</examples>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "releaseVersion": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Exact release version."
+        },
+        "projectId": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Optional numeric project ID for release health metadata."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional numeric project ID for release health metadata.",
+          "default": null
+        },
+        "includeHealth": {
+          "type": "boolean",
+          "default": false
+        },
+        "includeDeploys": {
+          "type": "boolean",
+          "default": true
+        },
+        "includeCommits": {
+          "type": "boolean",
+          "default": true
+        },
+        "limit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 50,
+          "default": 10
+        }
+      },
+      "required": ["organizationSlug", "releaseVersion"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["project:releases"],
+    "skills": ["inspect"],
+    "surface": "catalog"
+  },
+  {
     "name": "get_replay_details",
     "description": "Get high-level information about a specific Sentry replay by URL or replay ID.\n\nUSE THIS TOOL WHEN USERS:\n- Share a replay URL\n- Ask what happened in a specific replay\n- Want a concise replay summary plus the next issue or trace lookups to run\n\n<examples>\n### With replay URL\n```\nget_replay_details(replayUrl='https://my-organization.sentry.io/explore/replays/7e07485f-12f9-416b-8b14-26260799b51f/')\n```\n\n### With organization and replay ID\n```\nget_replay_details(organizationSlug='my-organization', replayId='7e07485f-12f9-416b-8b14-26260799b51f')\n```\n</examples>",
     "inputSchema": {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -889,7 +889,7 @@
   },
   {
     "name": "get_release_details",
-    "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project ID is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')\n</examples>",
+    "description": "Get details for a Sentry release.\n\nUse this tool when you need to:\n- Inspect an exact release version\n- Scope a release lookup to a specific project\n- See deploys and environments for a release\n- See recent commits attached to a release\n- Gather release health metadata when a project is known\n\n<examples>\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', projectSlugOrId='backend')\nget_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectSlugOrId='backend')\n</examples>",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -915,22 +915,22 @@
           "minLength": 1,
           "description": "Exact release version."
         },
-        "projectId": {
+        "projectSlugOrId": {
           "anyOf": [
             {
               "type": "string",
-              "description": "Optional numeric project ID for project-specific release health metadata."
+              "description": "Optional project slug or numeric ID. Use this to scope release details, deploys, and commits to one project; required for health metadata unless the session is already project-constrained."
             },
             {
               "type": "null"
             }
           ],
-          "description": "Optional numeric project ID for project-specific release health metadata.",
+          "description": "Optional project slug or numeric ID. Use this to scope release details, deploys, and commits to one project; required for health metadata unless the session is already project-constrained.",
           "default": null
         },
         "includeHealth": {
           "type": "boolean",
-          "description": "Include release health metadata. For organization-level calls, also provide projectId; project-constrained sessions use the active project.",
+          "description": "Include project-specific release health metadata. Requires projectSlugOrId unless the session is already project-constrained.",
           "default": false
         },
         "includeDeploys": {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -919,31 +919,35 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "Optional numeric project ID for release health metadata."
+              "description": "Optional numeric project ID for project-specific release health metadata."
             },
             {
               "type": "null"
             }
           ],
-          "description": "Optional numeric project ID for release health metadata.",
+          "description": "Optional numeric project ID for project-specific release health metadata.",
           "default": null
         },
         "includeHealth": {
           "type": "boolean",
+          "description": "Include release health metadata. For organization-level calls, also provide projectId; project-constrained sessions use the active project.",
           "default": false
         },
         "includeDeploys": {
           "type": "boolean",
+          "description": "Include recent deploys for this release.",
           "default": true
         },
         "includeCommits": {
           "type": "boolean",
+          "description": "Include recent commits attached to this release.",
           "default": true
         },
         "limit": {
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 50,
+          "description": "Maximum number of deploys and commits to return, up to 50.",
           "default": 10
         }
       },

--- a/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
@@ -18,7 +18,7 @@ describe("get_release_details", () => {
         organizationSlug: "sentry-mcp-evals",
         regionUrl: null,
         releaseVersion: "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
-        projectId: null,
+        projectSlugOrId: null,
         includeHealth: false,
         includeDeploys: true,
         includeCommits: true,
@@ -78,7 +78,7 @@ describe("get_release_details", () => {
           organizationSlug: "sentry-mcp-evals",
           regionUrl: null,
           releaseVersion,
-          projectId: null,
+          projectSlugOrId: null,
           includeHealth: false,
           includeDeploys: true,
           includeCommits: true,
@@ -111,7 +111,7 @@ describe("get_release_details", () => {
         organizationSlug: "sentry-mcp-evals",
         regionUrl: null,
         releaseVersion,
-        projectId: null,
+        projectSlugOrId: null,
         includeHealth: false,
         includeDeploys: false,
         includeCommits: false,
@@ -138,7 +138,7 @@ describe("get_release_details", () => {
           organizationSlug: "sentry-mcp-evals",
           regionUrl: null,
           releaseVersion: "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
-          projectId: "123",
+          projectSlugOrId: "123",
           includeHealth: true,
           includeDeploys: false,
           includeCommits: false,
@@ -153,7 +153,95 @@ describe("get_release_details", () => {
         },
       ),
     ).rejects.toThrow(
-      'Release health project is outside the active project constraint. Expected project "cloudflare-mcp".',
+      'Release project is outside the active project constraint. Expected project "cloudflare-mcp".',
+    );
+  });
+
+  it("requires a project when release health is requested", async () => {
+    await expect(
+      getReleaseDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          releaseVersion: "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
+          projectSlugOrId: null,
+          includeHealth: true,
+          includeDeploys: false,
+          includeCommits: false,
+          limit: 10,
+        },
+        context,
+      ),
+    ).rejects.toThrow(
+      "Release health metadata requires a project. Provide `projectSlugOrId` or use a project-constrained session.",
+    );
+  });
+
+  it("uses projectSlugOrId as the project scope", async () => {
+    const requests: Array<{
+      kind: "details" | "deploys" | "commits";
+      url: string;
+    }> = [];
+    const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/`,
+        ({ request }) => {
+          requests.push({ kind: "details", url: request.url });
+          return HttpResponse.json(releaseFixture);
+        },
+      ),
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/${releaseVersion}/deploys/`,
+        ({ request }) => {
+          requests.push({ kind: "deploys", url: request.url });
+          return HttpResponse.json([]);
+        },
+      ),
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/commits/`,
+        ({ request }) => {
+          requests.push({ kind: "commits", url: request.url });
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    await getReleaseDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        releaseVersion,
+        projectSlugOrId: "cloudflare-mcp",
+        includeHealth: false,
+        includeDeploys: true,
+        includeCommits: true,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(requests).toHaveLength(3);
+    const detailsRequest = requests.find(
+      (request) => request.kind === "details",
+    );
+    const deploysRequest = requests.find(
+      (request) => request.kind === "deploys",
+    );
+    const commitsRequest = requests.find(
+      (request) => request.kind === "commits",
+    );
+    expect(detailsRequest).toBeDefined();
+    expect(deploysRequest).toBeDefined();
+    expect(commitsRequest).toBeDefined();
+    expect(new URL(detailsRequest!.url).pathname).toBe(
+      `/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/`,
+    );
+    expect(new URL(deploysRequest!.url).searchParams.get("projectSlug")).toBe(
+      "cloudflare-mcp",
+    );
+    expect(new URL(commitsRequest!.url).pathname).toBe(
+      `/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/commits/`,
     );
   });
 
@@ -182,7 +270,7 @@ describe("get_release_details", () => {
         organizationSlug: "sentry-mcp-evals",
         regionUrl: null,
         releaseVersion,
-        projectId: null,
+        projectSlugOrId: null,
         includeHealth: false,
         includeDeploys: true,
         includeCommits: true,

--- a/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
@@ -1,0 +1,207 @@
+import { mswServer, releaseFixture } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import getReleaseDetails from "./get-release-details.js";
+
+const context = {
+  constraints: {
+    organizationSlug: null,
+  },
+  accessToken: "access-token",
+  userId: "1",
+};
+
+describe("get_release_details", () => {
+  it("serializes release details", async () => {
+    const result = await getReleaseDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        releaseVersion: "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
+        projectId: null,
+        includeHealth: false,
+        includeDeploys: true,
+        includeCommits: true,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Release 8ce89484-0fec-4913-a2cd-e8e2d41dee36 in **sentry-mcp-evals**
+
+      **ID**: 1402755016
+      **Short Version**: 8ce89484-0fec-4913-a2cd-e8e2d41dee36
+      **Created**: 2025-04-13T19:54:21.764Z
+      **First Event**: 2025-04-13T19:54:21.000Z
+      **Last Event**: 2025-04-13T20:28:23.000Z
+      **New Issues**: 0
+      **Projects**: cloudflare-mcp
+      **URL**: [Open Release](https://sentry-mcp-evals.sentry.io/releases/8ce89484-0fec-4913-a2cd-e8e2d41dee36/)
+
+      ## Deploys
+
+      ### Deploy 98765
+
+      **Environment**: production
+      **Name**: prod deploy
+      **Started**: 2025-04-13T20:00:00.000Z
+      **Finished**: 2025-04-13T20:05:30.000Z
+      **URL**: https://deploys.example.com/98765
+
+      ## Commits
+
+      - \`2ce6a2700fec4913a2cde8e2d41dee36\`: Fix duplicate tool registration
+        - Author: Jane Developer
+        - Repository: getsentry/sentry-mcp
+        - Created: 2025-04-13T19:40:00.000Z
+
+      ## Response Notes
+
+      - Search issues introduced in this release with query \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
+      "
+    `);
+  });
+
+  it("rejects releases outside the active project constraint", async () => {
+    const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/frontend/releases/${releaseVersion}/`,
+        () => HttpResponse.json(releaseFixture),
+      ),
+    );
+
+    await expect(
+      getReleaseDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          releaseVersion,
+          projectId: null,
+          includeHealth: false,
+          includeDeploys: true,
+          includeCommits: true,
+          limit: 10,
+        },
+        {
+          ...context,
+          constraints: {
+            organizationSlug: "sentry-mcp-evals",
+            projectSlug: "frontend",
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      'Release is outside the active project constraint. Expected project "frontend".',
+    );
+  });
+
+  it("allows scoped release details when project refs are omitted", async () => {
+    const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/`,
+        () => HttpResponse.json({ ...releaseFixture, projects: undefined }),
+      ),
+    );
+
+    const result = await getReleaseDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        releaseVersion,
+        projectId: null,
+        includeHealth: false,
+        includeDeploys: false,
+        includeCommits: false,
+        limit: 10,
+      },
+      {
+        ...context,
+        constraints: {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+        },
+      },
+    );
+
+    expect(result).toContain(
+      `# Release ${releaseVersion} in **sentry-mcp-evals**`,
+    );
+  });
+
+  it("rejects release health metadata outside the active project constraint", async () => {
+    await expect(
+      getReleaseDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          releaseVersion: "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
+          projectId: "123",
+          includeHealth: true,
+          includeDeploys: false,
+          includeCommits: false,
+          limit: 10,
+        },
+        {
+          ...context,
+          constraints: {
+            organizationSlug: "sentry-mcp-evals",
+            projectSlug: "cloudflare-mcp",
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      'Release health project is outside the active project constraint. Expected project "cloudflare-mcp".',
+    );
+  });
+
+  it("filters deploys and commits by projectSlug under an active project constraint", async () => {
+    const requestUrls: string[] = [];
+    const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/${releaseVersion}/deploys/`,
+        ({ request }) => {
+          requestUrls.push(request.url);
+          return HttpResponse.json([]);
+        },
+      ),
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/${releaseVersion}/commits/`,
+        ({ request }) => {
+          requestUrls.push(request.url);
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    await getReleaseDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        releaseVersion,
+        projectId: null,
+        includeHealth: false,
+        includeDeploys: true,
+        includeCommits: true,
+        limit: 10,
+      },
+      {
+        ...context,
+        constraints: {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+        },
+      },
+    );
+
+    expect(requestUrls).toHaveLength(2);
+    for (const requestUrl of requestUrls) {
+      const params = new URL(requestUrl).searchParams;
+      expect(params.get("projectSlug")).toBe("cloudflare-mcp");
+      expect(params.get("project")).toBeNull();
+    }
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
@@ -157,21 +157,21 @@ describe("get_release_details", () => {
     );
   });
 
-  it("filters deploys and commits by projectSlug under an active project constraint", async () => {
-    const requestUrls: string[] = [];
+  it("uses scoped release endpoints under an active project constraint", async () => {
+    const requests: Array<{ kind: "deploys" | "commits"; url: string }> = [];
     const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
     mswServer.use(
       http.get(
         `https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/${releaseVersion}/deploys/`,
         ({ request }) => {
-          requestUrls.push(request.url);
+          requests.push({ kind: "deploys", url: request.url });
           return HttpResponse.json([]);
         },
       ),
       http.get(
-        `https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/${releaseVersion}/commits/`,
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/commits/`,
         ({ request }) => {
-          requestUrls.push(request.url);
+          requests.push({ kind: "commits", url: request.url });
           return HttpResponse.json([]);
         },
       ),
@@ -197,11 +197,23 @@ describe("get_release_details", () => {
       },
     );
 
-    expect(requestUrls).toHaveLength(2);
-    for (const requestUrl of requestUrls) {
-      const params = new URL(requestUrl).searchParams;
-      expect(params.get("projectSlug")).toBe("cloudflare-mcp");
-      expect(params.get("project")).toBeNull();
-    }
+    expect(requests).toHaveLength(2);
+    const deploysRequest = requests.find(
+      (request) => request.kind === "deploys",
+    );
+    const commitsRequest = requests.find(
+      (request) => request.kind === "commits",
+    );
+    expect(deploysRequest).toBeDefined();
+    expect(commitsRequest).toBeDefined();
+    expect(new URL(deploysRequest!.url).searchParams.get("projectSlug")).toBe(
+      "cloudflare-mcp",
+    );
+    expect(new URL(commitsRequest!.url).pathname).toBe(
+      `/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/commits/`,
+    );
+    expect(
+      new URL(commitsRequest!.url).searchParams.get("projectSlug"),
+    ).toBeNull();
   });
 });

--- a/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
@@ -245,6 +245,43 @@ describe("get_release_details", () => {
     );
   });
 
+  it("hides health metadata when includeHealth is false", async () => {
+    const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/`,
+        () =>
+          HttpResponse.json({
+            ...releaseFixture,
+            currentProjectMeta: {
+              sessionsAdoption: "enabled",
+            },
+            adoptionStages: {
+              sessions: "adopted",
+            },
+          }),
+      ),
+    );
+
+    const result = await getReleaseDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        releaseVersion,
+        projectSlugOrId: "cloudflare-mcp",
+        includeHealth: false,
+        includeDeploys: false,
+        includeCommits: false,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(result).not.toContain("Health And Project Metadata");
+    expect(result).not.toContain("sessionsAdoption");
+    expect(result).not.toContain("adoptionStages");
+  });
+
   it("uses scoped release endpoints under an active project constraint", async () => {
     const requests: Array<{ kind: "deploys" | "commits"; url: string }> = [];
     const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";

--- a/packages/mcp-core/src/tools/catalog/get-release-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.ts
@@ -99,13 +99,32 @@ export default defineTool({
     projectId: z
       .string()
       .trim()
-      .describe("Optional numeric project ID for release health metadata.")
+      .describe(
+        "Optional numeric project ID for project-specific release health metadata.",
+      )
       .nullable()
       .default(null),
-    includeHealth: z.boolean().default(false),
-    includeDeploys: z.boolean().default(true),
-    includeCommits: z.boolean().default(true),
-    limit: z.number().int().positive().max(50).default(10),
+    includeHealth: z
+      .boolean()
+      .describe(
+        "Include release health metadata. For organization-level calls, also provide projectId; project-constrained sessions use the active project.",
+      )
+      .default(false),
+    includeDeploys: z
+      .boolean()
+      .describe("Include recent deploys for this release.")
+      .default(true),
+    includeCommits: z
+      .boolean()
+      .describe("Include recent commits attached to this release.")
+      .default(true),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(50)
+      .describe("Maximum number of deploys and commits to return, up to 50.")
+      .default(10),
   },
   annotations: {
     readOnlyHint: true,

--- a/packages/mcp-core/src/tools/catalog/get-release-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.ts
@@ -77,7 +77,7 @@ function formatHealthOrMeta(release: ReleaseDetails): string[] {
 export default defineTool({
   name: "get_release_details",
   skills: ["inspect"],
-  requiredScopes: ["project:releases"],
+  requiredScopes: ["project:read"],
   description: [
     "Get details for a Sentry release.",
     "",
@@ -155,7 +155,7 @@ export default defineTool({
         ? apiService.listReleaseDeploys({
             organizationSlug,
             releaseVersion: params.releaseVersion,
-            projectSlug: context.constraints.projectSlug ?? undefined,
+            projectSlug: scopedProjectSlug,
             limit: params.limit,
           })
         : Promise.resolve([]),
@@ -163,7 +163,7 @@ export default defineTool({
         ? apiService.listReleaseCommits({
             organizationSlug,
             releaseVersion: params.releaseVersion,
-            projectSlug: context.constraints.projectSlug ?? undefined,
+            projectSlug: scopedProjectSlug,
             limit: params.limit,
           })
         : Promise.resolve([]),

--- a/packages/mcp-core/src/tools/catalog/get-release-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.ts
@@ -6,6 +6,7 @@ import { UserInputError } from "../../errors";
 import type { Commit, Deploy, ReleaseDetails } from "../../api-client/types";
 import type { ServerContext } from "../../types";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../../schema";
+import { validateSlugOrId, isNumericId } from "../../utils/slug-validation";
 import {
   compactLines,
   formatActor,
@@ -83,31 +84,35 @@ export default defineTool({
     "",
     "Use this tool when you need to:",
     "- Inspect an exact release version",
+    "- Scope a release lookup to a specific project",
     "- See deploys and environments for a release",
     "- See recent commits attached to a release",
-    "- Gather release health metadata when a project ID is known",
+    "- Gather release health metadata when a project is known",
     "",
     "<examples>",
     "get_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')",
-    "get_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')",
+    "get_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', projectSlugOrId='backend')",
+    "get_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectSlugOrId='backend')",
     "</examples>",
   ].join("\n"),
   inputSchema: {
     organizationSlug: ParamOrganizationSlug,
     regionUrl: ParamRegionUrl.nullable().default(null),
     releaseVersion: z.string().trim().min(1).describe("Exact release version."),
-    projectId: z
+    projectSlugOrId: z
       .string()
+      .toLowerCase()
       .trim()
+      .superRefine(validateSlugOrId)
       .describe(
-        "Optional numeric project ID for project-specific release health metadata.",
+        "Optional project slug or numeric ID. Use this to scope release details, deploys, and commits to one project; required for health metadata unless the session is already project-constrained.",
       )
       .nullable()
       .default(null),
     includeHealth: z
       .boolean()
       .describe(
-        "Include release health metadata. For organization-level calls, also provide projectId; project-constrained sessions use the active project.",
+        "Include project-specific release health metadata. Requires projectSlugOrId unless the session is already project-constrained.",
       )
       .default(false),
     includeDeploys: z
@@ -138,27 +143,44 @@ export default defineTool({
     setTag("organization.slug", organizationSlug);
     setTag("release.version", params.releaseVersion);
     const scopedProjectSlug = context.constraints.projectSlug ?? undefined;
-    let projectId = params.projectId ?? undefined;
+    const requestedProjectSlugOrId = params.projectSlugOrId ?? undefined;
+    const projectSlugOrId = scopedProjectSlug ?? requestedProjectSlugOrId;
 
-    if (scopedProjectSlug && params.projectId) {
+    if (projectSlugOrId) {
+      if (isNumericId(projectSlugOrId)) {
+        setTag("project.id", projectSlugOrId);
+      } else {
+        setTag("project.slug", projectSlugOrId);
+      }
+    }
+
+    if (
+      scopedProjectSlug &&
+      requestedProjectSlugOrId &&
+      requestedProjectSlugOrId !== scopedProjectSlug
+    ) {
       const scopedProject = await apiService.getProject({
         organizationSlug,
         projectSlugOrId: scopedProjectSlug,
       });
       const scopedProjectId = String(scopedProject.id);
-      if (params.projectId !== scopedProjectId) {
+      if (requestedProjectSlugOrId !== scopedProjectId) {
         throw new UserInputError(
-          `Release health project is outside the active project constraint. Expected project "${scopedProjectSlug}".`,
+          `Release project is outside the active project constraint. Expected project "${scopedProjectSlug}".`,
         );
       }
-      projectId = scopedProjectId;
+    }
+
+    if (params.includeHealth && !projectSlugOrId) {
+      throw new UserInputError(
+        "Release health metadata requires a project. Provide `projectSlugOrId` or use a project-constrained session.",
+      );
     }
 
     const release = await apiService.getReleaseDetails({
       organizationSlug,
       releaseVersion: params.releaseVersion,
-      projectSlug: scopedProjectSlug,
-      projectId: scopedProjectSlug ? undefined : projectId,
+      projectSlugOrId,
       includeHealth: params.includeHealth,
     });
     if (release.projects && release.projects.length > 0) {
@@ -174,7 +196,7 @@ export default defineTool({
         ? apiService.listReleaseDeploys({
             organizationSlug,
             releaseVersion: params.releaseVersion,
-            projectSlug: scopedProjectSlug,
+            projectSlugOrId,
             limit: params.limit,
           })
         : Promise.resolve([]),
@@ -182,7 +204,7 @@ export default defineTool({
         ? apiService.listReleaseCommits({
             organizationSlug,
             releaseVersion: params.releaseVersion,
-            projectSlug: scopedProjectSlug,
+            projectSlugOrId,
             limit: params.limit,
           })
         : Promise.resolve([]),

--- a/packages/mcp-core/src/tools/catalog/get-release-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.ts
@@ -1,0 +1,253 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { UserInputError } from "../../errors";
+import type { Commit, Deploy, ReleaseDetails } from "../../api-client/types";
+import type { ServerContext } from "../../types";
+import { ParamOrganizationSlug, ParamRegionUrl } from "../../schema";
+import {
+  compactLines,
+  formatActor,
+  formatDate,
+  formatId,
+  formatUnknown,
+} from "./support/api-formatting";
+import { assertProjectListContainsConstraint } from "./support/project-constraints";
+
+function formatProjects(release: ReleaseDetails): string | null {
+  if (!release.projects || release.projects.length === 0) {
+    return null;
+  }
+
+  return release.projects
+    .map((project) => project.slug ?? project.name)
+    .join(", ");
+}
+
+function formatDeploy(deploy: Deploy): string {
+  const lines = compactLines([
+    `### Deploy ${formatId(deploy.id)}`,
+    "",
+    deploy.environment ? `**Environment**: ${deploy.environment}` : null,
+    deploy.name ? `**Name**: ${deploy.name}` : null,
+    formatDate(deploy.dateStarted)
+      ? `**Started**: ${formatDate(deploy.dateStarted)}`
+      : null,
+    formatDate(deploy.dateFinished)
+      ? `**Finished**: ${formatDate(deploy.dateFinished)}`
+      : null,
+    deploy.url ? `**URL**: ${deploy.url}` : null,
+  ]);
+
+  return lines.join("\n");
+}
+
+function formatCommit(commit: Commit): string {
+  const author = commit.author ? formatActor(commit.author) : null;
+  const message = commit.message?.split("\n")[0] ?? "No commit message";
+  const repository = commit.repository?.name;
+  return compactLines([
+    `- \`${formatId(commit.id)}\`: ${message}`,
+    author ? `  - Author: ${author}` : null,
+    repository ? `  - Repository: ${repository}` : null,
+    formatDate(commit.dateCreated)
+      ? `  - Created: ${formatDate(commit.dateCreated)}`
+      : null,
+  ]).join("\n");
+}
+
+function formatHealthOrMeta(release: ReleaseDetails): string[] {
+  const lines: string[] = [];
+  if (release.currentProjectMeta) {
+    for (const [key, value] of Object.entries(release.currentProjectMeta)) {
+      lines.push(`- **${key}**: ${formatUnknown(value)}`);
+    }
+  }
+
+  if (release.adoptionStages !== undefined) {
+    lines.push(
+      `- **adoptionStages**: ${formatUnknown(release.adoptionStages)}`,
+    );
+  }
+
+  return lines;
+}
+
+export default defineTool({
+  name: "get_release_details",
+  skills: ["inspect"],
+  requiredScopes: ["project:releases"],
+  description: [
+    "Get details for a Sentry release.",
+    "",
+    "Use this tool when you need to:",
+    "- Inspect an exact release version",
+    "- See deploys and environments for a release",
+    "- See recent commits attached to a release",
+    "- Gather release health metadata when a project ID is known",
+    "",
+    "<examples>",
+    "get_release_details(organizationSlug='my-organization', releaseVersion='1.2.3')",
+    "get_release_details(organizationSlug='my-organization', releaseVersion='1.2.3', includeHealth=true, projectId='450123')",
+    "</examples>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug,
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    releaseVersion: z.string().trim().min(1).describe("Exact release version."),
+    projectId: z
+      .string()
+      .trim()
+      .describe("Optional numeric project ID for release health metadata.")
+      .nullable()
+      .default(null),
+    includeHealth: z.boolean().default(false),
+    includeDeploys: z.boolean().default(true),
+    includeCommits: z.boolean().default(true),
+    limit: z.number().int().positive().max(50).default(10),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? undefined,
+    });
+    const organizationSlug = params.organizationSlug;
+    setTag("organization.slug", organizationSlug);
+    setTag("release.version", params.releaseVersion);
+    const scopedProjectSlug = context.constraints.projectSlug ?? undefined;
+    let projectId = params.projectId ?? undefined;
+
+    if (scopedProjectSlug && params.projectId) {
+      const scopedProject = await apiService.getProject({
+        organizationSlug,
+        projectSlugOrId: scopedProjectSlug,
+      });
+      const scopedProjectId = String(scopedProject.id);
+      if (params.projectId !== scopedProjectId) {
+        throw new UserInputError(
+          `Release health project is outside the active project constraint. Expected project "${scopedProjectSlug}".`,
+        );
+      }
+      projectId = scopedProjectId;
+    }
+
+    const release = await apiService.getReleaseDetails({
+      organizationSlug,
+      releaseVersion: params.releaseVersion,
+      projectSlug: scopedProjectSlug,
+      projectId: scopedProjectSlug ? undefined : projectId,
+      includeHealth: params.includeHealth,
+    });
+    if (release.projects && release.projects.length > 0) {
+      assertProjectListContainsConstraint({
+        resourceLabel: "Release",
+        scopedProjectSlug,
+        projects: release.projects,
+      });
+    }
+
+    const [deploys, commits] = await Promise.all([
+      params.includeDeploys
+        ? apiService.listReleaseDeploys({
+            organizationSlug,
+            releaseVersion: params.releaseVersion,
+            projectSlug: context.constraints.projectSlug ?? undefined,
+            limit: params.limit,
+          })
+        : Promise.resolve([]),
+      params.includeCommits
+        ? apiService.listReleaseCommits({
+            organizationSlug,
+            releaseVersion: params.releaseVersion,
+            projectSlug: context.constraints.projectSlug ?? undefined,
+            limit: params.limit,
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const releaseUrl = apiService.getReleaseUrl(
+      organizationSlug,
+      release.version,
+    );
+    const projects = formatProjects(release);
+    const author = release.lastCommit?.author
+      ? formatActor(release.lastCommit.author)
+      : null;
+
+    const output = compactLines([
+      `# Release ${release.version} in **${organizationSlug}**`,
+      "",
+      `**ID**: ${formatId(release.id)}`,
+      release.shortVersion
+        ? `**Short Version**: ${release.shortVersion}`
+        : null,
+      formatDate(release.dateCreated)
+        ? `**Created**: ${formatDate(release.dateCreated)}`
+        : null,
+      formatDate(release.dateReleased)
+        ? `**Released**: ${formatDate(release.dateReleased)}`
+        : null,
+      formatDate(release.firstEvent)
+        ? `**First Event**: ${formatDate(release.firstEvent)}`
+        : null,
+      formatDate(release.lastEvent)
+        ? `**Last Event**: ${formatDate(release.lastEvent)}`
+        : null,
+      release.newGroups !== undefined
+        ? `**New Issues**: ${release.newGroups}`
+        : null,
+      projects ? `**Projects**: ${projects}` : null,
+      `**URL**: [Open Release](${releaseUrl})`,
+    ]);
+
+    if (release.lastCommit) {
+      output.push("", "## Last Commit", "");
+      output.push(
+        compactLines([
+          `**Commit ID**: ${formatId(release.lastCommit.id)}`,
+          release.lastCommit.message
+            ? `**Message**: ${release.lastCommit.message}`
+            : null,
+          author ? `**Author**: ${author}` : null,
+          formatDate(release.lastCommit.dateCreated)
+            ? `**Created**: ${formatDate(release.lastCommit.dateCreated)}`
+            : null,
+        ]).join("\n"),
+      );
+    }
+
+    const healthLines = formatHealthOrMeta(release);
+    if (healthLines.length > 0) {
+      output.push("", "## Health And Project Metadata", "", ...healthLines);
+    }
+
+    if (params.includeDeploys) {
+      output.push("", "## Deploys", "");
+      output.push(
+        deploys.length === 0
+          ? "No deploys found."
+          : deploys.slice(0, params.limit).map(formatDeploy).join("\n\n"),
+      );
+    }
+
+    if (params.includeCommits) {
+      output.push("", "## Commits", "");
+      output.push(
+        commits.length === 0
+          ? "No commits found."
+          : commits.slice(0, params.limit).map(formatCommit).join("\n"),
+      );
+    }
+
+    output.push("", "## Response Notes", "");
+    output.push(
+      `- Search issues introduced in this release with query \`release:${release.version}\`.`,
+    );
+
+    return `${output.join("\n")}\n`;
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/get-release-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.ts
@@ -261,7 +261,7 @@ export default defineTool({
       );
     }
 
-    const healthLines = formatHealthOrMeta(release);
+    const healthLines = params.includeHealth ? formatHealthOrMeta(release) : [];
     if (healthLines.length > 0) {
       output.push("", "## Health And Project Metadata", "", ...healthLines);
     }

--- a/packages/mcp-core/src/tools/catalog/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-sentry-resource.test.ts
@@ -506,7 +506,7 @@ describe("get_sentry_resource", () => {
 
         To get release information:
 
-        - **View in Sentry**: [Open Release](https://my-org.sentry.io/releases/backend@2024.01.15-abc123/)
+        - **View in Sentry**: [Open Release](https://my-org.sentry.io/releases/backend%402024.01.15-abc123/)
         - **Find releases**: Use the Sentry tool \`find_releases(organizationSlug='my-org')\` to list releases and their details
         - **Search issues**: Use \`search_issues\` with query \`release:backend@2024.01.15-abc123\` to find issues in this release"
       `);

--- a/packages/mcp-core/src/tools/catalog/index.ts
+++ b/packages/mcp-core/src/tools/catalog/index.ts
@@ -3,6 +3,7 @@ import findOrganizations from "./find-organizations";
 import findTeams from "./find-teams";
 import findProjects from "./find-projects";
 import findReleases from "./find-releases";
+import getReleaseDetails from "./get-release-details";
 import getIssueDetails from "./get-issue-details";
 import getIssueActivity from "./get-issue-activity";
 import getIssueTagValues from "./get-issue-tag-values";
@@ -46,6 +47,7 @@ const catalogTools = {
   find_teams: findTeams,
   find_projects: findProjects,
   find_releases: findReleases,
+  get_release_details: getReleaseDetails,
   get_issue_details: getIssueDetails,
   get_issue_activity: getIssueActivity,
   get_issue_tag_values: getIssueTagValues,

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -8,6 +8,7 @@ import {
   getPreprodSnapshotUrl,
   getReplaysSearchUrl,
   getReplayUrl,
+  getReleaseUrl,
   getTraceUrl,
   getEventsExplorerUrl,
   getTraceMetricsExploreUrl,
@@ -159,6 +160,19 @@ describe("url-utils", () => {
       );
       expect(result).toBe(
         "http://sentry.internal:9000/organizations/myorg/issues/PROJ-123",
+      );
+    });
+  });
+
+  describe("getReleaseUrl", () => {
+    it("should encode release versions in the path segment", () => {
+      const result = getReleaseUrl(
+        "sentry.io",
+        "myorg",
+        "backend/web 2025.04.13",
+      );
+      expect(result).toBe(
+        "https://myorg.sentry.io/releases/backend%2Fweb%202025.04.13/",
       );
     });
   });

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -398,10 +398,11 @@ export function getReleaseUrl(
   releaseVersion: string,
   protocol: SentryProtocol = "https",
 ): string {
+  const encodedReleaseVersion = encodeURIComponent(releaseVersion);
   return getSentryWebBaseUrl(
     host,
     organizationSlug,
-    `/releases/${releaseVersion}/`,
+    `/releases/${encodedReleaseVersion}/`,
     protocol,
   );
 }

--- a/packages/mcp-server-mocks/src/fixtures/release-commits.json
+++ b/packages/mcp-server-mocks/src/fixtures/release-commits.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "2ce6a2700fec4913a2cde8e2d41dee36",
+    "message": "Fix duplicate tool registration",
+    "dateCreated": "2025-04-13T19:40:00.000Z",
+    "pullRequest": null,
+    "suspectCommitType": "",
+    "author": {
+      "name": "Jane Developer",
+      "email": "jane@example.com"
+    },
+    "repository": {
+      "name": "getsentry/sentry-mcp"
+    }
+  }
+]

--- a/packages/mcp-server-mocks/src/fixtures/release-deploys.json
+++ b/packages/mcp-server-mocks/src/fixtures/release-deploys.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "98765",
+    "environment": "production",
+    "name": "prod deploy",
+    "url": "https://deploys.example.com/98765",
+    "dateStarted": "2025-04-13T20:00:00.000Z",
+    "dateFinished": "2025-04-13T20:05:30.000Z"
+  }
+]

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -853,6 +853,11 @@ export const restHandlers = buildHandlers([
   },
   {
     method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/8ce89484-0fec-4913-a2cd-e8e2d41dee36/commits/",
+    fetch: () => HttpResponse.json(releaseCommitsFixture),
+  },
+  {
+    method: "get",
     path: "/api/0/organizations/sentry-mcp-evals/tags/",
     fetch: () => HttpResponse.json(tagsFixture),
   },

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -89,6 +89,12 @@ import performanceEventFixture from "./fixtures/performance-event.json" with {
 };
 import projectFixture from "./fixtures/project.json" with { type: "json" };
 import releaseFixture from "./fixtures/release.json" with { type: "json" };
+import releaseCommitsFixture from "./fixtures/release-commits.json" with {
+  type: "json",
+};
+import releaseDeploysFixture from "./fixtures/release-deploys.json" with {
+  type: "json",
+};
 import tagsFixture from "./fixtures/tags.json" with { type: "json" };
 import teamFixture from "./fixtures/team.json" with { type: "json" };
 import traceEventFixture from "./fixtures/trace-event.json" with {
@@ -822,8 +828,28 @@ export const restHandlers = buildHandlers([
   },
   {
     method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/releases/8ce89484-0fec-4913-a2cd-e8e2d41dee36/",
+    fetch: () => HttpResponse.json(releaseFixture),
+  },
+  {
+    method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/releases/8ce89484-0fec-4913-a2cd-e8e2d41dee36/deploys/",
+    fetch: () => HttpResponse.json(releaseDeploysFixture),
+  },
+  {
+    method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/releases/8ce89484-0fec-4913-a2cd-e8e2d41dee36/commits/",
+    fetch: () => HttpResponse.json(releaseCommitsFixture),
+  },
+  {
+    method: "get",
     path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/",
     fetch: () => HttpResponse.json([releaseFixture]),
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/8ce89484-0fec-4913-a2cd-e8e2d41dee36/",
+    fetch: () => HttpResponse.json(releaseFixture),
   },
   {
     method: "get",


### PR DESCRIPTION
Add a catalog-only release details tool for inspecting an exact Sentry release. It gives agents a focused path to release metadata, recent deploys, recent commits, and optional project health metadata without adding another direct MCP tool.

**Catalog Tool Surface**

`get_release_details` is registered only through the catalog metadata with the `inspect` skill. The direct tool surface stays unchanged, and the read-only metadata uses the `project:read` scope accepted by the upstream GET endpoints.

**Agent-Facing Project Scope**

The tool exposes `projectSlugOrId` as an optional project scope instead of leaking endpoint-specific params. Release details and commits use project release endpoints when scoped, deploys use the upstream deploy filter, and health metadata requires a project scope unless the session is already project-constrained.

**Regression Coverage**

Mocks and focused tests cover organization details, project-scoped details, project constraint checks, deploys, commits, scoped commit routing, encoded release URLs, and hiding health metadata unless `includeHealth` is true.