### PR TITLE
feat(oauth): Remember skill consent defaults

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ canonical workflow and required docs live in [../AGENTS.md](../AGENTS.md)
 
 - [specs/README.md](specs/README.md) - Specs index
 - [specs/embedded-agent-openai-routing.md](specs/embedded-agent-openai-routing.md) - Embedded agent OpenAI routing spec
+- [specs/remembered-oauth-skills.md](specs/remembered-oauth-skills.md) - Remembered OAuth skill defaults spec
 - [specs/search-events.md](specs/search-events.md) - Search Events spec
 - [specs/subpath-constraints.md](specs/subpath-constraints.md) - Subpath constraints spec
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -45,6 +45,13 @@ agent behavior so Azure compatibility no longer depends on hidden heuristics.
 - **Status**: 📝 Proposed
 - **Key Benefits**: Preserves Azure compatibility, keeps unknown OpenAI-compatible providers predictable, and removes alias-based footguns
 
+### [remembered-oauth-skills](./remembered-oauth-skills.md)
+A spec for remembering prior remote OAuth skill selections in a bounded signed
+browser cookie and using them as future consent UI defaults.
+
+- **Status**: 📝 Proposed
+- **Key Benefits**: Reduces repeated consent work without making remembered values an authorization source
+
 ### [search-events](./search-events.md)
 A unified event search tool that uses OpenAI GPT-5 to translate natural language queries into Sentry's search syntax. Replaced the separate `find_errors` and `find_transactions` tools with a single, more powerful interface.
 

--- a/docs/specs/remembered-oauth-skills.md
+++ b/docs/specs/remembered-oauth-skills.md
@@ -1,0 +1,157 @@
+# Remembered OAuth Skill Defaults
+
+## Overview
+
+Remote OAuth consent should remember the skills a browser previously selected
+for a Dynamic Client Registration client and use them as checkbox defaults on
+future authorization prompts.
+
+The remembered value is a signed browser cookie. It affects only the consent UI
+defaults; submitted skills still flow through signed OAuth state and are
+validated during the callback before becoming `grantedSkills`.
+
+## Motivation
+
+Users frequently re-authorize the same MCP client after token expiry, local
+client resets, or auth cache cleanup. The current approval screen always starts
+from built-in `defaultEnabled` skills, so users who intentionally enabled
+optional skills must reselect them each time.
+
+Remembering prior selections reduces repeated consent work without changing the
+authorization model.
+
+## Design
+
+Add a separate signed cookie:
+
+```typescript
+const COOKIE_NAME = "mcp-skill-preferences";
+
+type SkillPreferenceCookie = {
+  clients: Array<[clientId: string, skills: string[]]>;
+};
+```
+
+The cookie is separate from `mcp-approved-clients`, which continues to prove the
+client was approved before `/oauth/callback` completes authorization.
+
+### LRU Retention
+
+The cookie stores a tiny LRU list with newest entries at the end.
+
+```typescript
+const MAX_SKILL_PREFERENCE_CLIENTS = 10;
+
+const nextClients = existing.clients.filter(([id]) => id !== clientId);
+nextClients.push([clientId, filteredSkills]);
+const trimmedClients = nextClients.slice(-MAX_SKILL_PREFERENCE_CLIENTS);
+```
+
+This keeps the payload bounded while supporting normal DCR churn. No timestamps
+or server-side storage are required.
+
+### Validation
+
+On read and write:
+
+- Ignore malformed or unsigned cookies.
+- Require `clients` to be an array.
+- Require client IDs to be strings.
+- Filter skills to active approvable skill IDs.
+- Drop entries with no valid skills.
+- Ignore deprecated skills.
+
+Invalid cookie data must not block authorization. It only falls back to the
+built-in skill defaults.
+
+## Interface
+
+Extend consent rendering with remembered defaults:
+
+```typescript
+interface ApprovalDialogOptions {
+  // existing fields omitted
+  defaultSkills?: string[];
+}
+```
+
+Checkbox selection order:
+
+1. Use remembered skills for the current `clientId`, when present.
+2. Otherwise use existing `skill.defaultEnabled` values.
+
+## OAuth Flow
+
+### GET `/oauth/authorize`
+
+After `lookupClient(clientId)`, read `mcp-skill-preferences` from the request
+cookie and pass the matching client's skills to `renderApprovalDialog`.
+
+### POST `/oauth/authorize`
+
+After parsing and filtering submitted `skill` values:
+
+1. Update `mcp-approved-clients` as today.
+2. Update `mcp-skill-preferences` for the current `clientId`.
+3. Append both `Set-Cookie` headers.
+4. Embed the submitted skills into signed OAuth state for the upstream Sentry
+   OAuth redirect.
+
+### GET `/oauth/callback`
+
+No behavioral change. The callback parses `oauthReqInfo.skills` from signed
+state, validates with `parseSkills`, rejects empty valid skill sets, derives
+Sentry API scopes, and stores `grantedSkills` in OAuth token props.
+
+## Security Requirements
+
+- The preference cookie is not an authorization source.
+- Remembered skills must never skip the approval form.
+- The callback must continue to reject empty or invalid submitted skills.
+- Cookie contents must be HMAC-signed with `COOKIE_SECRET`.
+- Cookie attributes should match the existing approval cookie:
+  `HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=31536000`.
+- Do not store Sentry user IDs, tokens, scopes, redirect URIs, or secrets in the
+  preference cookie.
+
+## Implementation
+
+Primary files:
+
+- `packages/mcp-cloudflare/src/server/lib/approval-dialog.ts`
+- `packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts`
+- `packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts`
+- `packages/mcp-cloudflare/src/server/oauth/authorize.test.ts`
+
+Implementation steps:
+
+1. Add signed cookie helpers for `mcp-skill-preferences`.
+2. Add `defaultSkills?: string[]` to `ApprovalDialogOptions`.
+3. Render checkboxes from remembered defaults when provided.
+4. Read remembered defaults in GET `/oauth/authorize`.
+5. Write the preference cookie in POST `/oauth/authorize`.
+6. Preserve both approval and preference `Set-Cookie` headers.
+
+## Testing
+
+Add focused unit tests for:
+
+- No preference cookie falls back to built-in defaults.
+- Remembered skills pre-check the approval form.
+- Unknown, malformed, and deprecated skills are ignored.
+- POST writes both cookies.
+- LRU retention trims to 10 clients.
+- Saving an existing client moves it to the newest position.
+- A different `clientId` does not inherit remembered skills.
+
+## Migration
+
+No migration is required. Existing users without the new cookie continue to see
+the current built-in defaults. Existing `mcp-approved-clients` cookies remain
+valid and unchanged.
+
+## Future Work
+
+If the OAuth flow later learns the Sentry user before rendering consent, the
+preference key could become `(userId, clientId)`. That is intentionally out of
+scope for this cookie-only design.

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
@@ -1,6 +1,37 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderApprovalDialog, parseRedirectApproval } from "./approval-dialog";
+import {
+  getRememberedSkillsForClient,
+  parseRedirectApproval,
+  renderApprovalDialog,
+  SKILL_PREFERENCES_COOKIE_NAME,
+} from "./approval-dialog";
 import { signState } from "../oauth/state";
+
+function skillInputAttributes(html: string, skillId: string): string {
+  const match = html.match(
+    new RegExp(
+      `<input type="checkbox" name="skill" value="${skillId}"([^>]*)>`,
+    ),
+  );
+  return match?.[1] ?? "";
+}
+
+function expectSkillChecked(html: string, skillId: string): void {
+  expect(skillInputAttributes(html, skillId)).toContain("checked");
+}
+
+function expectSkillUnchecked(html: string, skillId: string): void {
+  expect(skillInputAttributes(html, skillId)).not.toContain("checked");
+}
+
+function extractCookiePair(setCookie: string, cookieName: string): string {
+  const marker = `${cookieName}=`;
+  const start = setCookie.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const rest = setCookie.slice(start);
+  const end = rest.indexOf(";");
+  return end === -1 ? rest : rest.slice(0, end);
+}
 
 describe("approval-dialog", () => {
   const TEST_SECRET = "test-cookie-secret-32-chars-long";
@@ -33,6 +64,61 @@ describe("approval-dialog", () => {
       // Check that state is included in the form
       expect(html).toContain('name="state"');
       expect(html).toContain('value="');
+    });
+
+    it("uses built-in skill defaults when no remembered defaults are provided", async () => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Test Server" },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+      const html = await response.text();
+
+      expectSkillChecked(html, "inspect");
+      expectSkillChecked(html, "seer");
+      expectSkillUnchecked(html, "triage");
+      expectSkillUnchecked(html, "project-management");
+    });
+
+    it("uses remembered skill defaults when provided", async () => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Test Server" },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+          defaultSkills: ["triage", "project-management"],
+        },
+      );
+      const html = await response.text();
+
+      expectSkillUnchecked(html, "inspect");
+      expectSkillUnchecked(html, "seer");
+      expectSkillChecked(html, "triage");
+      expectSkillChecked(html, "project-management");
+    });
+
+    it("ignores unknown and deprecated remembered skill defaults", async () => {
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Test Server" },
+          state: { oauthReqInfo: { clientId: "test-client" } },
+          cookieSecret: TEST_SECRET,
+          defaultSkills: ["docs", "unknown", "triage"],
+        },
+      );
+      const html = await response.text();
+
+      expectSkillChecked(html, "triage");
+      expect(html).not.toContain('value="docs"');
+      expect(html).not.toContain('value="unknown"');
     });
 
     it("does not render deprecated skill checkboxes", async () => {
@@ -251,6 +337,184 @@ describe("approval-dialog", () => {
       expect(result.state).toBeDefined();
       expect(result.state.oauthReqInfo).toEqual(oauthReqInfo);
       expect(result.skills).toEqual(["inspect"]);
+    });
+
+    it("should write approval and skill preference cookies", async () => {
+      const oauthReqInfo = {
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+      };
+      const response = await renderApprovalDialog(
+        new Request("https://example.com/oauth/authorize"),
+        {
+          client: mockClient,
+          server: { name: "Sentry MCP" },
+          state: { oauthReqInfo },
+          cookieSecret: TEST_SECRET,
+        },
+      );
+      const html = await response.text();
+      const stateMatch = html.match(/name="state" value="([^"]+)"/);
+      const encodedState = stateMatch![1];
+
+      const formData = new FormData();
+      formData.append("state", encodedState);
+      formData.append("skill", "triage");
+      formData.append("skill", "project-management");
+
+      const result = await parseRedirectApproval(
+        new Request("https://example.com/oauth/authorize", {
+          method: "POST",
+          body: formData,
+        }),
+        TEST_SECRET,
+      );
+
+      const setCookie = result.headers.get("Set-Cookie") ?? "";
+      expect(setCookie).toContain("mcp-approved-clients=");
+      expect(setCookie).toContain(`${SKILL_PREFERENCES_COOKIE_NAME}=`);
+
+      const preferenceCookie = extractCookiePair(
+        setCookie,
+        SKILL_PREFERENCES_COOKIE_NAME,
+      );
+      const remembered = await getRememberedSkillsForClient(
+        preferenceCookie,
+        "test-client",
+        TEST_SECRET,
+      );
+      expect(remembered).toEqual(["triage", "project-management"]);
+    });
+
+    it("should keep only the ten newest skill preference clients", async () => {
+      let preferenceCookie = "";
+
+      for (let index = 0; index < 12; index++) {
+        const oauthReqInfo = {
+          clientId: `client-${index}`,
+          redirectUri: "https://example.com/callback",
+          scope: ["read"],
+        };
+        const encodedState = await signState(
+          {
+            req: { oauthReqInfo },
+            iat: Date.now(),
+            exp: Date.now() + 10 * 60 * 1000,
+          },
+          TEST_SECRET,
+        );
+        const formData = new FormData();
+        formData.append("state", encodedState);
+        formData.append("skill", "triage");
+
+        const result = await parseRedirectApproval(
+          new Request("https://example.com/oauth/authorize", {
+            method: "POST",
+            headers: preferenceCookie ? { Cookie: preferenceCookie } : {},
+            body: formData,
+          }),
+          TEST_SECRET,
+        );
+        preferenceCookie = extractCookiePair(
+          result.headers.get("Set-Cookie") ?? "",
+          SKILL_PREFERENCES_COOKIE_NAME,
+        );
+      }
+
+      expect(
+        await getRememberedSkillsForClient(
+          preferenceCookie,
+          "client-0",
+          TEST_SECRET,
+        ),
+      ).toBeUndefined();
+      expect(
+        await getRememberedSkillsForClient(
+          preferenceCookie,
+          "client-1",
+          TEST_SECRET,
+        ),
+      ).toBeUndefined();
+      expect(
+        await getRememberedSkillsForClient(
+          preferenceCookie,
+          "client-2",
+          TEST_SECRET,
+        ),
+      ).toEqual(["triage"]);
+      expect(
+        await getRememberedSkillsForClient(
+          preferenceCookie,
+          "client-11",
+          TEST_SECRET,
+        ),
+      ).toEqual(["triage"]);
+    });
+
+    it("should refresh an existing skill preference client as newest", async () => {
+      let preferenceCookie = "";
+
+      for (const clientId of [
+        "client-0",
+        "client-1",
+        "client-2",
+        "client-3",
+        "client-4",
+        "client-5",
+        "client-6",
+        "client-7",
+        "client-8",
+        "client-9",
+        "client-0",
+        "client-10",
+      ]) {
+        const encodedState = await signState(
+          {
+            req: {
+              oauthReqInfo: {
+                clientId,
+                redirectUri: "https://example.com/callback",
+                scope: ["read"],
+              },
+            },
+            iat: Date.now(),
+            exp: Date.now() + 10 * 60 * 1000,
+          },
+          TEST_SECRET,
+        );
+        const formData = new FormData();
+        formData.append("state", encodedState);
+        formData.append("skill", "triage");
+
+        const result = await parseRedirectApproval(
+          new Request("https://example.com/oauth/authorize", {
+            method: "POST",
+            headers: preferenceCookie ? { Cookie: preferenceCookie } : {},
+            body: formData,
+          }),
+          TEST_SECRET,
+        );
+        preferenceCookie = extractCookiePair(
+          result.headers.get("Set-Cookie") ?? "",
+          SKILL_PREFERENCES_COOKIE_NAME,
+        );
+      }
+
+      expect(
+        await getRememberedSkillsForClient(
+          preferenceCookie,
+          "client-0",
+          TEST_SECRET,
+        ),
+      ).toEqual(["triage"]);
+      expect(
+        await getRememberedSkillsForClient(
+          preferenceCookie,
+          "client-1",
+          TEST_SECRET,
+        ),
+      ).toBeUndefined();
     });
 
     it("should reject state with wrong secret", async () => {

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -14,7 +14,9 @@ import {
 } from "../oauth/state";
 
 const COOKIE_NAME = "mcp-approved-clients";
+export const SKILL_PREFERENCES_COOKIE_NAME = "mcp-skill-preferences";
 const ONE_YEAR_IN_SECONDS = 31536000;
+const MAX_SKILL_PREFERENCE_CLIENTS = 10;
 // Hosted OAuth approvals only mint active skills. Deprecated skills may still
 // work for existing grants or explicit stdio use, but not through this form.
 const APPROVABLE_SKILLS = (skillDefinitions as SkillDefinition[]).filter(
@@ -23,6 +25,10 @@ const APPROVABLE_SKILLS = (skillDefinitions as SkillDefinition[]).filter(
 const APPROVABLE_SKILL_IDS = new Set(
   APPROVABLE_SKILLS.map((skill) => skill.id),
 );
+
+type SkillPreferencesCookie = {
+  clients: Array<[clientId: string, skills: string[]]>;
+};
 /**
  * Imports a secret key string for HMAC-SHA256 signing.
  * @param secret - The raw secret key string.
@@ -98,6 +104,73 @@ async function verifySignature(
   }
 }
 
+function getCookieValue(
+  cookieHeader: string | null,
+  cookieName: string,
+): string | null {
+  if (!cookieHeader) return null;
+
+  const cookies = cookieHeader.split(";").map((c) => c.trim());
+  const targetCookie = cookies.find((c) => c.startsWith(`${cookieName}=`));
+
+  if (!targetCookie) return null;
+
+  return targetCookie.substring(cookieName.length + 1);
+}
+
+async function getSignedCookiePayload(
+  cookieHeader: string | null,
+  cookieName: string,
+  secret: string,
+): Promise<string | null> {
+  const cookieValue = getCookieValue(cookieHeader, cookieName);
+  if (!cookieValue) return null;
+
+  const parts = cookieValue.split(".");
+
+  if (parts.length !== 2) {
+    logWarn("Invalid signed cookie format", {
+      loggerScope: ["cloudflare", "approval-dialog"],
+      extra: { cookieName },
+    });
+    return null;
+  }
+
+  const [signatureHex, base64Payload] = parts;
+  let payload: string;
+  try {
+    payload = atob(base64Payload);
+  } catch {
+    logWarn("Invalid signed cookie payload encoding", {
+      loggerScope: ["cloudflare", "approval-dialog"],
+      extra: { cookieName },
+    });
+    return null;
+  }
+
+  const key = await importKey(secret);
+  const isValid = await verifySignature(key, signatureHex, payload);
+
+  if (!isValid) {
+    logWarn("Signed cookie signature verification failed", {
+      loggerScope: ["cloudflare", "approval-dialog"],
+      extra: { cookieName },
+    });
+    return null;
+  }
+
+  return payload;
+}
+
+async function createSignedCookieValue(
+  payload: string,
+  secret: string,
+): Promise<string> {
+  const key = await importKey(secret);
+  const signature = await signData(key, payload);
+  return `${signature}.${btoa(payload)}`;
+}
+
 /**
  * Parses the signed cookie and verifies its integrity.
  * @param cookieHeader - The value of the Cookie header from the request.
@@ -108,35 +181,12 @@ async function getApprovedClientsFromCookie(
   cookieHeader: string | null,
   secret: string,
 ): Promise<string[] | null> {
-  if (!cookieHeader) return null;
-
-  const cookies = cookieHeader.split(";").map((c) => c.trim());
-  const targetCookie = cookies.find((c) => c.startsWith(`${COOKIE_NAME}=`));
-
-  if (!targetCookie) return null;
-
-  const cookieValue = targetCookie.substring(COOKIE_NAME.length + 1);
-  const parts = cookieValue.split(".");
-
-  if (parts.length !== 2) {
-    logWarn("Invalid approval cookie format", {
-      loggerScope: ["cloudflare", "approval-dialog"],
-    });
-    return null; // Invalid format
-  }
-
-  const [signatureHex, base64Payload] = parts;
-  const payload = atob(base64Payload); // Assuming payload is base64 encoded JSON string
-
-  const key = await importKey(secret);
-  const isValid = await verifySignature(key, signatureHex, payload);
-
-  if (!isValid) {
-    logWarn("Approval cookie signature verification failed", {
-      loggerScope: ["cloudflare", "approval-dialog"],
-    });
-    return null; // Signature invalid
-  }
+  const payload = await getSignedCookiePayload(
+    cookieHeader,
+    COOKIE_NAME,
+    secret,
+  );
+  if (!payload) return null;
 
   try {
     const approvedClients = JSON.parse(payload);
@@ -158,6 +208,117 @@ async function getApprovedClientsFromCookie(
     logIssue(new Error(`Error parsing cookie payload: ${e}`, { cause: e }));
     return null; // JSON parsing failed
   }
+}
+
+function filterApprovableSkillIds(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+
+  return Array.from(
+    new Set(
+      input.filter(
+        (skill): skill is string =>
+          typeof skill === "string" && APPROVABLE_SKILL_IDS.has(skill),
+      ),
+    ),
+  );
+}
+
+/**
+ * Parses the signed skill preference cookie format and drops invalid entries.
+ */
+function parseSkillPreferencesPayload(
+  payload: string,
+): SkillPreferencesCookie | null {
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray((parsed as { clients?: unknown }).clients)
+    ) {
+      return null;
+    }
+
+    const clients: SkillPreferencesCookie["clients"] = [];
+    for (const entry of (parsed as { clients: unknown[] }).clients) {
+      if (!Array.isArray(entry) || entry.length !== 2) {
+        continue;
+      }
+      const [clientId, skills] = entry;
+      if (typeof clientId !== "string" || !clientId) {
+        continue;
+      }
+      const filteredSkills = filterApprovableSkillIds(skills);
+      if (filteredSkills.length === 0) {
+        continue;
+      }
+      clients.push([clientId, filteredSkills]);
+    }
+
+    return { clients };
+  } catch {
+    return null;
+  }
+}
+
+async function getSkillPreferencesFromCookie(
+  cookieHeader: string | null,
+  secret: string,
+): Promise<SkillPreferencesCookie> {
+  const payload = await getSignedCookiePayload(
+    cookieHeader,
+    SKILL_PREFERENCES_COOKIE_NAME,
+    secret,
+  );
+  if (!payload) return { clients: [] };
+
+  return parseSkillPreferencesPayload(payload) ?? { clients: [] };
+}
+
+/**
+ * Returns signed remembered skills for preselecting the consent form only.
+ */
+export async function getRememberedSkillsForClient(
+  cookieHeader: string | null,
+  clientId: string,
+  cookieSecret: string,
+): Promise<string[] | undefined> {
+  if (!clientId) return undefined;
+
+  const preferences = await getSkillPreferencesFromCookie(
+    cookieHeader,
+    cookieSecret,
+  );
+  const entry = preferences.clients.find(([id]) => id === clientId);
+
+  return entry?.[1];
+}
+
+/**
+ * Updates the skill preference cookie as a newest-last, ten-client LRU.
+ */
+async function createSkillPreferencesSetCookie(
+  request: Request,
+  clientId: string,
+  skills: string[],
+  cookieSecret: string,
+): Promise<string> {
+  const preferences = await getSkillPreferencesFromCookie(
+    request.headers.get("Cookie"),
+    cookieSecret,
+  );
+  const filteredSkills = filterApprovableSkillIds(skills);
+  const clients = preferences.clients.filter(([id]) => id !== clientId);
+
+  if (filteredSkills.length > 0) {
+    clients.push([clientId, filteredSkills]);
+  }
+
+  const payload = JSON.stringify({
+    clients: clients.slice(-MAX_SKILL_PREFERENCE_CLIENTS),
+  } satisfies SkillPreferencesCookie);
+  const cookieValue = await createSignedCookieValue(payload, cookieSecret);
+  return `${SKILL_PREFERENCES_COOKIE_NAME}=${cookieValue}; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=${ONE_YEAR_IN_SECONDS}`;
 }
 
 /**
@@ -220,6 +381,10 @@ export interface ApprovalDialogOptions {
    * HMAC secret key for signing state parameters
    */
   cookieSecret: string;
+  /**
+   * Skill IDs to preselect. When omitted, built-in defaultEnabled values apply.
+   */
+  defaultSkills?: string[];
 }
 
 /**
@@ -287,14 +452,30 @@ export async function renderApprovalDialog(
   request: Request,
   options: ApprovalDialogOptions,
 ): Promise<Response> {
-  const { client, server, scope, redirectUri, state, cookieSecret } = options;
+  const {
+    client,
+    server,
+    scope,
+    redirectUri,
+    state,
+    cookieSecret,
+    defaultSkills,
+  } = options;
+  const defaultSkillIds =
+    defaultSkills === undefined
+      ? new Set(
+          APPROVABLE_SKILLS.filter((skill) => skill.defaultEnabled).map(
+            (skill) => skill.id,
+          ),
+        )
+      : new Set(filterApprovableSkillIds(defaultSkills));
 
   // Use static skill definitions bundled at build time
-  // Generate HTML for all skills (checked if defaultEnabled)
+  // Generate HTML for all approvable skills.
   const skillsHtml = APPROVABLE_SKILLS.map(
     (skill) => `
     <label class="permission-item">
-      <input type="checkbox" name="skill" value="${sanitizeHtml(skill.id)}"${skill.defaultEnabled ? " checked" : ""}>
+      <input type="checkbox" name="skill" value="${sanitizeHtml(skill.id)}"${defaultSkillIds.has(skill.id) ? " checked" : ""}>
       <span class="permission-checkbox"></span>
       <div class="permission-content">
         <div class="permission-header">
@@ -861,7 +1042,7 @@ export interface ParsedApprovalResult {
   /** The original state object passed through the form. */
   state: any;
   /** Headers to set on the redirect response, including the Set-Cookie header. */
-  headers: Record<string, string>;
+  headers: Headers;
   /** Selected skills */
   skills: string[];
 }
@@ -906,12 +1087,7 @@ export async function parseRedirectApproval(
     }
 
     // Extract skill selections from checkboxes - collect all 'skill' field values
-    skills = formData
-      .getAll("skill")
-      .filter(
-        (s): s is string =>
-          typeof s === "string" && APPROVABLE_SKILL_IDS.has(s),
-      );
+    skills = filterApprovableSkillIds(formData.getAll("skill"));
   } catch (error) {
     logError(error, {
       loggerScope: ["cloudflare", "approval-dialog"],
@@ -934,16 +1110,24 @@ export async function parseRedirectApproval(
     new Set([...existingApprovedClients, clientId]),
   );
 
-  // Sign the updated list
+  // Sign the updated approval list
   const payload = JSON.stringify(updatedApprovedClients);
-  const key = await importKey(cookieSecret);
-  const signature = await signData(key, payload);
-  const newCookieValue = `${signature}.${btoa(payload)}`; // signature.base64(payload)
+  const newCookieValue = await createSignedCookieValue(payload, cookieSecret);
 
-  // Generate Set-Cookie header
-  const headers: Record<string, string> = {
-    "Set-Cookie": `${COOKIE_NAME}=${newCookieValue}; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=${ONE_YEAR_IN_SECONDS}`,
-  };
+  const headers = new Headers();
+  headers.append(
+    "Set-Cookie",
+    `${COOKIE_NAME}=${newCookieValue}; HttpOnly; Secure; Path=/; SameSite=Lax; Max-Age=${ONE_YEAR_IN_SECONDS}`,
+  );
+  headers.append(
+    "Set-Cookie",
+    await createSkillPreferencesSetCookie(
+      request,
+      clientId,
+      skills,
+      cookieSecret,
+    ),
+  );
 
   return { state, headers, skills };
 }

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import oauthRoute from "./index";
 import type { Env } from "../types";
 import { verifyAndParseState, signState } from "./state";
+import { SKILL_PREFERENCES_COOKIE_NAME } from "../lib/approval-dialog";
 
 // Mock the OAuth provider
 const mockOAuthProvider = {
@@ -16,6 +17,73 @@ function createTestApp(env: Partial<Env> = {}) {
   const app = new Hono<{ Bindings: Env }>();
   app.route("/oauth", oauthRoute);
   return app;
+}
+
+function skillInputAttributes(html: string, skillId: string): string {
+  const match = html.match(
+    new RegExp(
+      `<input type="checkbox" name="skill" value="${skillId}"([^>]*)>`,
+    ),
+  );
+  return match?.[1] ?? "";
+}
+
+function expectSkillChecked(html: string, skillId: string): void {
+  expect(skillInputAttributes(html, skillId)).toContain("checked");
+}
+
+function expectSkillUnchecked(html: string, skillId: string): void {
+  expect(skillInputAttributes(html, skillId)).not.toContain("checked");
+}
+
+function extractCookiePair(setCookie: string, cookieName: string): string {
+  const marker = `${cookieName}=`;
+  const start = setCookie.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const rest = setCookie.slice(start);
+  const end = rest.indexOf(";");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+async function createSkillPreferenceCookie(
+  app: ReturnType<typeof createTestApp>,
+  testEnv: Partial<Env>,
+  clientId: string,
+  skills: string[],
+): Promise<string> {
+  const formData = new FormData();
+  const signedState = await signState(
+    {
+      req: {
+        oauthReqInfo: {
+          clientId,
+          redirectUri: "https://example.com/callback",
+          scope: ["read"],
+        },
+      },
+      iat: Date.now(),
+      exp: Date.now() + 10 * 60 * 1000,
+    },
+    testEnv.COOKIE_SECRET!,
+  );
+  formData.append("state", signedState);
+  for (const skill of skills) {
+    formData.append("skill", skill);
+  }
+
+  const response = await app.fetch(
+    new Request("http://localhost/oauth/authorize", {
+      method: "POST",
+      body: formData,
+    }),
+    testEnv as Env,
+  );
+  expect(response.status).toBe(302);
+
+  return extractCookiePair(
+    response.headers.get("Set-Cookie") ?? "",
+    SKILL_PREFERENCES_COOKIE_NAME,
+  );
 }
 
 describe("oauth authorize routes", () => {
@@ -113,6 +181,118 @@ describe("oauth authorize routes", () => {
       expect(await response.text()).toBe("Invalid redirect URI");
       expect(mockOAuthProvider.lookupClient).not.toHaveBeenCalled();
     });
+
+    it("preselects remembered skills for the matching client ID", async () => {
+      mockOAuthProvider.lookupClient.mockResolvedValue({
+        clientId: "test-client",
+        clientName: "Test Client",
+        redirectUris: ["https://example.com/callback"],
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+      const preferenceCookie = await createSkillPreferenceCookie(
+        app,
+        testEnv,
+        "test-client",
+        ["triage", "project-management"],
+      );
+      mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+        state: "orig",
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/oauth/authorize", {
+          method: "GET",
+          headers: { Cookie: preferenceCookie },
+        }),
+        testEnv as Env,
+      );
+      const html = await response.text();
+
+      expect(response.status).toBe(200);
+      expectSkillUnchecked(html, "inspect");
+      expectSkillUnchecked(html, "seer");
+      expectSkillChecked(html, "triage");
+      expectSkillChecked(html, "project-management");
+    });
+
+    it("does not reuse remembered skills for a different client ID", async () => {
+      mockOAuthProvider.lookupClient.mockResolvedValue({
+        clientId: "test-client",
+        clientName: "Test Client",
+        redirectUris: ["https://example.com/callback"],
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+      const preferenceCookie = await createSkillPreferenceCookie(
+        app,
+        testEnv,
+        "test-client",
+        ["triage"],
+      );
+      mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
+        clientId: "other-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+        state: "orig",
+      });
+      mockOAuthProvider.lookupClient.mockResolvedValueOnce({
+        clientId: "other-client",
+        clientName: "Other Client",
+        redirectUris: ["https://example.com/callback"],
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/oauth/authorize", {
+          method: "GET",
+          headers: { Cookie: preferenceCookie },
+        }),
+        testEnv as Env,
+      );
+      const html = await response.text();
+
+      expect(response.status).toBe(200);
+      expectSkillChecked(html, "inspect");
+      expectSkillChecked(html, "seer");
+      expectSkillUnchecked(html, "triage");
+    });
+
+    it("ignores tampered remembered skill cookies and falls back to built-in defaults", async () => {
+      mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read"],
+        state: "orig",
+      });
+      mockOAuthProvider.lookupClient.mockResolvedValueOnce({
+        clientId: "test-client",
+        clientName: "Test Client",
+        redirectUris: ["https://example.com/callback"],
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost/oauth/authorize", {
+          method: "GET",
+          headers: {
+            Cookie: `${SKILL_PREFERENCES_COOKIE_NAME}=bad-signature.${btoa(
+              JSON.stringify({
+                clients: [["test-client", ["triage"]]],
+              }),
+            )}`,
+          },
+        }),
+        testEnv as Env,
+      );
+      const html = await response.text();
+
+      expect(response.status).toBe(200);
+      expectSkillChecked(html, "inspect");
+      expectSkillChecked(html, "seer");
+      expectSkillUnchecked(html, "triage");
+    });
   });
 
   describe("POST /oauth/authorize", () => {
@@ -197,6 +377,57 @@ describe("oauth authorize routes", () => {
         "https://example.com/callback",
       );
       expect((decodedState.req as any).scope).toEqual(["read", "write"]);
+    });
+
+    it("uses submitted skills rather than remembered skills for redirect state", async () => {
+      mockOAuthProvider.lookupClient.mockResolvedValue({
+        clientId: "test-client",
+        clientName: "Test Client",
+        redirectUris: ["https://example.com/callback"],
+        tokenEndpointAuthMethod: "client_secret_basic",
+      });
+      const preferenceCookie = await createSkillPreferenceCookie(
+        app,
+        testEnv,
+        "test-client",
+        ["project-management"],
+      );
+      const oauthReqInfo = {
+        clientId: "test-client",
+        redirectUri: "https://example.com/callback",
+        scope: ["read", "write"],
+        state: "original-state",
+      };
+      const formData = new FormData();
+      const signedState = await signState(
+        {
+          req: { oauthReqInfo },
+          iat: Date.now(),
+          exp: Date.now() + 10 * 60 * 1000,
+        },
+        testEnv.COOKIE_SECRET!,
+      );
+      formData.append("state", signedState);
+      formData.append("skill", "triage");
+
+      const response = await app.fetch(
+        new Request("http://localhost/oauth/authorize", {
+          method: "POST",
+          headers: { Cookie: preferenceCookie },
+          body: formData,
+        }),
+        testEnv as Env,
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location");
+      const redirectUrl = new URL(location!);
+      const stateParam = redirectUrl.searchParams.get("state");
+      const decodedState = await verifyAndParseState(
+        stateParam!,
+        testEnv.COOKIE_SECRET!,
+      );
+      expect((decodedState.req as any).skills).toEqual(["triage"]);
     });
 
     it("should handle no skills selected", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import * as Sentry from "@sentry/cloudflare";
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
 import {
+  getRememberedSkillsForClient,
   renderApprovalDialog,
   parseRedirectApproval,
 } from "../../lib/approval-dialog";
@@ -31,24 +32,27 @@ async function redirectToUpstream(
   env: Env,
   request: Request,
   oauthReqInfo: AuthRequest | AuthRequestWithSkills,
-  headers: Record<string, string> = {},
+  headers: HeadersInit = {},
   stateOverride?: string,
 ) {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set(
+    "location",
+    getUpstreamAuthorizeUrl({
+      upstream_url: new URL(
+        SENTRY_AUTH_URL,
+        `https://${env.SENTRY_HOST || "sentry.io"}`,
+      ).href,
+      scope: Object.keys(SCOPES).join(" "),
+      client_id: env.SENTRY_CLIENT_ID,
+      redirect_uri: new URL("/oauth/callback", request.url).href,
+      state: stateOverride ?? btoa(JSON.stringify(oauthReqInfo)),
+    }),
+  );
+
   return new Response(null, {
     status: 302,
-    headers: {
-      ...headers,
-      location: getUpstreamAuthorizeUrl({
-        upstream_url: new URL(
-          SENTRY_AUTH_URL,
-          `https://${env.SENTRY_HOST || "sentry.io"}`,
-        ).href,
-        scope: Object.keys(SCOPES).join(" "),
-        client_id: env.SENTRY_CLIENT_ID,
-        redirect_uri: new URL("/oauth/callback", request.url).href,
-        state: stateOverride ?? btoa(JSON.stringify(oauthReqInfo)),
-      }),
-    },
+    headers: responseHeaders,
   });
 }
 
@@ -172,6 +176,11 @@ export default new Hono<{ Bindings: Env }>()
     // }
 
     const client = await c.env.OAUTH_PROVIDER.lookupClient(clientId);
+    const defaultSkills = await getRememberedSkillsForClient(
+      c.req.raw.headers.get("Cookie"),
+      clientId,
+      c.env.COOKIE_SECRET,
+    );
     const response = await renderApprovalDialog(c.req.raw, {
       client,
       server: {
@@ -181,6 +190,7 @@ export default new Hono<{ Bindings: Env }>()
       redirectUri: oauthReqInfoWithResource.redirectUri,
       state: { oauthReqInfo: oauthReqInfoWithResource },
       cookieSecret: c.env.COOKIE_SECRET,
+      defaultSkills,
     });
 
     Sentry.metrics.count("app.oauth.consent_prompted", 1, {


### PR DESCRIPTION
Remote OAuth consent now remembers the last skill selection for each DCR client in a separate signed browser cookie. The remembered value only preselects future consent checkboxes; authorization still comes from the submitted form values carried through signed OAuth state and validated in the callback.

The cookie stores a bounded 10-client LRU and ignores invalid or deprecated skill entries. The PR also documents the contract in a new spec and covers matching clients, different clients, tampered cookies, LRU retention, and POST state independence in the Cloudflare OAuth tests.

Validation run: `pnpm --filter @sentry/mcp-cloudflare test -- approval-dialog.test.ts authorize.test.ts`, `pnpm --filter @sentry/mcp-cloudflare tsc`, `pnpm run lint`, `pnpm docs:check`, and `git diff --check`.