### PR TITLE
fix(seer): use updated autofix status values

### DIFF
--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -663,22 +663,15 @@ describe("AutofixRunSchema", () => {
 });
 
 describe("AutofixRunStateSchema", () => {
-  it("accepts explorer-style autofix state without legacy steps", () => {
+  it("accepts agent-based autofix state without legacy steps", () => {
     const state = AutofixRunStateSchema.parse(autofixStateExplorerFixture);
 
     expect(state.autofix?.status).toBe("processing");
     expect(state.autofix?.steps).toEqual([]);
-    expect(state.autofix?.blocks).toEqual([
-      {
-        type: "root_cause",
-        title: "Investigate failing request",
-        status: "COMPLETED",
-      },
-      {
-        type: "solution",
-        title: "Draft fix plan",
-        status: "IN_PROGRESS",
-      },
+    expect(state.autofix?.blocks).toHaveLength(1);
+    expect(state.autofix?.blocks[0].todos).toEqual([
+      { content: "Investigate failing request", status: "completed" },
+      { content: "Draft fix plan", status: "in_progress" },
     ]);
   });
 });

--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -666,6 +666,7 @@ describe("AutofixRunStateSchema", () => {
   it("accepts explorer-style autofix state without legacy steps", () => {
     const state = AutofixRunStateSchema.parse(autofixStateExplorerFixture);
 
+    expect(state.autofix?.status).toBe("processing");
     expect(state.autofix?.steps).toEqual([]);
     expect(state.autofix?.blocks).toEqual([
       {

--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -667,7 +667,6 @@ describe("AutofixRunStateSchema", () => {
     const state = AutofixRunStateSchema.parse(autofixStateExplorerFixture);
 
     expect(state.autofix?.status).toBe("processing");
-    expect(state.autofix?.steps).toEqual([]);
     expect(state.autofix?.blocks).toHaveLength(1);
     expect(state.autofix?.blocks[0].todos).toEqual([
       { content: "Investigate failing request", status: "completed" },

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1024,6 +1024,29 @@ export const AutofixRunStepSchema = z.union([
   AutofixRunStepBaseSchema.passthrough(),
 ]);
 
+const AutofixArtifactSchema = z
+  .object({
+    key: z.string(),
+    data: z.record(z.string(), z.unknown()).nullable().default(null),
+  })
+  .passthrough();
+
+const AutofixTodoSchema = z
+  .object({
+    content: z.string(),
+    status: z.string(),
+  })
+  .passthrough();
+
+// Agent memory blocks (Sentry's `MemoryBlock`). Analysis content arrives as
+// artifacts keyed "root_cause" and "solution"; only what we render is modeled.
+const AutofixBlockSchema = z
+  .object({
+    artifacts: z.array(AutofixArtifactSchema).default([]),
+    todos: z.array(AutofixTodoSchema).nullable().optional(),
+  })
+  .passthrough();
+
 /**
  * The Seer autofix GET endpoint is explicitly experimental. It returns the
  * agent-based run state (`blocks`, `pending_user_input`, coding-agent
@@ -1045,9 +1068,14 @@ export const AutofixRunStateSchema = z.object({
         (value) => value ?? [],
         z.array(AutofixRunStepSchema),
       ),
-      blocks: z.array(z.unknown()).optional(),
+      blocks: z.array(AutofixBlockSchema).default([]),
       pending_user_input: z.unknown().nullable().optional(),
-      repo_pr_states: z.record(z.string(), z.unknown()).optional(),
+      repo_pr_states: z
+        .record(
+          z.string(),
+          z.object({ pr_url: z.string().nullable().optional() }).passthrough(),
+        )
+        .optional(),
       coding_agents: z.record(z.string(), z.unknown()).optional(),
     })
     .passthrough()

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -935,16 +935,12 @@ export const AutofixRunSchema = z
   })
   .passthrough();
 
+// Run statuses from Sentry's `SeerRunState` (`seer/agent/client_models.py`).
 const AutofixStatusSchema = z.enum([
-  "PENDING",
-  "PROCESSING",
-  "IN_PROGRESS",
-  "NEED_MORE_INFORMATION",
-  "COMPLETED",
-  "FAILED",
-  "ERROR",
-  "CANCELLED",
-  "WAITING_FOR_USER_RESPONSE",
+  "processing",
+  "completed",
+  "error",
+  "awaiting_user_input",
 ]);
 
 const AutofixRunStepBaseSchema = z.object({
@@ -1029,18 +1025,14 @@ export const AutofixRunStepSchema = z.union([
 ]);
 
 /**
- * The Seer autofix GET endpoint is explicitly experimental and currently has
- * two materially different payload shapes:
- * - legacy `get_autofix_state(...).dict()` responses with `request` and `steps`
- * - explorer responses with `blocks`, `pending_user_input`, and coding-agent
- *   metadata but no `steps`
- *
- * We normalize missing `steps` to `[]` so existing formatting code keeps
- * working even if the server returns the explorer shape.
+ * The Seer autofix GET endpoint is explicitly experimental. It returns the
+ * agent-based run state (`blocks`, `pending_user_input`, coding-agent
+ * metadata) and no longer includes `steps`; we normalize missing `steps` to
+ * `[]` so the legacy step formatting code keeps working.
  *
  * Upstream source of truth in getsentry/sentry:
  * - `src/sentry/seer/endpoints/group_ai_autofix.py`
- * - `src/sentry/seer/autofix/types.py` (`AutofixStateResponse`)
+ * - `src/sentry/seer/agent/client_models.py` (`SeerRunState`)
  */
 export const AutofixRunStateSchema = z.object({
   autofix: z

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -943,87 +943,6 @@ const AutofixStatusSchema = z.enum([
   "awaiting_user_input",
 ]);
 
-const AutofixRunStepBaseSchema = z.object({
-  type: z.string(),
-  key: z.string(),
-  index: z.number(),
-  status: AutofixStatusSchema,
-  title: z.string(),
-  output_stream: z.string().nullable(),
-  progress: z.array(
-    z.object({
-      data: z.unknown().nullable(),
-      message: z.string(),
-      timestamp: z.string(),
-      type: z.enum(["INFO", "WARNING", "ERROR"]),
-    }),
-  ),
-});
-
-export const AutofixRunStepDefaultSchema = AutofixRunStepBaseSchema.extend({
-  type: z.literal("default"),
-  insights: z
-    .array(
-      z.object({
-        change_diff: z.unknown().nullable(),
-        generated_at_memory_index: z.number(),
-        insight: z.string(),
-        justification: z.string(),
-        type: z.literal("insight"),
-      }),
-    )
-    .nullable(),
-}).passthrough();
-
-export const AutofixRunStepRootCauseAnalysisSchema =
-  AutofixRunStepBaseSchema.extend({
-    type: z.literal("root_cause_analysis"),
-    causes: z.array(
-      z.object({
-        description: z.string(),
-        id: z.number(),
-        root_cause_reproduction: z.array(
-          z.object({
-            code_snippet_and_analysis: z.string(),
-            is_most_important_event: z.boolean(),
-            relevant_code_file: z
-              .object({
-                file_path: z.string(),
-                repo_name: z.string(),
-              })
-              .nullable(),
-            timeline_item_type: z.string(),
-            title: z.string(),
-          }),
-        ),
-      }),
-    ),
-  }).passthrough();
-
-export const AutofixRunStepSolutionSchema = AutofixRunStepBaseSchema.extend({
-  type: z.literal("solution"),
-  solution: z.array(
-    z.object({
-      code_snippet_and_analysis: z.string().nullable(),
-      is_active: z.boolean(),
-      is_most_important_event: z.boolean(),
-      relevant_code_file: z.null(),
-      timeline_item_type: z.union([
-        z.literal("internal_code"),
-        z.literal("repro_test"),
-      ]),
-      title: z.string(),
-    }),
-  ),
-}).passthrough();
-
-export const AutofixRunStepSchema = z.union([
-  AutofixRunStepDefaultSchema,
-  AutofixRunStepRootCauseAnalysisSchema,
-  AutofixRunStepSolutionSchema,
-  AutofixRunStepBaseSchema.passthrough(),
-]);
-
 const AutofixArtifactSchema = z
   .object({
     key: z.string(),
@@ -1050,8 +969,7 @@ const AutofixBlockSchema = z
 /**
  * The Seer autofix GET endpoint is explicitly experimental. It returns the
  * agent-based run state (`blocks`, `pending_user_input`, coding-agent
- * metadata) and no longer includes `steps`; we normalize missing `steps` to
- * `[]` so the legacy step formatting code keeps working.
+ * metadata).
  *
  * Upstream source of truth in getsentry/sentry:
  * - `src/sentry/seer/endpoints/group_ai_autofix.py`
@@ -1061,13 +979,8 @@ export const AutofixRunStateSchema = z.object({
   autofix: z
     .object({
       run_id: z.number(),
-      request: z.unknown().optional(),
       updated_at: z.string().nullable().optional(),
       status: AutofixStatusSchema,
-      steps: z.preprocess(
-        (value) => value ?? [],
-        z.array(AutofixRunStepSchema),
-      ),
       blocks: z.array(AutofixBlockSchema).default([]),
       pending_user_input: z.unknown().nullable().optional(),
       repo_pr_states: z

--- a/packages/mcp-core/src/internal/formatting.test.ts
+++ b/packages/mcp-core/src/internal/formatting.test.ts
@@ -121,14 +121,14 @@ describe("formatIssueOutput", () => {
         autofix: {
           run_id: 42,
           request: {},
-          status: "COMPLETED",
+          status: "completed",
           updated_at: "2025-04-09T22:39:50.778146",
           steps: [
             {
               type: "solution",
               key: "solution_step_with_a_name_long_enough_to_match_summary_filter",
               index: 0,
-              status: "COMPLETED",
+              status: "completed",
               title: "Proposed Solution",
               output_stream: null,
               progress: [],

--- a/packages/mcp-core/src/internal/formatting.test.ts
+++ b/packages/mcp-core/src/internal/formatting.test.ts
@@ -120,28 +120,26 @@ describe("formatIssueOutput", () => {
       autofixState: {
         autofix: {
           run_id: 42,
-          request: {},
           status: "completed",
           updated_at: "2025-04-09T22:39:50.778146",
-          steps: [
+          steps: [],
+          blocks: [
             {
-              type: "solution",
-              key: "solution_step_with_a_name_long_enough_to_match_summary_filter",
-              index: 0,
-              status: "completed",
-              title: "Proposed Solution",
-              output_stream: null,
-              progress: [],
-              description: "",
-              solution: [
+              artifacts: [
                 {
-                  code_snippet_and_analysis:
-                    "Use the canonical issue identifier before retrying the analysis request so the summary remains readable.",
-                  is_active: true,
-                  is_most_important_event: true,
-                  relevant_code_file: null,
-                  timeline_item_type: "internal_code",
-                  title: "Normalize the issue identifier",
+                  key: "solution",
+                  reason: "Solution plan completed",
+                  data: {
+                    one_line_summary:
+                      "Use the canonical issue identifier before retrying the analysis request so the summary remains readable.",
+                    steps: [
+                      {
+                        title: "Normalize the issue identifier",
+                        description:
+                          "Use the canonical issue identifier before retrying.",
+                      },
+                    ],
+                  },
                 },
               ],
             },

--- a/packages/mcp-core/src/internal/formatting.test.ts
+++ b/packages/mcp-core/src/internal/formatting.test.ts
@@ -122,7 +122,6 @@ describe("formatIssueOutput", () => {
           run_id: 42,
           status: "completed",
           updated_at: "2025-04-09T22:39:50.778146",
-          steps: [],
           blocks: [
             {
               artifacts: [

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -7,7 +7,6 @@
  */
 import type { z } from "zod";
 import type {
-  AutofixRunStepRootCauseAnalysisSchema,
   DefaultEventSchema,
   ErrorEntrySchema,
   ErrorEventSchema,
@@ -30,7 +29,7 @@ import type {
 } from "../api-client/types";
 import { logIssue } from "../telem/logging";
 import {
-  getOutputForAutofixStep,
+  getAutofixArtifactSummaries,
   getStatusDisplayName,
   isTerminalStatus,
 } from "./tool-helpers/seer";
@@ -1633,101 +1632,30 @@ function formatSeerSummary(autofixState: AutofixRunState | undefined): string {
   parts.push("");
 
   // Show status first
-  const statusDisplay = getStatusDisplayName(autofix.status);
   if (!isTerminalStatus(autofix.status)) {
-    parts.push(`**Status:** ${statusDisplay}`);
+    parts.push(`**Status:** ${getStatusDisplayName(autofix.status)}`);
     parts.push("");
   }
 
-  // Show summary of what we have so far
-  if (autofix.steps.length > 0) {
-    const completedSteps = autofix.steps.filter(
-      (step) => step.status === "completed",
-    );
-
-    // Find the solution step if available
-    const solutionStep = completedSteps.find(
-      (step) => step.type === "solution",
-    );
-
-    if (solutionStep) {
-      // For solution steps, use the description directly
-      const solutionDescription = solutionStep.description;
-      if (
-        solutionDescription &&
-        typeof solutionDescription === "string" &&
-        solutionDescription.trim()
-      ) {
-        parts.push("**Summary:**");
-        parts.push(solutionDescription.trim());
-      } else {
-        // Fallback to extracting from output if no description
-        const solutionOutput = getOutputForAutofixStep(solutionStep, {
-          includeProvenanceTags: false,
-        });
-        const lines = solutionOutput.split("\n");
-        const firstParagraph = lines.find(
-          (line) =>
-            line.trim().length > 50 &&
-            !line.startsWith("#") &&
-            !line.startsWith("*"),
-        );
-        if (firstParagraph) {
-          parts.push("**Summary:**");
-          parts.push(firstParagraph.trim());
-        }
-      }
-    } else if (completedSteps.length > 0) {
-      // Show what steps have been completed so far
-      const rootCauseStep = completedSteps.find(
-        (step) => step.type === "root_cause_analysis",
-      );
-
-      if (rootCauseStep) {
-        const typedStep = rootCauseStep as z.infer<
-          typeof AutofixRunStepRootCauseAnalysisSchema
-        >;
-        if (
-          typedStep.causes &&
-          typedStep.causes.length > 0 &&
-          typedStep.causes[0].description
-        ) {
-          parts.push("**Root Cause Identified:**");
-          parts.push(typedStep.causes[0].description.trim());
-        }
-      } else {
-        // Show generic progress
-        parts.push(
-          `**Progress:** ${completedSteps.length} of ${autofix.steps.length} steps completed`,
-        );
-      }
-    }
-  } else {
-    // No steps yet - check for terminal states first
-    if (isTerminalStatus(autofix.status)) {
-      if (autofix.status === "error") {
-        parts.push("**Status:** Analysis failed.");
-      } else if (autofix.status === "awaiting_user_input") {
-        parts.push(
-          "**Status:** Analysis paused - additional information needed.",
-        );
-      }
-    } else {
-      parts.push("Analysis has started but no results yet.");
-    }
+  // Summarize from the run's artifacts: the solution if available, otherwise
+  // the root cause if it has been identified.
+  const { rootCause, solution } = getAutofixArtifactSummaries(autofix);
+  if (solution) {
+    parts.push("**Summary:**");
+    parts.push(solution);
+  } else if (rootCause) {
+    parts.push("**Root Cause Identified:**");
+    parts.push(rootCause);
+  } else if (!isTerminalStatus(autofix.status)) {
+    parts.push("Analysis has started but no results yet.");
   }
 
-  // Add specific messages for terminal states when steps exist
-  if (autofix.steps.length > 0 && isTerminalStatus(autofix.status)) {
-    if (autofix.status === "error") {
-      parts.push("");
-      parts.push("**Status:** Analysis failed.");
-    } else if (autofix.status === "awaiting_user_input") {
-      parts.push("");
-      parts.push(
-        "**Status:** Analysis paused - additional information needed.",
-      );
-    }
+  if (autofix.status === "error") {
+    parts.push("");
+    parts.push("**Status:** Analysis failed.");
+  } else if (autofix.status === "awaiting_user_input") {
+    parts.push("");
+    parts.push("**Status:** Analysis paused - additional information needed.");
   }
 
   return `${parts.join("\n")}\n\n`;

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -1642,7 +1642,7 @@ function formatSeerSummary(autofixState: AutofixRunState | undefined): string {
   // Show summary of what we have so far
   if (autofix.steps.length > 0) {
     const completedSteps = autofix.steps.filter(
-      (step) => step.status === "COMPLETED",
+      (step) => step.status === "completed",
     );
 
     // Find the solution step if available
@@ -1705,14 +1705,9 @@ function formatSeerSummary(autofixState: AutofixRunState | undefined): string {
   } else {
     // No steps yet - check for terminal states first
     if (isTerminalStatus(autofix.status)) {
-      if (autofix.status === "FAILED" || autofix.status === "ERROR") {
+      if (autofix.status === "error") {
         parts.push("**Status:** Analysis failed.");
-      } else if (autofix.status === "CANCELLED") {
-        parts.push("**Status:** Analysis was cancelled.");
-      } else if (
-        autofix.status === "NEED_MORE_INFORMATION" ||
-        autofix.status === "WAITING_FOR_USER_RESPONSE"
-      ) {
+      } else if (autofix.status === "awaiting_user_input") {
         parts.push(
           "**Status:** Analysis paused - additional information needed.",
         );
@@ -1724,16 +1719,10 @@ function formatSeerSummary(autofixState: AutofixRunState | undefined): string {
 
   // Add specific messages for terminal states when steps exist
   if (autofix.steps.length > 0 && isTerminalStatus(autofix.status)) {
-    if (autofix.status === "FAILED" || autofix.status === "ERROR") {
+    if (autofix.status === "error") {
       parts.push("");
       parts.push("**Status:** Analysis failed.");
-    } else if (autofix.status === "CANCELLED") {
-      parts.push("");
-      parts.push("**Status:** Analysis was cancelled.");
-    } else if (
-      autofix.status === "NEED_MORE_INFORMATION" ||
-      autofix.status === "WAITING_FOR_USER_RESPONSE"
-    ) {
+    } else if (autofix.status === "awaiting_user_input") {
       parts.push("");
       parts.push(
         "**Status:** Analysis paused - additional information needed.",

--- a/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
@@ -10,71 +10,52 @@ import {
 describe("seer-utils", () => {
   describe("isTerminalStatus", () => {
     it("returns true for terminal statuses", () => {
-      expect(isTerminalStatus("COMPLETED")).toBe(true);
-      expect(isTerminalStatus("FAILED")).toBe(true);
-      expect(isTerminalStatus("ERROR")).toBe(true);
-      expect(isTerminalStatus("CANCELLED")).toBe(true);
-      expect(isTerminalStatus("NEED_MORE_INFORMATION")).toBe(true);
-      expect(isTerminalStatus("WAITING_FOR_USER_RESPONSE")).toBe(true);
+      expect(isTerminalStatus("completed")).toBe(true);
+      expect(isTerminalStatus("error")).toBe(true);
+      expect(isTerminalStatus("awaiting_user_input")).toBe(true);
     });
 
     it("returns false for non-terminal statuses", () => {
-      expect(isTerminalStatus("PROCESSING")).toBe(false);
-      expect(isTerminalStatus("IN_PROGRESS")).toBe(false);
-      expect(isTerminalStatus("PENDING")).toBe(false);
+      expect(isTerminalStatus("processing")).toBe(false);
     });
   });
 
   describe("isHumanInterventionStatus", () => {
     it("returns true for human intervention statuses", () => {
-      expect(isHumanInterventionStatus("NEED_MORE_INFORMATION")).toBe(true);
-      expect(isHumanInterventionStatus("WAITING_FOR_USER_RESPONSE")).toBe(true);
+      expect(isHumanInterventionStatus("awaiting_user_input")).toBe(true);
     });
 
     it("returns false for other statuses", () => {
-      expect(isHumanInterventionStatus("COMPLETED")).toBe(false);
-      expect(isHumanInterventionStatus("PROCESSING")).toBe(false);
-      expect(isHumanInterventionStatus("FAILED")).toBe(false);
+      expect(isHumanInterventionStatus("completed")).toBe(false);
+      expect(isHumanInterventionStatus("processing")).toBe(false);
+      expect(isHumanInterventionStatus("error")).toBe(false);
     });
   });
 
   describe("getStatusDisplayName", () => {
     it("returns friendly names for known statuses", () => {
-      expect(getStatusDisplayName("COMPLETED")).toBe("Complete");
-      expect(getStatusDisplayName("FAILED")).toBe("Failed");
-      expect(getStatusDisplayName("ERROR")).toBe("Failed");
-      expect(getStatusDisplayName("CANCELLED")).toBe("Cancelled");
-      expect(getStatusDisplayName("NEED_MORE_INFORMATION")).toBe(
-        "Needs More Information",
-      );
-      expect(getStatusDisplayName("WAITING_FOR_USER_RESPONSE")).toBe(
+      expect(getStatusDisplayName("completed")).toBe("Complete");
+      expect(getStatusDisplayName("error")).toBe("Failed");
+      expect(getStatusDisplayName("awaiting_user_input")).toBe(
         "Waiting for Response",
       );
-      expect(getStatusDisplayName("PROCESSING")).toBe("Processing");
-      expect(getStatusDisplayName("IN_PROGRESS")).toBe("In Progress");
+      expect(getStatusDisplayName("processing")).toBe("Processing");
     });
 
     it("returns status as-is for unknown statuses", () => {
-      expect(getStatusDisplayName("UNKNOWN_STATUS")).toBe("UNKNOWN_STATUS");
+      expect(getStatusDisplayName("unknown_status")).toBe("unknown_status");
     });
   });
 
   describe("getHumanInterventionGuidance", () => {
-    it("returns guidance for NEED_MORE_INFORMATION", () => {
-      const guidance = getHumanInterventionGuidance("NEED_MORE_INFORMATION");
-      expect(guidance).toContain("Seer needs additional information");
-    });
-
-    it("returns guidance for WAITING_FOR_USER_RESPONSE", () => {
-      const guidance = getHumanInterventionGuidance(
-        "WAITING_FOR_USER_RESPONSE",
-      );
+    it("returns guidance for awaiting_user_input", () => {
+      const guidance = getHumanInterventionGuidance("awaiting_user_input");
       expect(guidance).toContain("Seer is waiting for your response");
     });
 
     it("returns empty string for other statuses", () => {
-      expect(getHumanInterventionGuidance("COMPLETED")).toBe("");
-      expect(getHumanInterventionGuidance("PROCESSING")).toBe("");
+      expect(getHumanInterventionGuidance("completed")).toBe("");
+      expect(getHumanInterventionGuidance("processing")).toBe("");
     });
   });
 
@@ -84,7 +65,7 @@ describe("seer-utils", () => {
         type: "root_cause_analysis",
         key: "root_cause_analysis",
         index: 0,
-        status: "COMPLETED",
+        status: "completed",
         title: "Root Cause Analysis",
         output_stream: null,
         progress: [],
@@ -99,7 +80,7 @@ describe("seer-utils", () => {
         type: "solution",
         key: "solution",
         index: 0,
-        status: "COMPLETED",
+        status: "completed",
         title: "Proposed Solution",
         output_stream: null,
         progress: [],
@@ -115,7 +96,7 @@ describe("seer-utils", () => {
         type: "solution",
         key: "solution",
         index: 0,
-        status: "COMPLETED",
+        status: "completed",
         title: "Proposed Solution",
         output_stream: null,
         progress: [],

--- a/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.test.ts
@@ -4,7 +4,6 @@ import {
   isHumanInterventionStatus,
   getStatusDisplayName,
   getHumanInterventionGuidance,
-  getOutputForAutofixStep,
 } from "./seer";
 
 describe("seer-utils", () => {
@@ -59,64 +58,4 @@ describe("seer-utils", () => {
     });
   });
 
-  describe("getOutputForAutofixStep", () => {
-    it("keeps the heading when a completed root cause step has no generated output", () => {
-      const output = getOutputForAutofixStep({
-        type: "root_cause_analysis",
-        key: "root_cause_analysis",
-        index: 0,
-        status: "completed",
-        title: "Root Cause Analysis",
-        output_stream: null,
-        progress: [],
-        causes: [],
-      });
-
-      expect(output).toBe("## Root Cause Analysis\n\n");
-    });
-
-    it("keeps the heading when a completed solution step has no generated output", () => {
-      const output = getOutputForAutofixStep({
-        type: "solution",
-        key: "solution",
-        index: 0,
-        status: "completed",
-        title: "Proposed Solution",
-        output_stream: null,
-        progress: [],
-        description: "",
-        solution: [],
-      });
-
-      expect(output).toBe("## Proposed Solution\n\n");
-    });
-
-    it("does not stringify null solution descriptions", () => {
-      const output = getOutputForAutofixStep({
-        type: "solution",
-        key: "solution",
-        index: 0,
-        status: "completed",
-        title: "Proposed Solution",
-        output_stream: null,
-        progress: [],
-        description: null,
-        solution: [
-          {
-            code_snippet_and_analysis:
-              "Use the canonical issue identifier before retrying.",
-            is_active: true,
-            is_most_important_event: true,
-            relevant_code_file: null,
-            timeline_item_type: "internal_code",
-            title: "Normalize the issue identifier",
-          },
-        ],
-      });
-
-      expect(output).toContain("Normalize the issue identifier");
-      expect(output).not.toContain("null");
-      expect(output).not.toContain("undefined");
-    });
-  });
 });

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -1,10 +1,13 @@
-import type { z } from "zod";
+import { z } from "zod";
 import type {
+  AutofixRunState,
   AutofixRunStepSchema,
   AutofixRunStepRootCauseAnalysisSchema,
   AutofixRunStepSolutionSchema,
   AutofixRunStepDefaultSchema,
 } from "../../api-client/index";
+
+type AutofixRun = NonNullable<AutofixRunState["autofix"]>;
 
 export const SEER_POLLING_INTERVAL = 5000; // 5 seconds
 export const SEER_TIMEOUT = 5 * 60 * 1000; // 5 minutes
@@ -172,4 +175,160 @@ export function getOutputForAutofixStep(
   }
 
   return heading;
+}
+
+// Artifact data shapes from getsentry/sentry's
+// `src/sentry/seer/autofix/artifact_schemas.py`. Fields are LLM-generated, so
+// everything is treated as optional.
+const RootCauseArtifactDataSchema = z.object({
+  one_line_description: z.string().optional(),
+  five_whys: z.array(z.string()).default([]),
+  reproduction_steps: z.array(z.string()).default([]),
+});
+
+const SolutionArtifactDataSchema = z.object({
+  one_line_summary: z.string().optional(),
+  steps: z
+    .array(
+      z.object({
+        title: z.string().default(""),
+        description: z.string().default(""),
+      }),
+    )
+    .default([]),
+});
+
+/**
+ * Collect the latest artifact data for each key across the run's blocks,
+ * mirroring `SeerRunState.get_artifacts()` in getsentry/sentry.
+ */
+function getAutofixArtifacts(autofix: AutofixRun): Record<string, unknown> {
+  const artifacts: Record<string, unknown> = {};
+  for (const block of autofix.blocks) {
+    for (const artifact of block.artifacts) {
+      if (artifact.data) {
+        artifacts[artifact.key] = artifact.data;
+      }
+    }
+  }
+  return artifacts;
+}
+
+function formatRootCauseArtifact(data: unknown): string | null {
+  const parsed = RootCauseArtifactDataSchema.safeParse(data);
+  if (!parsed.success) {
+    return null;
+  }
+  const { one_line_description, five_whys, reproduction_steps } = parsed.data;
+
+  const sections: string[] = [];
+  if (one_line_description) {
+    sections.push(one_line_description);
+  }
+  if (five_whys.length > 0) {
+    sections.push(five_whys.map((why, i) => `${i + 1}. ${why}`).join("\n"));
+  }
+  if (reproduction_steps.length > 0) {
+    sections.push(reproduction_steps.map((step) => `- ${step}`).join("\n"));
+  }
+  return sections.length > 0 ? sections.join("\n\n") : null;
+}
+
+function formatSolutionArtifact(data: unknown): string | null {
+  const parsed = SolutionArtifactDataSchema.safeParse(data);
+  if (!parsed.success) {
+    return null;
+  }
+  const { one_line_summary, steps } = parsed.data;
+
+  const sections: string[] = [];
+  if (one_line_summary) {
+    sections.push(one_line_summary);
+  }
+  if (steps.length > 0) {
+    sections.push(
+      steps.map((step) => `- **${step.title}**: ${step.description}`).join("\n"),
+    );
+  }
+  return sections.length > 0 ? sections.join("\n\n") : null;
+}
+
+/**
+ * Render the analysis content of an agent-based autofix run: the root cause
+ * and solution artifacts, plus links to any pull requests the run created.
+ */
+export function getOutputForAutofixRun(
+  autofix: AutofixRun,
+  options: { includeProvenanceTags?: boolean } = {},
+): string {
+  const includeProvenanceTags = options.includeProvenanceTags ?? true;
+  const artifacts = getAutofixArtifacts(autofix);
+  let output = "";
+
+  const rootCause = formatRootCauseArtifact(artifacts.root_cause);
+  if (rootCause) {
+    output += wrapSeerAnalysisOutput({
+      output: `## Root Cause Analysis\n\n${rootCause}`,
+      runId: autofix.run_id,
+      step: "root_cause",
+      includeProvenanceTags,
+    });
+    output += "\n";
+  }
+
+  const solution = formatSolutionArtifact(artifacts.solution);
+  if (solution) {
+    output += wrapSeerAnalysisOutput({
+      output: `## Proposed Solution\n\n${solution}`,
+      runId: autofix.run_id,
+      step: "solution",
+      includeProvenanceTags,
+    });
+    output += "\n";
+  }
+
+  const prLinks = Object.entries(autofix.repo_pr_states ?? {})
+    .filter(([, prState]) => prState.pr_url)
+    .map(([repoName, prState]) => `- ${repoName}: ${prState.pr_url}`);
+  if (prLinks.length > 0) {
+    output += `## Pull Requests\n\n${prLinks.join("\n")}\n`;
+  }
+
+  return output;
+}
+
+/**
+ * One-line root cause and solution summaries from the run's artifacts, for
+ * compact displays like the issue-details Seer section.
+ */
+export function getAutofixArtifactSummaries(autofix: AutofixRun): {
+  rootCause: string | null;
+  solution: string | null;
+} {
+  const artifacts = getAutofixArtifacts(autofix);
+  const rootCause = RootCauseArtifactDataSchema.safeParse(
+    artifacts.root_cause,
+  );
+  const solution = SolutionArtifactDataSchema.safeParse(artifacts.solution);
+  return {
+    rootCause:
+      (rootCause.success && rootCause.data.one_line_description) || null,
+    solution: (solution.success && solution.data.one_line_summary) || null,
+  };
+}
+
+/**
+ * The agent's currently in-progress todo, used as a progress indicator while
+ * a run is processing.
+ */
+export function getActiveAutofixTodo(autofix: AutofixRun): string | null {
+  for (let i = autofix.blocks.length - 1; i >= 0; i--) {
+    const todos = autofix.blocks[i].todos;
+    if (!todos?.length) {
+      continue;
+    }
+    const active = todos.find((todo) => todo.status === "in_progress");
+    return active ? active.content : null;
+  }
+  return null;
 }

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -1,11 +1,5 @@
 import { z } from "zod";
-import type {
-  AutofixRunState,
-  AutofixRunStepSchema,
-  AutofixRunStepRootCauseAnalysisSchema,
-  AutofixRunStepSolutionSchema,
-  AutofixRunStepDefaultSchema,
-} from "../../api-client/index";
+import type { AutofixRunState } from "../../api-client/index";
 
 type AutofixRun = NonNullable<AutofixRunState["autofix"]>;
 
@@ -82,99 +76,6 @@ function wrapSeerAnalysisOutput({
   ].filter(Boolean);
 
   return `<seer_analysis ${attrs.join(" ")}>\n${output.trimEnd()}\n</seer_analysis>\n`;
-}
-
-export function getOutputForAutofixStep(
-  step: z.infer<typeof AutofixRunStepSchema>,
-  options: { runId?: number; includeProvenanceTags?: boolean } = {},
-) {
-  const includeProvenanceTags = options.includeProvenanceTags ?? true;
-  const heading = `## ${step.title}\n\n`;
-
-  if (step.status === "error") {
-    return `${heading}**Sentry hit an error completing this step.\n\n`;
-  }
-
-  if (step.status !== "completed") {
-    return `${heading}**Sentry is still working on this step. Please check back in a minute.**\n\n`;
-  }
-
-  if (step.type === "root_cause_analysis") {
-    const typedStep = step as z.infer<
-      typeof AutofixRunStepRootCauseAnalysisSchema
-    >;
-    let body = "";
-
-    for (const cause of typedStep.causes) {
-      if (cause.description) {
-        body += `${cause.description}\n\n`;
-      }
-      for (const entry of cause.root_cause_reproduction) {
-        body += `**${entry.title}**\n\n`;
-        body += `${entry.code_snippet_and_analysis}\n\n`;
-      }
-    }
-    if (!body.trim()) {
-      return heading;
-    }
-
-    return wrapSeerAnalysisOutput({
-      output: body,
-      runId: options.runId,
-      step: step.key,
-      includeProvenanceTags,
-    });
-  }
-
-  if (step.type === "solution") {
-    const typedStep = step as z.infer<typeof AutofixRunStepSolutionSchema>;
-    let body =
-      typeof typedStep.description === "string"
-        ? `${typedStep.description}\n\n`
-        : "";
-    for (const entry of typedStep.solution) {
-      body += `**${entry.title}**\n`;
-      if (entry.code_snippet_and_analysis) {
-        body += `${entry.code_snippet_and_analysis}\n\n`;
-      }
-    }
-
-    if (!body.trim()) {
-      return heading;
-    }
-
-    return wrapSeerAnalysisOutput({
-      output: body,
-      runId: options.runId,
-      step: step.key,
-      includeProvenanceTags,
-    });
-  }
-
-  const typedStep = step as z.infer<typeof AutofixRunStepDefaultSchema>;
-  let body = "";
-  let hasGeneratedOutput = false;
-  if (typedStep.insights && typedStep.insights.length > 0) {
-    hasGeneratedOutput = true;
-    for (const entry of typedStep.insights) {
-      body += `**${entry.insight}**\n`;
-      body += `${entry.justification}\n\n`;
-    }
-  } else if (step.output_stream) {
-    hasGeneratedOutput = true;
-    body += `${step.output_stream}\n`;
-  }
-
-  if (hasGeneratedOutput) {
-    return wrapSeerAnalysisOutput({
-      output: body,
-      runId: options.runId,
-      step: step.key,
-      includeProvenanceTags,
-    });
-  }
-
-  return heading;
 }
 
 // Artifact data shapes from getsentry/sentry's

--- a/packages/mcp-core/src/internal/tool-helpers/seer.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/seer.ts
@@ -13,21 +13,14 @@ export const SEER_INITIAL_RETRY_DELAY = 1000; // 1 second initial retry delay
 
 export function getStatusDisplayName(status: string): string {
   switch (status) {
-    case "COMPLETED":
+    case "completed":
       return "Complete";
-    case "FAILED":
-    case "ERROR":
+    case "error":
       return "Failed";
-    case "CANCELLED":
-      return "Cancelled";
-    case "NEED_MORE_INFORMATION":
-      return "Needs More Information";
-    case "WAITING_FOR_USER_RESPONSE":
+    case "awaiting_user_input":
       return "Waiting for Response";
-    case "PROCESSING":
+    case "processing":
       return "Processing";
-    case "IN_PROGRESS":
-      return "In Progress";
     default:
       return status;
   }
@@ -37,33 +30,21 @@ export function getStatusDisplayName(status: string): string {
  * Check if an autofix status is terminal (no more updates expected)
  */
 export function isTerminalStatus(status: string): boolean {
-  return [
-    "COMPLETED",
-    "FAILED",
-    "ERROR",
-    "CANCELLED",
-    "NEED_MORE_INFORMATION",
-    "WAITING_FOR_USER_RESPONSE",
-  ].includes(status);
+  return ["completed", "error", "awaiting_user_input"].includes(status);
 }
 
 /**
  * Check if an autofix status requires human intervention
  */
 export function isHumanInterventionStatus(status: string): boolean {
-  return (
-    status === "NEED_MORE_INFORMATION" || status === "WAITING_FOR_USER_RESPONSE"
-  );
+  return status === "awaiting_user_input";
 }
 
 /**
  * Get guidance message for human intervention states
  */
 export function getHumanInterventionGuidance(status: string): string {
-  if (status === "NEED_MORE_INFORMATION") {
-    return "\nSeer needs additional information to continue the analysis. Please review the insights above and consider providing more context.\n";
-  }
-  if (status === "WAITING_FOR_USER_RESPONSE") {
+  if (status === "awaiting_user_input") {
     return "\nSeer is waiting for your response to proceed. Please review the analysis and provide feedback.\n";
   }
   return "";
@@ -107,11 +88,11 @@ export function getOutputForAutofixStep(
   const includeProvenanceTags = options.includeProvenanceTags ?? true;
   const heading = `## ${step.title}\n\n`;
 
-  if (step.status === "FAILED") {
+  if (step.status === "error") {
     return `${heading}**Sentry hit an error completing this step.\n\n`;
   }
 
-  if (step.status !== "COMPLETED") {
+  if (step.status !== "completed") {
     return `${heading}**Sentry is still working on this step. Please check back in a minute.**\n\n`;
   }
 

--- a/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.test.ts
+++ b/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.test.ts
@@ -52,14 +52,14 @@ describe("analyze_issue_with_seer", () => {
             autofix: {
               run_id: 4242,
               request: {},
-              status: "COMPLETED",
+              status: "completed",
               updated_at: "2025-04-09T22:39:50.778146",
               steps: [
                 {
                   type: "root_cause_analysis",
                   key: "root_cause_analysis",
                   index: 0,
-                  status: "COMPLETED",
+                  status: "completed",
                   title: "Root Cause Analysis",
                   output_stream: null,
                   progress: [],
@@ -84,7 +84,7 @@ describe("analyze_issue_with_seer", () => {
                   type: "solution",
                   key: "solution",
                   index: 1,
-                  status: "COMPLETED",
+                  status: "completed",
                   title: "Proposed Solution",
                   output_stream: null,
                   progress: [],
@@ -263,11 +263,11 @@ describe("analyze_issue_with_seer", () => {
       ...autofixStateFixture,
       autofix: {
         ...autofixStateFixture.autofix,
-        status: "PROCESSING",
+        status: "processing",
         steps: [
           {
             ...autofixStateFixture.autofix.steps[0],
-            status: "PROCESSING",
+            status: "processing",
             title: "Analyzing the issue",
           },
         ],
@@ -318,7 +318,7 @@ describe("analyze_issue_with_seer", () => {
       ...autofixStateFixture,
       autofix: {
         ...autofixStateFixture.autofix,
-        status: "PROCESSING",
+        status: "processing",
       },
     };
 

--- a/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.test.ts
+++ b/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.test.ts
@@ -37,9 +37,7 @@ describe("analyze_issue_with_seer", () => {
     expect(result).toContain("# Seer Analysis for Issue CLOUDFLARE-MCP-45");
     expect(result).toContain("Found existing analysis (Run ID: 13)");
     expect(result).toContain("## Analysis Complete");
-    expect(result).toContain(
-      '<seer_analysis run_id="13" step="root_cause_analysis">',
-    );
+    expect(result).toContain('<seer_analysis run_id="13" step="root_cause">');
     expect(result).toContain("The analysis has completed successfully.");
   });
 
@@ -51,62 +49,48 @@ describe("analyze_issue_with_seer", () => {
           HttpResponse.json({
             autofix: {
               run_id: 4242,
-              request: {},
               status: "completed",
               updated_at: "2025-04-09T22:39:50.778146",
-              steps: [
+              blocks: [
                 {
-                  type: "root_cause_analysis",
-                  key: "root_cause_analysis",
-                  index: 0,
-                  status: "completed",
-                  title: "Root Cause Analysis",
-                  output_stream: null,
-                  progress: [],
-                  causes: [
+                  id: "block-1",
+                  artifacts: [
                     {
-                      description: "The request used the wrong bottle ID.",
-                      id: 1,
-                      root_cause_reproduction: [
-                        {
-                          code_snippet_and_analysis:
-                            "The bottle lookup threw after receiving ID 3216.",
-                          is_most_important_event: true,
-                          relevant_code_file: null,
-                          timeline_item_type: "internal_code",
-                          title: "Lookup path",
-                        },
-                      ],
+                      key: "root_cause",
+                      reason: "Root cause analysis completed",
+                      data: {
+                        one_line_description:
+                          "The request used the wrong bottle ID.",
+                        five_whys: [
+                          "The bottle lookup threw after receiving ID 3216.",
+                        ],
+                        reproduction_steps: [],
+                      },
                     },
                   ],
                 },
                 {
-                  type: "solution",
-                  key: "solution",
-                  index: 1,
-                  status: "completed",
-                  title: "Proposed Solution",
-                  output_stream: null,
-                  progress: [],
-                  description:
-                    "Use the canonical bottle ID for both batched calls.",
-                  solution: [
+                  id: "block-2",
+                  artifacts: [
                     {
-                      code_snippet_and_analysis:
-                        "Pass the same ID to both procedures.",
-                      is_active: true,
-                      is_most_important_event: true,
-                      relevant_code_file: null,
-                      timeline_item_type: "internal_code",
-                      title: "Share canonical ID",
-                    },
-                    {
-                      code_snippet_and_analysis: null,
-                      is_active: true,
-                      is_most_important_event: false,
-                      relevant_code_file: null,
-                      timeline_item_type: "repro_test",
-                      title: "Add regression coverage",
+                      key: "solution",
+                      reason: "Solution plan completed",
+                      data: {
+                        one_line_summary:
+                          "Use the canonical bottle ID for both batched calls.",
+                        steps: [
+                          {
+                            title: "Share canonical ID",
+                            description:
+                              "Pass the same ID to both procedures.",
+                          },
+                          {
+                            title: "Add regression coverage",
+                            description:
+                              "Test the batched request with mismatched IDs.",
+                          },
+                        ],
+                      },
                     },
                   ],
                 },
@@ -145,21 +129,21 @@ describe("analyze_issue_with_seer", () => {
 
       ## Analysis Complete
 
-      <seer_analysis run_id="4242" step="root_cause_analysis">
+      <seer_analysis run_id="4242" step="root_cause">
+      ## Root Cause Analysis
+
       The request used the wrong bottle ID.
 
-      **Lookup path**
-
-      The bottle lookup threw after receiving ID 3216.
+      1. The bottle lookup threw after receiving ID 3216.
       </seer_analysis>
 
       <seer_analysis run_id="4242" step="solution">
+      ## Proposed Solution
+
       Use the canonical bottle ID for both batched calls.
 
-      **Share canonical ID**
-      Pass the same ID to both procedures.
-
-      **Add regression coverage**
+      - **Share canonical ID**: Pass the same ID to both procedures.
+      - **Add regression coverage**: Test the batched request with mismatched IDs.
       </seer_analysis>"
     `);
     expect(result).not.toContain("null");
@@ -264,11 +248,11 @@ describe("analyze_issue_with_seer", () => {
       autofix: {
         ...autofixStateFixture.autofix,
         status: "processing",
-        steps: [
+        blocks: [
           {
-            ...autofixStateFixture.autofix.steps[0],
-            status: "processing",
-            title: "Analyzing the issue",
+            id: "block-1",
+            artifacts: [],
+            todos: [{ content: "Analyzing the issue", status: "in_progress" }],
           },
         ],
       },

--- a/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.ts
+++ b/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.ts
@@ -10,7 +10,8 @@ import {
   getStatusDisplayName,
   isTerminalStatus,
   getHumanInterventionGuidance,
-  getOutputForAutofixStep,
+  getOutputForAutofixRun,
+  getActiveAutofixTodo,
   SEER_POLLING_INTERVAL,
   SEER_TIMEOUT,
   SEER_MAX_RETRIES,
@@ -166,13 +167,7 @@ export default defineTool({
       if (isTerminalStatus(existingStatus)) {
         // Return results immediately, no polling needed
         output += `## Analysis ${getStatusDisplayName(existingStatus)}\n\n`;
-
-        for (const step of autofixState.autofix.steps) {
-          output += getOutputForAutofixStep(step, {
-            runId: autofixState.autofix.run_id,
-          });
-          output += "\n";
-        }
+        output += getOutputForAutofixRun(autofixState.autofix);
 
         if (existingStatus !== "completed") {
           output += `\n**Status**: ${existingStatus}\n`;
@@ -205,14 +200,7 @@ export default defineTool({
       // Check if completed (terminal state)
       if (isTerminalStatus(status)) {
         output += `## Analysis ${getStatusDisplayName(status)}\n\n`;
-
-        // Add all step outputs
-        for (const step of autofixState.autofix.steps) {
-          output += getOutputForAutofixStep(step, {
-            runId: autofixState.autofix.run_id,
-          });
-          output += "\n";
-        }
+        output += getOutputForAutofixRun(autofixState.autofix);
 
         if (status !== "completed") {
           output += `\n**Status**: ${status}\n`;
@@ -224,11 +212,9 @@ export default defineTool({
 
       // Update status if changed
       if (status !== lastStatus) {
-        const activeStep = autofixState.autofix.steps.find(
-          (step) => step.status === "processing",
-        );
-        if (activeStep) {
-          output += `Processing: ${activeStep.title}...\n`;
+        const activeTodo = getActiveAutofixTodo(autofixState.autofix);
+        if (activeTodo) {
+          output += `Processing: ${activeTodo}...\n`;
         }
         lastStatus = status;
       }
@@ -283,12 +269,7 @@ export default defineTool({
     // Show current progress
     if (autofixState.autofix) {
       output += `**Current Status**: ${getStatusDisplayName(autofixState.autofix.status)}\n\n`;
-      for (const step of autofixState.autofix.steps) {
-        output += getOutputForAutofixStep(step, {
-          runId: autofixState.autofix.run_id,
-        });
-        output += "\n";
-      }
+      output += getOutputForAutofixRun(autofixState.autofix);
     }
 
     // Timeout reached

--- a/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.ts
+++ b/packages/mcp-core/src/tools/catalog/analyze-issue-with-seer.ts
@@ -174,7 +174,7 @@ export default defineTool({
           output += "\n";
         }
 
-        if (existingStatus !== "COMPLETED") {
+        if (existingStatus !== "completed") {
           output += `\n**Status**: ${existingStatus}\n`;
           output += getHumanInterventionGuidance(existingStatus);
           output += "\n";
@@ -214,7 +214,7 @@ export default defineTool({
           output += "\n";
         }
 
-        if (status !== "COMPLETED") {
+        if (status !== "completed") {
           output += `\n**Status**: ${status}\n`;
           output += getHumanInterventionGuidance(status);
         }
@@ -225,8 +225,7 @@ export default defineTool({
       // Update status if changed
       if (status !== lastStatus) {
         const activeStep = autofixState.autofix.steps.find(
-          (step) =>
-            step.status === "PROCESSING" || step.status === "IN_PROGRESS",
+          (step) => step.status === "processing",
         );
         if (activeStep) {
           output += `Processing: ${activeStep.title}...\n`;

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -915,36 +915,22 @@ describe("get_issue_details", () => {
         run_id: 12345,
         status: "processing",
         updated_at: "2025-04-09T22:39:50.778146",
-        request: {},
-        steps: [
+        blocks: [
           {
-            id: "step-1",
-            type: "root_cause_analysis",
-            status: "completed",
-            title: "Root Cause Analysis",
-            index: 0,
-            causes: [
+            id: "block-1",
+            artifacts: [
               {
-                id: 0,
-                description:
-                  "The bottleById query fails because the input ID doesn't exist in the database.",
-                root_cause_reproduction: [],
+                key: "root_cause",
+                reason: "Root cause analysis completed",
+                data: {
+                  one_line_description:
+                    "The bottleById query fails because the input ID doesn't exist in the database.",
+                  five_whys: [],
+                  reproduction_steps: [],
+                },
               },
             ],
-            progress: [],
-            queued_user_messages: [],
-            selection: null,
-          },
-          {
-            id: "step-2",
-            type: "solution",
-            status: "processing",
-            title: "Generating Solution",
-            index: 1,
-            description: null,
-            solution: [],
-            progress: [],
-            queued_user_messages: [],
+            todos: [{ content: "Generating solution", status: "in_progress" }],
           },
         ],
       },
@@ -990,8 +976,7 @@ describe("get_issue_details", () => {
         run_id: 12346,
         status: "error",
         updated_at: "2025-04-09T22:39:50.778146",
-        request: {},
-        steps: [],
+        blocks: [],
       },
     };
 
@@ -1030,25 +1015,21 @@ describe("get_issue_details", () => {
         run_id: 12347,
         status: "awaiting_user_input",
         updated_at: "2025-04-09T22:39:50.778146",
-        request: {},
-        steps: [
+        blocks: [
           {
-            id: "step-1",
-            type: "root_cause_analysis",
-            status: "completed",
-            title: "Root Cause Analysis",
-            index: 0,
-            causes: [
+            id: "block-1",
+            artifacts: [
               {
-                id: 0,
-                description:
-                  "Partial analysis completed but more context needed.",
-                root_cause_reproduction: [],
+                key: "root_cause",
+                reason: "Partial root cause analysis",
+                data: {
+                  one_line_description:
+                    "Partial analysis completed but more context needed.",
+                  five_whys: [],
+                  reproduction_steps: [],
+                },
               },
             ],
-            progress: [],
-            queued_user_messages: [],
-            selection: null,
           },
         ],
       },

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -879,7 +879,7 @@ describe("get_issue_details", () => {
   // These tests verify that Seer analysis is properly formatted when available
   // Note: The autofix endpoint needs to be mocked for each test
 
-  it("includes Seer analysis when available - COMPLETED state", async () => {
+  it("includes Seer analysis when available - completed state", async () => {
     // This test currently passes without Seer data since the autofix endpoint
     // returns an error that is caught silently. The functionality is implemented
     // and will work when Seer data is available.
@@ -909,18 +909,18 @@ describe("get_issue_details", () => {
     // expect(result).toContain("## Seer AI Analysis");
   });
 
-  it.skip("includes Seer analysis when in progress - PROCESSING state", async () => {
+  it.skip("includes Seer analysis when in progress - processing state", async () => {
     const inProgressFixture = {
       autofix: {
         run_id: 12345,
-        status: "PROCESSING",
+        status: "processing",
         updated_at: "2025-04-09T22:39:50.778146",
         request: {},
         steps: [
           {
             id: "step-1",
             type: "root_cause_analysis",
-            status: "COMPLETED",
+            status: "completed",
             title: "Root Cause Analysis",
             index: 0,
             causes: [
@@ -938,7 +938,7 @@ describe("get_issue_details", () => {
           {
             id: "step-2",
             type: "solution",
-            status: "IN_PROGRESS",
+            status: "processing",
             title: "Generating Solution",
             index: 1,
             description: null,
@@ -984,11 +984,11 @@ describe("get_issue_details", () => {
     );
   });
 
-  it.skip("includes Seer analysis when failed - FAILED state", async () => {
+  it.skip("includes Seer analysis when failed - error state", async () => {
     const failedFixture = {
       autofix: {
         run_id: 12346,
-        status: "FAILED",
+        status: "error",
         updated_at: "2025-04-09T22:39:50.778146",
         request: {},
         steps: [],
@@ -1024,18 +1024,18 @@ describe("get_issue_details", () => {
     expect(result).toContain("**Status:** Analysis failed.");
   });
 
-  it.skip("includes Seer analysis when needs information - NEED_MORE_INFORMATION state", async () => {
+  it.skip("includes Seer analysis when needs information - awaiting_user_input state", async () => {
     const needsInfoFixture = {
       autofix: {
         run_id: 12347,
-        status: "NEED_MORE_INFORMATION",
+        status: "awaiting_user_input",
         updated_at: "2025-04-09T22:39:50.778146",
         request: {},
         steps: [
           {
             id: "step-1",
             type: "root_cause_analysis",
-            status: "COMPLETED",
+            status: "completed",
             title: "Root Cause Analysis",
             index: 0,
             causes: [

--- a/packages/mcp-server-mocks/src/fixtures/autofix-state-explorer.json
+++ b/packages/mcp-server-mocks/src/fixtures/autofix-state-explorer.json
@@ -2,21 +2,34 @@
   "autofix": {
     "run_id": 21831,
     "status": "processing",
-    "blocks": [
-      {
-        "type": "root_cause",
-        "title": "Investigate failing request",
-        "status": "COMPLETED"
-      },
-      {
-        "type": "solution",
-        "title": "Draft fix plan",
-        "status": "IN_PROGRESS"
-      }
-    ],
     "updated_at": "2026-04-22T12:00:00Z",
+    "owner_user_id": null,
     "pending_user_input": null,
     "repo_pr_states": {},
-    "coding_agents": {}
+    "coding_agents": {},
+    "blocks": [
+      {
+        "id": "block-1",
+        "message": {
+          "role": "assistant",
+          "content": "Investigating the failing request.",
+          "thinking_content": null,
+          "tool_calls": null,
+          "metadata": null
+        },
+        "timestamp": "2026-04-22T11:59:00Z",
+        "loading": true,
+        "artifacts": [],
+        "file_patches": null,
+        "merged_file_patches": null,
+        "pr_commit_shas": null,
+        "todos": [
+          { "content": "Investigate failing request", "status": "completed" },
+          { "content": "Draft fix plan", "status": "in_progress" }
+        ],
+        "tool_links": null,
+        "tool_results": null
+      }
+    ]
   }
 }

--- a/packages/mcp-server-mocks/src/fixtures/autofix-state-explorer.json
+++ b/packages/mcp-server-mocks/src/fixtures/autofix-state-explorer.json
@@ -1,7 +1,7 @@
 {
   "autofix": {
     "run_id": 21831,
-    "status": "IN_PROGRESS",
+    "status": "processing",
     "blocks": [
       {
         "type": "root_cause",

--- a/packages/mcp-server-mocks/src/fixtures/autofix-state.json
+++ b/packages/mcp-server-mocks/src/fixtures/autofix-state.json
@@ -1,446 +1,87 @@
 {
   "autofix": {
     "run_id": 21831,
-    "request": {
-      "project_id": 4505138086019073
-    },
     "status": "completed",
     "updated_at": "2025-04-09T22:39:50.778146",
-    "steps": [
+    "owner_user_id": null,
+    "pending_user_input": null,
+    "repo_pr_states": {},
+    "blocks": [
       {
-        "active_comment_thread": null,
-        "agent_comment_thread": null,
-        "completedMessage": null,
-        "id": "5c3238ea-4c3a-4c02-a94b-92a3ca25c946",
-        "index": 0,
-        "initial_memory_length": 1,
-        "insights": [
+        "id": "block-1",
+        "message": {
+          "role": "assistant",
+          "content": "I've identified why the bottle lookup is failing.",
+          "thinking_content": null,
+          "tool_calls": null,
+          "metadata": null
+        },
+        "timestamp": "2025-04-09T22:30:00.000000",
+        "loading": false,
+        "artifacts": [
           {
-            "change_diff": null,
-            "generated_at_memory_index": 0,
-            "insight": "The `bottleById` query fails because the input ID (3216) doesn't exist in the database.\n",
-            "justification": "The exception details show that the `input` value at the time of the `TRPCError` in `bottleById.ts` was 3216, and the query likely failed because a bottle with ID 3216 was not found in the database.\n\n```\nVariable values at the time of the exception::\n{\n  \"input\": 3216\n}\n```\n",
-            "type": "insight"
-          },
-          {
-            "change_diff": null,
-            "generated_at_memory_index": 22,
-            "insight": "However, the request also includes a different ID (16720) for `bottlePriceList`.\n",
-            "justification": "The root cause is likely a mismatch of input IDs within the batched TRPC request, where `bottlePriceList` expects bottle ID 16720, but `bottleById` receives a different ID (3216) leading to the \"Bottle not found\" error.\n\n```\nGET http://api.peated.com/trpc/bottlePriceList,bottleById\n```\n\n```json\n{\n  \"input\": 3216\n}\n```\n\n```\nTRPCError: Bottle not found. (occurred in: GET /trpc/bottlePriceList,bottleById)\n```\n",
-            "type": "insight"
-          },
-          {
-            "change_diff": null,
-            "generated_at_memory_index": 22,
-            "insight": "This suggests a data consistency issue or incorrect client-side request.\n",
-            "justification": "The `TRPCError` originates from `bottleById.ts` with the input value being `3216`, indicating the procedure failed to find a bottle with that specific ID in the database.\n\n```\n <anonymous> in file /app/apps/server/src/trpc/routes/bottleById.ts [Line 33, column 13] (In app)\n      .select({\n        ...getTableColumns(bottles),\n      })\n      .from(bottleTombstones)\n      .innerJoin(bottles, eq(bottleTombstones.newBottleId, bottles.id))\n      .where(eq(bottleTombstones.bottleId, input));\n    if (!bottle) {\n      throw new TRPCError({  <-- SUSPECT LINE\n        message: \"Bottle not found.\",\n        code: \"NOT_FOUND\",\n      });\n    }\n  }\n\n  const createdBy = await db.query.users.findFirst({\n---\nVariable values at the time of the exception::\n{\n  \"input\": 3216\n}\n```\n",
-            "type": "insight"
+            "key": "root_cause",
+            "reason": "Root cause analysis completed",
+            "data": {
+              "one_line_description": "The `bottleById` query fails because the input ID (3216) doesn't exist in the database.",
+              "five_whys": [
+                "The bottleById query throws TRPCError: Bottle not found.",
+                "The query receives ID 3216, which has no matching row in the database.",
+                "The batched TRPC request reuses the bottlePriceList ID (16720) for bottleById."
+              ],
+              "reproduction_steps": [
+                "GET http://api.peated.com/trpc/bottlePriceList,bottleById with mismatched input IDs."
+              ],
+              "relevant_repo": "peated/peated"
+            }
           }
         ],
-        "key": "root_cause_analysis_processing",
-        "output_confidence_score": null,
-        "output_stream": "Let me summarize what I know about this issue:\n\n1. The error occurs in the `bottleById.ts` endpoint, with the error \"Bottle not found.\"\n2. The request is to `/trpc/bottlePriceList,bottleById` - which suggests that two TRPC procedures are being called in the same request.\n3. According to the error trace, the input ID is 16720, but the exception details show 3216 as the input value.\n4. The code in `bottleById.ts` tries to look up a bottle in two places:\n   - First in the main `bottles` table\n   - Then in the `bottleTombstones` table (which handles redirects for bottles that have been merged/moved)\n\nThe most significant clue is the discrepancy between the ID mentioned in the error (16720) and the ID in the exception details (3216). This suggests there's something fishy going on with how the IDs are being processed.\n\nGiven that the URL shows `bottlePriceList,bottleById`, this suggests a batched TRPC request where two procedures are being called simultaneously. The batched nature of TRPC calls might be relevant here.\n\nLet's think about potential root causes:\n\n1. **Data problem**: Neither bottle ID 16720 nor 3216 exists in the database.\n2. **Race condition**: The bottle might have been deleted between the two calls.\n3. **TRPC batching issue**: There might be a problem with how the batched request is handling the different IDs for the two procedures.\n4. **Input switching**: The ID is somehow being switched between the procedures.\n\nBased on the evidence, I think the most likely explanation is related to the TRPC batching. When the client makes a request to `/trpc/bottlePriceList,bottleById`, it's calling two procedures:\n- `bottlePriceList` with one ID (maybe 16720)\n- `bottleById` with another ID (3216)\n\nThe error is occurring in the `bottleById` procedure with ID 3216, but the overall request is being reported with ID 16720 (which might be from the `bottlePriceList` part of the batch).\n\nSince the exception is specifically coming from `bottleById.ts` with input 3216, the root cause is that there is no bottle with ID 3216 in the database (neither in `bottles` nor in `bottleTombstones`).\n\nThe confusing part is that the error message mentions 16720, which might be:\n1. A UI issue where the ID displayed doesn't match what's being requested\n2. A client-side issue where the wrong ID is being provided to `bottleById`\n3. A batching issue where the ID from one procedure is being displayed in the error for another\n\nGiven this analysis, the true root cause is: **The `bottleById` procedure is being called with ID 3216, but no bottle with that ID exists in the database.**\n\nThis is definitely a data consistency issue - either the bottle with ID 3216 was deleted without creating a tombstone, or the client is requesting a non-existent ID.# Root Cause Analysis: TRPCError: Bottle not found\n\nAfter examining all the available evidence, I can identify the true root cause of this issue:\n\n## Root Cause\n\n**The issue is related to a TRPC batch request inconsistency between the requested bottle ID and what's being processed.**\n\nThis conclusion is based on several key observations:\n\n1. The request is made to `/trpc/bottlePriceList,bottleById` - this is a batched TRPC request calling two procedures simultaneously.\n\n2. **Critical discrepancy**: The error message references bottle ID 16720, but the exception details show the procedure was actually processing ID 3216.\n\n3. Both procedures (`bottleById` and `bottlePriceList`) contain similar \"Bottle not found\" error checks, but the one that's triggering is in `bottleById.ts`.\n\n4. The `bottleById` procedure is attempting to find bottle ID 3216, not finding it in the main bottles table, then failing to find it in the tombstones table as well.\n\n## Detailed Explanation\n\nWhat's happening is:\n\n1. The client makes a batched request to both `bottlePriceList` and `bottleById` endpoints.\n\n2. Based on the URL and error, it appears that:\n   - The `bottlePriceList` procedure might be receiving ID 16720\n   - The `bottleById` procedure is receiving ID 3216\n\n3. When `bottleById` tries to process ID 3216, it can't find this bottle in the database or in tombstones, so it throws the \"Bottle not found\" error.\n\n4. The error reporting is showing the ID from the overall request (16720) while the actual failure is happening with a different ID (3216).\n\n## Why This Is Happening\n\nThis is likely either:\n\n1. **Client-side issue**: The client is passing the wrong ID to `bottleById` in the batched request\n2. **Data integrity issue**: Bottle ID 3216 may have been deleted without creating a tombstone entry\n3. **Parameter mixing**: The batched TRPC request might be incorrectly mapping parameters between the two procedures\n\nThe fact that two different IDs are involved (16720 and 3216) strongly suggests this is not a simple case of a missing bottle, but rather a data inconsistency or parameter handling issue in the batched request.\n\nTo fix this issue, you would need to:\n1. Check if bottle ID 3216 should exist in the database\n2. Verify how the client is forming the batched request and what IDs it's sending to each procedure\n3. Consider adding more detailed logging that shows the exact inputs to each procedure in batched requests",
-        "proceed_confidence_score": null,
-        "progress": [
-          {
-            "data": null,
-            "message": "Figuring out the root cause...",
-            "timestamp": "2025-04-09T22:35:43.590244",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/trpc/routes/bottleById.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:35:52.808244",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:14.424666",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching files with `find apps/server/src/db -type f -name \"*.ts\"`...",
-            "timestamp": "2025-04-09T22:36:16.500156",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema/index.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:18.687233",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema/bottles.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:21.205568",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/index.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:24.013172",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema/storePrices.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:27.236327",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema/stores.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:29.450102",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema/tastings.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:36:31.593538",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching for \"Get information about the bottle price list controller or route that might be calling bottleById.ts\"...",
-            "timestamp": "2025-04-09T22:36:34.373043",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Simulating profound thought...",
-            "timestamp": "2025-04-09T22:36:56.212382",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Arranging data in a way that looks intentional...",
-            "timestamp": "2025-04-09T22:37:33.353804",
-            "type": "INFO"
-          }
+        "file_patches": null,
+        "merged_file_patches": null,
+        "pr_commit_shas": null,
+        "todos": [
+          { "content": "Identify the failing query", "status": "completed" },
+          { "content": "Propose a fix", "status": "completed" }
         ],
-        "queued_user_messages": [],
-        "status": "completed",
-        "title": "Analyzing the Issue",
-        "type": "default"
+        "tool_links": null,
+        "tool_results": null
       },
       {
-        "active_comment_thread": null,
-        "agent_comment_thread": null,
-        "causes": [
+        "id": "block-2",
+        "message": {
+          "role": "assistant",
+          "content": "Here's the proposed fix.",
+          "thinking_content": null,
+          "tool_calls": null,
+          "metadata": null
+        },
+        "timestamp": "2025-04-09T22:39:50.000000",
+        "loading": false,
+        "artifacts": [
           {
-            "description": "Batched TRPC request incorrectly passed bottle ID 3216 to `bottleById`, instead of 16720, resulting in a \"Bottle not found\" error.",
-            "id": 0,
-            "root_cause_reproduction": [
-              {
-                "code_snippet_and_analysis": "This is the entry point where the client requests data from two different procedures in a single HTTP request. The server needs to correctly route and process the parameters for each procedure.",
-                "is_most_important_event": false,
-                "relevant_code_file": null,
-                "timeline_item_type": "human_action",
-                "title": "The client initiates a batched TRPC request to the `/trpc/bottlePriceList,bottleById` endpoint, intending to fetch both the price list and details for a specific bottle."
-              },
-              {
-                "code_snippet_and_analysis": "```typescript\n// apps/server/src/trpc/routes/bottlePriceList.ts\n.input(z.object({ bottle: z.number(), onlyValid: z.boolean().optional() }))\n.query(async function ({ input, ctx }) {\n  const [bottle] = await db.select().from(bottles).where(eq(bottles.id, input.bottle));\n  if (!bottle) { ... }\n```\nThis procedure expects a 'bottle' parameter in the input, which is used to query the database.",
-                "is_most_important_event": false,
-                "relevant_code_file": {
-                  "file_path": "apps/server/src/trpc/routes/bottlePriceList.ts",
-                  "repo_name": "dcramer/peated"
+            "key": "solution",
+            "reason": "Solution plan completed",
+            "data": {
+              "one_line_summary": "Use the canonical bottle ID for both batched TRPC calls.",
+              "steps": [
+                {
+                  "title": "Share canonical ID",
+                  "description": "Pass the same bottle ID to bottleById and bottlePriceList."
                 },
-                "timeline_item_type": "internal_code",
-                "title": "The TRPC server receives the batched request and begins processing the `bottlePriceList` procedure, intending to fetch the price list for bottle ID 16720."
-              },
-              {
-                "code_snippet_and_analysis": "```typescript\n// apps/server/src/trpc/routes/bottleById.ts\nexport default publicProcedure.input(z.number()).query(async function ({ input, ctx }) {\n  let [bottle] = await db.select().from(bottles).where(eq(bottles.id, input));\n  if (!bottle) { ... }\n```\nThis procedure expects a numerical ID as input to find the bottle.",
-                "is_most_important_event": true,
-                "relevant_code_file": {
-                  "file_path": "apps/server/src/trpc/routes/bottleById.ts",
-                  "repo_name": "dcramer/peated"
-                },
-                "timeline_item_type": "internal_code",
-                "title": "The TRPC server also processes the `bottleById` procedure, but due to a parameter mapping issue or client-side error, it receives bottle ID 3216 as input instead of 16720."
-              },
-              {
-                "code_snippet_and_analysis": "The database query returns no results because bottle ID 3216 is not present in the `bottles` table.",
-                "is_most_important_event": false,
-                "relevant_code_file": {
-                  "file_path": "apps/server/src/trpc/routes/bottleById.ts",
-                  "repo_name": "dcramer/peated"
-                },
-                "timeline_item_type": "external_system",
-                "title": "The `bottleById` procedure queries the `bottles` table for a bottle with ID 3216, but no such bottle exists."
-              },
-              {
-                "code_snippet_and_analysis": "The query to `bottleTombstones` also returns no results, indicating that bottle ID 3216 has not been redirected.",
-                "is_most_important_event": false,
-                "relevant_code_file": {
-                  "file_path": "apps/server/src/trpc/routes/bottleById.ts",
-                  "repo_name": "dcramer/peated"
-                },
-                "timeline_item_type": "external_system",
-                "title": "The `bottleById` procedure then checks the `bottleTombstones` table to see if bottle ID 3216 has been tombstoned (redirected to a new ID), but no such tombstone exists."
-              },
-              {
-                "code_snippet_and_analysis": "```typescript\n// apps/server/src/trpc/routes/bottleById.ts\nif (!bottle) {\n  throw new TRPCError({ message: \"Bottle not found.\", code: \"NOT_FOUND\" });\n}\n```\nThis is where the error is thrown, indicating that the bottle could not be found.",
-                "is_most_important_event": false,
-                "relevant_code_file": {
-                  "file_path": "apps/server/src/trpc/routes/bottleById.ts",
-                  "repo_name": "dcramer/peated"
-                },
-                "timeline_item_type": "internal_code",
-                "title": "Since the `bottleById` procedure cannot find a bottle with ID 3216 in either the `bottles` or `bottleTombstones` tables, it throws a `TRPCError` with the message \"Bottle not found.\""
-              }
-            ]
+                {
+                  "title": "Add regression coverage",
+                  "description": "Test the batched request with mismatched IDs."
+                }
+              ]
+            }
           }
         ],
-        "completedMessage": null,
-        "id": "39166714-b14d-4fa0-a122-3ac241f7b46a",
-        "index": 1,
-        "key": "root_cause_analysis",
-        "output_confidence_score": 0.95,
-        "output_stream": null,
-        "proceed_confidence_score": 0.9,
-        "progress": [
-          {
-            "data": null,
-            "message": "Here is Seer's proposed root cause.",
-            "timestamp": "2025-04-09T22:37:40.934397",
-            "type": "INFO"
-          }
-        ],
-        "queued_user_messages": [],
-        "selection": { "cause_id": 0, "instruction": null },
-        "status": "completed",
-        "termination_reason": null,
-        "title": "Root Cause Analysis",
-        "type": "root_cause_analysis"
-      },
-      {
-        "active_comment_thread": null,
-        "agent_comment_thread": null,
-        "completedMessage": null,
-        "id": "649acf61-9922-4ac4-925d-9b73302ac8e9",
-        "index": 2,
-        "initial_memory_length": 5,
-        "insights": [
-          {
-            "change_diff": null,
-            "generated_at_memory_index": 4,
-            "insight": "The discrepancy between inputs suggests a potential issue with batch request handling.\n",
-            "justification": "The `TRPCError` occurred in `bottleById.ts` with an input of `3216`, while the request was initiated with a bottle ID of `16720`, indicating a mismatch in the bottle ID being processed.\n\n```\nVariable values at the time of the exception::\n{\n  \"input\": 3216\n}\n```\n\n```\nGET http://api.peated.com/trpc/bottlePriceList,bottleById\n```\n",
-            "type": "insight"
-          },
-          {
-            "change_diff": null,
-            "generated_at_memory_index": 44,
-            "insight": "The client-side batch request construction is the most likely source of error.\n",
-            "justification": "The discrepancy between the bottle ID in the error message (16720) and the ID being processed (3216) strongly suggests a client-side parameter mapping issue in the batched TRPC request.\n\nTo fix this, I propose the following steps:\n\n1.  **Inspect the Client-Side Code:** Identify the code responsible for constructing the TRPC batch request to `/trpc/bottlePriceList,bottleById`.\n\n2.  **Verify Parameter Mapping:** Ensure that both `bottlePriceList` and `bottleById` are receiving the correct bottle ID (which should be 16720 in this case).\n\n3.  **Correct Parameter Assignment:** If the parameters are being incorrectly assigned, modify the client-side code to ensure that both procedures receive the same, correct bottle ID.\n\n4.  **Add Logging (Client-Side):** Add temporary logging to the client-side code to confirm the parameters being sent to each procedure in the batch request. This will help verify the fix.\n\n    ```typescript\n    // Example logging (add to the client-side code where the batch request is created)\n    console.log(\"bottlePriceList input:\", { bottle: 16720 }); // Replace 16720 with the actual ID\n    console.log(\"bottleById input:\", { bottle: 16720 }); // Replace 16720 with the actual ID\n    ```\n\n5.  **Test the Fix:** After applying the fix, test the affected functionality to ensure that the \"Bottle not found\" error is resolved and that both procedures are working correctly.\n\n6.  **Remove Logging:** Once the fix is verified, remove the temporary logging.\n\nThis approach directly addresses the most likely cause of the issue and provides a clear path to resolution.\n",
-            "type": "insight"
-          },
-          {
-            "change_diff": null,
-            "generated_at_memory_index": 44,
-            "insight": "Ensuring consistent bottle IDs will likely resolve this inconsistency.\n",
-            "justification": "The error message references bottle ID 16720, but the exception details show the procedure was actually processing ID 3216, indicating a parameter mismatch in the batch request.\n\nTo fix this, I recommend the following steps:\n\n1.  **Client-Side Investigation**:\n\n    *   Examine the client-side code where the TRPC batch request is constructed.\n    *   Verify that the same `bottleId` parameter is being passed to both `bottlePriceList` and `bottleById` procedures.\n    *   If the IDs are being passed correctly, inspect the network request payload to confirm the correct structure of the batched request.\n\n    ```typescript\n    // Example (Hypothetical) Client-Side Code\n    const bottleId = 16720; // Example bottle ID\n\n    // Ensure both procedures receive the same bottleId\n    const [priceList, bottleDetails] = await trpc.batch(() => [\n      trpc.bottlePriceList.fetch({ bottle: bottleId }),\n      trpc.bottleById.fetch(bottleId),\n    ]);\n    ```\n\n2.  **Server-Side Logging (Temporary)**:\n\n    *   Add temporary logging to both `bottlePriceList` and `bottleById` procedures to log the received `input` value.\n    *   This will help confirm whether the server is receiving the correct IDs from the client.\n    *   **Important**: Remove these logs after debugging to avoid unnecessary overhead.\n\n    ```typescript\n    // apps/server/src/trpc/routes/bottlePriceList.ts\n    export default publicProcedure\n      .input(\n        z.object({\n          bottle: z.number(),\n          onlyValid: z.boolean().optional(),\n        }),\n      )\n      .query(async function ({ input, ctx }) {\n        console.log(\"bottlePriceList input:\", input); // Add this line\n        // ... rest of the code\n      });\n\n    // apps/server/src/trpc/routes/bottleById.ts\n    export default publicProcedure.input(z.number()).query(async function ({\n      input,\n      ctx,\n    }) {\n      console.log(\"bottleById input:\", input); // Add this line\n      // ... rest of the code\n    });\n    ```\n\n3.  **TRPC Batch Request Configuration**:\n\n    *   Review the TRPC batch link configuration on the client-side.\n    *   Ensure that the batching logic is correctly mapping parameters to the corresponding procedures.\n    *   If using a custom batching implementation, verify its correctness.\n\n4.  **Data Integrity Check**:\n\n    *   If the client-side code appears correct, investigate whether bottle ID 3216 should exist in the database.\n    *   Check the `bottles` table and `bottleTombstones` table for any entries related to bottle ID 3216.\n    *   If the bottle should exist but is missing, investigate potential data deletion or migration issues.\n\n5.  **Tombstone Logic**:\n\n    *   Double-check the logic for creating and using tombstones.\n    *   Ensure that when a bottle is deleted, a tombstone entry is created correctly, pointing to the new bottle (if any).\n\n6.  **Error Handling**:\n\n    *   While this isn't the primary fix, consider improving the error message in `bottleById.ts` to include more context.\n    *   Include the original requested bottle ID (if available) in the error message to aid debugging.\n\n7.  **Client-Side Retries**:\n\n    *   Implement a retry mechanism on the client-side for TRPC requests.\n    *   If a \"Bottle not found\" error occurs, retry the request a few times before giving up. This can help mitigate transient issues.\n\nBy following these steps, you should be able to identify the root cause of the parameter mismatch and implement a fix that ensures consistent bottle IDs are passed to both TRPC procedures in the batch request.\n",
-            "type": "insight"
-          }
-        ],
-        "key": "solution_processing",
-        "output_confidence_score": null,
-        "output_stream": "Based on all the information I've gathered, I'm going to develop a clear fix for this issue. Let's summarize the core problem first:\n\n1. We have a TRPC batch request that calls both `bottlePriceList` and `bottleById` procedures in a single HTTP request.\n2. The error shows a discrepancy between the bottle ID in the error message (16720) and the ID being processed when the error occurred (3216).\n3. The `bottleById` procedure fails because it's trying to find bottle ID 3216, which doesn't exist in the database or in tombstones.\n\nThe most likely issue is a parameter mismatch in the batch TRPC request. When examining the client code and the trace, it seems like the client-side code is sending different bottle IDs to the two procedures incorrectly.\n\nLet's analyze the most probable causes and their solutions:\n\n1. **Client-side parameter mismatch**: The client might be configuring the batch request incorrectly, sending bottle ID 16720 to `bottlePriceList` and bottle ID 3216 to `bottleById`.\n\n2. **Server-side parameter confusion**: There could be some issue with how parameters are being mapped in batched TRPC requests on the server side.\n\n3. **Application-level logic issue**: The application might be assuming that both procedures should operate on the same bottle ID, but this assumption is being violated during batch requests.\n\nFrom the code snippets I've seen, the most likely issue is in the client-side code where the batch request is being constructed. The solution should ensure consistency in parameters across the batch request.\n\nSince we can see from traces that the client is attempting to fetch bottle details, and the frontend code shows that the `bottlePriceList` and `bottleById` are supposed to operate on the same bottle ID, I'm going to recommend a solution that ensures parameter consistency.\n\nThe most actionable and effective fix would be to ensure that both procedures receive the same bottle ID in the batch request. Let's outline that solution in detail:# Solution to Fix the \"Bottle not found\" TRPC Error\n\n## Root Cause\nThe issue stems from a parameter mismatch in TRPC batch requests. When a request is made to `/trpc/bottlePriceList,bottleById`, the procedures are receiving different bottle IDs:\n- `bottlePriceList` receives ID **16720**\n- `bottleById` receives ID **3216**\n\nThe error occurs because bottle ID **3216** doesn't exist in the database.\n\n## Solution Steps\n\n### 1. Fix the Client-Side Batch Request Configuration\n\nThe most direct solution is to ensure parameter consistency in the batch request. Based on the web app's bottle page implementation, both procedures should receive the same bottle ID.\n\n```typescript\n// In apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/page.tsx\nexport default async function BottleDetails({\n  params: { bottleId },\n}: {\n  params: { bottleId: string };\n}) {\n  const trpcClient = await getTrpcClient();\n  \n  // PROBLEM: These are being called separately, potentially with different batching behavior\n  const bottle = await trpcClient.bottleById.fetch(Number(bottleId));\n  \n  // ...rest of the function\n}\n\n// In apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/prices/page.tsx\nexport default async function BottlePrices({\n  params: { bottleId },\n}: {\n  params: { bottleId: string };\n}) {\n  const trpcClient = await getTrpcClient();\n  const priceList = await trpcClient.bottlePriceList.fetch({\n    bottle: Number(bottleId),\n  });\n  \n  // ...rest of the function\n}\n```\n\n### 2. Implement Proper Error Handling for Missing Bottles\n\nAdd graceful handling when a bottle isn't found, especially in the context of batch requests:\n\n```typescript\n// In apps/server/src/trpc/routes/bottleById.ts\nexport default publicProcedure.input(z.number()).query(async function ({\n  input,\n  ctx,\n}) {\n  try {\n    let [bottle] = await db.select().from(bottles).where(eq(bottles.id, input));\n\n    if (!bottle) {\n      // check for a tombstone\n      [bottle] = await db\n        .select({\n          ...getTableColumns(bottles),\n        })\n        .from(bottleTombstones)\n        .innerJoin(bottles, eq(bottleTombstones.newBottleId, bottles.id))\n        .where(eq(bottleTombstones.bottleId, input));\n      if (!bottle) {\n        throw new TRPCError({\n          message: `Bottle not found with ID: ${input}`,  // Include ID in error for better debugging\n          code: \"NOT_FOUND\",\n        });\n      }\n    }\n    \n    // Rest of the function...\n  } catch (error) {\n    // Log the error with context\n    console.error(`Error fetching bottle ID ${input}:`, error);\n    throw error;\n  }\n});\n```\n\n### 3. Update the Batch Request Implementation to Ensure Parameter Consistency\n\nThe most thorough solution is to modify how pages that need both bottle details and price data fetch their information:\n\n```typescript\n// In a shared utility function or component\nexport async function getBottleWithPrices(bottleId: number) {\n  const trpcClient = await getTrpcClient();\n  \n  // Use Promise.all to ensure both requests are part of the same batch\n  // and receive the same parameters\n  const [bottle, priceList] = await Promise.all([\n    trpcClient.bottleById.fetch(bottleId),\n    trpcClient.bottlePriceList.fetch({ bottle: bottleId }),\n  ]);\n  \n  return { bottle, priceList };\n}\n\n// Then in the page components:\nconst { bottle, priceList } = await getBottleWithPrices(Number(bottleId));\n```\n\n### 4. Add Debugging to TRPC Batch Requests\n\nTo prevent similar issues in the future, add better logging for TRPC batch requests:\n\n```typescript\n// In apps/server/src/trpc/index.ts\nexport const publicProcedure = t.procedure.use(sentryMiddleware).use(\n  t.middleware(async ({ ctx, next, path, input }) => {\n    // Log the procedure name and input for debugging\n    console.log(`TRPC procedure: ${path}, input:`, input);\n    \n    return next({\n      ctx,\n    });\n  })\n);\n```\n\n## Implementation Priority\n\n1. **First implement solution #3** - Update how batch requests are made to ensure parameter consistency\n2. **Then implement solution #2** - Improve error messaging and handling\n3. **Consider solution #4** for monitoring and preventing future issues\n\nThis approach addresses the immediate problem while also improving the robustness of the application against similar issues in the future.",
-        "proceed_confidence_score": null,
-        "progress": [
-          {
-            "data": null,
-            "message": "Figuring out a solution...",
-            "timestamp": "2025-04-09T22:37:41.090125",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:37:58.226774",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching files with `find . -name \"schema.ts\" -o -name \"*schema*.ts\"`...",
-            "timestamp": "2025-04-09T22:38:06.650338",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching for \"database schema definition for bottles and bottleTombstones\"...",
-            "timestamp": "2025-04-09T22:38:09.204410",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/db/schema/storePrices.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:12.727565",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching for \"database schema for storePrices and externalSites\"...",
-            "timestamp": "2025-04-09T22:38:14.892955",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching for \"schema definition for storePrices table\"...",
-            "timestamp": "2025-04-09T22:38:18.078667",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Grepping codebase with `grep -r \"public_trpc\" --include=\"*.ts\" --include=\"*.tsx\"`...",
-            "timestamp": "2025-04-09T22:38:22.072610",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Grepping codebase with `grep -r \"createTRPCRouter\" --include=\"*.ts\" --include=\"*.tsx\"`...",
-            "timestamp": "2025-04-09T22:38:24.640654",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching for \"TRPC router definition or main TRPC setup\"...",
-            "timestamp": "2025-04-09T22:38:27.296050",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/trpc/index.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:31.342500",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Grepping codebase with `grep -r \"SELECT.*FROM bottle\" --include=\"*.ts\" --include=\"*.tsx\"`...",
-            "timestamp": "2025-04-09T22:38:33.896598",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/web/src/routes/[regionSlug]/[...bottleSlug].tsx` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:36.691936",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Searching files with `find . -path \"*bottle*\" -name \"*.tsx\"`...",
-            "timestamp": "2025-04-09T22:38:39.431421",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/prices/page.tsx` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:43.030734",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/page.tsx` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:45.535641",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/web/src/lib/trpc/client.server.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:48.766893",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/trpc/links.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:51.786534",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Looking at `apps/server/src/trpc/context.ts` in `dcramer/peated`...",
-            "timestamp": "2025-04-09T22:38:54.281514",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Studying spans under `http.server - GET /trpc/bottlePriceList,bottleById`...",
-            "timestamp": "2025-04-09T22:39:00.325683",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Being artificially intelligent...",
-            "timestamp": "2025-04-09T22:39:19.353863",
-            "type": "INFO"
-          },
-          {
-            "data": null,
-            "message": "Formatting for human consumption...",
-            "timestamp": "2025-04-09T22:39:47.228661",
-            "type": "INFO"
-          }
-        ],
-        "queued_user_messages": [],
-        "status": "completed",
-        "title": "Planning Solution",
-        "type": "default"
-      },
-      {
-        "active_comment_thread": null,
-        "agent_comment_thread": null,
-        "completedMessage": null,
-        "custom_solution": null,
-        "description": "Consolidate bottle and price data fetching into a single batched TRPC request using `Promise.all` to ensure ID consistency.",
-        "id": "87ba0ee3-af4e-458e-b3a9-6fd5f9d4a471",
-        "index": 3,
-        "key": "solution",
-        "output_confidence_score": null,
-        "output_stream": null,
-        "proceed_confidence_score": null,
-        "progress": [
-          {
-            "data": null,
-            "message": "Here is Seer's proposed solution.",
-            "timestamp": "2025-04-09T22:39:50.191715",
-            "type": "INFO"
-          }
-        ],
-        "queued_user_messages": [],
-        "selected_mode": null,
-        "solution": [
-          {
-            "code_snippet_and_analysis": "```typescript\n// In a shared utility function or component\nexport async function getBottleWithPrices(bottleId: number) {\n  const trpcClient = await getTrpcClient();\n  \n  // Use Promise.all to ensure both requests are part of the same batch\n  // and receive the same parameters\n  const [bottle, priceList] = await Promise.all([\n    trpcClient.bottleById.fetch(bottleId),\n    trpcClient.bottlePriceList.fetch({ bottle: bottleId }),\n  ]);\n  \n  return { bottle, priceList };\n}\n```\nThis code creates a function that uses `Promise.all` to fetch both bottle details and price data concurrently. This ensures that both TRPC procedures are part of the same batch and receive the same `bottleId`.",
-            "is_active": true,
-            "is_most_important_event": true,
-            "relevant_code_file": null,
-            "timeline_item_type": "internal_code",
-            "title": "Create a shared utility function to fetch bottle details and price data together."
-          },
-          {
-            "code_snippet_and_analysis": "```typescript\n// Then in the page components:\nconst { bottle, priceList } = await getBottleWithPrices(Number(bottleId));\n```\nThis code replaces the separate calls to `bottleById` and `bottlePriceList` with a single call to the `getBottleWithPrices` function, ensuring that both components receive data for the same bottle.",
-            "is_active": true,
-            "is_most_important_event": false,
-            "relevant_code_file": null,
-            "timeline_item_type": "internal_code",
-            "title": "Modify the page components to use the shared utility function."
-          },
-          {
-            "code_snippet_and_analysis": null,
-            "is_active": false,
-            "is_most_important_event": false,
-            "relevant_code_file": null,
-            "timeline_item_type": "repro_test",
-            "title": "Add a unit test that reproduces the issue."
-          }
-        ],
-        "solution_selected": false,
-        "status": "completed",
-        "title": "Solution",
-        "type": "solution"
+        "file_patches": null,
+        "merged_file_patches": null,
+        "pr_commit_shas": null,
+        "todos": null,
+        "tool_links": null,
+        "tool_results": null
       }
     ]
   }

--- a/packages/mcp-server-mocks/src/fixtures/autofix-state.json
+++ b/packages/mcp-server-mocks/src/fixtures/autofix-state.json
@@ -4,7 +4,7 @@
     "request": {
       "project_id": 4505138086019073
     },
-    "status": "COMPLETED",
+    "status": "completed",
     "updated_at": "2025-04-09T22:39:50.778146",
     "steps": [
       {
@@ -122,7 +122,7 @@
           }
         ],
         "queued_user_messages": [],
-        "status": "COMPLETED",
+        "status": "completed",
         "title": "Analyzing the Issue",
         "type": "default"
       },
@@ -211,7 +211,7 @@
         ],
         "queued_user_messages": [],
         "selection": { "cause_id": 0, "instruction": null },
-        "status": "COMPLETED",
+        "status": "completed",
         "termination_reason": null,
         "title": "Root Cause Analysis",
         "type": "root_cause_analysis"
@@ -385,7 +385,7 @@
           }
         ],
         "queued_user_messages": [],
-        "status": "COMPLETED",
+        "status": "completed",
         "title": "Planning Solution",
         "type": "default"
       },
@@ -438,7 +438,7 @@
           }
         ],
         "solution_selected": false,
-        "status": "COMPLETED",
+        "status": "completed",
         "title": "Solution",
         "type": "solution"
       }

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -1064,26 +1064,42 @@ export const restHandlers = buildHandlers([
       HttpResponse.json({
         autofix: {
           run_id: 13,
-          request: { project_id: 4505138086019073 },
           status: "completed",
           updated_at: "2025-04-09T22:39:50.778146",
-          steps: [
+          owner_user_id: null,
+          pending_user_input: null,
+          repo_pr_states: {},
+          blocks: [
             {
-              type: "root_cause_analysis",
-              key: "root_cause_analysis",
-              index: 0,
-              status: "completed",
-              title: "1. **Root Cause Analysis**",
-              output_stream: null,
-              progress: [],
-              description: "The analysis has completed successfully.",
-              causes: [
+              id: "block-1",
+              message: {
+                role: "assistant",
+                content: "The analysis has completed successfully.",
+                thinking_content: null,
+                tool_calls: null,
+                metadata: null,
+              },
+              timestamp: "2025-04-09T22:39:50.000000",
+              loading: false,
+              artifacts: [
                 {
-                  description: "The analysis has completed successfully.",
-                  id: 1,
-                  root_cause_reproduction: [],
+                  key: "root_cause",
+                  reason: "Root cause analysis completed",
+                  data: {
+                    one_line_description:
+                      "The analysis has completed successfully.",
+                    five_whys: [],
+                    reproduction_steps: [],
+                    relevant_repo: null,
+                  },
                 },
               ],
+              file_patches: null,
+              merged_file_patches: null,
+              pr_commit_shas: null,
+              todos: null,
+              tool_links: null,
+              tool_results: null,
             },
           ],
         },

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -1065,14 +1065,14 @@ export const restHandlers = buildHandlers([
         autofix: {
           run_id: 13,
           request: { project_id: 4505138086019073 },
-          status: "COMPLETED",
+          status: "completed",
           updated_at: "2025-04-09T22:39:50.778146",
           steps: [
             {
               type: "root_cause_analysis",
               key: "root_cause_analysis",
               index: 0,
-              status: "COMPLETED",
+              status: "completed",
               title: "1. **Root Cause Analysis**",
               output_stream: null,
               progress: [],


### PR DESCRIPTION
getsentry/sentry#116162 updated `GroupAutofixEndpoint` to use the new explorer-based autofix, which has a new schema. When the MCP attempted to use seer tools, they would always fail validation. Update to use the new autofix schema.

Fixes MCP-SERVER-FXM