### PR TITLE
docs: Make MCP QA playbook agentic

### DIFF
--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: qa
-description: QA test changes against the local dev server. Use when explicitly invoked via /qa to verify changes work end-to-end.
+description: QA MCP tool changes with local CLI and real agent clients. Use when explicitly invoked via /qa to verify changes work end-to-end.
 ---
 
-# QA Testing
+# MCP QA Playbook
 
-Verify changes work end-to-end before committing or creating a PR.
+Verify MCP tool behavior end-to-end before committing or creating a PR. Prefer
+agent-callable paths over browser or inspector workflows.
 
-## Step 1: Run Quality Gate
+## 1. Quality Gate
 
 ```bash
 pnpm run tsc && pnpm run lint && pnpm run test
@@ -15,179 +16,137 @@ pnpm run tsc && pnpm run lint && pnpm run test
 
 Fix any failures before proceeding.
 
-## Step 2: Test with CLI Client (Agent)
+## 2. Stdio CLI
 
-This is the primary QA method. It uses an AI agent to exercise MCP tools against the local dev server.
-
-### Start the dev server
-
-Run `pnpm dev` in the background. It starts at `http://localhost:5173`. Verify it's up:
-
-```bash
-curl -s -o /dev/null -w "%{http_code}" http://localhost:5173/
-```
-
-If it returns a non-200 or fails to connect, the server isn't running yet — wait and retry.
-
-### Run test queries
-
-The CLI connects to the local dev server via HTTP by default (no flags needed):
+This is the primary QA path for tool behavior. Stdio runs the local MCP server
+against prod Sentry without depending on the Cloudflare worker, local `/mcp`
+route, or Cloudflare OAuth configuration.
+When validating code or tool changes, build first because the test client
+launches `packages/mcp-server/dist/index.js`:
 
 ```bash
-# Verify auth and connectivity
-pnpm -w run cli "who am I?"
-
-# Verify tools are available (count varies by granted skills)
-pnpm -w run cli "list all available tools"
-
-# Test a specific tool relevant to your changes
-pnpm -w run cli "find my organizations"
+pnpm -w run build
 ```
 
-Look for `Connected to MCP server (remote)` in output to confirm HTTP transport to the dev server.
-
-### Agent mode (optional)
-
-Tests the `use_sentry` meta-tool instead of individual tools. ~2x slower:
+Check auth first:
 
 ```bash
-pnpm -w run cli --agent "show me my recent errors"
+pnpm --filter @sentry/mcp-server start auth status
 ```
 
-### Experimental tools
-
-If your changes involve experimental tools:
+If no cache exists, warm the device-code cache:
 
 ```bash
-pnpm -w run cli --experimental "your query"
+pnpm --filter @sentry/mcp-server start auth login
 ```
 
-## Step 3: Test Stdio / Auth Flows When Relevant
+Device-code auth uses the bundled stdio public client ID, requires no client
+secret, is separate from the Cloudflare OAuth app, and caches the token in
+`~/.sentry/mcp.json`.
 
-Run this step when your changes touch stdio transport, auth, device-code flow, token caching, npm package behavior, or `mcp-test-client`.
-
-### Fast stdio checks
-
-These do not require a browser:
-
-```bash
-# Explicit-token stdio path
-pnpm -w run cli --transport stdio --access-token=TOKEN --list-tools
-
-# No-token, non-interactive path should fail with the auth guidance
-pnpm -w run cli --transport stdio --list-tools
-```
-
-Look for `Connected to MCP server (stdio)` in the explicit-token case.
-In the no-token non-interactive case, expect the error that instructs you to run `sentry-mcp auth login` interactively first.
-
-### Device-code auth with isolated cache
-
-Use an isolated cache file so QA does not depend on or overwrite `~/.sentry/mcp.json`:
-
-```bash
-AUTH_DIR=$(mktemp -d /tmp/sentry-mcp-auth.XXXXXX)
-export SENTRY_MCP_AUTH_CACHE="$AUTH_DIR/mcp.json"
-pnpm -w run cli --transport stdio --list-tools
-```
-
-This must run in a real TTY. The server should print a Sentry device-code URL and wait for authorization.
-Complete the browser flow, then confirm the client connects and lists tools.
-
-### Cached-token reuse
-
-After the device-code login succeeds, run the same command again with the same `SENTRY_MCP_AUTH_CACHE`:
+First prove startup and auth:
 
 ```bash
 pnpm -w run cli --transport stdio --list-tools
+pnpm -w run cli --transport stdio "who am I?"
 ```
 
-Confirm that it reuses the cached token and lists tools without starting another browser-based login.
-
-## Step 4: Test Real Agent CLIs When Relevant
-
-Run this step when validating Claude Code, Codex, or another issue that only reproduces in a real agent client.
-
-The repo includes a harness package that uses the installed local CLI session instead of the `mcp-test-client`:
+Then prove the changed behavior with a realistic prod prompt. Choose a prompt
+that requires the new or modified tool path, uses real org/project/resource
+inputs, and asks for enough detail to prove the endpoint response is usable.
 
 ```bash
-# Claude Code against the local dev server MCP entry
-pnpm -w run agent-cli-test --provider claude --setup repo
+pnpm -w run cli --transport stdio \
+  "<prompt that exercises the changed MCP behavior against prod data>"
+```
 
-# Codex against the local dev server MCP entry
-pnpm -w run agent-cli-test --provider codex --setup repo
+Passing QA means the local CLI prints `Connected to MCP server (stdio)`, uses
+the expected MCP tool path, and returns real prod data that demonstrates the
+behavior. For catalog tools, expect `search_tools` followed by
+`execute_tool(name: <changed_tool>)`. For direct tools, expect the tool name in
+the transcript. `--list-tools` alone is not QA.
 
-# Claude Code against the checked-in stdio MCP entry
+If your changes involve agent mode or experimental tools:
+
+```bash
+pnpm -w run cli --transport stdio --agent "show me my recent errors"
+pnpm -w run cli --transport stdio --experimental "your query"
+```
+
+## 3. Real Agent Clients
+
+Use these when validating Claude Code, Codex, or behavior that only reproduces
+in a real agent client:
+
+```bash
+pnpm -w run build
+pnpm -w run agent-cli-test auth login
 pnpm -w run agent-cli-test --provider claude --setup stdio
-
-# Codex against the checked-in stdio MCP entry
 pnpm -w run agent-cli-test --provider codex --setup stdio
 ```
 
 What this verifies:
 - The CLI is installed and can see the named MCP server
-- The provider can run a real prompt against Sentry MCP
+- The provider can run a connectivity prompt against Sentry MCP
 - The final answer includes the authenticated email from `whoami`
 
-Use `--setup repo --server sentry` if you want to test the hosted server instead of the local `sentry-dev` entry.
+For agent-client-specific behavior, replace the default harness prompt with the
+same realistic prod prompt used for stdio QA. Passing QA requires the same
+changed-tool transcript evidence, not only `whoami`.
 
-The checked-in `stdio` setup uses `packages/agent-cli-test/projects/stdio/.sentry/mcp.json` as an isolated auth cache.
-Real clients do not give stdio subprocesses a TTY, so the first-run device-code flow must be warmed separately:
+The `stdio` setup uses `packages/agent-cli-test/projects/stdio/.sentry/mcp.json`
+as an isolated auth cache. Real clients do not give stdio subprocesses a TTY,
+so warm the cache before running the harness. It also runs the built
+`packages/mcp-server/dist/index.js`, so build first to avoid stale code.
+
+## 4. Cloudflare HTTP Only When Relevant
+
+Run this only when changes touch Cloudflare, HTTP transport, `/mcp`
+routing, OAuth, web UI, or hosted-server compatibility. It is not required for
+ordinary tool handler changes.
+
+Start the dev server in a separate terminal or background process:
 
 ```bash
-pnpm -w run agent-cli-test auth login
+pnpm dev
 ```
 
-If the harness fails, rerun the provider directly with debug enabled so you can see the MCP startup failure:
+Then verify it is reachable:
 
 ```bash
-# Claude Code: capture a debug log for the real prompt run
-claude --mcp-config /tmp/claude-sentry-dev-config.json --strict-mcp-config --permission-mode bypassPermissions --no-session-persistence --debug-file /tmp/claude-sentry-dev.log -p 'Use the "whoami" tool from the MCP server named "sentry-dev". Call it exactly once. Reply with only the authenticated email address.'
-
-# Codex: capture MCP handshake and transport logs
-RUST_LOG=codex_core=debug,rmcp=debug RUST_BACKTRACE=1 codex exec --skip-git-repo-check --sandbox read-only --output-last-message /tmp/codex-sentry-dev-last.txt 'Use only the MCP server named "sentry-dev". Call the "whoami" tool exactly once. Reply with only the authenticated email address.'
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5173/
 ```
 
-Look for these signatures:
-- Claude: `ToolSearchTool`, `mcp__sentry-dev__whoami`, missing server/tool selection, `tool permission denied`
-- Codex: `UnexpectedContentType`, `AuthRequired`, `resources/list failed`
-
-## Step 5: Human-Only Testing (Reference)
-
-These methods require human interaction and cannot be run by the agent. Suggest them to the user when relevant.
-
-### MCP Inspector
-
-Interactive web UI for testing individual tools with specific parameters:
+If `pnpm dev` fails because local Cloudflare/Wrangler is not configured, note
+the failure and continue with stdio QA for tool behavior.
 
 ```bash
-pnpm inspector          # HTTP transport, opens http://localhost:6274
-pnpm inspector:stdio    # Stdio transport, direct connection
+pnpm -w run cli "who am I?"
+pnpm -w run cli "list all available tools"
+pnpm -w run cli "<same realistic prod prompt used for stdio QA>"
+pnpm -w run cli --mcp-host=http://localhost:5173/mcp/<org> \
+  "<same realistic prod prompt used for stdio QA>"
+pnpm -w run cli --mcp-host=http://localhost:5173/mcp/<org>/<project> \
+  "<same realistic prod prompt used for stdio QA>"
+pnpm -w run agent-cli-test --provider claude --setup repo
+pnpm -w run agent-cli-test --provider codex --setup repo
 ```
 
-### Web UI with OAuth
+Look for `Connected to MCP server (<resolved MCP URL>)` to confirm HTTP
+transport, plus the same changed-tool transcript evidence required for stdio
+QA. Use scoped `/mcp/<org>` or `/mcp/<org>/<project>` URLs when validating
+routing, OAuth, or resource-scope behavior. Use `--setup repo --server sentry`
+to test the hosted server instead.
 
-Full browser-based testing with OAuth authentication:
+## 5. Source Build Stdio Only When Relevant
 
-1. Start dev server: `pnpm dev`
-2. Open `http://localhost:5173`
-3. Authenticate via OAuth flow
-4. Test via chat interface
-
-Constraint testing via URL paths:
-- `http://localhost:5173/mcp/org-slug` — org-scoped
-- `http://localhost:5173/mcp/org-slug/project-slug` — project-scoped
-
-## Stdio / Production Build Testing (Rare)
-
-Use this when specifically testing the published/package build rather than the local dev server:
+Use this when specifically checking the built local stdio server rather than
+dev-time source execution:
 
 ```bash
-# Build first
 pnpm -w run build
-
-# Test via stdio transport with an explicit token
-pnpm -w run cli --transport stdio --access-token=TOKEN "who am I?"
+pnpm --filter @sentry/mcp-server start auth status
+pnpm -w run cli --transport stdio "who am I?"
 ```
 
 Look for `Connected to MCP server (stdio)` to confirm stdio transport.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,4 @@
 # AGENTS.md
-
 Sentry MCP is a Model Context Protocol server that exposes Sentry's error tracking and performance monitoring to AI assistants through 19 tools.
 
 ## Principles
@@ -61,9 +60,9 @@ pnpm run dev                              # Start dev server
 pnpm run build                            # Build all packages
 
 # Testing
-pnpm -w run cli "who am I?"               # Test local dev server
-pnpm -w run cli --access-token=TOKEN "q"  # Test stdio transport
-pnpm -w run cli --agent "query"           # Test agent mode (~2x slower)
+pnpm -w run cli --transport stdio "q"      # Test MCP tools
+pnpm -w run cli --transport stdio --access-token=TOKEN "q"
+pnpm -w run cli --transport stdio --agent "query"
 
 # Quality (run before committing)
 pnpm run tsc && pnpm run lint && pnpm run test
@@ -77,7 +76,9 @@ pnpm run --filter @sentry/mcp-core generate-definitions
 
 ## QA Playbook
 
-For end-to-end validation with the local dev server and CLI client, follow `.agents/skills/qa/SKILL.md`. It covers the required quality gate, `pnpm dev` on `http://localhost:5173`, local CLI smoke tests, and when to extend coverage to stdio, auth, or real agent clients.
+For MCP tool QA, follow `.agents/skills/qa/SKILL.md`: stdio-first local CLI and
+real agent clients; Cloudflare HTTP or `/mcp` only for transport, OAuth,
+routing, or hosted-server compatibility.
 
 ## Task Management
 


### PR DESCRIPTION
The QA playbook now treats MCP tool behavior as the primary validation target: agents should start with local stdio against prod Sentry auth, pass a realistic prompt for the changed behavior, and verify the transcript shows the expected MCP tool path returning real prod data.

Cloudflare HTTP and /mcp validation remain documented, but only for changes that touch transport, OAuth, routing, web UI, or hosted-server compatibility. AGENTS.md points future agents at the same stdio-first playbook.

Validated locally with cached device-code auth by running the stdio CLI against prod data for the alert-rule change; the transcript called the expected catalog discovery and execution path and returned real issue and metric alert data.