### PR TITLE
fix(triage): Close clear spam issues

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -110,7 +110,7 @@ If `repositoryContext.checkoutAvailable` is true, inspect code under `repository
    - Keep broad/impractical feature requests open for human review unless duplicate status is confirmed by the duplicate stage.
 9. Decide whether to close spam:
    - Set `should_close` to true only for clear spam, automated external promotion, registry listing notifications, package-claim solicitations, SEO/link drops, or marketing outreach that has no repository maintenance action.
-   - Use `disposition: "spam"`, `labels_to_apply: ["invalid"]` when that label exists, `close_reason: "not planned"`, and a concise `close_comment`.
+   - Use `severity: "low"`, `disposition: "spam"`, `labels_to_apply: ["invalid"]` when that label exists, `close_reason: "not planned"`, and a concise `close_comment`.
    - Do not close security reports, legal/ownership disputes, maintainer-authored issues, ambiguous partner/integration requests, or anything needing human judgment.
    - Be decisive when the evidence is direct. Do not say a maintainer can decide whether to close a clear spam issue.
 

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -90,6 +90,7 @@ If `repositoryContext.checkoutAvailable` is true, inspect code under `repository
    - `needs_more_info`: likely valid, but missing concrete repro, motivation, or acceptance criteria.
    - `low_actionability`: the request has a recognizable shape but little useful signal.
    - `impractical_scope`: the request is broad enough that it needs a proposal, owner, migration plan, or product decision before normal issue triage makes sense.
+   - `spam`: promotional, automated, or SEO/link-drop content that is not a repo bug, docs issue, support request, feature request, security report, or maintainer decision.
    - `unclear`: the concern cannot be identified.
 6. Choose the rewrite mode before drafting anything:
    - `none`: leave the issue body alone. Use this for weak or low-signal reports when rewriting would launder them into a better-looking ticket than they are.
@@ -107,6 +108,11 @@ If `repositoryContext.checkoutAvailable` is true, inspect code under `repository
    - Set `should_comment` to true when the best next step is a short ask for missing context, a scope note for maintainer review, or a concise explanation that the request is not actionable as written.
    - Provide `triage_comment` when `should_comment` is true.
    - Keep broad/impractical feature requests open for human review unless duplicate status is confirmed by the duplicate stage.
+9. Decide whether to close spam:
+   - Set `should_close` to true only for clear spam, automated external promotion, registry listing notifications, package-claim solicitations, SEO/link drops, or marketing outreach that has no repository maintenance action.
+   - Use `disposition: "spam"`, `labels_to_apply: ["invalid"]` when that label exists, `close_reason: "not planned"`, and a concise `close_comment`.
+   - Do not close security reports, legal/ownership disputes, maintainer-authored issues, ambiguous partner/integration requests, or anything needing human judgment.
+   - Be decisive when the evidence is direct. Do not say a maintainer can decide whether to close a clear spam issue.
 
 ### Low-Signal and Impractical Requests
 
@@ -178,7 +184,7 @@ Return:
 
 - `severity`: `low`, `medium`, `high`, or `critical`
 - `category`: `bug`, `documentation`, `feature_request`, `support`, `security`, `maintenance`, or `unknown`
-- `disposition`: `actionable`, `needs_more_info`, `low_actionability`, `impractical_scope`, or `unclear`
+- `disposition`: `actionable`, `needs_more_info`, `low_actionability`, `impractical_scope`, `spam`, or `unclear`
 - `rewrite_mode`: `none`, `light_cleanup`, `technical_diagnosis`, or `scope_clarification`
 - `validity`: `confirmed`, `likely`, `not_reproducible`, or `unclear`
 - `summary`: concise diagnosis
@@ -190,4 +196,7 @@ Return:
 - `proposed_body` when `should_update_issue` is true
 - `triage_comment` when `should_comment` is true
 - `update_comment` when `should_update_issue` is true
+- `should_close`: true only for clear spam that should be closed automatically
+- `close_reason`: `not planned` when `should_close` is true
+- `close_comment` when `should_close` is true
 - `needs_human_review`: true for security-sensitive, high-risk, ambiguous, or destructive cases

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -437,6 +437,20 @@ function buildSpamCloseComment() {
   ].join("\n");
 }
 
+function buildUnsafeCloseComment(diagnosis: Diagnosis) {
+  const lines = [
+    "Triage bot here.",
+    "",
+    "The agent flagged this for spam closure, but the request did not pass the auto-close guardrails, so I left it open for maintainer review.",
+  ];
+
+  if (diagnosis.summary.trim()) {
+    lines.push("", `Current read: ${diagnosis.summary.trim()}`);
+  }
+
+  return lines.join("\n");
+}
+
 function selectCloseComment(diagnosis: Diagnosis) {
   const comment =
     diagnosis.close_comment?.trim() || diagnosis.triage_comment?.trim();
@@ -446,6 +460,21 @@ function selectCloseComment(diagnosis: Diagnosis) {
   }
 
   return buildSpamCloseComment();
+}
+
+function selectUnsafeCloseComment(diagnosis: Diagnosis) {
+  const comment =
+    diagnosis.triage_comment?.trim() || diagnosis.close_comment?.trim();
+
+  if (
+    comment &&
+    !/\bclos/i.test(comment) &&
+    !hasPuntingCloseLanguage(comment)
+  ) {
+    return comment;
+  }
+
+  return buildUnsafeCloseComment(diagnosis);
 }
 
 async function closeSpamIssue(
@@ -587,12 +616,16 @@ async function applyTriageUpdate(
       diagnosis.proposed_body,
     );
 
-    const comment = selectTriageComment(diagnosis, bodyUpdated);
+    const comment = unsafeCloseRequest
+      ? selectUnsafeCloseComment(diagnosis)
+      : selectTriageComment(diagnosis, bodyUpdated);
     if (comment) {
       commentPosted = await postComment(session, context, comment);
     }
   } else {
-    const comment = selectTriageComment(diagnosis, false);
+    const comment = unsafeCloseRequest
+      ? selectUnsafeCloseComment(diagnosis)
+      : selectTriageComment(diagnosis, false);
     if (comment) {
       commentPosted = await postComment(session, context, comment);
     }

--- a/.flue/agents/issue-triage.ts
+++ b/.flue/agents/issue-triage.ts
@@ -32,6 +32,7 @@ const dispositionSchema = v.picklist([
   "needs_more_info",
   "low_actionability",
   "impractical_scope",
+  "spam",
   "unclear",
 ]);
 const rewriteModeSchema = v.picklist([
@@ -40,6 +41,7 @@ const rewriteModeSchema = v.picklist([
   "technical_diagnosis",
   "scope_clarification",
 ]);
+const closeReasonSchema = v.picklist(["not planned"]);
 
 const duplicateCandidateSchema = v.object({
   number: v.pipe(v.number(), v.integer(), v.minValue(1)),
@@ -73,6 +75,9 @@ const diagnosisSchema = v.object({
   proposed_body: v.optional(v.string()),
   triage_comment: v.optional(v.string()),
   update_comment: v.optional(v.string()),
+  should_close: v.optional(v.boolean()),
+  close_reason: v.optional(closeReasonSchema),
+  close_comment: v.optional(v.string()),
   needs_human_review: v.boolean(),
 });
 type Diagnosis = v.InferOutput<typeof diagnosisSchema>;
@@ -82,6 +87,8 @@ const updateSchema = v.object({
   body_updated: v.boolean(),
   labels_applied: v.array(v.string()),
   comment_posted: v.boolean(),
+  issue_closed: v.boolean(),
+  close_reason: v.optional(closeReasonSchema),
   needs_human_review: v.boolean(),
   summary: v.string(),
 });
@@ -407,6 +414,59 @@ async function closeDuplicate(
   return labelsApplied;
 }
 
+function shouldCloseAsSpam(diagnosis: Diagnosis) {
+  return (
+    diagnosis.should_close === true &&
+    diagnosis.close_reason === "not planned" &&
+    diagnosis.disposition === "spam" &&
+    diagnosis.severity === "low" &&
+    diagnosis.category !== "security" &&
+    diagnosis.needs_human_review === false
+  );
+}
+
+function hasPuntingCloseLanguage(comment: string) {
+  return /maintainer can decide whether to .*close/i.test(comment);
+}
+
+function buildSpamCloseComment() {
+  return [
+    "Triage bot here.",
+    "",
+    "This is an automated external promotion rather than a repo bug, docs issue, support request, or feature request, so I'm closing it as invalid for normal repo triage.",
+  ].join("\n");
+}
+
+function selectCloseComment(diagnosis: Diagnosis) {
+  const comment =
+    diagnosis.close_comment?.trim() || diagnosis.triage_comment?.trim();
+
+  if (comment && /\bclos/i.test(comment) && !hasPuntingCloseLanguage(comment)) {
+    return comment;
+  }
+
+  return buildSpamCloseComment();
+}
+
+async function closeSpamIssue(
+  session: FlueSession,
+  context: IssueContext,
+  diagnosis: Diagnosis,
+) {
+  const commentPosted = await postComment(
+    session,
+    context,
+    selectCloseComment(diagnosis),
+  );
+  await runGhCommand(
+    session,
+    `gh issue close ${context.issueNumber}${repoArg(context.repository)} --reason ${shellQuote("not planned")}`,
+    "Closing spam issue",
+  );
+
+  return commentPosted;
+}
+
 function buildIssueUpdateComment(
   diagnosis: v.InferOutput<typeof diagnosisSchema>,
 ) {
@@ -483,6 +543,7 @@ async function applyTriageUpdate(
       body_updated: false,
       labels_applied: [],
       comment_posted: false,
+      issue_closed: false,
       needs_human_review: true,
       summary: "Skipped triage update because the issue is already closed.",
     };
@@ -496,6 +557,23 @@ async function applyTriageUpdate(
   let titleUpdated = false;
   let bodyUpdated = false;
   let commentPosted = false;
+
+  if (shouldCloseAsSpam(diagnosis)) {
+    commentPosted = await closeSpamIssue(session, context, diagnosis);
+
+    return {
+      title_updated: false,
+      body_updated: false,
+      labels_applied: labelsApplied,
+      comment_posted: commentPosted,
+      issue_closed: true,
+      close_reason: "not planned",
+      needs_human_review: false,
+      summary: "Closed issue as spam.",
+    };
+  }
+
+  const unsafeCloseRequest = diagnosis.should_close === true;
 
   if (diagnosis.should_update_issue) {
     titleUpdated = await editIssueTitle(
@@ -532,9 +610,11 @@ async function applyTriageUpdate(
     body_updated: bodyUpdated,
     labels_applied: labelsApplied,
     comment_posted: commentPosted,
-    needs_human_review: diagnosis.needs_human_review,
-    summary:
-      changed.length > 0
+    issue_closed: false,
+    needs_human_review: diagnosis.needs_human_review || unsafeCloseRequest,
+    summary: unsafeCloseRequest
+      ? "Skipped unsafe spam close request and left the issue open for maintainer review."
+      : changed.length > 0
         ? `Updated issue ${changed.join(", ")}.`
         : "No issue update was needed.",
   };
@@ -755,7 +835,11 @@ export default async function ({ init, payload }: FlueContext) {
   const update = await applyTriageUpdate(session, updateContext, diagnosis);
 
   return {
-    outcome: update.needs_human_review ? "needs_human_review" : "triaged",
+    outcome: update.issue_closed
+      ? "closed_spam"
+      : update.needs_human_review
+        ? "needs_human_review"
+        : "triaged",
     steps: [
       { name: "search-duplicates", result: duplicateSearch.status },
       {
@@ -774,6 +858,8 @@ export default async function ({ init, payload }: FlueContext) {
     comment_posted: update.comment_posted,
     title_updated: update.title_updated,
     body_updated: update.body_updated,
+    issue_closed: update.issue_closed,
+    close_reason: update.close_reason,
     needs_human_review: update.needs_human_review,
     summary: update.summary,
   };

--- a/.flue/fixtures/issue-triage/external-registry-spam-1059.json
+++ b/.flue/fixtures/issue-triage/external-registry-spam-1059.json
@@ -1,0 +1,59 @@
+{
+  "name": "external-registry-spam-1059",
+  "description": "Real GitHub issue fixture for an automated external registry notification that the triage agent should close as invalid/spam instead of punting to a maintainer.",
+  "source": {
+    "repository": "getsentry/sentry-mcp",
+    "issueNumber": 1059,
+    "issueUrl": "https://github.com/getsentry/sentry-mcp/issues/1059",
+    "workflowRunUrl": "https://github.com/getsentry/sentry-mcp/actions/runs/27094165697",
+    "capturedAt": "2026-06-07T13:39:51Z"
+  },
+  "issue": {
+    "number": 1059,
+    "title": "Your project is now listed on CodeGuilds",
+    "author": {
+      "login": "xdevsapps",
+      "association": "NONE",
+      "type": "User"
+    },
+    "stateAtCapture": "open",
+    "createdAt": "2026-06-07T13:38:41Z",
+    "updatedAt": "2026-06-07T13:39:51Z",
+    "labelsAtCapture": ["invalid"],
+    "body": "Hi @getsentry \ud83d\udc4b\n\nWe added your project **Sentry MCP Server** to **CodeGuilds** \u2014 a community registry for the Claude Code ecosystem (like npmjs but for Claude skills, agents, MCP servers, and tools).\n\nYour package is live at: **https://codeguilds.dev/packages/sentry-mcp**\n\nIf you'd like to claim ownership of the listing and manage it yourself, you can sign in with GitHub at https://codeguilds.dev and claim the package from your dashboard.\n\nThanks for building this \u2014 the community appreciates it!\n\n*This issue was opened automatically by the CodeGuilds team. Feel free to close it.*"
+  },
+  "observedTriage": {
+    "diagnosis": {
+      "severity": "low",
+      "category": "maintenance",
+      "disposition": "low_actionability",
+      "rewrite_mode": "none",
+      "validity": "likely",
+      "summary": "This is an external registry notification saying Sentry MCP has been listed on CodeGuilds and can be claimed by maintainers. It does not report a repo bug, docs issue, setup problem, or concrete feature request.",
+      "evidence": [
+        "Read the current issue body and comments from the provided context.",
+        "Read AGENTS.md and the README in the available checkout. The repository is Sentry MCP, matching the project named in the notification.",
+        "Duplicate search found no other CodeGuilds/listing issue in this repository.",
+        "No code, documentation, or test validation is relevant because the issue is an external listing notification rather than repository behavior."
+      ],
+      "labels_to_apply": ["invalid"],
+      "should_comment": true,
+      "should_update_issue": false,
+      "triage_comment": "Triage bot here.\n\nThis looks like an external registry notification rather than a repo bug, docs issue, or feature request. I\u2019m marking it as not actionable for normal repo triage; a maintainer can decide whether to claim the listing or close it.",
+      "needs_human_review": false
+    },
+    "comment": "Triage bot here.\n\nThis looks like an external registry notification rather than a repo bug, docs issue, or feature request. I\u2019m marking it as not actionable for normal repo triage; a maintainer can decide whether to claim the listing or close it.",
+    "problem": "The agent had enough evidence to classify the issue as non-repo promotional automation, but its available schema only let it label/comment. The comment also lacked conviction by deferring closure to a maintainer."
+  },
+  "expectedTriage": {
+    "category": "unknown",
+    "disposition": "spam",
+    "labels_to_apply": ["invalid"],
+    "should_update_issue": false,
+    "should_comment": true,
+    "should_close": true,
+    "close_reason": "not planned",
+    "needs_human_review": false,
+    "commentExpectation": "The comment should state that this is automated external registry promotion, not a repo issue, and that it is being closed. It should not ask a maintainer to decide whether to close."
+  }
+}

--- a/.flue/fixtures/issue-triage/external-registry-spam-1059.json
+++ b/.flue/fixtures/issue-triage/external-registry-spam-1059.json
@@ -46,6 +46,7 @@
     "problem": "The agent had enough evidence to classify the issue as non-repo promotional automation, but its available schema only let it label/comment. The comment also lacked conviction by deferring closure to a maintainer."
   },
   "expectedTriage": {
+    "severity": "low",
     "category": "unknown",
     "disposition": "spam",
     "labels_to_apply": ["invalid"],

--- a/docs/flue-hooks.md
+++ b/docs/flue-hooks.md
@@ -33,7 +33,10 @@ The stages are:
 2. Close confirmed duplicates with a comment pointing at the canonical issue.
 3. Prepare a repository checkout for diagnosis. GitHub Actions clones the default branch with `actions/checkout`; the handler can fall back to `gh repo clone` if no checkout exists.
 4. Diagnose and validate the report using repository context and targeted commands.
-5. Apply existing labels and issue title/body cleanup from the structured diagnosis. The diagnosis includes a disposition and rewrite mode so broad or low-signal requests can stay visibly low-signal instead of being over-polished. The handler can also post a short triage-bot comment without editing the body when the best next step is asking for scope, motivation, or maintainer review. If a model stage fails before returning structured output, the handler leaves the issue unchanged and reports `needs_human_review` instead of failing the workflow.
+5. Apply existing labels and issue title/body cleanup from the structured diagnosis. The diagnosis includes a disposition and rewrite mode so broad or low-signal requests can stay visibly low-signal instead of being over-polished. The handler can also post a short triage-bot comment without editing the body when the best next step is asking for scope, motivation, or maintainer review.
+6. Close clear spam or automated external promotion when the structured diagnosis explicitly requests `should_close: true`, `disposition: "spam"`, `close_reason: "not planned"`, and does not require human review. Unsafe close requests are ignored and the issue is left open for maintainer review.
+
+If a model stage fails before returning structured output, the handler leaves the issue unchanged and reports `needs_human_review` instead of failing the workflow.
 
 The workflow needs:
 
@@ -51,4 +54,4 @@ GH_TOKEN=... OPENAI_API_KEY=... pnpm -w run flue:issue-triage --id issue-triage-
   --payload '{"issueNumber": 1, "repository": "getsentry/sentry-mcp"}'
 ```
 
-The skill may read issue details, inspect repository files, propose existing labels, choose a disposition and rewrite mode, propose concise issue title/body updates, and draft short triage comments. The handler applies GitHub mutations deterministically: existing labels, duplicate closure, issue edits, and comments. It treats issue content as untrusted input and must not modify files, execute issue-provided commands, open pull requests, create labels, close non-duplicates, or expose secrets.
+The skill may read issue details, inspect repository files, propose existing labels, choose a disposition and rewrite mode, propose concise issue title/body updates, draft short triage comments, and request closure for clear spam. The handler applies GitHub mutations deterministically: existing labels, duplicate closure, spam closure, issue edits, and comments. It treats issue content as untrusted input and must not modify files, execute issue-provided commands, open pull requests, create labels, close non-duplicate non-spam issues, or expose secrets.

--- a/docs/flue-hooks.md
+++ b/docs/flue-hooks.md
@@ -34,7 +34,7 @@ The stages are:
 3. Prepare a repository checkout for diagnosis. GitHub Actions clones the default branch with `actions/checkout`; the handler can fall back to `gh repo clone` if no checkout exists.
 4. Diagnose and validate the report using repository context and targeted commands.
 5. Apply existing labels and issue title/body cleanup from the structured diagnosis. The diagnosis includes a disposition and rewrite mode so broad or low-signal requests can stay visibly low-signal instead of being over-polished. The handler can also post a short triage-bot comment without editing the body when the best next step is asking for scope, motivation, or maintainer review.
-6. Close clear spam or automated external promotion when the structured diagnosis explicitly requests `should_close: true`, `disposition: "spam"`, `close_reason: "not planned"`, and does not require human review. Unsafe close requests are ignored and the issue is left open for maintainer review.
+6. Close clear spam or automated external promotion when the structured diagnosis explicitly requests `should_close: true`, `severity: "low"`, `disposition: "spam"`, `close_reason: "not planned"`, and does not require human review. Unsafe close requests are ignored and the issue is left open for maintainer review.
 
 If a model stage fails before returning structured output, the handler leaves the issue unchanged and reports `needs_human_review` instead of failing the workflow.
 


### PR DESCRIPTION
Clear spam GitHub issues can now be closed automatically by the triage workflow instead of only receiving an invalid label and a maintainer-punt comment. The handler requires an explicit spam disposition, low severity, no human review flag, and the allowlisted `not planned` close reason before mutating issue state.

**Spam Closure Guardrails**

The Flue handler now accepts `should_close`, `close_reason`, and `close_comment` from the structured diagnosis, but only honors them for clear spam. Unsafe close requests are ignored and moved to human review.

**Regression Fixture**

The original external registry notification from #1059 is captured as a fixture with the weak observed triage output and the expected future close behavior.

Refs #1059