### PR TITLE
Update redirect uri validation and consent dialog

### DIFF
--- a/packages/mcp-cloudflare/src/server/index.test.ts
+++ b/packages/mcp-cloudflare/src/server/index.test.ts
@@ -287,6 +287,50 @@ describe("worker entrypoint", () => {
     expect(header.match(/resource_metadata\s*=/gi)?.length).toBe(1);
   });
 
+  it("rejects client registration with a userinfo-spoofed redirect URI", async () => {
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Sentry MCP",
+          redirect_uris: ["https://mcp.sentry.dev@example.io/callback"],
+        }),
+      }),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe("invalid_redirect_uri");
+    expect(mockOAuthProviderFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows client registration with legitimate redirect URIs", async () => {
+    mockOAuthProviderFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ client_id: "abc" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Test Client",
+          redirect_uris: ["https://example.com/callback"],
+        }),
+      }),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockOAuthProviderFetch).toHaveBeenCalled();
+  });
+
   it("ignores commas inside quoted error_description values when parsing the challenge", async () => {
     mockOAuthProviderFetch.mockResolvedValueOnce(
       new Response("unauthorized", {

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { SCOPES } from "../constants";
 import app from "./app";
 import { resolveClientFamily } from "./lib/client-family";
+import { redirectUriHasUserInfo } from "./lib/html-utils";
 import sentryMcpHandler from "./lib/mcp-handler";
 import {
   type RateLimitScope,
@@ -173,6 +174,42 @@ const wrappedOAuthProvider = {
 
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
     Sentry.getActiveSpan()?.setAttribute("app.client.family", clientFamily);
+
+    // Reject registrations with userinfo-spoofed redirect URIs before the
+    // library stores the client (e.g. host@example.io).
+    if (request.method === "POST" && url.pathname === "/oauth/register") {
+      try {
+        const body = (await request.clone().json()) as {
+          redirect_uris?: unknown;
+        };
+        const redirectUris = Array.isArray(body.redirect_uris)
+          ? body.redirect_uris
+          : [];
+        if (
+          redirectUris.some(
+            (uri) => typeof uri === "string" && redirectUriHasUserInfo(uri),
+          )
+        ) {
+          return finalizeResponse(
+            request,
+            url,
+            new Response(
+              JSON.stringify({
+                error: "invalid_redirect_uri",
+                error_description:
+                  "redirect_uris must not contain a userinfo component",
+              }),
+              {
+                status: 400,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+        }
+      } catch {
+        // Malformed body — let the library produce its own error.
+      }
+    }
 
     // --- Phase 2: Let the OAuth library handle the request ---
     // We normalize any CORS headers it returns in the response handling below.

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -3,7 +3,7 @@ import type {
   ClientInfo,
 } from "@cloudflare/workers-oauth-provider";
 import { logError, logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
-import { sanitizeHtml, sanitizeHrefUrl } from "./html-utils";
+import { getUrlHost, sanitizeHtml, sanitizeHrefUrl } from "./html-utils";
 import skillDefinitions, {
   type SkillDefinition,
 } from "@sentry/mcp-core/skillDefinitions";
@@ -325,19 +325,27 @@ export async function renderApprovalDialog(
     ? sanitizeHtml(sanitizeHrefUrl(client.tosUri))
     : "";
 
-  const redirectWarningUri =
+  const rawRedirectUri =
     typeof redirectUri === "string" && redirectUri.length > 0
-      ? sanitizeHtml(redirectUri)
+      ? redirectUri
       : client?.redirectUris?.length === 1
-        ? sanitizeHtml(client.redirectUris[0])
+        ? client.redirectUris[0]
         : null;
+
+  const redirectWarningUri = rawRedirectUri
+    ? sanitizeHtml(rawRedirectUri)
+    : null;
+  const redirectHost = rawRedirectUri ? getUrlHost(rawRedirectUri) : "";
+  const redirectDestination = redirectHost
+    ? `<strong>${sanitizeHtml(redirectHost)}</strong>`
+    : "this URL";
 
   const redirectWarningsHtml = redirectWarningUri
     ? `
         <div class="redirect-warning">
           <div class="redirect-uri-display">${redirectWarningUri}</div>
           <div class="redirect-warning-text">
-            After approval, you will be redirected to this URL. Only approve if you recognize and trust this destination.
+            After approval, you will be redirected to ${redirectDestination}. Only approve if you recognize and trust this destination.
           </div>
         </div>
       `

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeHrefUrl, sanitizeHtml } from "./html-utils";
+import {
+  redirectUriHasUserInfo,
+  sanitizeHrefUrl,
+  sanitizeHtml,
+} from "./html-utils";
 
 describe("sanitizeHrefUrl", () => {
   describe("blocks dangerous URI schemes", () => {
@@ -57,6 +61,34 @@ describe("sanitizeHrefUrl", () => {
 
     it("rejects URLs with embedded control characters", () => {
       expect(sanitizeHrefUrl("\x01javascript:alert(1)")).toBe("");
+    });
+  });
+});
+
+describe("redirectUriHasUserInfo", () => {
+  describe("detects userinfo components", () => {
+    it.each([
+      ["https://mcp.sentry.dev@example.io/callback", "host-spoofing username"],
+      ["https://user:pass@example.io/callback", "username and password"],
+      ["https://user@example.com", "bare username"],
+      [
+        "https://mcp.sentry.dev%40example.io@example.net/callback",
+        "encoded host",
+      ],
+    ])("flags %s (%s)", (input) => {
+      expect(redirectUriHasUserInfo(input)).toBe(true);
+    });
+  });
+
+  describe("allows legitimate redirect URIs", () => {
+    it.each([
+      ["https://example.com/callback", "basic HTTPS"],
+      ["http://127.0.0.1:8765/callback", "loopback"],
+      ["http://localhost:3000/callback", "localhost"],
+      ["cursor://callback", "custom scheme"],
+      ["https://example.com/callback?next=user@host", "userinfo only in query"],
+    ])("allows %s (%s)", (input) => {
+      expect(redirectUriHasUserInfo(input)).toBe(false);
     });
   });
 });

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  getUrlHost,
   redirectUriHasUserInfo,
   sanitizeHrefUrl,
   sanitizeHtml,
@@ -90,6 +91,17 @@ describe("redirectUriHasUserInfo", () => {
     ])("allows %s (%s)", (input) => {
       expect(redirectUriHasUserInfo(input)).toBe(false);
     });
+  });
+});
+
+describe("getUrlHost", () => {
+  it.each([
+    ["https://example.com/callback", "example.com"],
+    ["http://localhost:5173/api/auth/callback", "localhost:5173"],
+    ["https://example.com:8443/cb", "example.com:8443"],
+    ["not a url", ""],
+  ])("returns host of %s", (input, expected) => {
+    expect(getUrlHost(input)).toBe(expected);
   });
 });
 

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.ts
@@ -34,6 +34,17 @@ export function redirectUriHasUserInfo(uri: string): boolean {
 }
 
 /**
+ * Returns the host of a URL, or an empty string if it can't be parsed.
+ */
+export function getUrlHost(url: string): string {
+  try {
+    return new URL(url.trim()).host;
+  } catch {
+    return "";
+  }
+}
+
+/**
  * Sanitizes HTML content to prevent XSS attacks
  */
 export function sanitizeHtml(unsafe: string): string {

--- a/packages/mcp-cloudflare/src/server/lib/html-utils.ts
+++ b/packages/mcp-cloudflare/src/server/lib/html-utils.ts
@@ -20,6 +20,20 @@ export function sanitizeHrefUrl(url: string): string {
 }
 
 /**
+ * Rejects redirect URIs carrying a userinfo component (e.g.
+ * `https://mcp.sentry.dev@example.io/callback`). Returns true if userinfo
+ *  is present or the URI is unparseable.
+ */
+export function redirectUriHasUserInfo(uri: string): boolean {
+  try {
+    const parsed = new URL(uri.trim());
+    return parsed.username !== "" || parsed.password !== "";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Sanitizes HTML content to prevent XSS attacks
  */
 export function sanitizeHtml(unsafe: string): string {

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -91,6 +91,24 @@ describe("oauth authorize routes", () => {
         html.match(/After approval, you will be redirected to this URL\./g),
       ).toHaveLength(1);
     });
+
+    it("rejects redirect URIs with a userinfo component", async () => {
+      mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
+        clientId: "test-client",
+        redirectUri: "https://mcp.sentry.dev@example.io/callback",
+        scope: ["read"],
+        state: "orig",
+      });
+
+      const request = new Request("http://localhost/oauth/authorize", {
+        method: "GET",
+      });
+      const response = await app.fetch(request, testEnv as Env);
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Invalid redirect URI");
+      expect(mockOAuthProvider.lookupClient).not.toHaveBeenCalled();
+    });
   });
 
   describe("POST /oauth/authorize", () => {
@@ -102,6 +120,33 @@ describe("oauth authorize routes", () => {
         tokenEndpointAuthMethod: "client_secret_basic",
       });
     });
+    it("rejects redirect URIs with a userinfo component", async () => {
+      const oauthReqInfo = {
+        clientId: "test-client",
+        redirectUri: "https://mcp.sentry.dev@example.io/callback",
+        scope: ["read"],
+        state: "original-state",
+      };
+      const formData = new FormData();
+      const signedState = await signState(
+        {
+          req: { oauthReqInfo },
+          iat: Date.now(),
+          exp: Date.now() + 10 * 60 * 1000,
+        },
+        testEnv.COOKIE_SECRET!,
+      );
+      formData.append("state", signedState);
+      const request = new Request("http://localhost/oauth/authorize", {
+        method: "POST",
+        body: formData,
+      });
+      const response = await app.fetch(request, testEnv as Env);
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe("Invalid redirect URI");
+    });
+
     it("should encode skills in the redirect state", async () => {
       const oauthReqInfo = {
         clientId: "test-client",

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -88,8 +88,12 @@ describe("oauth authorize routes", () => {
       expect(html).not.toContain("https://example.com/another-callback");
       expect(html).not.toContain("https://example.com/fallback-callback");
       expect(
-        html.match(/After approval, you will be redirected to this URL\./g),
+        html.match(/After approval, you will be redirected to/g),
       ).toHaveLength(1);
+      // The true host is surfaced in the warning sentence.
+      expect(html).toContain(
+        "After approval, you will be redirected to <strong>example.com</strong>.",
+      );
     });
 
     it("rejects redirect URIs with a userinfo component", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -5,6 +5,7 @@ import {
   renderApprovalDialog,
   parseRedirectApproval,
 } from "../../lib/approval-dialog";
+import { redirectUriHasUserInfo } from "../../lib/html-utils";
 import { resolveClientFamilyFromName } from "../../lib/client-family";
 import type { Env } from "../../types";
 import { SENTRY_AUTH_URL } from "../constants";
@@ -100,6 +101,15 @@ export default new Hono<{ Bindings: Env }>()
     const { clientId } = oauthReqInfo;
     if (!clientId) {
       return c.text("Invalid request", 400);
+    }
+
+    // Reject userinfo-spoofed redirect URIs (e.g. host@example.io)
+    if (redirectUriHasUserInfo(oauthReqInfo.redirectUri)) {
+      logWarn("Rejected redirect URI with userinfo component", {
+        loggerScope: ["cloudflare", "oauth", "authorize"],
+        extra: { clientId, redirectUri: oauthReqInfo.redirectUri },
+      });
+      return c.text("Invalid redirect URI", 400);
     }
 
     // Validate resource parameter per RFC 8707
@@ -212,6 +222,18 @@ export default new Hono<{ Bindings: Env }>()
       ...state.oauthReqInfo,
       skills,
     };
+
+    // Reject userinfo-spoofed redirect URIs (e.g. host@example.io)
+    if (redirectUriHasUserInfo(oauthReqWithSkills.redirectUri)) {
+      logWarn("Rejected redirect URI with userinfo component", {
+        loggerScope: ["cloudflare", "oauth", "authorize"],
+        extra: {
+          clientId: oauthReqWithSkills.clientId,
+          redirectUri: oauthReqWithSkills.redirectUri,
+        },
+      });
+      return c.text("Invalid redirect URI", 400);
+    }
 
     // Validate redirectUri first to prevent open redirects from error responses
     let client = null;

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -103,7 +103,7 @@ export default new Hono<{ Bindings: Env }>()
       return c.text("Invalid request", 400);
     }
 
-    // Reject userinfo-spoofed redirect URIs (e.g. host@example.io)
+    // Reject redirect URIs with userinfo components
     if (redirectUriHasUserInfo(oauthReqInfo.redirectUri)) {
       logWarn("Rejected redirect URI with userinfo component", {
         loggerScope: ["cloudflare", "oauth", "authorize"],
@@ -223,7 +223,7 @@ export default new Hono<{ Bindings: Env }>()
       skills,
     };
 
-    // Reject userinfo-spoofed redirect URIs (e.g. host@example.io)
+    // Reject redirect URIs with userinfo components)
     if (redirectUriHasUserInfo(oauthReqWithSkills.redirectUri)) {
       logWarn("Rejected redirect URI with userinfo component", {
         loggerScope: ["cloudflare", "oauth", "authorize"],


### PR DESCRIPTION
Rejecting userinfo components from redirect_uri's. I had specifically considered it during https://github.com/getsentry/sentry-mcp/pull/608 but opted to allow them since it was still early in adoption. We've seen no benefit from having them since, so rejecting them outright now to save on phishing attempts. 

Also updating the consent description to call out the true host that you're being redirected to. That way something like `https://mcp.sentry.dev.supersus.com/callback` in the longer redirect_uri will prominently display as `suspersus.com` in the sentence description. Just a free thing to add, harmless depth of awareness. 