### PR TITLE
feat(alerts): Add alert rule catalog tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ pnpm run measure-tokens                   # Check tool definition size
 pnpm run --filter @sentry/mcp-core generate-definitions
 ```
 
+## QA Playbook
+
+For end-to-end validation with the local dev server and CLI client, follow `.agents/skills/qa/SKILL.md`. It covers the required quality gate, `pnpm dev` on `http://localhost:5173`, local CLI smoke tests, and when to extend coverage to stdio, auth, or real agent clients.
+
 ## Task Management
 
 Use `/dex` skill to coordinate complex work. Create tasks with full context, break down into subtasks, complete with detailed results.

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -65,6 +65,10 @@ import {
   TraceSchema,
   UserSchema,
   UserRegionsSchema,
+  IssueAlertRuleListSchema,
+  IssueAlertRuleSchema,
+  MetricAlertRuleListSchema,
+  MetricAlertRuleSchema,
   FlamegraphSchema,
   ProfileChunkResponseSchema,
   TransactionProfileSchema,
@@ -90,6 +94,8 @@ import type {
   EventAttachmentList,
   Issue,
   IssueActivityList,
+  IssueAlertRule,
+  IssueAlertRuleList,
   IssueComment,
   IssueCommentList,
   IssueList,
@@ -101,6 +107,8 @@ import type {
   MonitorCheckInList,
   MonitorList,
   MonitorStats,
+  MetricAlertRule,
+  MetricAlertRuleList,
   OrganizationList,
   Project,
   ProjectList,
@@ -902,6 +910,30 @@ export class SentryApiService {
     );
   }
 
+  getIssueAlertRuleUrl(
+    organizationSlug: string,
+    projectSlug: string,
+    ruleId: string | number,
+  ): string {
+    const encodedProject = encodeURIComponent(projectSlug);
+    const encodedRuleId = encodeURIComponent(String(ruleId));
+    if (this.isSaas()) {
+      return `${this.protocol}://${organizationSlug}.sentry.io/issues/alerts/rules/${encodedProject}/${encodedRuleId}/details/`;
+    }
+    return `${this.protocol}://${this.host}/organizations/${organizationSlug}/issues/alerts/rules/${encodedProject}/${encodedRuleId}/details/`;
+  }
+
+  getMetricAlertRuleUrl(
+    organizationSlug: string,
+    ruleId: string | number,
+  ): string {
+    const encodedRuleId = encodeURIComponent(String(ruleId));
+    if (this.isSaas()) {
+      return `${this.protocol}://${organizationSlug}.sentry.io/issues/alerts/rules/details/${encodedRuleId}/`;
+    }
+    return `${this.protocol}://${this.host}/organizations/${organizationSlug}/issues/alerts/rules/details/${encodedRuleId}/`;
+  }
+
   // ================================================================================
   // URL BUILDERS FOR DIFFERENT SENTRY APIS
   // ================================================================================
@@ -1684,6 +1716,248 @@ export class SentryApiService {
       opts,
     );
     return ProjectRepoLinkSchema.parse(body);
+  }
+
+  async listIssueAlertRules(
+    params: {
+      organizationSlug: string;
+      projectSlug: string;
+      query?: string;
+      cursor?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<IssueAlertRuleList> {
+    const page = await this.listIssueAlertRulesPage(params, opts);
+    return page.rules;
+  }
+
+  async listIssueAlertRulesPage(
+    {
+      organizationSlug,
+      projectSlug,
+      query,
+      cursor,
+      limit,
+    }: {
+      organizationSlug: string;
+      projectSlug: string;
+      query?: string;
+      cursor?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<{ rules: IssueAlertRuleList; nextCursor: string | null }> {
+    if (query) {
+      const project = await this.getProject(
+        {
+          organizationSlug,
+          projectSlugOrId: projectSlug,
+        },
+        opts,
+      );
+      const body = await this.listCombinedAlertRules(
+        {
+          organizationSlug,
+          name: query,
+          alertType: "rule",
+          projectId: project.id,
+          cursor,
+          limit,
+        },
+        opts,
+      );
+      return {
+        rules: IssueAlertRuleListSchema.parse(body.data),
+        nextCursor: body.nextCursor,
+      };
+    }
+
+    const searchQuery = new URLSearchParams();
+    if (cursor) {
+      searchQuery.set("cursor", cursor);
+    }
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
+    }
+
+    const queryString = searchQuery.toString();
+    const response = await this.request(
+      `/projects/${organizationSlug}/${projectSlug}/rules/${queryString ? `?${queryString}` : ""}`,
+      undefined,
+      opts,
+    );
+    const body = await this.parseJsonResponse(response);
+    return {
+      rules: IssueAlertRuleListSchema.parse(body),
+      nextCursor: getNextCursor(response.headers.get("link")),
+    };
+  }
+
+  async getIssueAlertRule(
+    {
+      organizationSlug,
+      projectSlug,
+      ruleId,
+    }: {
+      organizationSlug: string;
+      projectSlug: string;
+      ruleId: string | number;
+    },
+    opts?: RequestOptions,
+  ): Promise<IssueAlertRule> {
+    const body = await this.requestJSON(
+      `/projects/${organizationSlug}/${projectSlug}/rules/${encodeURIComponent(String(ruleId))}/`,
+      undefined,
+      opts,
+    );
+    return IssueAlertRuleSchema.parse(body);
+  }
+
+  async listMetricAlertRules(
+    params: {
+      organizationSlug: string;
+      projectSlug?: string;
+      query?: string;
+      cursor?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<MetricAlertRuleList> {
+    const page = await this.listMetricAlertRulesPage(params, opts);
+    return page.rules;
+  }
+
+  async listMetricAlertRulesPage(
+    {
+      organizationSlug,
+      projectSlug,
+      query,
+      cursor,
+      limit,
+    }: {
+      organizationSlug: string;
+      projectSlug?: string;
+      query?: string;
+      cursor?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<{ rules: MetricAlertRuleList; nextCursor: string | null }> {
+    if (query) {
+      const project = projectSlug
+        ? await this.getProject(
+            {
+              organizationSlug,
+              projectSlugOrId: projectSlug,
+            },
+            opts,
+          )
+        : undefined;
+      const body = await this.listCombinedAlertRules(
+        {
+          organizationSlug,
+          name: query,
+          alertType: "alert_rule",
+          projectId: project?.id,
+          cursor,
+          limit,
+        },
+        opts,
+      );
+      return {
+        rules: MetricAlertRuleListSchema.parse(body.data),
+        nextCursor: body.nextCursor,
+      };
+    }
+
+    const searchQuery = new URLSearchParams();
+    if (cursor) {
+      searchQuery.set("cursor", cursor);
+    }
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
+    }
+
+    const queryString = searchQuery.toString();
+    const path = projectSlug
+      ? `/projects/${organizationSlug}/${projectSlug}/alert-rules/`
+      : `/organizations/${organizationSlug}/alert-rules/`;
+    const response = await this.request(
+      `${path}${queryString ? `?${queryString}` : ""}`,
+      undefined,
+      opts,
+    );
+    const body = await this.parseJsonResponse(response);
+    return {
+      rules: MetricAlertRuleListSchema.parse(body),
+      nextCursor: getNextCursor(response.headers.get("link")),
+    };
+  }
+
+  async getMetricAlertRule(
+    {
+      organizationSlug,
+      projectSlug,
+      ruleId,
+    }: {
+      organizationSlug: string;
+      projectSlug?: string;
+      ruleId: string | number;
+    },
+    opts?: RequestOptions,
+  ): Promise<MetricAlertRule> {
+    const path = projectSlug
+      ? `/projects/${organizationSlug}/${projectSlug}/alert-rules/${encodeURIComponent(String(ruleId))}/`
+      : `/organizations/${organizationSlug}/alert-rules/${encodeURIComponent(String(ruleId))}/`;
+    const body = await this.requestJSON(path, undefined, opts);
+    return MetricAlertRuleSchema.parse(body);
+  }
+
+  /**
+   * Uses Sentry's combined-rules endpoint for supported name search.
+   * `rule` selects issue alerts and `alert_rule` selects metric alerts.
+   */
+  private async listCombinedAlertRules(
+    {
+      organizationSlug,
+      name,
+      alertType,
+      projectId,
+      cursor,
+      limit,
+    }: {
+      organizationSlug: string;
+      name: string;
+      alertType: "rule" | "alert_rule";
+      projectId?: string | number;
+      cursor?: string;
+      limit?: number;
+    },
+    opts?: RequestOptions,
+  ): Promise<{ data: unknown; nextCursor: string | null }> {
+    const searchQuery = new URLSearchParams();
+    searchQuery.set("name", name);
+    searchQuery.append("alertType", alertType);
+    if (projectId !== undefined) {
+      searchQuery.append("project", String(projectId));
+    }
+    if (cursor) {
+      searchQuery.set("cursor", cursor);
+    }
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
+    }
+
+    const response = await this.request(
+      `/organizations/${organizationSlug}/combined-rules/?${searchQuery.toString()}`,
+      undefined,
+      opts,
+    );
+    return {
+      data: await this.parseJsonResponse(response),
+      nextCursor: getNextCursor(response.headers.get("link")),
+    };
   }
 
   /**

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -258,6 +258,46 @@ export const DashboardSchema = z
   })
   .passthrough();
 
+export const AlertRuleComponentSchema = z.record(z.string(), z.unknown());
+
+export const IssueAlertRuleSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    name: z.string(),
+    status: z.string().optional(),
+    actionMatch: z.string().nullable().optional(),
+    filterMatch: z.string().nullable().optional(),
+    conditions: z.array(AlertRuleComponentSchema).optional().default([]),
+    filters: z.array(AlertRuleComponentSchema).optional().default([]),
+    actions: z.array(AlertRuleComponentSchema).optional().default([]),
+    frequency: z.number().nullable().optional(),
+    environment: z.string().nullable().optional(),
+    owner: z.unknown().optional(),
+    dateCreated: z.string().optional(),
+  })
+  .passthrough();
+
+export const IssueAlertRuleListSchema = z.array(IssueAlertRuleSchema);
+
+export const MetricAlertRuleSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    name: z.string(),
+    status: z.union([z.string(), z.number()]).optional(),
+    query: z.string().nullable().optional(),
+    aggregate: z.string().nullable().optional(),
+    dataset: z.string().nullable().optional(),
+    timeWindow: z.number().nullable().optional(),
+    environment: z.string().nullable().optional(),
+    owner: z.unknown().optional(),
+    projects: z.array(z.string()).optional().default([]),
+    triggers: z.array(AlertRuleComponentSchema).optional().default([]),
+    dateCreated: z.string().optional(),
+  })
+  .passthrough();
+
+export const MetricAlertRuleListSchema = z.array(MetricAlertRuleSchema);
+
 const ReplayTagsSchema = z.preprocess(
   (value) => {
     if (value === undefined || value === null || Array.isArray(value)) {

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -69,6 +69,8 @@ import type {
   GenericEventSchema,
   IssueActivityListResponseSchema,
   IssueActivitySchema,
+  IssueAlertRuleListSchema,
+  IssueAlertRuleSchema,
   IssueCommentListSchema,
   IssueCommentSchema,
   IssueListSchema,
@@ -80,6 +82,8 @@ import type {
   MonitorSchema,
   MonitorStatsSchema,
   MonitorStatSchema,
+  MetricAlertRuleListSchema,
+  MetricAlertRuleSchema,
   OrganizationListSchema,
   OrganizationSchema,
   ProfileChunkResponseSchema,
@@ -113,6 +117,8 @@ export type User = z.infer<typeof UserSchema>;
 export type Organization = z.infer<typeof OrganizationSchema>;
 export type Team = z.infer<typeof TeamSchema>;
 export type Project = z.infer<typeof ProjectSchema>;
+export type IssueAlertRule = z.infer<typeof IssueAlertRuleSchema>;
+export type MetricAlertRule = z.infer<typeof MetricAlertRuleSchema>;
 export type ClientKey = z.infer<typeof ClientKeySchema>;
 export type Release = z.infer<typeof ReleaseSchema>;
 export type ReleaseDetails = z.infer<typeof ReleaseDetailsSchema>;
@@ -155,6 +161,8 @@ export type ReplayRecordingSegments = z.infer<
 export type OrganizationList = z.infer<typeof OrganizationListSchema>;
 export type TeamList = z.infer<typeof TeamListSchema>;
 export type ProjectList = z.infer<typeof ProjectListSchema>;
+export type IssueAlertRuleList = z.infer<typeof IssueAlertRuleListSchema>;
+export type MetricAlertRuleList = z.infer<typeof MetricAlertRuleListSchema>;
 export type ReleaseList = z.infer<typeof ReleaseListSchema>;
 export type DeployList = z.infer<typeof DeployListSchema>;
 export type CommitList = z.infer<typeof CommitListSchema>;

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,8 +5,13 @@
     "description": "Read-only access to core Sentry data: issues, events, traces, replays, releases, monitors, profiles, documentation, and project metadata",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 28,
+    "toolCount": 30,
     "tools": [
+      {
+        "name": "find_alert_rules",
+        "description": "Find Sentry alert rules.\n\nUse this tool when you need to:\n- List issue alert rules for a project\n- List metric alert rules for an organization or project\n- Find an alert rule ID by name before inspecting it\n- Check alert conditions, queries, triggers, actions, owner, or environment\n\n<examples>\nfind_alert_rules(organizationSlug='my-org')\nfind_alert_rules(organizationSlug='my-org', projectSlug='backend')\nfind_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')\n</examples>\n\n<hints>\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n- Metric alert rules can be listed organization-wide or project-scoped.\n</hints>",
+        "requiredScopes": ["org:read", "project:read"]
+      },
       {
         "name": "find_dashboards",
         "description": "Find Sentry dashboards in an organization.\n\nUse this tool when you need to:\n- List dashboards in an organization\n- Find a dashboard ID before calling get_dashboard_details\n- Search dashboards by title\n\n<examples>\nfind_dashboards(organizationSlug='my-organization')\nfind_dashboards(organizationSlug='my-organization', titleQuery='errors')\n</examples>\n\n<hints>\n- Dashboard IDs are organization-scoped.\n- Use `get_dashboard_details` after finding the correct dashboard ID.\n</hints>",
@@ -41,6 +46,11 @@
         "name": "get_ai_conversation_details",
         "description": "Fetch all spans for an AI conversation by its gen_ai.conversation.id.\n\nA conversation is a set of spans sharing the same gen_ai.conversation.id. To discover conversation IDs, use search_events with dataset='spans' and query='has:gen_ai.conversation.id'.",
         "requiredScopes": ["event:read", "project:read"]
+      },
+      {
+        "name": "get_alert_rule",
+        "description": "Get details for a Sentry alert rule.\n\nUse this tool when you need to inspect an alert rule's exact conditions, query, triggers, and actions before explaining or planning changes.\n\n<examples>\nget_alert_rule(organizationSlug='my-org', kind='metric', ruleIdOrName='12345')\nget_alert_rule(organizationSlug='my-org', kind='issue', projectSlug='backend', ruleIdOrName='Notify backend team')\nget_alert_rule(organizationSlug='my-org', projectSlug='backend', ruleIdOrName='P95 latency')\n</examples>\n\n<hints>\n- Use `kind='issue'` or `kind='metric'` for numeric IDs because issue and metric alerts use separate endpoints.\n- With `kind='all'`, a digit-only `ruleIdOrName` is treated as an exact alert rule name.\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n</hints>",
+        "requiredScopes": ["org:read", "project:read"]
       },
       {
         "name": "get_dashboard_details",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -258,6 +258,90 @@
     "surface": "direct"
   },
   {
+    "name": "find_alert_rules",
+    "description": "Find Sentry alert rules.\n\nUse this tool when you need to:\n- List issue alert rules for a project\n- List metric alert rules for an organization or project\n- Find an alert rule ID by name before inspecting it\n- Check alert conditions, queries, triggers, actions, owner, or environment\n\n<examples>\nfind_alert_rules(organizationSlug='my-org')\nfind_alert_rules(organizationSlug='my-org', projectSlug='backend')\nfind_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')\n</examples>\n\n<hints>\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n- Metric alert rules can be listed organization-wide or project-scoped.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["all", "issue", "metric"],
+          "description": "Which alert rule family to search. Use `all` to include metric alerts, plus issue alerts when a project is available.",
+          "default": "all"
+        },
+        "projectSlug": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+          "default": null
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Optional search query for alert rule name."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional search query for alert rule name.",
+          "default": null
+        },
+        "cursor": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Optional pagination cursor from a previous Sentry API response."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional pagination cursor from a previous Sentry API response.",
+          "default": null
+        },
+        "limit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 100,
+          "description": "Maximum number of alert rules to return per alert family.",
+          "default": 10
+        }
+      },
+      "required": ["organizationSlug"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["org:read", "project:read"],
+    "skills": ["inspect"],
+    "surface": "catalog"
+  },
+  {
     "name": "find_dashboards",
     "description": "Find Sentry dashboards in an organization.\n\nUse this tool when you need to:\n- List dashboards in an organization\n- Find a dashboard ID before calling get_dashboard_details\n- Search dashboards by title\n\n<examples>\nfind_dashboards(organizationSlug='my-organization')\nfind_dashboards(organizationSlug='my-organization', titleQuery='errors')\n</examples>\n\n<hints>\n- Dashboard IDs are organization-scoped.\n- Use `get_dashboard_details` after finding the correct dashboard ID.\n</hints>",
     "inputSchema": {
@@ -659,6 +743,62 @@
     },
     "requiredScopes": ["event:read", "project:read"],
     "skills": ["inspect", "triage", "seer"],
+    "surface": "catalog"
+  },
+  {
+    "name": "get_alert_rule",
+    "description": "Get details for a Sentry alert rule.\n\nUse this tool when you need to inspect an alert rule's exact conditions, query, triggers, and actions before explaining or planning changes.\n\n<examples>\nget_alert_rule(organizationSlug='my-org', kind='metric', ruleIdOrName='12345')\nget_alert_rule(organizationSlug='my-org', kind='issue', projectSlug='backend', ruleIdOrName='Notify backend team')\nget_alert_rule(organizationSlug='my-org', projectSlug='backend', ruleIdOrName='P95 latency')\n</examples>\n\n<hints>\n- Use `kind='issue'` or `kind='metric'` for numeric IDs because issue and metric alerts use separate endpoints.\n- With `kind='all'`, a digit-only `ruleIdOrName` is treated as an exact alert rule name.\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["all", "issue", "metric"],
+          "description": "Which alert rule family to inspect. Use `issue` or `metric` for numeric IDs; `all` treats the value as an exact-name lookup.",
+          "default": "all"
+        },
+        "projectSlug": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+          "default": null
+        },
+        "ruleIdOrName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The alert rule's numeric ID, or an exact alert rule name."
+        }
+      },
+      "required": ["organizationSlug", "ruleIdOrName"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["org:read", "project:read"],
+    "skills": ["inspect"],
     "surface": "catalog"
   },
   {

--- a/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
@@ -1,0 +1,350 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import findAlertRules from "./find-alert-rules.js";
+
+const context = {
+  constraints: {
+    organizationSlug: null,
+  },
+  accessToken: "access-token",
+  userId: "1",
+};
+
+const issueAlertRule = {
+  id: "123",
+  name: "Notify backend team",
+  status: "active",
+  actionMatch: "any",
+  filterMatch: "all",
+  frequency: 30,
+  environment: "production",
+  owner: "team:backend",
+  dateCreated: "2026-01-02T03:04:05.000Z",
+  conditions: [
+    {
+      id: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+    },
+  ],
+  filters: [
+    {
+      id: "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
+    },
+  ],
+  actions: [
+    {
+      id: "sentry.mail.actions.NotifyEmailAction",
+      targetType: "Team",
+      targetIdentifier: "1",
+    },
+  ],
+};
+
+const metricAlertRule = {
+  id: "456",
+  name: "P95 latency",
+  status: 0,
+  dataset: "transactions",
+  aggregate: "p95(transaction.duration)",
+  query: "environment:production",
+  timeWindow: 5,
+  projects: ["cloudflare-mcp"],
+  environment: "production",
+  owner: "team:backend",
+  dateCreated: "2026-01-03T03:04:05.000Z",
+  triggers: [
+    {
+      label: "critical",
+      alertThreshold: 500,
+      actions: [
+        {
+          type: "slack",
+          targetIdentifier: "alerts",
+        },
+      ],
+    },
+  ],
+};
+
+const project = {
+  id: "4509109104082945",
+  slug: "cloudflare-mcp",
+  name: "cloudflare-mcp",
+};
+
+function useAlertRuleHandlers() {
+  mswServer.use(
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+      () => HttpResponse.json(project),
+    ),
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/",
+      () => HttpResponse.json([issueAlertRule]),
+    ),
+    http.get(
+      "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/",
+      () => HttpResponse.json([metricAlertRule]),
+    ),
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/",
+      () => HttpResponse.json([metricAlertRule]),
+    ),
+  );
+}
+
+describe("find_alert_rules", () => {
+  it("serializes project-scoped issue and metric alert rules", async () => {
+    useAlertRuleHandlers();
+    let metricRequestUrl: string | null = null;
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/",
+        ({ request }) => {
+          metricRequestUrl = request.url;
+          return HttpResponse.json([metricAlertRule]);
+        },
+      ),
+    );
+
+    const result = await findAlertRules.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "all",
+        projectSlug: "cloudflare-mcp",
+        query: null,
+        cursor: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(metricRequestUrl).not.toBeNull();
+    expect(result).toMatchInlineSnapshot(`
+      "# Alert Rules in **sentry-mcp-evals/cloudflare-mcp**
+
+      ## Issue Alert Rules
+
+      ### Notify backend team
+
+      **Kind**: Issue Alert
+      **ID**: 123
+      **Project**: cloudflare-mcp
+      **Status**: active
+      **Action Match**: any
+      **Filter Match**: all
+      **Frequency**: 30 minutes
+      **Environment**: production
+      **Owner**: team:backend
+      **Created**: 2026-01-02T03:04:05.000Z
+      **URL**: https://sentry-mcp-evals.sentry.io/issues/alerts/rules/cloudflare-mcp/123/details/
+
+      ## Metric Alert Rules
+
+      ### P95 latency
+
+      **Kind**: Metric Alert
+      **ID**: 456
+      **Status**: 0
+      **Dataset**: transactions
+      **Aggregate**: p95(transaction.duration)
+      **Query**: environment:production
+      **Time Window**: 5 minutes
+      **Projects**: cloudflare-mcp
+      **Environment**: production
+      **Owner**: team:backend
+      **Created**: 2026-01-03T03:04:05.000Z
+      **URL**: https://sentry-mcp-evals.sentry.io/issues/alerts/rules/details/456/
+
+      ## Response Notes
+
+      - Use \`get_alert_rule\` with \`kind\` and the numeric rule ID for full details.
+      - Alert rule actions can include integration-specific payloads; inspect existing rules before planning mutations.
+      "
+    `);
+  });
+
+  it("lists organization metric alerts when no project is available", async () => {
+    useAlertRuleHandlers();
+
+    const result = await findAlertRules.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "all",
+        projectSlug: null,
+        query: null,
+        cursor: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(result).toContain("## Metric Alert Rules");
+    expect(result).not.toContain("## Issue Alert Rules");
+    expect(result).toContain(
+      "Issue alert rules are project-scoped; pass `projectSlug` to include them.",
+    );
+  });
+
+  it("returns next cursors for direct alert rule list endpoints", async () => {
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/",
+        () =>
+          HttpResponse.json([issueAlertRule], {
+            headers: {
+              Link: '<https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/?cursor=issue-page-2>; rel="next"; results="true"; cursor="issue-page-2"',
+            },
+          }),
+      ),
+    );
+
+    const result = await findAlertRules.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "issue",
+        projectSlug: "cloudflare-mcp",
+        query: null,
+        cursor: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(result).toContain(
+      'More issue alert rules are available. Pass `kind: "issue"` and `cursor: "issue-page-2"`',
+    );
+  });
+
+  it("uses the supported combined-rules name filter for query searches", async () => {
+    const requestUrls: string[] = [];
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          requestUrls.push(request.url);
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "rule"
+              ? [issueAlertRule]
+              : [metricAlertRule],
+          );
+        },
+      ),
+    );
+
+    const result = await findAlertRules.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "all",
+        projectSlug: "cloudflare-mcp",
+        query: "backend",
+        cursor: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(result).toContain("Notify backend team");
+    expect(result).toContain("P95 latency");
+    expect(requestUrls).toHaveLength(2);
+    for (const requestUrl of requestUrls) {
+      const params = new URL(requestUrl).searchParams;
+      expect(params.get("name")).toBe("backend");
+      expect(params.get("query")).toBeNull();
+      expect(params.get("project")).toBe(project.id);
+    }
+    expect(
+      requestUrls
+        .map((url) => new URL(url).searchParams.get("alertType"))
+        .sort(),
+    ).toMatchInlineSnapshot(`
+        [
+          "alert_rule",
+          "rule",
+        ]
+      `);
+  });
+
+  it("returns next cursors for combined-rules query searches", async () => {
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "alert_rule" ? [metricAlertRule] : [],
+            {
+              headers: {
+                Link: '<https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/?cursor=metric-query-page-2>; rel="next"; results="true"; cursor="metric-query-page-2"',
+              },
+            },
+          );
+        },
+      ),
+    );
+
+    const result = await findAlertRules.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "metric",
+        projectSlug: "cloudflare-mcp",
+        query: "latency",
+        cursor: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(result).toContain("P95 latency");
+    expect(result).toContain(
+      'More metric alert rules are available. Pass `kind: "metric"` and `cursor: "metric-query-page-2"`',
+    );
+  });
+
+  it("rejects issue alert search without a project", async () => {
+    await expect(
+      findAlertRules.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          kind: "issue",
+          projectSlug: null,
+          query: null,
+          cursor: null,
+          limit: 10,
+        },
+        context,
+      ),
+    ).rejects.toThrow(
+      "projectSlug is required when searching issue alert rules.",
+    );
+  });
+
+  it("rejects shared cursors when searching issue and metric alerts together", async () => {
+    await expect(
+      findAlertRules.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          kind: "all",
+          projectSlug: "cloudflare-mcp",
+          query: null,
+          cursor: "endpoint-specific-cursor",
+          limit: 10,
+        },
+        context,
+      ),
+    ).rejects.toThrow(
+      "cursor cannot be used with `kind='all'` when both issue and metric alert rules are included.",
+    );
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/find-alert-rules.ts
+++ b/packages/mcp-core/src/tools/catalog/find-alert-rules.ts
@@ -1,0 +1,198 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { UserInputError } from "../../errors";
+import type { ServerContext } from "../../types";
+import {
+  ParamOrganizationSlug,
+  ParamProjectSlugOrAll,
+  ParamRegionUrl,
+} from "../../schema";
+import { assertProjectRefWithinConstraint } from "./support/project-constraints";
+import { formatIssueAlertRule, formatMetricAlertRule } from "./support/alerts";
+
+const AlertRuleKind = z
+  .enum(["all", "issue", "metric"])
+  .describe(
+    "Which alert rule family to search. Use `all` to include metric alerts, plus issue alerts when a project is available.",
+  );
+
+export default defineTool({
+  name: "find_alert_rules",
+  skills: ["inspect"],
+  requiredScopes: ["org:read", "project:read"],
+  description: [
+    "Find Sentry alert rules.",
+    "",
+    "Use this tool when you need to:",
+    "- List issue alert rules for a project",
+    "- List metric alert rules for an organization or project",
+    "- Find an alert rule ID by name before inspecting it",
+    "- Check alert conditions, queries, triggers, actions, owner, or environment",
+    "",
+    "<examples>",
+    "find_alert_rules(organizationSlug='my-org')",
+    "find_alert_rules(organizationSlug='my-org', projectSlug='backend')",
+    "find_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')",
+    "</examples>",
+    "",
+    "<hints>",
+    "- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.",
+    "- Metric alert rules can be listed organization-wide or project-scoped.",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug,
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    kind: AlertRuleKind.default("all"),
+    projectSlug: ParamProjectSlugOrAll.nullable().default(null),
+    query: z
+      .string()
+      .trim()
+      .describe("Optional search query for alert rule name.")
+      .nullable()
+      .default(null),
+    cursor: z
+      .string()
+      .trim()
+      .describe(
+        "Optional pagination cursor from a previous Sentry API response.",
+      )
+      .nullable()
+      .default(null),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .describe("Maximum number of alert rules to return per alert family.")
+      .default(10),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const requestedProjectSlug =
+      params.projectSlug && params.projectSlug !== "all"
+        ? params.projectSlug
+        : undefined;
+    if (requestedProjectSlug) {
+      assertProjectRefWithinConstraint({
+        resourceLabel: "Alert rule list",
+        scopedProjectSlug: context.constraints.projectSlug,
+        project: { slug: requestedProjectSlug },
+      });
+    }
+    const projectSlug = context.constraints.projectSlug ?? requestedProjectSlug;
+
+    if (params.kind === "issue" && !projectSlug) {
+      throw new UserInputError(
+        "projectSlug is required when searching issue alert rules.",
+      );
+    }
+
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? undefined,
+    });
+    const organizationSlug = params.organizationSlug;
+    setTag("organization.slug", organizationSlug);
+    if (projectSlug) {
+      setTag("project.slug", projectSlug);
+    }
+
+    const includeIssue = params.kind !== "metric" && Boolean(projectSlug);
+    const includeMetric = params.kind !== "issue";
+    if (params.cursor && includeIssue && includeMetric) {
+      throw new UserInputError(
+        "cursor cannot be used with `kind='all'` when both issue and metric alert rules are included. Retry with `kind='issue'` or `kind='metric'` using a cursor from the same alert rule family.",
+      );
+    }
+    const issuePage =
+      includeIssue && projectSlug
+        ? await apiService.listIssueAlertRulesPage({
+            organizationSlug,
+            projectSlug,
+            query: params.query ?? undefined,
+            cursor: params.cursor ?? undefined,
+            limit: params.limit,
+          })
+        : { rules: [], nextCursor: null };
+    const metricPage = includeMetric
+      ? await apiService.listMetricAlertRulesPage({
+          organizationSlug,
+          projectSlug,
+          query: params.query ?? undefined,
+          cursor: params.cursor ?? undefined,
+          limit: params.limit,
+        })
+      : { rules: [], nextCursor: null };
+    const issueRules = issuePage.rules;
+    const metricRules = metricPage.rules;
+
+    const scopeLabel = projectSlug
+      ? `${organizationSlug}/${projectSlug}`
+      : organizationSlug;
+    let output = `# Alert Rules in **${scopeLabel}**\n\n`;
+    if (issueRules.length === 0 && metricRules.length === 0) {
+      output += "No alert rules found.\n";
+      if (params.kind === "all" && !projectSlug) {
+        output +=
+          "\nIssue alert rules are project-scoped; pass `projectSlug` to include them.\n";
+      }
+      return output;
+    }
+
+    if (issueRules.length > 0) {
+      output += "## Issue Alert Rules\n\n";
+      output += issueRules
+        .slice(0, params.limit)
+        .map((rule) =>
+          formatIssueAlertRule(rule, projectSlug ?? "", {
+            headingLevel: 3,
+            includeComponents: false,
+            url: apiService.getIssueAlertRuleUrl(
+              organizationSlug,
+              projectSlug ?? "",
+              rule.id,
+            ),
+          }),
+        )
+        .join("\n\n");
+      output += "\n\n";
+    }
+
+    if (metricRules.length > 0) {
+      output += "## Metric Alert Rules\n\n";
+      output += metricRules
+        .slice(0, params.limit)
+        .map((rule) =>
+          formatMetricAlertRule(rule, {
+            headingLevel: 3,
+            includeComponents: false,
+            url: apiService.getMetricAlertRuleUrl(organizationSlug, rule.id),
+          }),
+        )
+        .join("\n\n");
+      output += "\n\n";
+    }
+
+    output += "## Response Notes\n\n";
+    output +=
+      "- Use `get_alert_rule` with `kind` and the numeric rule ID for full details.\n";
+    output +=
+      "- Alert rule actions can include integration-specific payloads; inspect existing rules before planning mutations.\n";
+    if (issuePage.nextCursor) {
+      output += `- More issue alert rules are available. Pass \`kind: "issue"\` and \`cursor: "${issuePage.nextCursor}"\` with the same search scope to fetch the next page.\n`;
+    }
+    if (metricPage.nextCursor) {
+      output += `- More metric alert rules are available. Pass \`kind: "metric"\` and \`cursor: "${metricPage.nextCursor}"\` with the same search scope to fetch the next page.\n`;
+    }
+    if (params.kind === "all" && !projectSlug) {
+      output +=
+        "- Issue alert rules are project-scoped; pass `projectSlug` to include them.\n";
+    }
+    return output;
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/get-alert-rule.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-alert-rule.test.ts
@@ -1,0 +1,467 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import getAlertRule from "./get-alert-rule.js";
+
+const context = {
+  constraints: {
+    organizationSlug: null,
+  },
+  accessToken: "access-token",
+  userId: "1",
+};
+
+const projectConstrainedContext = {
+  ...context,
+  constraints: {
+    organizationSlug: null,
+    projectSlug: "cloudflare-mcp",
+  },
+};
+
+const issueAlertRule = {
+  id: "123",
+  name: "Notify backend team",
+  status: "active",
+  actionMatch: "any",
+  filterMatch: "all",
+  frequency: 30,
+  environment: "production",
+  owner: "team:backend",
+  dateCreated: "2026-01-02T03:04:05.000Z",
+  conditions: [
+    {
+      id: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+    },
+  ],
+  filters: [
+    {
+      id: "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
+    },
+  ],
+  actions: [
+    {
+      id: "sentry.mail.actions.NotifyEmailAction",
+      targetType: "Team",
+      targetIdentifier: "1",
+    },
+  ],
+};
+
+const metricAlertRule = {
+  id: "456",
+  name: "P95 latency",
+  status: 0,
+  dataset: "transactions",
+  aggregate: "p95(transaction.duration)",
+  query: "environment:production",
+  timeWindow: 5,
+  projects: ["cloudflare-mcp"],
+  environment: "production",
+  owner: "team:backend",
+  dateCreated: "2026-01-03T03:04:05.000Z",
+  triggers: [
+    {
+      label: "critical",
+      alertThreshold: 500,
+      actions: [
+        {
+          type: "slack",
+          targetIdentifier: "alerts",
+        },
+      ],
+    },
+  ],
+};
+
+const project = {
+  id: "4509109104082945",
+  slug: "cloudflare-mcp",
+  name: "cloudflare-mcp",
+};
+
+function useAlertRuleHandlers() {
+  mswServer.use(
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+      () => HttpResponse.json(project),
+    ),
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/",
+      () => HttpResponse.json([issueAlertRule]),
+    ),
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/123/",
+      () => HttpResponse.json(issueAlertRule),
+    ),
+    http.get(
+      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/",
+      () => HttpResponse.json([metricAlertRule]),
+    ),
+    http.get(
+      "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/456/",
+      () => HttpResponse.json(metricAlertRule),
+    ),
+  );
+}
+
+describe("get_alert_rule", () => {
+  it("gets an issue alert by numeric ID when kind is explicit", async () => {
+    useAlertRuleHandlers();
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "issue",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "123",
+      },
+      context,
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Alert Rule in **sentry-mcp-evals/cloudflare-mcp**
+
+      ## Notify backend team
+
+      **Kind**: Issue Alert
+      **ID**: 123
+      **Project**: cloudflare-mcp
+      **Status**: active
+      **Action Match**: any
+      **Filter Match**: all
+      **Frequency**: 30 minutes
+      **Environment**: production
+      **Owner**: team:backend
+      **Created**: 2026-01-02T03:04:05.000Z
+      **URL**: https://sentry-mcp-evals.sentry.io/issues/alerts/rules/cloudflare-mcp/123/details/
+      ### Conditions
+
+      - sentry.rules.conditions.first_seen_event.FirstSeenEventCondition
+      ### Filters
+
+      - sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter
+      ### Actions
+
+      - sentry.mail.actions.NotifyEmailAction {"targetType":"Team","targetIdentifier":"1"}
+
+      ## Response Notes
+
+      - This tool is read-only. Treat the returned payload as the canonical source for any future clone or mutation workflow.
+      "
+    `);
+  });
+
+  it("gets a metric alert by numeric ID when kind is explicit", async () => {
+    useAlertRuleHandlers();
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "metric",
+        projectSlug: null,
+        ruleIdOrName: "456",
+      },
+      context,
+    );
+
+    expect(result).toContain("# Alert Rule in **sentry-mcp-evals**");
+    expect(result).toContain("**Kind**: Metric Alert");
+    expect(result).toContain("**ID**: 456");
+    expect(result).toContain("### Triggers");
+  });
+
+  it("falls back to organization metric alert details after a project ID miss", async () => {
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/456/",
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+    );
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "metric",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "456",
+      },
+      context,
+    );
+
+    expect(result).toContain("**Kind**: Metric Alert");
+    expect(result).toContain("**ID**: 456");
+    expect(result).toContain("### Triggers");
+  });
+
+  it("rejects organization metric alert fallback outside the active project constraint", async () => {
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/456/",
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/456/",
+        () =>
+          HttpResponse.json({
+            ...metricAlertRule,
+            projects: ["frontend"],
+          }),
+      ),
+    );
+
+    await expect(
+      getAlertRule.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          kind: "metric",
+          projectSlug: null,
+          ruleIdOrName: "456",
+        },
+        projectConstrainedContext,
+      ),
+    ).rejects.toThrow('Metric alert rule is outside project "cloudflare-mcp"');
+  });
+
+  it("falls back to organization metric alert details after resolving an exact name", async () => {
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "alert_rule"
+              ? [
+                  {
+                    id: metricAlertRule.id,
+                    name: metricAlertRule.name,
+                  },
+                ]
+              : [],
+          );
+        },
+      ),
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/456/",
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+    );
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "metric",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "P95 latency",
+      },
+      context,
+    );
+
+    expect(result).toContain("**Kind**: Metric Alert");
+    expect(result).toContain("**ID**: 456");
+    expect(result).toContain("### Triggers");
+  });
+
+  it("handles workflow-engine issue alerts with null match fields", async () => {
+    useAlertRuleHandlers();
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/123/",
+        () =>
+          HttpResponse.json({
+            ...issueAlertRule,
+            actionMatch: null,
+            filterMatch: null,
+          }),
+      ),
+    );
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "issue",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "123",
+      },
+      context,
+    );
+
+    expect(result).toContain("**Kind**: Issue Alert");
+    expect(result).not.toContain("**Action Match**");
+    expect(result).not.toContain("**Filter Match**");
+  });
+
+  it("fetches issue alert details after resolving an exact name", async () => {
+    useAlertRuleHandlers();
+    let detailRequestCount = 0;
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "rule"
+              ? [
+                  {
+                    id: issueAlertRule.id,
+                    name: issueAlertRule.name,
+                  },
+                ]
+              : [],
+          );
+        },
+      ),
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/123/",
+        () => {
+          detailRequestCount += 1;
+          return HttpResponse.json(issueAlertRule);
+        },
+      ),
+    );
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "issue",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "Notify backend team",
+      },
+      context,
+    );
+
+    expect(detailRequestCount).toBe(1);
+    expect(result).toContain("### Conditions");
+    expect(result).toContain(
+      "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+    );
+  });
+
+  it("resolves digit-only issue alert names after a numeric ID miss", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+        () => HttpResponse.json(project),
+      ),
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/123/",
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "rule"
+              ? [{ ...issueAlertRule, id: "789", name: "123" }]
+              : [],
+          );
+        },
+      ),
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/rules/789/",
+        () => HttpResponse.json({ ...issueAlertRule, id: "789", name: "123" }),
+      ),
+    );
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "issue",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "123",
+      },
+      context,
+    );
+
+    expect(result).toContain("## 123");
+    expect(result).toContain("**ID**: 789");
+  });
+
+  it("treats digit-only values as exact names with kind all", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+        () => HttpResponse.json(project),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "alert_rule"
+              ? [{ ...metricAlertRule, id: "789", name: "123" }]
+              : [],
+          );
+        },
+      ),
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/789/",
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/789/",
+        () => HttpResponse.json({ ...metricAlertRule, id: "789", name: "123" }),
+      ),
+    );
+
+    const result = await getAlertRule.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "all",
+        projectSlug: "cloudflare-mcp",
+        ruleIdOrName: "123",
+      },
+      context,
+    );
+
+    expect(result).toContain("## 123");
+    expect(result).toContain("**Kind**: Metric Alert");
+    expect(result).toContain("**ID**: 789");
+  });
+
+  it("rejects ambiguous exact-name lookups", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+        () => HttpResponse.json(project),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(
+            params.get("alertType") === "rule"
+              ? [{ ...issueAlertRule, name: "Same name" }]
+              : [{ ...metricAlertRule, name: "Same name" }],
+          );
+        },
+      ),
+    );
+
+    await expect(
+      getAlertRule.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          kind: "all",
+          projectSlug: "cloudflare-mcp",
+          ruleIdOrName: "Same name",
+        },
+        context,
+      ),
+    ).rejects.toThrow('Multiple alert rules named "Same name" were found');
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/get-alert-rule.ts
+++ b/packages/mcp-core/src/tools/catalog/get-alert-rule.ts
@@ -1,0 +1,245 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { UserInputError } from "../../errors";
+import type { IssueAlertRule, MetricAlertRule } from "../../api-client/types";
+import type { ServerContext } from "../../types";
+import {
+  ParamOrganizationSlug,
+  ParamProjectSlugOrAll,
+  ParamRegionUrl,
+} from "../../schema";
+import { assertProjectRefWithinConstraint } from "./support/project-constraints";
+import {
+  formatIssueAlertRule,
+  formatMetricAlertRule,
+  getMetricAlertRuleWithOrgFallback,
+  resolveIssueAlertRule,
+  resolveMetricAlertRule,
+} from "./support/alerts";
+
+const AlertRuleKind = z
+  .enum(["all", "issue", "metric"])
+  .describe(
+    "Which alert rule family to inspect. Use `issue` or `metric` for numeric IDs; `all` treats the value as an exact-name lookup.",
+  );
+
+type AlertRuleMatch =
+  | {
+      kind: "issue";
+      rule: IssueAlertRule;
+      projectSlug: string;
+    }
+  | {
+      kind: "metric";
+      rule: MetricAlertRule;
+      projectSlug?: string;
+    };
+
+function describeMatch(match: AlertRuleMatch): string {
+  const project = match.projectSlug ? ` project ${match.projectSlug}` : "";
+  return `${match.kind} alert ${String(match.rule.id)} (${match.rule.name})${project}`;
+}
+
+function assertMetricAlertRuleWithinProject(
+  rule: MetricAlertRule,
+  projectSlug?: string,
+): void {
+  if (!projectSlug) {
+    return;
+  }
+
+  if (!rule.projects?.includes(projectSlug)) {
+    throw new UserInputError(
+      `Metric alert rule is outside project "${projectSlug}".`,
+    );
+  }
+}
+
+export default defineTool({
+  name: "get_alert_rule",
+  skills: ["inspect"],
+  requiredScopes: ["org:read", "project:read"],
+  description: [
+    "Get details for a Sentry alert rule.",
+    "",
+    "Use this tool when you need to inspect an alert rule's exact conditions, query, triggers, and actions before explaining or planning changes.",
+    "",
+    "<examples>",
+    "get_alert_rule(organizationSlug='my-org', kind='metric', ruleIdOrName='12345')",
+    "get_alert_rule(organizationSlug='my-org', kind='issue', projectSlug='backend', ruleIdOrName='Notify backend team')",
+    "get_alert_rule(organizationSlug='my-org', projectSlug='backend', ruleIdOrName='P95 latency')",
+    "</examples>",
+    "",
+    "<hints>",
+    "- Use `kind='issue'` or `kind='metric'` for numeric IDs because issue and metric alerts use separate endpoints.",
+    "- With `kind='all'`, a digit-only `ruleIdOrName` is treated as an exact alert rule name.",
+    "- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug,
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    kind: AlertRuleKind.default("all"),
+    projectSlug: ParamProjectSlugOrAll.nullable().default(null),
+    ruleIdOrName: z
+      .string()
+      .trim()
+      .min(1)
+      .describe("The alert rule's numeric ID, or an exact alert rule name."),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const requestedProjectSlug =
+      params.projectSlug && params.projectSlug !== "all"
+        ? params.projectSlug
+        : undefined;
+    if (requestedProjectSlug) {
+      assertProjectRefWithinConstraint({
+        resourceLabel: "Alert rule",
+        scopedProjectSlug: context.constraints.projectSlug,
+        project: { slug: requestedProjectSlug },
+      });
+    }
+    const projectSlug = context.constraints.projectSlug ?? requestedProjectSlug;
+
+    if (params.kind === "issue" && !projectSlug) {
+      throw new UserInputError(
+        "projectSlug is required when inspecting an issue alert rule.",
+      );
+    }
+
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? undefined,
+    });
+    const organizationSlug = params.organizationSlug;
+    setTag("organization.slug", organizationSlug);
+    if (projectSlug) {
+      setTag("project.slug", projectSlug);
+    }
+
+    let match: AlertRuleMatch;
+    if (params.kind === "issue") {
+      const rule = await resolveIssueAlertRule(apiService, {
+        organizationSlug,
+        projectSlug: projectSlug ?? "",
+        ruleIdOrName: params.ruleIdOrName,
+      });
+      match = { kind: "issue", rule, projectSlug: projectSlug ?? "" };
+    } else if (params.kind === "metric") {
+      const rule = await resolveMetricAlertRule(apiService, {
+        organizationSlug,
+        projectSlug,
+        ruleIdOrName: params.ruleIdOrName,
+      });
+      assertMetricAlertRuleWithinProject(rule, projectSlug);
+      match = { kind: "metric", rule, projectSlug };
+    } else {
+      const matches: AlertRuleMatch[] = [];
+      if (projectSlug) {
+        const issueRules = await apiService.listIssueAlertRules({
+          organizationSlug,
+          projectSlug,
+          query: params.ruleIdOrName,
+          limit: 100,
+        });
+        matches.push(
+          ...issueRules
+            .filter(
+              (rule) =>
+                rule.name.toLowerCase() === params.ruleIdOrName.toLowerCase(),
+            )
+            .map(
+              (rule): AlertRuleMatch => ({
+                kind: "issue",
+                rule,
+                projectSlug,
+              }),
+            ),
+        );
+      }
+
+      const metricRules = await apiService.listMetricAlertRules({
+        organizationSlug,
+        projectSlug,
+        query: params.ruleIdOrName,
+        limit: 100,
+      });
+      matches.push(
+        ...metricRules
+          .filter(
+            (rule) =>
+              rule.name.toLowerCase() === params.ruleIdOrName.toLowerCase(),
+          )
+          .map(
+            (rule): AlertRuleMatch => ({
+              kind: "metric",
+              rule,
+              projectSlug,
+            }),
+          ),
+      );
+
+      if (matches.length === 0) {
+        throw new UserInputError(
+          `Alert rule "${params.ruleIdOrName}" was not found.`,
+        );
+      }
+      if (matches.length > 1) {
+        throw new UserInputError(
+          `Multiple alert rules named "${params.ruleIdOrName}" were found: ${matches.map(describeMatch).join(", ")}. Retry with the numeric rule ID and explicit kind.`,
+        );
+      }
+      const [found] = matches;
+      match =
+        found.kind === "issue"
+          ? {
+              ...found,
+              rule: await apiService.getIssueAlertRule({
+                organizationSlug,
+                projectSlug: found.projectSlug,
+                ruleId: found.rule.id,
+              }),
+            }
+          : {
+              ...found,
+              rule: await getMetricAlertRuleWithOrgFallback(apiService, {
+                organizationSlug,
+                projectSlug: found.projectSlug,
+                ruleId: found.rule.id,
+              }),
+            };
+      if (match.kind === "metric") {
+        assertMetricAlertRuleWithinProject(match.rule, match.projectSlug);
+      }
+    }
+
+    const scopeLabel = projectSlug
+      ? `${organizationSlug}/${projectSlug}`
+      : organizationSlug;
+    let output = `# Alert Rule in **${scopeLabel}**\n\n`;
+    output +=
+      match.kind === "issue"
+        ? formatIssueAlertRule(match.rule, match.projectSlug, {
+            url: apiService.getIssueAlertRuleUrl(
+              organizationSlug,
+              match.projectSlug,
+              match.rule.id,
+            ),
+          })
+        : formatMetricAlertRule(match.rule, {
+            url: apiService.getMetricAlertRuleUrl(
+              organizationSlug,
+              match.rule.id,
+            ),
+          });
+    output += "\n\n## Response Notes\n\n";
+    output +=
+      "- This tool is read-only. Treat the returned payload as the canonical source for any future clone or mutation workflow.\n";
+    return output;
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/index.ts
+++ b/packages/mcp-core/src/tools/catalog/index.ts
@@ -8,6 +8,8 @@ import findDashboards from "./find-dashboards";
 import getDashboardDetails from "./get-dashboard-details";
 import findMonitors from "./find-monitors";
 import getMonitorDetails from "./get-monitor-details";
+import findAlertRules from "./find-alert-rules";
+import getAlertRule from "./get-alert-rule";
 import getIssueDetails from "./get-issue-details";
 import getIssueActivity from "./get-issue-activity";
 import getIssueTagValues from "./get-issue-tag-values";
@@ -56,6 +58,8 @@ const catalogTools = {
   get_dashboard_details: getDashboardDetails,
   find_monitors: findMonitors,
   get_monitor_details: getMonitorDetails,
+  find_alert_rules: findAlertRules,
+  get_alert_rule: getAlertRule,
   get_issue_details: getIssueDetails,
   get_issue_activity: getIssueActivity,
   get_issue_tag_values: getIssueTagValues,

--- a/packages/mcp-core/src/tools/catalog/support/alerts.ts
+++ b/packages/mcp-core/src/tools/catalog/support/alerts.ts
@@ -1,0 +1,294 @@
+import type {
+  IssueAlertRule,
+  MetricAlertRule,
+} from "../../../api-client/types";
+import type { SentryApiService } from "../../../api-client";
+import { ApiNotFoundError } from "../../../api-client";
+import { UserInputError } from "../../../errors";
+import {
+  compactLines,
+  formatActor,
+  formatDate,
+  formatId,
+  formatUnknown,
+} from "./api-formatting";
+
+const NUMERIC_ID_PATTERN = /^\d+$/;
+
+type AlertComponent = Record<string, unknown>;
+
+export function isNumericAlertRuleId(value: string): boolean {
+  return NUMERIC_ID_PATTERN.test(value);
+}
+
+function formatComponent(component: AlertComponent): string {
+  const id = component.id;
+  if (typeof id === "string" && id.trim()) {
+    const { id: _id, ...params } = component;
+    if (Object.keys(params).length === 0) {
+      return id;
+    }
+    return `${id} ${formatUnknown(params)}`;
+  }
+  return formatUnknown(component);
+}
+
+function formatComponentSummary(
+  label: string,
+  components: AlertComponent[] | undefined,
+  headingLevel: number,
+): string[] {
+  if (!components || components.length === 0) {
+    return [];
+  }
+  const heading = "#".repeat(Math.min(headingLevel, 6));
+  const lines = [`${heading} ${label}`, ""];
+  for (const component of components.slice(0, 5)) {
+    lines.push(`- ${formatComponent(component)}`);
+  }
+  if (components.length > 5) {
+    lines.push(`- ...and ${components.length - 5} more`);
+  }
+  return lines;
+}
+
+export function formatIssueAlertRule(
+  rule: IssueAlertRule,
+  projectSlug: string,
+  options: {
+    headingLevel?: number;
+    includeComponents?: boolean;
+    url?: string;
+  } = {},
+): string {
+  const headingLevel = options.headingLevel ?? 2;
+  const includeComponents = options.includeComponents ?? true;
+  const heading = "#".repeat(Math.min(headingLevel, 6));
+  const owner = rule.owner ? formatActor(rule.owner) : null;
+  const lines = compactLines([
+    `${heading} ${rule.name}`,
+    "",
+    `**Kind**: Issue Alert`,
+    `**ID**: ${formatId(rule.id)}`,
+    `**Project**: ${projectSlug}`,
+    rule.status ? `**Status**: ${rule.status}` : null,
+    rule.actionMatch ? `**Action Match**: ${rule.actionMatch}` : null,
+    rule.filterMatch ? `**Filter Match**: ${rule.filterMatch}` : null,
+    rule.frequency !== undefined && rule.frequency !== null
+      ? `**Frequency**: ${rule.frequency} minutes`
+      : null,
+    rule.environment ? `**Environment**: ${rule.environment}` : null,
+    owner ? `**Owner**: ${owner}` : null,
+    formatDate(rule.dateCreated)
+      ? `**Created**: ${formatDate(rule.dateCreated)}`
+      : null,
+    options.url ? `**URL**: ${options.url}` : null,
+  ]);
+
+  if (includeComponents) {
+    lines.push(
+      ...formatComponentSummary(
+        "Conditions",
+        rule.conditions,
+        headingLevel + 1,
+      ),
+      ...formatComponentSummary("Filters", rule.filters, headingLevel + 1),
+      ...formatComponentSummary("Actions", rule.actions, headingLevel + 1),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export function formatMetricAlertRule(
+  rule: MetricAlertRule,
+  options: {
+    headingLevel?: number;
+    includeComponents?: boolean;
+    url?: string;
+  } = {},
+): string {
+  const headingLevel = options.headingLevel ?? 2;
+  const includeComponents = options.includeComponents ?? true;
+  const heading = "#".repeat(Math.min(headingLevel, 6));
+  const owner = rule.owner ? formatActor(rule.owner) : null;
+  const projects = rule.projects ?? [];
+  const lines = compactLines([
+    `${heading} ${rule.name}`,
+    "",
+    `**Kind**: Metric Alert`,
+    `**ID**: ${formatId(rule.id)}`,
+    rule.status !== undefined
+      ? `**Status**: ${formatUnknown(rule.status)}`
+      : null,
+    rule.dataset ? `**Dataset**: ${rule.dataset}` : null,
+    rule.aggregate ? `**Aggregate**: ${rule.aggregate}` : null,
+    rule.query ? `**Query**: ${rule.query}` : null,
+    rule.timeWindow !== undefined && rule.timeWindow !== null
+      ? `**Time Window**: ${rule.timeWindow} minutes`
+      : null,
+    projects.length > 0 ? `**Projects**: ${projects.join(", ")}` : null,
+    rule.environment ? `**Environment**: ${rule.environment}` : null,
+    owner ? `**Owner**: ${owner}` : null,
+    formatDate(rule.dateCreated)
+      ? `**Created**: ${formatDate(rule.dateCreated)}`
+      : null,
+    options.url ? `**URL**: ${options.url}` : null,
+  ]);
+
+  if (includeComponents) {
+    lines.push(
+      ...formatComponentSummary("Triggers", rule.triggers, headingLevel + 1),
+    );
+  }
+  return lines.join("\n");
+}
+
+async function findExactIssueAlertRuleMatches(
+  apiService: SentryApiService,
+  params: {
+    organizationSlug: string;
+    projectSlug: string;
+    ruleName: string;
+  },
+): Promise<IssueAlertRule[]> {
+  const rules = await apiService.listIssueAlertRules({
+    organizationSlug: params.organizationSlug,
+    projectSlug: params.projectSlug,
+    query: params.ruleName,
+    limit: 100,
+  });
+  return rules.filter(
+    (rule) => rule.name.toLowerCase() === params.ruleName.toLowerCase(),
+  );
+}
+
+async function findExactMetricAlertRuleMatches(
+  apiService: SentryApiService,
+  params: {
+    organizationSlug: string;
+    projectSlug?: string;
+    ruleName: string;
+  },
+): Promise<MetricAlertRule[]> {
+  const rules = await apiService.listMetricAlertRules({
+    organizationSlug: params.organizationSlug,
+    projectSlug: params.projectSlug,
+    query: params.ruleName,
+    limit: 100,
+  });
+  return rules.filter(
+    (rule) => rule.name.toLowerCase() === params.ruleName.toLowerCase(),
+  );
+}
+
+export async function getMetricAlertRuleWithOrgFallback(
+  apiService: SentryApiService,
+  params: {
+    organizationSlug: string;
+    projectSlug?: string;
+    ruleId: string | number;
+  },
+): Promise<MetricAlertRule> {
+  try {
+    return await apiService.getMetricAlertRule(params);
+  } catch (error) {
+    if (!(error instanceof ApiNotFoundError) || !params.projectSlug) {
+      throw error;
+    }
+  }
+  return apiService.getMetricAlertRule({
+    organizationSlug: params.organizationSlug,
+    ruleId: params.ruleId,
+  });
+}
+
+export async function resolveIssueAlertRule(
+  apiService: SentryApiService,
+  params: {
+    organizationSlug: string;
+    projectSlug: string;
+    ruleIdOrName: string;
+  },
+): Promise<IssueAlertRule> {
+  if (isNumericAlertRuleId(params.ruleIdOrName)) {
+    try {
+      return await apiService.getIssueAlertRule({
+        organizationSlug: params.organizationSlug,
+        projectSlug: params.projectSlug,
+        ruleId: params.ruleIdOrName,
+      });
+    } catch (error) {
+      if (!(error instanceof ApiNotFoundError)) {
+        throw error;
+      }
+    }
+  }
+
+  const matches = await findExactIssueAlertRuleMatches(apiService, {
+    organizationSlug: params.organizationSlug,
+    projectSlug: params.projectSlug,
+    ruleName: params.ruleIdOrName,
+  });
+
+  if (matches.length === 1) {
+    return apiService.getIssueAlertRule({
+      organizationSlug: params.organizationSlug,
+      projectSlug: params.projectSlug,
+      ruleId: matches[0].id,
+    });
+  }
+  if (matches.length > 1) {
+    throw new UserInputError(
+      `Multiple issue alert rules named "${params.ruleIdOrName}" were found. Retry with the numeric rule ID.`,
+    );
+  }
+  throw new UserInputError(
+    `Issue alert rule "${params.ruleIdOrName}" was not found in project ${params.projectSlug}.`,
+  );
+}
+
+export async function resolveMetricAlertRule(
+  apiService: SentryApiService,
+  params: {
+    organizationSlug: string;
+    projectSlug?: string;
+    ruleIdOrName: string;
+  },
+): Promise<MetricAlertRule> {
+  if (isNumericAlertRuleId(params.ruleIdOrName)) {
+    try {
+      return await getMetricAlertRuleWithOrgFallback(apiService, {
+        organizationSlug: params.organizationSlug,
+        projectSlug: params.projectSlug,
+        ruleId: params.ruleIdOrName,
+      });
+    } catch (error) {
+      if (!(error instanceof ApiNotFoundError)) {
+        throw error;
+      }
+    }
+  }
+
+  const matches = await findExactMetricAlertRuleMatches(apiService, {
+    organizationSlug: params.organizationSlug,
+    projectSlug: params.projectSlug,
+    ruleName: params.ruleIdOrName,
+  });
+
+  if (matches.length === 1) {
+    return getMetricAlertRuleWithOrgFallback(apiService, {
+      organizationSlug: params.organizationSlug,
+      projectSlug: params.projectSlug,
+      ruleId: matches[0].id,
+    });
+  }
+  if (matches.length > 1) {
+    throw new UserInputError(
+      `Multiple metric alert rules named "${params.ruleIdOrName}" were found. Retry with the numeric rule ID.`,
+    );
+  }
+  throw new UserInputError(
+    `Metric alert rule "${params.ruleIdOrName}" was not found.`,
+  );
+}


### PR DESCRIPTION
Add read-only catalog tools for finding and inspecting Sentry alert rules. The new `find_alert_rules` tool returns compact issue and metric alert summaries, while `get_alert_rule` resolves a numeric ID or exact name and returns the detailed rule payload, including condition/action parameters needed for planning future clone or mutation workflows.

The API client uses Sentry's supported issue and metric alert endpoints for direct list/get calls, and routes name search through `combined-rules` with `name`, `alertType`, and numeric project scoping verified against upstream Sentry. The schemas stay permissive for workflow-engine responses, including nullable issue match fields. Validation passed with root typecheck, lint, and test, plus focused alert-rule catalog tests.
