### PR TITLE
fix: keep stdio transport types self-contained

### DIFF
--- a/.github/workflows/mcp-server-package.yml
+++ b/.github/workflows/mcp-server-package.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build package dependencies
+        run: pnpm --filter @sentry/mcp-core build
+
       - name: Build stdio package
         run: pnpm --filter @sentry/mcp-server build
 

--- a/.github/workflows/mcp-server-package.yml
+++ b/.github/workflows/mcp-server-package.yml
@@ -1,0 +1,116 @@
+name: MCP Server Package
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - ".github/workflows/mcp-server-package.yml"
+      - "packages/mcp-core/**"
+      - "packages/mcp-server/**"
+      - "packages/mcp-server-tsconfig/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+
+permissions:
+  contents: read
+
+jobs:
+  package-consumer:
+    name: Clean Consumer Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build stdio package
+        run: pnpm --filter @sentry/mcp-server build
+
+      - name: Pack stdio package
+        run: pnpm --dir packages/mcp-server pack --pack-destination "$RUNNER_TEMP"
+
+      - name: Typecheck clean consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          consumer="$RUNNER_TEMP/mcp-server-consumer"
+          mkdir -p "$consumer"
+          cd "$consumer"
+
+          export npm_config_cache="$RUNNER_TEMP/npm-cache"
+          cat > package.json <<'EOF'
+          {
+            "private": true,
+            "type": "module"
+          }
+          EOF
+
+          npm install --ignore-scripts --no-audit --no-fund "$RUNNER_TEMP"/sentry-mcp-server-*.tgz typescript@^5.8.3 @types/node@^22
+
+          cat > tsconfig.json <<'EOF'
+          {
+            "compilerOptions": {
+              "module": "NodeNext",
+              "moduleResolution": "NodeNext",
+              "noEmit": true,
+              "strict": true,
+              "target": "ES2022"
+            },
+            "include": ["index.ts"]
+          }
+          EOF
+
+          cat > index.ts <<'EOF'
+          import {
+            startStdio,
+            type StdioServerContext,
+          } from "@sentry/mcp-server/transports/stdio";
+
+          declare const server: Parameters<typeof startStdio>[0];
+
+          const telemetryContext: StdioServerContext = {
+            agentMode: false,
+            experimentalMode: false,
+            mcpUrl: "https://example.com/mcp",
+            sentryHost: "sentry.io",
+          };
+
+          void startStdio(server, telemetryContext);
+          void startStdio(server, {
+            accessToken: "token",
+            constraints: {},
+            sentryHost: "sentry.io",
+          });
+          EOF
+
+          npx tsc --noEmit

--- a/packages/mcp-server/src/transports/stdio.ts
+++ b/packages/mcp-server/src/transports/stdio.ts
@@ -23,42 +23,11 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { LIB_VERSION } from "@sentry/mcp-core/version";
 import * as Sentry from "@sentry/node";
 
-type SentryProtocol = "http" | "https";
-type TransportType = "stdio" | "http";
-
-type ProjectCapabilities = {
-  profiles?: boolean;
-  replays?: boolean;
-  logs?: boolean;
-  traces?: boolean;
-};
-
-type Constraints = {
-  organizationSlug?: string | null;
-  projectSlug?: string | null;
-  regionUrl?: string | null;
-  projectCapabilities?: ProjectCapabilities | null;
-};
-
 export type StdioServerContext = {
   sentryHost?: string;
-  sentryProtocol?: SentryProtocol;
   mcpUrl?: string;
-  accessToken?: string;
-  clientName?: string | null;
-  clientFamily?: string | null;
-  openaiBaseUrl?: string;
-  userId?: string | null;
-  userIpAddress?: string | null;
-  clientId?: string;
-  grantedSkills?: ReadonlySet<string>;
-  constraints?: Constraints;
   agentMode?: boolean;
   experimentalMode?: boolean;
-  availableToolNames?: ReadonlySet<string>;
-  directToolNames?: ReadonlySet<string>;
-  transport?: TransportType;
-  onUpstreamUnauthorized?: () => void | Promise<void>;
 };
 
 function getStdioSpanAttributes(
@@ -91,7 +60,7 @@ function getStdioSpanAttributes(
  * All operations are wrapped in Sentry tracing for observability.
  *
  * @param server - Configured and instrumented MCP server instance (with context in closures)
- * @param context - Server context with authentication and configuration (for telemetry attributes)
+ * @param context - Context values used for telemetry attributes
  *
  * @example CLI Integration
  * ```typescript
@@ -110,9 +79,9 @@ function getStdioSpanAttributes(
  * await startStdio(server, context);
  * ```
  */
-export async function startStdio(
+export async function startStdio<Context extends StdioServerContext>(
   server: McpServer,
-  context: StdioServerContext,
+  context: Context,
 ) {
   await Sentry.startNewTrace(async () => {
     return await Sentry.startSpan(

--- a/packages/mcp-server/src/transports/stdio.ts
+++ b/packages/mcp-server/src/transports/stdio.ts
@@ -20,12 +20,49 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  * ```
  */
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { ServerContext } from "@sentry/mcp-core/types";
 import { LIB_VERSION } from "@sentry/mcp-core/version";
 import * as Sentry from "@sentry/node";
 
+type SentryProtocol = "http" | "https";
+type TransportType = "stdio" | "http";
+
+type ProjectCapabilities = {
+  profiles?: boolean;
+  replays?: boolean;
+  logs?: boolean;
+  traces?: boolean;
+};
+
+type Constraints = {
+  organizationSlug?: string | null;
+  projectSlug?: string | null;
+  regionUrl?: string | null;
+  projectCapabilities?: ProjectCapabilities | null;
+};
+
+export type StdioServerContext = {
+  sentryHost?: string;
+  sentryProtocol?: SentryProtocol;
+  mcpUrl?: string;
+  accessToken?: string;
+  clientName?: string | null;
+  clientFamily?: string | null;
+  openaiBaseUrl?: string;
+  userId?: string | null;
+  userIpAddress?: string | null;
+  clientId?: string;
+  grantedSkills?: ReadonlySet<string>;
+  constraints?: Constraints;
+  agentMode?: boolean;
+  experimentalMode?: boolean;
+  availableToolNames?: ReadonlySet<string>;
+  directToolNames?: ReadonlySet<string>;
+  transport?: TransportType;
+  onUpstreamUnauthorized?: () => void | Promise<void>;
+};
+
 function getStdioSpanAttributes(
-  context: ServerContext,
+  context: StdioServerContext,
 ): Record<string, string | boolean> {
   const attributes: Record<string, string | boolean> = {
     "app.transport": "stdio",
@@ -73,7 +110,10 @@ function getStdioSpanAttributes(
  * await startStdio(server, context);
  * ```
  */
-export async function startStdio(server: McpServer, context: ServerContext) {
+export async function startStdio(
+  server: McpServer,
+  context: StdioServerContext,
+) {
   await Sentry.startNewTrace(async () => {
     return await Sentry.startSpan(
       {


### PR DESCRIPTION
## Summary

Make the public `@sentry/mcp-server/transports/stdio` declaration self-contained by exporting a local `StdioServerContext` type instead of leaking the private workspace-only `@sentry/mcp-core/types` package.

## Reproduction

With the published `@sentry/mcp-server@0.35.0`, a clean TypeScript consumer of the public stdio subpath fails:

```text
node_modules/@sentry/mcp-server/dist/transports/stdio.d.ts(2,31): error TS2307: Cannot find module '@sentry/mcp-core/types' or its corresponding type declarations.
```

The runtime bundle is self-contained, but the emitted declaration still imports the private `@sentry/mcp-core` workspace package that consumers do not receive.

## Validation

- `pnpm --filter @sentry/mcp-core build`
- `pnpm --filter @sentry/mcp-server tsc`
- `pnpm --filter @sentry/mcp-server build`
- `pnpm pack --pack-destination /Users/aliou/Desktop/MakeMoney/tmp`
- Clean consumer install of the patched tarball plus `typescript@latest`
- `npx tsc --noEmit`
- `node -e "import('@sentry/mcp-server/transports/stdio').then(m=>console.log(typeof m.startStdio))"`
- `git diff --check`
