### PR TITLE
fix(telemetry): Record search tool results

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -148,6 +148,8 @@ Current MCP spans also use related OpenTelemetry attributes outside the `mcp.*` 
 - `rpc.response.status_code` - The JSON-RPC response status or error code
 - `network.transport` - Transport protocol (`pipe` for stdio, `tcp` or `quic` for HTTP)
 - `gen_ai.tool.call.arguments.<key>` - Per-key effective tool arguments after constraints
+- `gen_ai.tool.call.result` - Tool result payload when explicitly recorded for low-risk structured outputs
+- `gen_ai.tool.call.result.count` - Sentry MCP extension for result counts, including zero-result tool calls
 
 ### Application-Owned Attributes
 These are Sentry MCP application attributes that are not part of the MCP semantic convention:

--- a/packages/mcp-core/src/tools/special/search-tools.ts
+++ b/packages/mcp-core/src/tools/special/search-tools.ts
@@ -1,3 +1,4 @@
+import { getActiveSpan } from "@sentry/core";
 import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { ALL_SKILLS } from "../../skills";
@@ -34,6 +35,16 @@ export const searchToolsOutputSchema = z.object({
 type SearchToolsOutput = z.infer<typeof searchToolsOutputSchema>;
 
 function createSearchToolsResult(payload: SearchToolsOutput) {
+  const activeSpan = getActiveSpan();
+
+  if (activeSpan) {
+    activeSpan.setAttribute("gen_ai.tool.call.result", JSON.stringify(payload));
+    activeSpan.setAttribute(
+      "gen_ai.tool.call.result.count",
+      payload.results.length,
+    );
+  }
+
   return {
     content: [
       {


### PR DESCRIPTION
Record the structured search_tools payload on the active tool span using gen_ai.tool.call.result, and always set gen_ai.tool.call.result.count from the returned result list. This makes zero-result catalog searches visible in telemetry while keeping the MCP tool response unchanged.

Also documents the tool result attributes alongside the existing MCP span attributes.