### PR TITLE
chore(warden): Report low findings

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -2,7 +2,7 @@ version = 1
 
 [defaults]
 failOn = "high"
-reportOn = "medium"
+reportOn = "low"
 
 [[skills]]
 name = "mcp-audit"


### PR DESCRIPTION
Lower Warden's reporting threshold so low-severity findings are posted on reviews.

The failure threshold remains high, so this increases visibility without making low findings block the PR.