### PR TITLE
fix(telemetry): Add spans for catalog tool dispatch

### DIFF
--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1,8 +1,10 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { setUser } from "@sentry/core";
+import { type Span, setTag, setUser, startSpan } from "@sentry/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { buildServer } from "./server";
+import { createExecuteTool } from "./tools/special/execute-tool";
 import type { ToolConfig } from "./tools/types";
 import type { ServerContext } from "./types";
 
@@ -11,8 +13,21 @@ vi.mock("@sentry/core", () => ({
   setTag: vi.fn(),
   setUser: vi.fn(),
   getActiveSpan: vi.fn(),
+  startSpan: vi.fn(),
   wrapMcpServerWithSentry: vi.fn((server) => server),
 }));
+
+function createMockSpan() {
+  return {
+    setAttribute: vi.fn(),
+    setStatus: vi.fn(),
+    recordException: vi.fn(),
+  };
+}
+
+type MockSpan = ReturnType<typeof createMockSpan>;
+
+let startedSpans: MockSpan[] = [];
 
 /**
  * Helper to get registered tool names from an McpServer.
@@ -111,6 +126,15 @@ const DEFAULT_DIRECT_TOOL_NAMES_WITH_DOCS = [
 describe("buildServer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    startedSpans = [];
+    vi.mocked(startSpan).mockImplementation((<T>(
+      _options: Parameters<typeof startSpan>[0],
+      callback: (span: Span) => T,
+    ) => {
+      const span = createMockSpan();
+      startedSpans.push(span);
+      return callback(span as unknown as Span);
+    }) as typeof startSpan);
   });
 
   const baseContext: ServerContext = {
@@ -1069,6 +1093,135 @@ describe("buildServer", () => {
       expect(getTextContent(result)).toContain(
         "# Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**",
       );
+    });
+
+    it("execute_tool creates a catalog tool span with effective arguments", async () => {
+      const handler = vi.fn(async (params: unknown) => {
+        const parsed = params as {
+          organizationSlug: string;
+          filter: string;
+          nested: { limit: number };
+        };
+        return `${parsed.organizationSlug}:${parsed.filter}:${parsed.nested.limit}`;
+      });
+      const registry: Record<string, ToolConfig> = {};
+      registry.fake_catalog_tool = createMockTool("fake_catalog_tool", {
+        inputSchema: {
+          organizationSlug: z.string(),
+          filter: z.string(),
+          nested: z.object({ limit: z.number() }),
+        },
+        handler,
+      });
+      registry.execute_tool = createExecuteTool(() => registry);
+      const server = buildServer({
+        context: {
+          ...baseContext,
+          constraints: {
+            organizationSlug: "bound-org",
+            projectSlug: null,
+          },
+        },
+        tools: registry,
+      });
+
+      const result = await callRegisteredTool(server, "execute_tool", {
+        name: "fake_catalog_tool",
+        arguments: {
+          filter: "handled",
+          nested: { limit: 3 },
+        },
+      });
+
+      expect(getTextContent(result)).toBe("bound-org:handled:3");
+      expect(startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "execute_tool fake_catalog_tool",
+          op: "gen_ai.execute_tool",
+          attributes: {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": "fake_catalog_tool",
+          },
+        }),
+        expect.any(Function),
+      );
+      expect(handler).toHaveBeenCalledWith(
+        {
+          organizationSlug: "bound-org",
+          filter: "handled",
+          nested: { limit: 3 },
+        },
+        expect.any(Object),
+      );
+      const span = startedSpans[0];
+      expect(span?.setAttribute).toHaveBeenCalledWith(
+        "gen_ai.tool.call.arguments.organizationSlug",
+        "bound-org",
+      );
+      expect(span?.setAttribute).toHaveBeenCalledWith(
+        "gen_ai.tool.call.arguments.filter",
+        "handled",
+      );
+      expect(span?.setAttribute).toHaveBeenCalledWith(
+        "gen_ai.tool.call.arguments.nested",
+        JSON.stringify({ limit: 3 }),
+      );
+      expect(span?.setStatus).toHaveBeenCalledWith({ code: 1 });
+      expect(setTag).not.toHaveBeenCalledWith(
+        "catalog.tool",
+        "fake_catalog_tool",
+      );
+    });
+
+    it("does not create a catalog child span for direct tool calls", async () => {
+      const server = buildServer({
+        context: baseContext,
+        tools: {
+          fake_catalog_tool: createMockTool("fake_catalog_tool", {
+            handler: async () => "direct-result",
+          }),
+        },
+      });
+
+      const result = await callRegisteredTool(server, "fake_catalog_tool", {});
+
+      expect(getTextContent(result)).toBe("direct-result");
+      expect(startSpan).not.toHaveBeenCalled();
+    });
+
+    it("marks the catalog tool span as errored when execute_tool validation fails", async () => {
+      const registry: Record<string, ToolConfig> = {};
+      registry.fake_catalog_tool = createMockTool("fake_catalog_tool", {
+        inputSchema: {
+          requiredValue: z.string(),
+        },
+      });
+      registry.execute_tool = createExecuteTool(() => registry);
+      const server = buildServer({
+        context: baseContext,
+        tools: registry,
+      });
+
+      const result = await callRegisteredTool(server, "execute_tool", {
+        name: "fake_catalog_tool",
+        arguments: {},
+      });
+
+      expect(result).toMatchObject({ isError: true });
+      expect(getTextContent(result)).toContain(
+        "Invalid arguments for fake_catalog_tool",
+      );
+      expect(startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            "gen_ai.tool.name": "fake_catalog_tool",
+          }),
+        }),
+        expect.any(Function),
+      );
+      const span = startedSpans[0];
+      expect(span?.setStatus).toHaveBeenCalledWith({ code: 2 });
+      expect(span?.recordException).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it("execute_tool injects constrained arguments for catalog-only tools", async () => {

--- a/packages/mcp-core/src/tools/catalog-runtime/availability.ts
+++ b/packages/mcp-core/src/tools/catalog-runtime/availability.ts
@@ -3,7 +3,6 @@ import type {
   ServerNotification,
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
-import { setTag } from "@sentry/core";
 import { z } from "zod";
 import { UserInputError } from "../../errors";
 import {
@@ -260,6 +259,20 @@ export async function executeToolHandler({
   params: Record<string, unknown>;
   context: ServerContext;
 }) {
+  const paramsWithConstraints = prepareToolParams({ tool, params, context });
+
+  return tool.handler(paramsWithConstraints as never, context);
+}
+
+export function prepareToolParams({
+  tool,
+  params,
+  context,
+}: {
+  tool: ToolConfig<any>;
+  params: Record<string, unknown>;
+  context: ServerContext;
+}): Record<string, unknown> {
   const filteredInputSchema = getFilteredInputSchema(tool, context);
   const schema = z.object(filteredInputSchema);
   const parsed = schema.safeParse(params);
@@ -270,15 +283,7 @@ export async function executeToolHandler({
     );
   }
 
-  const paramsWithConstraints = injectConstraintParams(
-    parsed.data,
-    tool,
-    context,
-  );
-
-  setTag("catalog.tool", tool.name);
-
-  return tool.handler(paramsWithConstraints as never, context);
+  return injectConstraintParams(parsed.data, tool, context);
 }
 
 export function resolveToolDescription(

--- a/packages/mcp-core/src/tools/special/execute-tool.ts
+++ b/packages/mcp-core/src/tools/special/execute-tool.ts
@@ -1,13 +1,72 @@
+import { type Span, type SpanAttributeValue, startSpan } from "@sentry/core";
 import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { UserInputError } from "../../errors";
 import { ALL_SKILLS } from "../../skills";
 import type { ServerContext } from "../../types";
 import {
-  executeToolHandler,
   getSearchableTools,
+  prepareToolParams,
   type ToolRegistry,
 } from "../catalog-runtime/availability";
+import type { ToolConfig } from "../types";
+
+function setToolArgumentAttributes(
+  span: Span,
+  params: Record<string, unknown>,
+) {
+  for (const [key, value] of Object.entries(params)) {
+    const attributeValue =
+      value == null || typeof value === "object"
+        ? JSON.stringify(value)
+        : value;
+    span.setAttribute(
+      `gen_ai.tool.call.arguments.${key}`,
+      attributeValue as SpanAttributeValue | undefined,
+    );
+  }
+}
+
+async function executeCatalogToolWithSpan({
+  tool,
+  params,
+  context,
+}: {
+  tool: ToolConfig<any>;
+  params: Record<string, unknown>;
+  context: ServerContext;
+}) {
+  return startSpan(
+    {
+      name: `execute_tool ${tool.name}`,
+      op: "gen_ai.execute_tool",
+      attributes: {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": tool.name,
+      },
+    },
+    async (span) => {
+      try {
+        const paramsWithConstraints = prepareToolParams({
+          tool,
+          params,
+          context,
+        });
+        setToolArgumentAttributes(span, paramsWithConstraints);
+        const output = await tool.handler(
+          paramsWithConstraints as never,
+          context,
+        );
+        span.setStatus({ code: 1 });
+        return output;
+      } catch (error) {
+        span.setStatus({ code: 2 });
+        span.recordException(error);
+        throw error;
+      }
+    },
+  );
+}
 
 export function createExecuteTool(getTools: () => ToolRegistry) {
   return defineTool({
@@ -67,7 +126,7 @@ export function createExecuteTool(getTools: () => ToolRegistry) {
         );
       }
 
-      return executeToolHandler({
+      return executeCatalogToolWithSpan({
         tool: match.tool,
         params: params.arguments,
         context,


### PR DESCRIPTION
Catalog tools dispatched through `execute_tool` now create their own child span with `gen_ai.tool.name` set to the resolved catalog tool and effective argument attributes recorded after validation and constraint injection. This preserves the existing direct-tool auto-instrumentation path while making catalog latency and errors queryable by tool name.

The obsolete `catalog.tool` tag is removed from catalog runtime dispatch because it was transaction-scoped and did not provide span-level attribution. The regression coverage exercises catalog dispatch spans, direct-tool non-duplication, validation failures, and effective argument attributes.

Fixes GH-1069