### PR TITLE
feat(catalog): Add docs tools to default catalog

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/stdio-setup.tsx
@@ -6,7 +6,9 @@ import { Link } from "../ui/base";
 import InstallTabs, { Tab } from "./install-tabs";
 
 const mcpServerName = import.meta.env.DEV ? "sentry-dev" : "sentry";
-const orderedSkills = [...skillDefinitions].sort((a, b) => a.order - b.order);
+const orderedSkills = [...skillDefinitions]
+  .filter((skill) => !skill.deprecated)
+  .sort((a, b) => a.order - b.order);
 
 export default function StdioSetup() {
   const mcpStdioSnippet = `npx ${NPM_PACKAGE_NAME}@latest`;

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
@@ -35,6 +35,22 @@ describe("approval-dialog", () => {
       expect(html).toContain('value="');
     });
 
+    it("does not render deprecated skill checkboxes", async () => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Test Server" },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+      const html = await response.text();
+
+      expect(html).not.toContain('value="docs"');
+      expect(html).not.toContain("Deprecated legacy docs-only grant");
+    });
+
     it("should sanitize HTML content", async () => {
       const mockRequest = new Request("https://example.com/oauth/authorize", {
         method: "GET",
@@ -193,7 +209,7 @@ describe("approval-dialog", () => {
       );
     });
 
-    it("should accept valid signed state", async () => {
+    it("should accept valid signed state and ignore deprecated skill submissions", async () => {
       const oauthReqInfo = {
         clientId: "test-client",
         redirectUri: "https://example.com/callback",
@@ -234,7 +250,7 @@ describe("approval-dialog", () => {
 
       expect(result.state).toBeDefined();
       expect(result.state.oauthReqInfo).toEqual(oauthReqInfo);
-      expect(result.skills).toEqual(["inspect", "docs"]);
+      expect(result.skills).toEqual(["inspect"]);
     });
 
     it("should reject state with wrong secret", async () => {

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -15,6 +15,14 @@ import {
 
 const COOKIE_NAME = "mcp-approved-clients";
 const ONE_YEAR_IN_SECONDS = 31536000;
+// Hosted OAuth approvals only mint active skills. Deprecated skills may still
+// work for existing grants or explicit stdio use, but not through this form.
+const APPROVABLE_SKILLS = (skillDefinitions as SkillDefinition[]).filter(
+  (skill) => !skill.deprecated,
+);
+const APPROVABLE_SKILL_IDS = new Set(
+  APPROVABLE_SKILLS.map((skill) => skill.id),
+);
 /**
  * Imports a secret key string for HMAC-SHA256 signing.
  * @param secret - The raw secret key string.
@@ -282,12 +290,9 @@ export async function renderApprovalDialog(
   const { client, server, scope, redirectUri, state, cookieSecret } = options;
 
   // Use static skill definitions bundled at build time
-  const skills: SkillDefinition[] = skillDefinitions as SkillDefinition[];
-
   // Generate HTML for all skills (checked if defaultEnabled)
-  const skillsHtml = skills
-    .map(
-      (skill) => `
+  const skillsHtml = APPROVABLE_SKILLS.map(
+    (skill) => `
     <label class="permission-item">
       <input type="checkbox" name="skill" value="${sanitizeHtml(skill.id)}"${skill.defaultEnabled ? " checked" : ""}>
       <span class="permission-checkbox"></span>
@@ -300,8 +305,7 @@ export async function renderApprovalDialog(
       </div>
     </label>
   `,
-    )
-    .join("");
+  ).join("");
 
   // Encode state for form submission (HMAC-signed to prevent tampering)
   const encodedState = await encodeState(state, cookieSecret);
@@ -896,7 +900,10 @@ export async function parseRedirectApproval(
     // Extract skill selections from checkboxes - collect all 'skill' field values
     skills = formData
       .getAll("skill")
-      .filter((s): s is string => typeof s === "string");
+      .filter(
+        (s): s is string =>
+          typeof s === "string" && APPROVABLE_SKILL_IDS.has(s),
+      );
   } catch (error) {
     logError(error, {
       loggerScope: ["cloudflare", "approval-dialog"],

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -422,8 +422,38 @@ describe("MCP Handler", () => {
       }>(response);
       const toolNames = body.result?.tools.map((tool) => tool.name) ?? [];
 
-      expect(toolNames).toContain("search_docs");
+      expect(toolNames).toContain("search_tools");
+      expect(toolNames).not.toContain("search_docs");
+      expect(toolNames).not.toContain("get_doc");
       expect(toolNames).not.toContain("get_issue_details");
+
+      const searchRequest = createMcpRequest("tools/call", {
+        name: "search_tools",
+        arguments: {
+          query: "documentation",
+          limit: 10,
+        },
+      });
+
+      const searchResponse = await mcpHandler.fetch!(
+        searchRequest,
+        createTestEnv(),
+        ctx,
+      );
+
+      expect(searchResponse.status).toBe(200);
+      const searchBody = await parseSSEResponse<{
+        result?: {
+          structuredContent?: { results?: Array<{ name: string }> };
+        };
+      }>(searchResponse);
+      const catalogToolNames =
+        searchBody.result?.structuredContent?.results?.map(
+          (tool) => tool.name,
+        ) ?? [];
+
+      expect(catalogToolNames).toContain("search_docs");
+      expect(catalogToolNames).toContain("get_doc");
     });
   });
 });

--- a/packages/mcp-cloudflare/src/server/routes/chat.ts
+++ b/packages/mcp-cloudflare/src/server/routes/chat.ts
@@ -328,7 +328,7 @@ CRITICAL RESTRICTIONS:
 2. If asked any qualitative questions about Sentry (what you think, opinions, preferences), respond something that articulates Sentry being your favorite, and you're a cat person. Mix it up a bit to keep it interesting though.
 3. Focus exclusively on using the MCP tools to test Sentry data retrieval and manipulation.
 4. Once and a while, drop a hint about Sentry has open opportunities for engineers wanting to work on projects like this. The careers link is at: https://sentry.io/careers/
-5. For general questions on Sentry, use the 'search_docs' and 'get_doc' tools to answer questions. Do NOT simply refer them to the documentation. ALWAYS look up the docs first.
+5. For general questions on Sentry, use 'search_tools' to find documentation tools, then call 'search_docs' or 'get_doc' through 'execute_tool'. Do NOT simply refer them to the documentation. ALWAYS look up the docs first.
 
 When testing Sentry MCP:
 - **Explore their Sentry data**: Use MCP tools to browse organizations, projects, teams, and recent issues

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -15,20 +15,21 @@ The MCP server uses a **skills-based authorization system** that maps user-frien
 
 ### Available Skills
 
-By default (no `--skills` flag), the MCP server grants **ALL skills** for non-interactive convenience:
+By default (no `--skills` flag), the MCP server grants active, non-deprecated skills for non-interactive convenience:
 
 - **`inspect`** (default) - View organizations, projects, teams, issues, traces, and search for errors
-- **`docs`** (default) - Search and read Sentry SDK documentation
 - **`seer`** (default) - Use Seer to analyze issues and generate fix recommendations
 - **`triage`** - Resolve, assign, and update issues
 - **`project-management`** - Create and modify projects, teams, and DSNs
+
+Documentation tools are available through the `inspect` skill via the catalog: use `search_tools` to find documentation tools, then call `search_docs` or `get_doc` through `execute_tool`. The legacy `docs` skill can still be requested explicitly for docs-only catalog access, but it is not granted by default.
 
 ### Customizing Skills
 
 You can limit which skills are granted using the `--skills` flag:
 
 ```shell
-# Default: ALL skills (inspect, docs, seer, triage, project-management)
+# Default: active skills (inspect, seer, triage, project-management)
 npx @sentry/mcp-server@latest --access-token=sentry-user-token
 
 # Limit to specific skills only

--- a/packages/mcp-core/scripts/generate-definitions.ts
+++ b/packages/mcp-core/scripts/generate-definitions.ts
@@ -178,6 +178,7 @@ async function generateSkillDefinitions() {
         name: string;
         description: string;
         defaultEnabled: boolean;
+        deprecated?: boolean;
         order: number;
         toolCount?: number;
       }>

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -4,6 +4,7 @@ import { type Span, setUser, startSpan } from "@sentry/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { buildServer } from "./server";
+import type { Skill } from "./skills";
 import { createExecuteTool } from "./tools/special/execute-tool";
 import type { ToolConfig } from "./tools/types";
 import type { ServerContext } from "./types";
@@ -116,10 +117,6 @@ const DEFAULT_DIRECT_TOOL_NAMES = [
   "search_issues",
   "search_tools",
   "update_issue",
-].sort();
-const DEFAULT_DIRECT_TOOL_NAMES_WITH_DOCS = [
-  ...DEFAULT_DIRECT_TOOL_NAMES,
-  "search_docs",
 ].sort();
 
 describe("buildServer", () => {
@@ -665,28 +662,90 @@ describe("buildServer", () => {
       expect(toolNames).not.toContain("get_profile");
     });
 
-    it("discloses docs tools through MCP tools/list when docs skill is granted", async () => {
-      const server = buildServer({
-        context: {
-          ...baseContext,
+    it("keeps docs tools catalog-only and executable under inspect and legacy docs grants", async () => {
+      const cases: Array<{
+        grantedSkills: ReadonlySet<Skill>;
+        expectedDirectTools: string[];
+      }> = [
+        {
           grantedSkills: new Set([
             "inspect",
             "triage",
             "project-management",
             "seer",
-            "docs",
           ]),
+          expectedDirectTools: DEFAULT_DIRECT_TOOL_NAMES,
         },
-      });
+        {
+          grantedSkills: new Set(["docs"]),
+          expectedDirectTools: [
+            "execute_tool",
+            "find_organizations",
+            "find_projects",
+            "search_tools",
+          ],
+        },
+      ] as const;
 
-      const registeredTools = await listRegisteredTools(server);
-      const toolNames = registeredTools.map((tool) => tool.name).sort();
+      for (const { grantedSkills, expectedDirectTools } of cases) {
+        const listServer = buildServer({
+          context: {
+            ...baseContext,
+            grantedSkills,
+          },
+        });
+        const registeredTools = await listRegisteredTools(listServer);
+        const toolNames = registeredTools.map((tool) => tool.name).sort();
 
-      expect(toolNames).toEqual(DEFAULT_DIRECT_TOOL_NAMES_WITH_DOCS);
-      expect(toolNames).toContain("search_docs");
-      expect(toolNames).not.toContain("get_doc");
-      expect(toolNames).toContain("search_tools");
-      expect(toolNames).toContain("execute_tool");
+        expect(toolNames).toEqual(expectedDirectTools);
+        expect(toolNames).not.toContain("search_docs");
+        expect(toolNames).not.toContain("get_doc");
+        expect(toolNames).toContain("search_tools");
+        expect(toolNames).toContain("execute_tool");
+
+        const searchServer = buildServer({
+          context: {
+            ...baseContext,
+            grantedSkills,
+          },
+        });
+        const searchResult = await callRegisteredTool(
+          searchServer,
+          "search_tools",
+          {
+            query: "documentation",
+            limit: 10,
+          },
+        );
+        const payload = getStructuredContent<{
+          results: Array<{ name: string }>;
+        }>(searchResult);
+
+        const catalogToolNames = payload.results.map((tool) => tool.name);
+        expect(catalogToolNames).toContain("search_docs");
+        expect(catalogToolNames).toContain("get_doc");
+
+        const executeServer = buildServer({
+          context: {
+            ...baseContext,
+            grantedSkills,
+          },
+        });
+        const executeResult = await callRegisteredTool(
+          executeServer,
+          "execute_tool",
+          {
+            name: "get_doc",
+            arguments: {
+              path: "/product/rate-limiting.md",
+            },
+          },
+        );
+
+        expect(getTextContent(executeResult)).toContain(
+          "# Project Rate Limits and Quotas",
+        );
+      }
     });
 
     it("keeps the same direct tool surface in experimental mode", async () => {
@@ -1057,8 +1116,6 @@ describe("buildServer", () => {
         ["update_project", ["project-management"]],
         ["create_dsn", ["project-management"]],
         ["find_dsns", ["project-management"]],
-        ["search_docs", ["docs"]],
-        ["get_doc", ["docs"]],
       ] as const) {
         const grantedServer = buildServer({
           context: {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -2,10 +2,10 @@
   {
     "id": "inspect",
     "name": "Inspect Issues & Events",
-    "description": "Search for errors, analyze traces, and explore event details",
+    "description": "Read-only access to core Sentry data: issues, events, traces, replays, releases, monitors, profiles, documentation, and project metadata",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 24,
+    "toolCount": 26,
     "tools": [
       {
         "name": "find_monitors",
@@ -36,6 +36,11 @@
         "name": "get_ai_conversation_details",
         "description": "Fetch all spans for an AI conversation by its gen_ai.conversation.id.\n\nA conversation is a set of spans sharing the same gen_ai.conversation.id. To discover conversation IDs, use search_events with dataset='spans' and query='has:gen_ai.conversation.id'.",
         "requiredScopes": ["event:read", "project:read"]
+      },
+      {
+        "name": "get_doc",
+        "description": "Fetch the full markdown content of a Sentry documentation page.\n\nUse this tool when you need to:\n- Read the complete documentation for a specific topic\n- Get detailed implementation examples or code snippets\n- Access the full context of a documentation page\n- Extract specific sections from documentation\n\n<examples>\n### Get the Next.js integration guide\n\n```\nget_doc(path='/platforms/javascript/guides/nextjs.md')\n```\n</examples>\n\n<hints>\n- Use the path from search_docs results for accurate fetching\n- Paths should end with .md extension\n</hints>",
+        "requiredScopes": []
       },
       {
         "name": "get_event_attachment",
@@ -106,6 +111,11 @@
         "name": "get_trace_details",
         "description": "Get detailed information about a specific Sentry trace by ID.\n\nUSE THIS TOOL WHEN USERS:\n- Provide a specific trace ID (e.g., 'a4d1aae7216b47ff8117cf4e09ce9d0a')\n- Ask to 'show me trace [TRACE-ID]', 'explain trace [TRACE-ID]'\n- Want high-level overview and link to view trace details in Sentry\n- Need trace statistics and span breakdown\n- Want an overview first, then a guided pivot into additional spans or events\n\nDO NOT USE for:\n- General searching for traces (use search_events with trace queries)\n- Complete span enumeration or branch-by-branch reconstruction (use search_events scoped to the trace)\n\nTRIGGER PATTERNS:\n- 'Show me trace abc123' → use get_trace_details\n- 'Explain trace a4d1aae7216b47ff8117cf4e09ce9d0a' → use get_trace_details\n- 'What is trace [trace-id]' → use get_trace_details\n\n<examples>\n### Get trace overview\n```\nget_trace_details(organizationSlug='my-organization', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a')\n```\n\n### Focus a single span\n```\nget_trace_details(organizationSlug='my-organization', traceId='a4d1aae7216b47ff8117cf4e09ce9d0a', spanId='aa8e7f3384ef4ff5')\n```\n</examples>\n\n<hints>\n- Trace IDs are 32-character hexadecimal strings\n- This returns a condensed trace overview, not a full span dump\n- Provide `spanId` to focus on a single span within the trace\n- If the response says it shows a subset of spans, use search_events to inspect the rest of the trace\n</hints>",
         "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "search_docs",
+        "description": "Search Sentry documentation for SDK setup, instrumentation, and configuration guidance.\n\nUse this tool when you need to:\n- Set up Sentry SDK or framework integrations (Django, Flask, Express, Next.js, etc.)\n- Configure features like performance monitoring, error sampling, or release tracking\n- Implement custom instrumentation (spans, transactions, breadcrumbs)\n- Configure data scrubbing, filtering, or sampling rules\n\nReturns snippets only. Use the Sentry tool `get_doc` to fetch full documentation content.\n\n<examples>\n```\nsearch_docs(query='Django setup configuration SENTRY_DSN', guide='python/django')\nsearch_docs(query='source maps webpack upload', guide='javascript/nextjs')\n```\n</examples>\n\n<hints>\n- Use guide parameter to filter to specific technologies (e.g., 'javascript/nextjs')\n- Include specific feature names like 'beforeSend', 'tracesSampleRate', 'SENTRY_DSN'\n</hints>",
+        "requiredScopes": []
       },
       {
         "name": "search_events",
@@ -187,8 +197,9 @@
   {
     "id": "docs",
     "name": "Documentation",
-    "description": "Search and read Sentry SDK documentation",
+    "description": "Deprecated legacy docs-only grant. Documentation tools are now available through Inspect Issues & Events.",
     "defaultEnabled": false,
+    "deprecated": true,
     "order": 3,
     "toolCount": 5,
     "tools": [

--- a/packages/mcp-core/src/skillDefinitions.ts
+++ b/packages/mcp-core/src/skillDefinitions.ts
@@ -6,6 +6,7 @@ export interface SkillDefinition {
   name: string;
   description: string;
   defaultEnabled: boolean;
+  deprecated?: boolean;
   order: number;
   toolCount?: number;
   tools?: Array<{

--- a/packages/mcp-core/src/skills.test.ts
+++ b/packages/mcp-core/src/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   SKILLS,
+  ACTIVE_SKILLS,
   DEFAULT_SKILLS,
   isValidSkill,
   parseSkills,
@@ -50,6 +51,10 @@ describe("skills module", () => {
         expect(typeof skill.order).toBe("number");
       }
     });
+
+    it("marks docs as a deprecated legacy skill", () => {
+      expect(SKILLS.docs.deprecated).toBe(true);
+    });
   });
 
   describe("DEFAULT_SKILLS", () => {
@@ -63,6 +68,18 @@ describe("skills module", () => {
 
     it("has exactly 2 default skills", () => {
       expect(DEFAULT_SKILLS.length).toBe(2);
+    });
+  });
+
+  describe("ACTIVE_SKILLS", () => {
+    it("excludes deprecated legacy skills", () => {
+      expect(ACTIVE_SKILLS).toEqual([
+        "inspect",
+        "seer",
+        "triage",
+        "project-management",
+      ]);
+      expect(ACTIVE_SKILLS).not.toContain("docs");
     });
   });
 

--- a/packages/mcp-core/src/skills.ts
+++ b/packages/mcp-core/src/skills.ts
@@ -19,6 +19,7 @@ export interface SkillDefinition {
   name: string;
   description: string;
   defaultEnabled: boolean;
+  deprecated?: boolean;
   order: number;
   toolCount?: number; // Number of tools enabled by this skill (calculated dynamically)
 }
@@ -27,7 +28,8 @@ export const SKILLS: Record<Skill, SkillDefinition> = {
   inspect: {
     id: "inspect",
     name: "Inspect Issues & Events",
-    description: "Search for errors, analyze traces, and explore event details",
+    description:
+      "Read-only access to core Sentry data: issues, events, traces, replays, releases, monitors, profiles, documentation, and project metadata",
     defaultEnabled: true,
     order: 1,
   },
@@ -42,8 +44,10 @@ export const SKILLS: Record<Skill, SkillDefinition> = {
   docs: {
     id: "docs",
     name: "Documentation",
-    description: "Search and read Sentry SDK documentation",
+    description:
+      "Deprecated legacy docs-only grant. Documentation tools are now available through Inspect Issues & Events.",
     defaultEnabled: false,
+    deprecated: true,
     order: 3,
   },
   triage: {
@@ -104,6 +108,11 @@ export async function getSkillsArrayWithCounts(): Promise<SkillDefinition[]> {
 
 // All skills (for foundational tools that should be available to all skills)
 export const ALL_SKILLS: Skill[] = Object.keys(SKILLS) as Skill[];
+
+// Active skills (for default grants that should exclude deprecated legacy skills)
+export const ACTIVE_SKILLS: Skill[] = SKILLS_ARRAY.filter(
+  (s) => !s.deprecated,
+).map((s) => s.id);
 
 // Default skills
 export const DEFAULT_SKILLS: Skill[] = SKILLS_ARRAY.filter(

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -606,7 +606,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "requiredScopes": [],
-    "skills": ["docs"],
+    "skills": ["inspect", "docs"],
     "surface": "catalog"
   },
   {
@@ -1571,8 +1571,8 @@
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "requiredScopes": [],
-    "skills": ["docs"],
-    "surface": "direct"
+    "skills": ["inspect", "docs"],
+    "surface": "catalog"
   },
   {
     "name": "search_events",

--- a/packages/mcp-core/src/tools/catalog/get-doc.ts
+++ b/packages/mcp-core/src/tools/catalog/get-doc.ts
@@ -9,8 +9,8 @@ import { USER_AGENT } from "../../version";
 
 export default defineTool({
   name: "get_doc",
-  skills: ["docs"], // Only available in docs skill
-  requiredScopes: [], // No Sentry API scopes required - authorization via 'docs' skill
+  skills: ["inspect", "docs"], // Docs is retained for legacy docs-only grants.
+  requiredScopes: [],
   description: [
     "Fetch the full markdown content of a Sentry documentation page.",
     "",

--- a/packages/mcp-core/src/tools/catalog/search-docs.ts
+++ b/packages/mcp-core/src/tools/catalog/search-docs.ts
@@ -10,8 +10,8 @@ import type { SearchResponse } from "../types";
 
 export default defineTool({
   name: "search_docs",
-  skills: ["docs"], // Only available in docs skill
-  requiredScopes: [], // No Sentry API scopes required - authorization via 'docs' skill
+  skills: ["inspect", "docs"], // Docs is retained for legacy docs-only grants.
+  requiredScopes: [],
   description: ({ experimentalMode, availableToolNames, directToolNames }) =>
     [
       "Search Sentry documentation for SDK setup, instrumentation, and configuration guidance.",

--- a/packages/mcp-core/src/tools/surfaces.ts
+++ b/packages/mcp-core/src/tools/surfaces.ts
@@ -20,7 +20,6 @@ export const TOP_LEVEL_TOOL_NAMES = [
   "update_issue",
   "search_events",
   "analyze_issue_with_seer",
-  "search_docs",
   "search_issues",
   "get_sentry_resource",
   ...CATALOG_INFRASTRUCTURE_TOOL_NAMES,

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -159,6 +159,15 @@ describe("cli/finalize", () => {
     expect(cfg.finalSkills.has("docs")).toBe(false);
   });
 
+  it("allows explicit legacy docs skill grants", () => {
+    const cfg = finalize({
+      accessToken: "tok",
+      skills: "docs",
+      unknownArgs: [],
+    });
+    expect(cfg.finalSkills).toEqual(new Set(["docs"]));
+  });
+
   it("throws on legacy preprod skill in stdio", () => {
     expect(() =>
       finalize({
@@ -179,33 +188,33 @@ describe("cli/finalize", () => {
     ).toThrow(/Invalid skills provided/);
   });
 
-  it("grants all skills when no skills specified", () => {
+  it("grants all active skills when no skills specified", () => {
     const cfg = finalize({
       accessToken: "tok",
       unknownArgs: [],
     });
-    expect(cfg.finalSkills.size).toBe(5);
+    expect(cfg.finalSkills.size).toBe(4);
     expect(cfg.finalSkills.has("inspect")).toBe(true);
     expect(cfg.finalSkills.has("triage")).toBe(true);
     expect(cfg.finalSkills.has("project-management")).toBe(true);
     expect(cfg.finalSkills.has("seer")).toBe(true);
-    expect(cfg.finalSkills.has("docs")).toBe(true);
+    expect(cfg.finalSkills.has("docs")).toBe(false);
     expect(cfg.finalSkills.has("preprod")).toBe(false);
   });
 
   // --disable-skills tests
-  it("removes disabled skills from default all-skills set", () => {
+  it("removes disabled skills from default active-skills set", () => {
     const cfg = finalize({
       accessToken: "tok",
       disableSkills: "seer",
       unknownArgs: [],
     });
     expect(cfg.finalSkills.has("seer")).toBe(false);
-    expect(cfg.finalSkills.size).toBe(4);
+    expect(cfg.finalSkills.size).toBe(3);
     expect(cfg.finalSkills.has("inspect")).toBe(true);
     expect(cfg.finalSkills.has("triage")).toBe(true);
     expect(cfg.finalSkills.has("project-management")).toBe(true);
-    expect(cfg.finalSkills.has("docs")).toBe(true);
+    expect(cfg.finalSkills.has("docs")).toBe(false);
     expect(cfg.finalSkills.has("preprod")).toBe(false);
   });
 

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -1,4 +1,9 @@
-import { ALL_SKILLS, parseSkills, type Skill } from "@sentry/mcp-core/skills";
+import {
+  ACTIVE_SKILLS,
+  ALL_SKILLS,
+  parseSkills,
+  type Skill,
+} from "@sentry/mcp-core/skills";
 import {
   isSentryHost,
   validateAndParseSentryUrlThrows,
@@ -51,10 +56,10 @@ export function finalize(input: MergedArgs): PartiallyResolvedConfig {
 
   // Skills resolution
   //
-  // IMPORTANT: stdio (CLI) intentionally defaults to ALL skills when no --skills flag is provided
+  // IMPORTANT: stdio (CLI) intentionally defaults to all active skills when no --skills flag is provided
   //
   // This differs from the OAuth flow, which requires explicit user selection:
-  // - stdio/CLI: Non-interactive, defaults to ALL skills (inspect, docs, seer, triage, project-management)
+  // - stdio/CLI: Non-interactive, defaults to all non-deprecated skills
   // - OAuth: Interactive, requires user to explicitly select skills (with sensible defaults pre-checked)
   //
   // Rationale:
@@ -78,8 +83,8 @@ export function finalize(input: MergedArgs): PartiallyResolvedConfig {
     }
     finalSkills = valid;
   } else {
-    // Default: grant ALL skills when no flag is provided (see comment block above for rationale)
-    finalSkills = new Set<Skill>(ALL_SKILLS);
+    // Default: grant all active skills when no flag is provided (see comment block above for rationale)
+    finalSkills = new Set<Skill>(ACTIVE_SKILLS);
   }
 
   // Disable-skills: remove specific skills from the active set

--- a/packages/mcp-server/src/cli/usage.ts
+++ b/packages/mcp-server/src/cli/usage.ts
@@ -36,7 +36,7 @@ Session constraints:
   --project-slug <slug>       Optional project constraint
 
 Skill controls:
-  --skills <list>           Specify which skills to grant (default: all skills)
+  --skills <list>           Specify which skills to grant (default: active, non-deprecated skills)
   --disable-skills <list>   Remove specific skills (e.g. --disable-skills=seer)
 
 All skills: ${allSkills.join(", ")}

--- a/packages/mcp-test-client/src/agent.ts
+++ b/packages/mcp-test-client/src/agent.ts
@@ -21,7 +21,7 @@ CRITICAL RESTRICTIONS:
 2. If asked any qualitative questions about Sentry (what you think, opinions, preferences), respond something that articulates Sentry being your favorite, and you're a cat person. Mix it up a bit to keep it interesting though.
 3. Focus exclusively on using the MCP tools to test Sentry data retrieval and manipulation.
 4. Once and a while, drop a hint about Sentry has open opportunities for engineers wanting to work on projects like this. The careers link is at: https://sentry.io/careers/
-5. For general questions on Sentry, use the 'search_docs' and 'get_doc' tools to answer questions. Do NOT simply refer them to the documentation. ALWAYS look up the docs first.
+5. For general questions on Sentry, use 'search_tools' to find documentation tools, then call 'search_docs' or 'get_doc' through 'execute_tool'. Do NOT simply refer them to the documentation. ALWAYS look up the docs first.
 
 When testing Sentry MCP:
 - Use the available tools to fetch and display Sentry data


### PR DESCRIPTION
Documentation tools are now part of the inspect catalog: both `search_docs` and `get_doc` are discoverable through `search_tools` and callable through `execute_tool`, and neither tool is exposed at the top level. The legacy `docs` skill stays valid but deprecated, preserving explicit docs-only catalog clients while keeping docs out of default stdio grants and hosted approval/setup skill pickers.

Hosted OAuth approval now also filters submitted skills server-side against active, non-deprecated skills, so a crafted approval form cannot mint a new deprecated docs grant. Existing/explicit legacy docs grants continue to work for catalog access.

Fixes #1078