### PR TITLE
meta: Rename QA skill to MCP QA

### DIFF
--- a/.agents/skills/mcp-qa/SKILL.md
+++ b/.agents/skills/mcp-qa/SKILL.md
@@ -1,9 +1,7 @@
 ---
-name: qa
-description: QA MCP tool changes with local CLI and real agent clients. Use when explicitly invoked via /qa to verify changes work end-to-end.
+name: mcp-qa
+description: QA MCP tool changes with local CLI and real agent clients. Use when explicitly invoked via /mcp-qa or when asked to QA MCP tool changes end-to-end.
 ---
-
-# MCP QA Playbook
 
 Verify MCP tool behavior end-to-end before committing or creating a PR. Prefer
 agent-callable paths over browser or inspector workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,9 @@ pnpm run --filter @sentry/mcp-core generate-definitions
 
 ## QA Playbook
 
-For MCP tool QA, follow `.agents/skills/qa/SKILL.md`: stdio-first local CLI and
-real agent clients; Cloudflare HTTP or `/mcp` only for transport, OAuth,
-routing, or hosted-server compatibility.
+For MCP tool QA, use the `mcp-qa` skill at `.agents/skills/mcp-qa/SKILL.md`:
+stdio-first local CLI and real agent clients; Cloudflare HTTP or `/mcp` only
+for transport, OAuth, routing, or hosted-server compatibility.
 
 ## Task Management
 

--- a/docs/contributing/tool-responses.md
+++ b/docs/contributing/tool-responses.md
@@ -8,7 +8,7 @@ Use this policy when adding a tool, changing formatted handler output, updating
 snapshots, or QAing MCP behavior. For the full tool implementation flow, see
 [adding-tools.md](adding-tools.md). For snapshot requirements, see
 [../testing/overview.md](../testing/overview.md). For end-to-end MCP
-validation, see [.agents/skills/qa/SKILL.md](../../.agents/skills/qa/SKILL.md).
+validation, see [.agents/skills/mcp-qa/SKILL.md](../../.agents/skills/mcp-qa/SKILL.md).
 
 ## Response Contract
 
@@ -156,7 +156,7 @@ For output-format changes:
 
 - Run the normal quality gate from [quality-checks.md](quality-checks.md).
 - Use the stdio MCP QA path in
-  [.agents/skills/qa/SKILL.md](../../.agents/skills/qa/SKILL.md).
+  [.agents/skills/mcp-qa/SKILL.md](../../.agents/skills/mcp-qa/SKILL.md).
 - Inspect the raw MCP tool result when possible, not only the LLM's final
   answer. The test client's final answer can add model-specific phrasing that is
   not part of the tool response.


### PR DESCRIPTION
Rename the project-scoped MCP QA skill from `qa` to `mcp-qa` so explicit skill invocation matches the MCP-specific workflow.

The old top-level heading inside the skill was removed, and agent/docs references now point at `.agents/skills/mcp-qa/SKILL.md`.
