### PR TITLE
fix(trace): Tolerate missing trace metadata fields

### DIFF
--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -21,6 +21,7 @@ import {
   ReleaseSchema,
   ReplayDetailsSchema,
   TagSchema,
+  TraceMetaSchema,
   TransactionProfileSampleSchema,
   TransactionProfileSchema,
 } from "./schema";
@@ -602,6 +603,53 @@ describe("TagSchema", () => {
       key: "transaction",
       name: "Transaction",
       totalValues: 1080,
+    });
+  });
+});
+
+describe("TraceMetaSchema", () => {
+  it("defaults missing trace metadata counts and maps", () => {
+    expect(TraceMetaSchema.parse({})).toEqual({
+      logs: 0,
+      errors: 0,
+      performance_issues: 0,
+      span_count: 0,
+      transaction_child_count_map: [],
+      span_count_map: {},
+    });
+  });
+
+  it("normalizes current trace-meta response keys", () => {
+    expect(
+      TraceMetaSchema.parse({
+        logsCount: 3,
+        errorsCount: 2,
+        performanceIssuesCount: 1,
+        spansCount: 4,
+        transactionChildCountMap: [
+          {
+            "transaction.event_id": "0daf40dc453a429c8c57e4c215c4e82c",
+            "count()": 4,
+          },
+        ],
+        spansCountMap: {
+          "http.client": 4,
+        },
+      }),
+    ).toEqual({
+      logs: 3,
+      errors: 2,
+      performance_issues: 1,
+      span_count: 4,
+      transaction_child_count_map: [
+        {
+          "transaction.event_id": "0daf40dc453a429c8c57e4c215c4e82c",
+          "count()": 4,
+        },
+      ],
+      span_count_map: {
+        "http.client": 4,
+      },
     });
   });
 });

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1069,19 +1069,40 @@ export const ExternalIssueListSchema = z.array(ExternalIssueSchema);
  * Upstream source of truth in getsentry/sentry:
  * - `src/sentry/api/endpoints/organization_trace_meta.py`
  */
-export const TraceMetaSchema = z.object({
-  logs: z.number(),
-  errors: z.number(),
-  performance_issues: z.number(),
-  span_count: z.number(),
-  transaction_child_count_map: z.array(
-    z.object({
-      "transaction.event_id": z.string().nullable(),
-      "count()": z.number(),
-    }),
-  ),
-  span_count_map: z.record(z.string(), z.number()),
+const TraceMetaTransactionChildCountSchema = z.object({
+  "transaction.event_id": z.string().nullable(),
+  "count()": z.number(),
 });
+
+export const TraceMetaSchema = z
+  .object({
+    logs: z.number().optional(),
+    errors: z.number().optional(),
+    performance_issues: z.number().optional(),
+    span_count: z.number().optional(),
+    transaction_child_count_map: z
+      .array(TraceMetaTransactionChildCountSchema)
+      .optional(),
+    span_count_map: z.record(z.string(), z.number()).optional(),
+    logsCount: z.number().optional(),
+    errorsCount: z.number().optional(),
+    performanceIssuesCount: z.number().optional(),
+    spansCount: z.number().optional(),
+    transactionChildCountMap: z
+      .array(TraceMetaTransactionChildCountSchema)
+      .optional(),
+    spansCountMap: z.record(z.string(), z.number()).optional(),
+  })
+  .transform((meta) => ({
+    logs: meta.logs ?? meta.logsCount ?? 0,
+    errors: meta.errors ?? meta.errorsCount ?? 0,
+    performance_issues:
+      meta.performance_issues ?? meta.performanceIssuesCount ?? 0,
+    span_count: meta.span_count ?? meta.spansCount ?? 0,
+    transaction_child_count_map:
+      meta.transaction_child_count_map ?? meta.transactionChildCountMap ?? [],
+    span_count_map: meta.span_count_map ?? meta.spansCountMap ?? {},
+  }));
 
 /**
  * Schema for individual spans within a trace.

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
@@ -417,6 +417,45 @@ describe("get_trace_details", () => {
     expect(result).not.toContain("## Overview");
   });
 
+  it("handles trace meta responses with missing count fields", async () => {
+    const traceId = "c4d1aae7216b47ff8117cf4e09ce9d0c";
+
+    mswServer.use(
+      ...httpGetRegional(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/${traceId}/`,
+        () => {
+          return HttpResponse.json({});
+        },
+      ),
+      ...httpGetRegional(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/${traceId}/`,
+        () => {
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    const result = await getTraceDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        traceId,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain("**Total Spans**: 0");
+    expect(result).toContain("**Errors**: 0");
+    expect(result).toContain("**Performance Issues**: 0");
+    expect(result).toContain("**Logs**: 0");
+  });
+
   it("handles API error gracefully", async () => {
     mswServer.use(
       ...httpGetRegional(


### PR DESCRIPTION
Trace lookups now tolerate trace-meta responses that omit count and map fields instead of failing schema validation. The API client normalizes missing or camelCase upstream metadata into the existing snake-case shape used by trace tools.

**Trace metadata defaults**

Missing counts now become `0`, missing maps become empty collections, and current upstream keys like `spansCount` and `spansCountMap` are accepted so callers can continue using the existing `span_count` fields.

Fixes #1058