### PR TITLE
fix(cloudflare): Add OAuth lifecycle telemetry

### DIFF
--- a/docs/cloudflare/oauth-architecture.md
+++ b/docs/cloudflare/oauth-architecture.md
@@ -190,7 +190,9 @@ interface WorkerProps {
   id: string;                    // Sentry user ID
   accessToken: string;            // Sentry access token
   refreshToken?: string;          // Sentry refresh token
-  accessTokenExpiresAt?: number;  // Sentry token expiry timestamp
+  accessTokenExpiresAt?: number;  // Cached validity deadline; extended after probes
+  sessionStartedAt?: number;      // MCP grant creation timestamp
+  upstreamExpiresAt?: number;     // Original Sentry expiry timestamp
   clientId: string;               // MCP client ID
   scope: string;                  // MCP permissions granted
   grantedSkills?: string[];       // Skills granted (primary authorization)
@@ -241,6 +243,8 @@ const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
     accessToken: payload.access_token,       // Sentry's access token
     refreshToken: payload.refresh_token,     // Sentry's refresh token
     accessTokenExpiresAt: Date.now() + payload.expires_in * 1000,
+    sessionStartedAt: Date.now(),
+    upstreamExpiresAt: Date.now() + payload.expires_in * 1000,
     clientId: oauthReqInfo.clientId,         // MCP client ID
     scope: oauthReqInfo.scope.join(" "),     // MCP scopes
     grantedSkills: Array.from(validSkills),  // Skills granted (primary authorization)

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -291,6 +291,9 @@ Optional OAuth error attributes:
   `wrapper`, or `malformed`
 - `app.oauth.grant.id_hash` - Non-secret grant fingerprint on grant lifecycle
   logs
+- `app.oauth.grant.age_bucket` - Bounded MCP grant age at refresh/revocation
+- `app.oauth.upstream.expires_in_bucket` - Bounded remaining time before the
+  original upstream Sentry expiry at refresh/revocation
 
 Interpretation:
 

--- a/docs/operations/oauth-signout-playbook.md
+++ b/docs/operations/oauth-signout-playbook.md
@@ -54,6 +54,8 @@ Attributes:
 - `app.oauth.token_exchange.outcome` — see above
 - `app.client.family` — bucketed User-Agent (`claude-code`, `cursor`, `codex`, `copilot`, `claude-desktop`, `opencode`, `reactor-netty`, `java-http-client`, `go-http-client`, `python`, `bun`, `node`, `other`, `unknown`)
 - `app.oauth.grant.shape` — currently always `refreshable`
+- `app.oauth.grant.age_bucket` — elapsed time since the MCP grant was created (`lt_1h`, `1h_6h`, `6h_1d`, `1d_7d`, `7d_14d`, `14d_30d`, `gte_30d`, `future`, `unknown`)
+- `app.oauth.upstream.expires_in_bucket` — remaining time before the original upstream Sentry expiry (`expired`, `lt_1h`, `1h_1d`, `1d_7d`, `7d_14d`, `14d_30d`, `gte_30d`, `unknown`)
 - `app.oauth.probe.status_code` — upstream HTTP status on outcomes where a probe fired (`200` / `400` / `401` / `403` / `429` / `500` / …)
 - `app.oauth.probe.reason` — `rate_limit` / `server_error` / `unknown` on `verification_indeterminate`
 
@@ -67,6 +69,8 @@ Attributes:
 
 - `app.oauth.grant_revoked.reason` — `stale_props_no_refresh` / `upstream_rejected` / `upstream_rejected_in_use`
 - `app.client.family`
+- `app.oauth.grant.age_bucket`
+- `app.oauth.upstream.expires_in_bucket`
 - `user.id` (via Sentry user context)
 
 `upstream_rejected_in_use` indicates Sentry returned 401 to a tool call while the stored access token still looked locally valid — the sub-30d sign-out signal users typically report. The grant is revoked via `env.OAUTH_PROVIDER.revokeGrant` under `ctx.waitUntil`, short-circuiting the death-spiral where subsequent refreshes kept handing out wrapper tokens backed by a dead upstream token.
@@ -74,7 +78,9 @@ Attributes:
 The handler also emits a low-volume Sentry Log message,
 `OAuth grant rejected for reauthorization`, when it decides to force a client
 to reauthorize. This log carries the same `app.oauth.grant_revoked.reason`,
-`app.client.family`, `userId`, `clientId`, and `app.oauth.grant.id_hash`.
+`app.client.family`, `userId`, `clientId`, `app.oauth.grant.id_hash`,
+`app.oauth.grant.age_bucket`, and
+`app.oauth.upstream.expires_in_bucket`.
 Use the hash to correlate one grant/session without logging raw bearer-token
 components.
 
@@ -124,7 +130,7 @@ Copy/paste-ready. All use the Sentry MCP's `search_events` natural-language quer
 
 ```
 metric app.oauth.grant_revoked filtered by user.id:"<id>" sum of value grouped by app.oauth.grant_revoked.reason over 30 days
-logs message:"OAuth grant rejected for reauthorization" userId:"<id>" grouped by app.oauth.grant_revoked.reason, app.client.family, clientId, app.oauth.grant.id_hash over 30 days
+logs message:"OAuth grant rejected for reauthorization" userId:"<id>" grouped by app.oauth.grant_revoked.reason, app.client.family, app.oauth.grant.age_bucket, app.oauth.upstream.expires_in_bucket, clientId, app.oauth.grant.id_hash over 30 days
 ```
 
 ### Per-client sign-out rate
@@ -138,6 +144,7 @@ spans /mcp http.response.status_code:401 grouped by app.client.family, app.oauth
 
 ```
 metric app.oauth.token_exchange filtered by app.oauth.token_exchange.outcome:upstream_rejected sum of value grouped by app.oauth.probe.status_code over 7 days
+metric app.oauth.token_exchange filtered by app.oauth.token_exchange.outcome:upstream_rejected sum of value grouped by app.oauth.grant.age_bucket, app.oauth.upstream.expires_in_bucket over 7 days
 ```
 
 ### Session-lifetime proxy (callbacks vs revocations per client)
@@ -201,7 +208,7 @@ Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real con
    `metric app.oauth.grant_revoked filtered by user.id:"<id>" grouped by app.oauth.grant_revoked.reason over 30 days`
 2. **Interpret the `reason`:**
    - `upstream_rejected_in_use` — Sentry invalidated the token mid-session (SSO / org / password / admin revocation). Most common for sub-30d sign-outs. The grant was revoked automatically; user should re-auth cleanly on next request.
-   - `upstream_rejected` — natural 30d expiry (probe path). Expected.
+   - `upstream_rejected` — refresh probing got an upstream 4xx. Use `app.oauth.grant.age_bucket` and `app.oauth.upstream.expires_in_bucket` to separate near-scheduled expiry from premature upstream rejection.
    - `stale_props_no_refresh` — legacy grant predating PR #537. Expected, one-time.
 3. **If no revocations are recorded** (reason counts are empty), the user hasn't been revoked server-side. Either they're still authenticated and the perception is wrong, OR the client lost local state and re-registered without going through `/oauth/callback`:
    - Check `app.oauth.register grouped by app.client.family` for that client — high register:callback ratio (claude-code and cursor re-register on every cold start) is normal client behavior, not a server-side sign-out.
@@ -213,4 +220,4 @@ Trade-off: KV storage holds extra grant entries (each up to 30d). Not a real con
 - #917 — carried probe status as a metric attribute.
 - #918 — added client family, user tagging, `callback_completed` / `register` metrics, probe reason, structured Invalid-redirect-URI fields.
 - #919 — added `expired_on_schedule` on `upstream_rejected`. Removed in #920 once we realized the probe path can't produce `"false"` by construction.
-- #920 — closes Gaps #1 and #2 via tool-call 401 detection, grant revocation, and `app.oauth.grant_revoked.reason:upstream_rejected_in_use`. Also removes the unreachable `expired_on_schedule` attribute and its `upstreamExpiresAt` grant field.
+- #920 — closes Gaps #1 and #2 via tool-call 401 detection, grant revocation, and `app.oauth.grant_revoked.reason:upstream_rejected_in_use`. Also removes the unreachable `expired_on_schedule` attribute.

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -2,6 +2,19 @@ import type { ExecutionContext, RateLimit } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
 
+const { sentryMetricsCount, sentrySetUser } = vi.hoisted(() => ({
+  sentryMetricsCount: vi.fn(),
+  sentrySetUser: vi.fn(),
+}));
+
+vi.mock("@sentry/cloudflare", () => ({
+  getActiveSpan: vi.fn(() => undefined),
+  metrics: {
+    count: sentryMetricsCount,
+  },
+  setUser: sentrySetUser,
+}));
+
 import mcpHandler from "./mcp-handler";
 
 interface OAuthProps {
@@ -9,6 +22,8 @@ interface OAuthProps {
   clientId: string;
   accessToken: string;
   refreshToken: string;
+  sessionStartedAt?: number;
+  upstreamExpiresAt?: number;
   grantedSkills: string[];
   constraintOrganizationSlug?: string | null;
   constraintProjectSlug?: string | null;
@@ -94,6 +109,8 @@ function createTestEnv(): Env {
 describe("MCP Handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sentryMetricsCount.mockReset();
+    sentrySetUser.mockReset();
   });
 
   describe("authentication", () => {
@@ -110,9 +127,18 @@ describe("MCP Handler", () => {
     });
 
     it("should reject legacy tokens without grantedSkills", async () => {
-      const request = createMcpRequest("tools/list");
+      const now = Date.now();
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        {
+          bearerToken: "test-user-123:legacy-grant-id:secret",
+        },
+      );
       const ctx = createMcpContext({
         grantedSkills: undefined as unknown as string[],
+        sessionStartedAt: now - 2 * 24 * 60 * 60 * 1000,
+        upstreamExpiresAt: now + 3 * 24 * 60 * 60 * 1000,
       });
       (ctx.props as Record<string, unknown>).grantedScopes = [
         "org:read",
@@ -127,9 +153,21 @@ describe("MCP Handler", () => {
       expect(response.headers.get("WWW-Authenticate")).toContain(
         "invalid_token",
       );
+      expect(sentryMetricsCount).toHaveBeenCalledWith(
+        "app.oauth.grant_revoked",
+        1,
+        {
+          attributes: expect.objectContaining({
+            "app.oauth.grant_revoked.reason": "stale_props_no_refresh",
+            "app.oauth.grant.age_bucket": "1d_7d",
+            "app.oauth.upstream.expires_in_bucket": "1d_7d",
+          }),
+        },
+      );
     });
 
     it("should revoke and reject stale grants missing a refresh token", async () => {
+      const now = Date.now();
       const request = createMcpRequest(
         "tools/list",
         {},
@@ -139,6 +177,8 @@ describe("MCP Handler", () => {
       );
       const ctx = createMcpContext({
         refreshToken: undefined as unknown as string,
+        sessionStartedAt: now - 2 * 24 * 60 * 60 * 1000,
+        upstreamExpiresAt: now + 3 * 24 * 60 * 60 * 1000,
       });
       const env = createTestEnv();
 
@@ -150,6 +190,17 @@ describe("MCP Handler", () => {
         "invalid_token",
       );
       expect(ctx.waitUntil).toHaveBeenCalled();
+      expect(sentryMetricsCount).toHaveBeenCalledWith(
+        "app.oauth.grant_revoked",
+        1,
+        {
+          attributes: expect.objectContaining({
+            "app.oauth.grant_revoked.reason": "stale_props_no_refresh",
+            "app.oauth.grant.age_bucket": "1d_7d",
+            "app.oauth.upstream.expires_in_bucket": "1d_7d",
+          }),
+        },
+      );
 
       await (ctx.waitUntil as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
       expect(env.OAUTH_PROVIDER.revokeGrant).toHaveBeenCalledTimes(1);

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -17,7 +17,10 @@ import { logWarn } from "@sentry/mcp-core/telem/logging";
 import type { ServerContext } from "@sentry/mcp-core/types";
 import { createMcpHandler } from "agents/mcp";
 import { annotateResponseMetric } from "../metrics";
-import { getOAuthGrantTelemetry } from "../oauth/telemetry";
+import {
+  getOAuthGrantLifecycleTelemetry,
+  getOAuthGrantTelemetry,
+} from "../oauth/telemetry";
 import type { WorkerProps } from "../types";
 import type { Env } from "../types";
 import {
@@ -74,6 +77,7 @@ function logGrantReauthorization(
   clientId: string,
   clientFamily: string,
   grantId: string | null,
+  lifecycleTelemetry: Record<string, string>,
 ): void {
   logWarn("OAuth grant rejected for reauthorization", {
     loggerScope: ["cloudflare", "mcp-handler"],
@@ -83,6 +87,7 @@ function logGrantReauthorization(
       userId,
       clientId,
       ...getOAuthGrantTelemetry(grantId),
+      ...lifecycleTelemetry,
     },
   });
 }
@@ -100,14 +105,26 @@ function revokeStaleGrant(
   logLabel: string,
   revokeReason: Exclude<GrantRevokedReason, "upstream_rejected_in_use">,
   clientFamily: string,
+  lifecycleTelemetry: Record<string, string>,
   errorDescription = "Token requires re-authorization",
 ): Response {
+  if (grantId) {
+    Sentry.metrics.count("app.oauth.grant_revoked", 1, {
+      attributes: {
+        "app.oauth.grant_revoked.reason": revokeReason,
+        "app.client.family": clientFamily,
+        ...lifecycleTelemetry,
+      },
+    });
+  }
+
   logGrantReauthorization(
     revokeReason,
     userId,
     clientId,
     clientFamily,
     grantId,
+    lifecycleTelemetry,
   );
 
   ctx.waitUntil(
@@ -201,6 +218,7 @@ const mcpHandler: ExportedHandler<Env> = {
     const sentryHost = env.SENTRY_HOST || "sentry.io";
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
     const requestGrantId = getRequestGrantId(request);
+    const lifecycleTelemetry = getOAuthGrantLifecycleTelemetry(rawProps);
     const { ip_address: userIpAddress } = setSentryUserFromRequest(
       request,
       userId,
@@ -231,20 +249,13 @@ const mcpHandler: ExportedHandler<Env> = {
         "legacy grant",
         "stale_props_no_refresh",
         clientFamily,
+        lifecycleTelemetry,
       );
     }
 
     // Attribute values avoid the substring "token" so Sentry's default PII
     // scrubber doesn't replace them with "[Filtered]" on ingest.
     if (!rawProps.refreshToken) {
-      if (requestGrantId) {
-        Sentry.metrics.count("app.oauth.grant_revoked", 1, {
-          attributes: {
-            "app.oauth.grant_revoked.reason": "stale_props_no_refresh",
-            "app.client.family": clientFamily,
-          },
-        });
-      }
       return revokeStaleGrant(
         ctx,
         env,
@@ -254,18 +265,11 @@ const mcpHandler: ExportedHandler<Env> = {
         "stale grant (missing refresh token)",
         "stale_props_no_refresh",
         clientFamily,
+        lifecycleTelemetry,
       );
     }
 
     if (rawProps.upstreamTokenInvalid) {
-      if (requestGrantId) {
-        Sentry.metrics.count("app.oauth.grant_revoked", 1, {
-          attributes: {
-            "app.oauth.grant_revoked.reason": "upstream_rejected",
-            "app.client.family": clientFamily,
-          },
-        });
-      }
       return revokeStaleGrant(
         ctx,
         env,
@@ -275,6 +279,7 @@ const mcpHandler: ExportedHandler<Env> = {
         "stale grant (invalid upstream token)",
         "upstream_rejected",
         clientFamily,
+        lifecycleTelemetry,
         "Upstream authorization is no longer valid",
       );
     }
@@ -407,6 +412,7 @@ const mcpHandler: ExportedHandler<Env> = {
           attributes: {
             "app.oauth.grant_revoked.reason": "upstream_rejected_in_use",
             "app.client.family": clientFamily,
+            ...lifecycleTelemetry,
           },
         });
         logGrantReauthorization(
@@ -415,6 +421,7 @@ const mcpHandler: ExportedHandler<Env> = {
           clientId,
           clientFamily,
           requestGrantId,
+          lifecycleTelemetry,
         );
         ctx.waitUntil(
           (async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.test.ts
@@ -223,9 +223,12 @@ describe("tokenExchangeCallback", () => {
   });
 
   it("should return cached token TTL when token is locally valid", async () => {
+    const now = Date.now();
     const futureExpiry = Date.now() + 10 * 60 * 1000;
     const options = createRefreshOptions({
       accessTokenExpiresAt: futureExpiry,
+      sessionStartedAt: now - 2 * 24 * 60 * 60 * 1000,
+      upstreamExpiresAt: now + 3 * 24 * 60 * 60 * 1000,
     });
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
@@ -238,6 +241,17 @@ describe("tokenExchangeCallback", () => {
       accessTokenTTL: expect.any(Number),
     });
     expect(fetchSpy).not.toHaveBeenCalled();
+    expect(sentryMetricsCount).toHaveBeenCalledWith(
+      "app.oauth.token_exchange",
+      1,
+      {
+        attributes: expect.objectContaining({
+          "app.oauth.token_exchange.outcome": "cached_valid_local",
+          "app.oauth.grant.age_bucket": "1d_7d",
+          "app.oauth.upstream.expires_in_bucket": "1d_7d",
+        }),
+      },
+    );
   });
 
   it("should clear upstreamTokenInvalid after a successful probe", async () => {

--- a/packages/mcp-cloudflare/src/server/oauth/helpers.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/helpers.ts
@@ -14,6 +14,7 @@ import type { z } from "zod";
 import type { WorkerProps } from "../types";
 import { setSentryUserFromRequest } from "../utils/sentry-user";
 import { TokenResponseSchema } from "./constants";
+import { getOAuthGrantLifecycleTelemetry } from "./telemetry";
 
 function escapeHtml(value: string): string {
   return value
@@ -590,6 +591,7 @@ export async function tokenExchangeCallback(
       recordTokenExchangeOutcome("cached_valid_local", {
         "app.oauth.grant.shape": "refreshable",
         "app.client.family": clientFamily,
+        ...getOAuthGrantLifecycleTelemetry(props),
       });
       return buildSuccessfulTokenExchangeResult(
         props,
@@ -611,6 +613,7 @@ export async function tokenExchangeCallback(
   const outcomeAttributes: Record<string, string> = {
     "app.oauth.grant.shape": "refreshable",
     "app.client.family": clientFamily,
+    ...getOAuthGrantLifecycleTelemetry(props),
   };
   if (typeof status === "number") {
     outcomeAttributes["app.oauth.probe.status_code"] = String(status);

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -279,6 +279,7 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
 
   // Return back to the MCP client a new token
   const accessTokenExpiresAt = getUpstreamTokenExpiryTimestamp(payload);
+  const sessionStartedAt = Date.now();
   const userLabel = getUpstreamUserLabel(payload);
 
   const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
@@ -306,6 +307,8 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       // Cache upstream expiry so future refresh grants can avoid
       // unnecessary upstream refresh calls when still valid
       accessTokenExpiresAt,
+      sessionStartedAt,
+      upstreamExpiresAt: accessTokenExpiresAt,
       clientId: oauthReqInfo.clientId,
       clientName: registeredClientName,
       scope: oauthReqInfo.scope.join(" "),

--- a/packages/mcp-cloudflare/src/server/oauth/telemetry.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/telemetry.test.ts
@@ -4,6 +4,7 @@ import {
   bucketOAuthErrorDescription,
   getOAuthErrorTelemetry,
   getOAuthGrantTelemetry,
+  getOAuthGrantLifecycleTelemetry,
   getOAuthTokenShape,
 } from "./telemetry";
 
@@ -153,5 +154,23 @@ describe("OAuth telemetry", () => {
       first["app.oauth.grant.id_hash"],
     );
     expect(JSON.stringify(first)).not.toContain("grant-id");
+  });
+
+  it("projects lifecycle timestamps into bounded diagnostic buckets", () => {
+    const now = Date.now();
+
+    expect(
+      getOAuthGrantLifecycleTelemetry({
+        sessionStartedAt: now - 2 * 24 * 60 * 60 * 1000,
+        upstreamExpiresAt: now + 3 * 24 * 60 * 60 * 1000,
+      }),
+    ).toEqual({
+      "app.oauth.grant.age_bucket": "1d_7d",
+      "app.oauth.upstream.expires_in_bucket": "1d_7d",
+    });
+    expect(getOAuthGrantLifecycleTelemetry({})).toEqual({
+      "app.oauth.grant.age_bucket": "unknown",
+      "app.oauth.upstream.expires_in_bucket": "unknown",
+    });
   });
 });

--- a/packages/mcp-cloudflare/src/server/oauth/telemetry.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/telemetry.ts
@@ -25,6 +25,87 @@ export type OAuthErrorTelemetry = {
   oauthTokenShape?: OAuthTokenShape;
 };
 
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function getTimestamp(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function bucketElapsedMs(value: unknown, now = Date.now()): string {
+  const timestamp = getTimestamp(value);
+  if (!timestamp) {
+    return "unknown";
+  }
+
+  const elapsedMs = now - timestamp;
+  if (elapsedMs < 0) {
+    return "future";
+  }
+  if (elapsedMs < HOUR_MS) {
+    return "lt_1h";
+  }
+  if (elapsedMs < 6 * HOUR_MS) {
+    return "1h_6h";
+  }
+  if (elapsedMs < DAY_MS) {
+    return "6h_1d";
+  }
+  if (elapsedMs < 7 * DAY_MS) {
+    return "1d_7d";
+  }
+  if (elapsedMs < 14 * DAY_MS) {
+    return "7d_14d";
+  }
+  if (elapsedMs < 30 * DAY_MS) {
+    return "14d_30d";
+  }
+  return "gte_30d";
+}
+
+function bucketRemainingMs(value: unknown, now = Date.now()): string {
+  const timestamp = getTimestamp(value);
+  if (!timestamp) {
+    return "unknown";
+  }
+
+  const remainingMs = timestamp - now;
+  if (remainingMs <= 0) {
+    return "expired";
+  }
+  if (remainingMs < HOUR_MS) {
+    return "lt_1h";
+  }
+  if (remainingMs < DAY_MS) {
+    return "1h_1d";
+  }
+  if (remainingMs < 7 * DAY_MS) {
+    return "1d_7d";
+  }
+  if (remainingMs < 14 * DAY_MS) {
+    return "7d_14d";
+  }
+  if (remainingMs < 30 * DAY_MS) {
+    return "14d_30d";
+  }
+  return "gte_30d";
+}
+
+/**
+ * Projects OAuth grant lifecycle timestamps into bounded diagnostic buckets.
+ */
+export function getOAuthGrantLifecycleTelemetry(props: {
+  sessionStartedAt?: unknown;
+  upstreamExpiresAt?: unknown;
+}): Record<string, string> {
+  return {
+    "app.oauth.grant.age_bucket": bucketElapsedMs(props.sessionStartedAt),
+    "app.oauth.upstream.expires_in_bucket": bucketRemainingMs(
+      props.upstreamExpiresAt,
+    ),
+  };
+}
+
 /**
  * Buckets OAuth error codes before they become span or metric attributes.
  */

--- a/packages/mcp-cloudflare/src/server/types.ts
+++ b/packages/mcp-cloudflare/src/server/types.ts
@@ -18,6 +18,8 @@ export type WorkerProps = {
   accessToken: string;
   refreshToken: string;
   accessTokenExpiresAt?: number; // Cached validity deadline; extended on successful probe.
+  sessionStartedAt?: number;
+  upstreamExpiresAt?: number;
   upstreamTokenInvalid?: boolean;
   clientId: string;
   clientName?: string;


### PR DESCRIPTION
Add bounded lifecycle context to Cloudflare OAuth telemetry so production queries can separate expected upstream expiry from premature upstream rejection or client-side auth loss.

This records the MCP grant age bucket and the original upstream Sentry expiry remaining-time bucket on token exchange and grant revocation metrics/logs. The values are categorical diagnostic fields only; no bearer tokens or raw secrets are logged.

The grant revocation metric now lives in the shared stale-grant revoke helper so legacy and stale-props paths emit the same attributes, and the OAuth sign-out runbook documents how to group by the new fields while investigating sub-30d sign-outs.

Validation run locally:
- pnpm --dir packages/mcp-cloudflare exec vitest run src/server/oauth/telemetry.test.ts src/server/oauth/helpers.test.ts src/server/lib/mcp-handler.test.ts
- pnpm --filter @sentry/mcp-cloudflare run tsc
- pnpm run lint
- pnpm run tsc