### PR TITLE
feat(tools): add update_dsn tool for managing DSN client key settings

### DIFF
--- a/.agents/skills/mcp-qa/SKILL.md
+++ b/.agents/skills/mcp-qa/SKILL.md
@@ -64,6 +64,12 @@ behavior. For catalog tools, expect `search_sentry_tools` followed by
 `execute_sentry_tool(name: <changed_tool>)`. For direct tools, expect the tool name in
 the transcript. `--list-tools` alone is not QA.
 
+For mutating catalog-only tools, avoid live prod changes unless there is a
+disposable resource prepared for the test. Add or run a server-level
+`execute_sentry_tool` dispatch test with MSW coverage to prove catalog
+discovery, generated schema exposure, constraint injection, and tool dispatch
+without changing real Sentry data.
+
 For output-format changes, also inspect the raw MCP tool result when possible,
 not only the LLM's final answer. The final answer can add model-specific text
 that is not part of the tool response. Review raw tool output against

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -79,6 +79,10 @@ Fast, focused tests of actual functionality:
   formatted handler response with `toMatchInlineSnapshot()`. Supplemental
   `toContain()` assertions are fine, but they do not replace a full-response
   snapshot.
+- For catalog-only tools, include server-level coverage that executes the tool
+  through `execute_sentry_tool` when the change affects discovery, generated
+  schemas, constraint injection, or dispatch. Prefer this MSW-backed route for
+  mutating tools when live QA would change real Sentry data.
 - Review tool output snapshots against
   [../contributing/tool-responses.md](../contributing/tool-responses.md) so
   formatted output stays user-facing and avoids raw internals.

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -218,6 +218,27 @@ type RequestOptions = {
 };
 
 export type TraceItemType = "spans" | "logs" | "tracemetrics";
+
+type ClientKeyRateLimit = {
+  window: number;
+  count: number;
+};
+
+type ClientKeyDynamicSdkLoaderOptions = {
+  hasReplay?: boolean;
+  hasPerformance?: boolean;
+  hasDebug?: boolean;
+  hasFeedback?: boolean;
+  hasLogsAndMetrics?: boolean;
+};
+
+type UpdateClientKeyRequest = {
+  name?: string;
+  isActive?: boolean;
+  rateLimit?: ClientKeyRateLimit | null;
+  browserSdkVersion?: string;
+  dynamicSdkLoaderOptions?: ClientKeyDynamicSdkLoaderOptions;
+};
 export type TraceItemAttributeType = "string" | "number" | "boolean";
 export type TraceItemAttributeSourceType = "sentry" | "user";
 
@@ -2090,26 +2111,25 @@ export class SentryApiService {
       organizationSlug: string;
       projectSlug: string;
       keyId: string | number;
-      name?: string;
-      isActive?: boolean;
-      rateLimit?: { window: number; count: number } | null;
-      browserSdkVersion?: string;
-      dynamicSdkLoaderOptions?: {
-        hasReplay?: boolean;
-        hasPerformance?: boolean;
-        hasDebug?: boolean;
-        hasFeedback?: boolean;
-        hasLogsAndMetrics?: boolean;
-      };
-    },
+    } & UpdateClientKeyRequest,
     opts?: RequestOptions,
   ): Promise<ClientKey> {
-    const updateData: Record<string, any> = {};
-    if (name !== undefined) updateData.name = name;
-    if (isActive !== undefined) updateData.isActive = isActive;
-    if (rateLimit !== undefined) updateData.rateLimit = rateLimit;
-    if (browserSdkVersion !== undefined) updateData.browserSdkVersion = browserSdkVersion;
-    if (dynamicSdkLoaderOptions !== undefined) updateData.dynamicSdkLoaderOptions = dynamicSdkLoaderOptions;
+    const updateData: UpdateClientKeyRequest = {};
+    if (name !== undefined) {
+      updateData.name = name;
+    }
+    if (isActive !== undefined) {
+      updateData.isActive = isActive;
+    }
+    if (rateLimit !== undefined) {
+      updateData.rateLimit = rateLimit;
+    }
+    if (browserSdkVersion !== undefined) {
+      updateData.browserSdkVersion = browserSdkVersion;
+    }
+    if (dynamicSdkLoaderOptions !== undefined) {
+      updateData.dynamicSdkLoaderOptions = dynamicSdkLoaderOptions;
+    }
 
     const body = await this.requestJSON(
       `/projects/${organizationSlug}/${projectSlug}/keys/${keyId}/`,
@@ -2121,7 +2141,6 @@ export class SentryApiService {
     );
     return ClientKeySchema.parse(body);
   }
-
 
   /**
    * Lists all client keys (DSNs) for a project.

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2062,6 +2062,68 @@ export class SentryApiService {
   }
 
   /**
+   * Updates a client key (DSN) for a project.
+   *
+   * @param params Key update parameters
+   * @param params.organizationSlug Organization identifier
+   * @param params.projectSlug Project identifier
+   * @param params.keyId The ID of the key to update
+   * @param params.name Human-readable name for the key (optional)
+   * @param params.isActive Activate or deactivate the client key (optional)
+   * @param params.rateLimit Applies a rate limit to cap the number of errors accepted during a given time window (optional, null to disable)
+   * @param params.browserSdkVersion Sentry Javascript SDK version to use (optional)
+   * @param params.dynamicSdkLoaderOptions Configures options for the Javascript Loader Script (optional)
+   * @param opts Request options
+   * @returns Updated client key with DSN information
+   */
+  async updateClientKey(
+    {
+      organizationSlug,
+      projectSlug,
+      keyId,
+      name,
+      isActive,
+      rateLimit,
+      browserSdkVersion,
+      dynamicSdkLoaderOptions,
+    }: {
+      organizationSlug: string;
+      projectSlug: string;
+      keyId: string | number;
+      name?: string;
+      isActive?: boolean;
+      rateLimit?: { window: number; count: number } | null;
+      browserSdkVersion?: string;
+      dynamicSdkLoaderOptions?: {
+        hasReplay?: boolean;
+        hasPerformance?: boolean;
+        hasDebug?: boolean;
+        hasFeedback?: boolean;
+        hasLogsAndMetrics?: boolean;
+      };
+    },
+    opts?: RequestOptions,
+  ): Promise<ClientKey> {
+    const updateData: Record<string, any> = {};
+    if (name !== undefined) updateData.name = name;
+    if (isActive !== undefined) updateData.isActive = isActive;
+    if (rateLimit !== undefined) updateData.rateLimit = rateLimit;
+    if (browserSdkVersion !== undefined) updateData.browserSdkVersion = browserSdkVersion;
+    if (dynamicSdkLoaderOptions !== undefined) updateData.dynamicSdkLoaderOptions = dynamicSdkLoaderOptions;
+
+    const body = await this.requestJSON(
+      `/projects/${organizationSlug}/${projectSlug}/keys/${keyId}/`,
+      {
+        method: "PUT",
+        body: JSON.stringify(updateData),
+      },
+      opts,
+    );
+    return ClientKeySchema.parse(body);
+  }
+
+
+  /**
    * Lists all client keys (DSNs) for a project.
    *
    * @param params Query parameters

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -424,6 +424,23 @@ export const ClientKeySchema = z
     }),
     isActive: z.boolean(),
     dateCreated: z.string().datetime().nullable(),
+    rateLimit: z
+      .object({
+        window: z.number(),
+        count: z.number(),
+      })
+      .nullable()
+      .optional(),
+    browserSdkVersion: z.string().optional(),
+    dynamicSdkLoaderOptions: z
+      .object({
+        hasReplay: z.boolean(),
+        hasPerformance: z.boolean(),
+        hasDebug: z.boolean(),
+        hasFeedback: z.boolean().optional(),
+        hasLogsAndMetrics: z.boolean().optional(),
+      })
+      .optional(),
   })
   .passthrough();
 

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -419,9 +419,11 @@ export const ClientKeySchema = z
   .object({
     id: z.union([z.string(), z.number()]),
     name: z.string(),
-    dsn: z.object({
-      public: z.string(),
-    }),
+    dsn: z
+      .object({
+        public: z.string(),
+      })
+      .passthrough(),
     isActive: z.boolean(),
     dateCreated: z.string().datetime().nullable(),
     rateLimit: z

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1257,6 +1257,33 @@ describe("buildServer", () => {
       );
     });
 
+    it("execute_sentry_tool dispatches to catalog-only update_dsn", async () => {
+      const server = buildServer({
+        context: baseContext,
+      });
+
+      const toolNames = getRegisteredToolNames(server);
+      expect(toolNames).not.toContain("update_dsn");
+
+      const result = await callRegisteredTool(server, "execute_sentry_tool", {
+        name: "update_dsn",
+        arguments: {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+          rateLimitWindow: 3600,
+          rateLimitCount: 0,
+        },
+      });
+
+      expect(getTextContent(result)).toContain(
+        "# Updated DSN in **sentry-mcp-evals/cloudflare-mcp**",
+      );
+      expect(getTextContent(result)).toContain(
+        "**Rate Limit**: 0 events per 3600 seconds",
+      );
+    });
+
     it("execute_sentry_tool dispatches to catalog-only whoami", async () => {
       const server = buildServer({
         context: {

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1279,9 +1279,7 @@ describe("buildServer", () => {
       expect(getTextContent(result)).toContain(
         "# Updated DSN in **sentry-mcp-evals/cloudflare-mcp**",
       );
-      expect(getTextContent(result)).toContain(
-        "**Rate Limit**: 0 events per 3600 seconds",
-      );
+      expect(getTextContent(result)).toContain("**Rate Limit**: Disabled");
     });
 
     it("execute_sentry_tool dispatches to catalog-only whoami", async () => {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -331,7 +331,7 @@
     "description": "Create and modify projects, teams, and DSNs",
     "defaultEnabled": false,
     "order": 5,
-    "toolCount": 9,
+    "toolCount": 10,
     "tools": [
       {
         "name": "create_dsn",
@@ -367,6 +367,11 @@
         "name": "find_teams",
         "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
         "requiredScopes": ["team:read"]
+      },
+      {
+        "name": "update_dsn",
+        "description": "Update settings for an existing DSN (client key) in a project, such as name, active status, rate limit, and loader script options.\n\nUSE THIS TOOL WHEN:\n- Deactivating or activating a DSN/client key\n- Setting or removing DSN rate limits ('set rate limit of 1000 per hour on DSN X')\n- Renaming a DSN ('rename DSN X to Production')\n- Configuring Javascript SDK loader script options (session replay, performance, debug, feedback, etc.)\n\nBe careful when using this tool!\n\n<examples>\n### Rename DSN and set rate limit\n```\nupdate_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', name='Production Key', rateLimitWindow=3600, rateLimitCount=500)\n```\n\n### Deactivate a DSN\n```\nupdate_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', isActive=false)\n```\n\n### Disable rate limit entirely\n```\nupdate_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', disableRateLimit=true)\n```\n</examples>\n\n<hints>\n- Use `find_dsns()` first to find the `keyId` for the DSN you want to update.\n- Both `rateLimitWindow` (seconds) and `rateLimitCount` (error cap) must be provided together to set a rate limit.\n</hints>",
+        "requiredScopes": ["project:write"]
       },
       {
         "name": "update_project",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -2129,6 +2129,92 @@
     "surface": "direct"
   },
   {
+    "name": "update_dsn",
+    "description": "Update settings for an existing DSN (client key) in a project, such as name, active status, rate limit, and loader script options.\n\nUSE THIS TOOL WHEN:\n- Deactivating or activating a DSN/client key\n- Setting or removing DSN rate limits ('set rate limit of 1000 per hour on DSN X')\n- Renaming a DSN ('rename DSN X to Production')\n- Configuring Javascript SDK loader script options (session replay, performance, debug, feedback, etc.)\n\nBe careful when using this tool!\n\n<examples>\n### Rename DSN and set rate limit\n```\nupdate_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', name='Production Key', rateLimitWindow=3600, rateLimitCount=500)\n```\n\n### Deactivate a DSN\n```\nupdate_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', isActive=false)\n```\n\n### Disable rate limit entirely\n```\nupdate_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', disableRateLimit=true)\n```\n</examples>\n\n<hints>\n- Use `find_dsns()` first to find the `keyId` for the DSN you want to update.\n- Both `rateLimitWindow` (seconds) and `rateLimitCount` (error cap) must be provided together to set a rate limit.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "projectSlug": {
+          "type": "string",
+          "description": "The project's slug. You can find a list of existing projects in an organization using the `find_projects()` tool."
+        },
+        "keyId": {
+          "type": "string",
+          "description": "The ID of the DSN (client key) to update. Use find_dsns() to retrieve this ID first."
+        },
+        "name": {
+          "type": "string",
+          "description": "The new name for the DSN."
+        },
+        "isActive": {
+          "type": "boolean",
+          "description": "Activate or deactivate the DSN."
+        },
+        "rateLimitWindow": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "The time window in seconds for the rate limit."
+        },
+        "rateLimitCount": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "The maximum number of errors allowed within the rate limit window."
+        },
+        "disableRateLimit": {
+          "type": "boolean",
+          "description": "Set to true to disable the rate limit entirely (removes the cap)."
+        },
+        "browserSdkVersion": {
+          "type": "string",
+          "description": "The Sentry Javascript SDK version to use (e.g. 'latest', '7.x')."
+        },
+        "loaderHasReplay": {
+          "type": "boolean",
+          "description": "Configure Session Replay for the Javascript Loader Script."
+        },
+        "loaderHasPerformance": {
+          "type": "boolean",
+          "description": "Configure Performance Monitoring for the Javascript Loader Script."
+        },
+        "loaderHasDebug": {
+          "type": "boolean",
+          "description": "Configure Debug Bundles & Logging for the Javascript Loader Script."
+        },
+        "loaderHasFeedback": {
+          "type": "boolean",
+          "description": "Configure User Feedback for the Javascript Loader Script."
+        },
+        "loaderHasLogsAndMetrics": {
+          "type": "boolean",
+          "description": "Configure Logs and Metrics for the Javascript Loader Script (requires SDK >= 10.0.0)."
+        }
+      },
+      "required": ["organizationSlug", "projectSlug", "keyId"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["project:write"],
+    "skills": ["project-management"],
+    "surface": "catalog"
+  },
+  {
     "name": "update_issue",
     "description": "Update a Sentry issue's status or assignment.\n\nUse this to resolve, reopen, assign, or ignore an issue.\n\n<examples>\n```\nupdate_issue(organizationSlug='my-org', issueId='PROJECT-123', status='resolved')\nupdate_issue(organizationSlug='my-org', issueId='PROJECT-123', assignedTo='user:123456')\nupdate_issue(organizationSlug='my-org', issueId='PROJECT-123', status='ignored')\nupdate_issue(organizationSlug='my-org', issueId='PROJECT-123', status='ignored', ignoreMode='forever')\nupdate_issue(organizationSlug='my-org', issueId='PROJECT-123', status='ignored', ignoreMode='untilOccurrenceCount', ignoreCount=100, ignoreWindowMinutes=60)\nupdate_issue(organizationSlug='my-org', issueId='PROJECT-123', status='ignored', reason='Ignoring because this is expected noise from the staging deploy')\n```\n</examples>\n\n<hints>\n- Provide `issueUrl` or `organizationSlug` + `issueId`.\n- At least one of `status` or `assignedTo` is required.\n- `assignedTo` format: `user:ID` or `team:ID_OR_SLUG`.\n- Use `execute_sentry_tool(name='whoami', arguments={})` to find your user ID for self-assignment.\n- Status values: `resolved`, `resolvedInNextRelease`, `unresolved`, `ignored`.\n- `status='ignored'` defaults to `ignoreMode='untilEscalating'`.\n- Ignore modes: `untilEscalating`, `forever`, `forDuration`, `untilOccurrenceCount`, `untilUserCount`.\n- Matching ignore inputs are `ignoreDurationMinutes`, `ignoreCount` + optional `ignoreWindowMinutes`, or `ignoreUserCount` + optional `ignoreUserWindowMinutes`.\n- To switch an already ignored issue between `untilEscalating`, `forever`, and condition-based ignore modes, first set `status='unresolved'`, then ignore it again with the new rule.\n- `reason` is optional. When provided, it will be posted as a comment on the issue's activity feed explaining why the action was taken.\n</hints>",
     "inputSchema": {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -2161,6 +2161,7 @@
         },
         "name": {
           "type": "string",
+          "maxLength": 64,
           "description": "The new name for the DSN."
         },
         "isActive": {
@@ -2169,12 +2170,13 @@
         },
         "rateLimitWindow": {
           "type": "integer",
-          "exclusiveMinimum": 0,
+          "minimum": 0,
+          "maximum": 86400,
           "description": "The time window in seconds for the rate limit."
         },
         "rateLimitCount": {
           "type": "integer",
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "description": "The maximum number of errors allowed within the rate limit window."
         },
         "disableRateLimit": {

--- a/packages/mcp-core/src/tools/catalog/index.ts
+++ b/packages/mcp-core/src/tools/catalog/index.ts
@@ -23,6 +23,7 @@ import createProject from "./create-project";
 import updateProject from "./update-project";
 import createDsn from "./create-dsn";
 import findDsns from "./find-dsns";
+import updateDsn from "./update-dsn";
 import analyzeIssueWithSeer from "./analyze-issue-with-seer";
 import searchDocs from "./search-docs";
 import getDoc from "./get-doc";
@@ -73,6 +74,7 @@ const catalogTools = {
   update_project: updateProject,
   create_dsn: createDsn,
   find_dsns: findDsns,
+  update_dsn: updateDsn,
   analyze_issue_with_seer: analyzeIssueWithSeer,
   search_docs: searchDocs,
   get_doc: getDoc,

--- a/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import updateDsn from "./update-dsn.js";
+import { UserInputError } from "../../errors.js";
+
+describe("update_dsn", () => {
+  it("updates name and active status", async () => {
+    const result = await updateDsn.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+        name: "New Key Name",
+        isActive: false,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          projectSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Updated DSN in **sentry-mcp-evals/cloudflare-mcp**
+
+      **DSN ID**: d20df0a1ab5031c7f3c7edca9c02814d
+      **DSN**: https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945
+      **Name**: New Key Name
+      **Status**: Inactive
+      **Rate Limit**: Disabled
+      **Browser SDK Version**: 8.x
+      **Loader Options**: Replay: Enabled, Performance: Enabled, Debug: Disabled
+
+      ## Updates Applied
+      - Updated name to "New Key Name"
+      - Updated status to inactive
+
+      ## Response Notes
+
+      - Please tell the user the updated DSN settings.
+      "
+    `);
+  });
+
+  it("updates rate limit settings", async () => {
+    const result = await updateDsn.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+        rateLimitWindow: 3600,
+        rateLimitCount: 100,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          projectSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+    expect(result).toContain("**Rate Limit**: 100 events per 3600 seconds");
+    expect(result).toContain("- Updated rate limit to 100 events per 3600s");
+  });
+
+  it("disables rate limit entirely", async () => {
+    const result = await updateDsn.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+        disableRateLimit: true,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          projectSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+    expect(result).toContain("**Rate Limit**: Disabled");
+    expect(result).toContain("- Updated rate limit disabled");
+  });
+
+  it("updates loader options", async () => {
+    const result = await updateDsn.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+        loaderHasReplay: true,
+        loaderHasPerformance: false,
+        loaderHasDebug: true,
+        loaderHasFeedback: true,
+        loaderHasLogsAndMetrics: true,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          projectSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+    expect(result).toContain(
+      "**Loader Options**: Replay: Enabled, Performance: Disabled, Debug: Enabled, Feedback: Enabled, Logs & Metrics: Enabled",
+    );
+    expect(result).toContain("- Updated loader options updated");
+  });
+
+  it("validates rate limit input combinations", async () => {
+    const mockContext = {
+      constraints: { organizationSlug: null, projectSlug: null },
+      accessToken: "access-token",
+      userId: "1",
+    };
+
+    await expect(
+      updateDsn.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+          rateLimitWindow: 3600,
+          regionUrl: null,
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow(UserInputError);
+
+    await expect(
+      updateDsn.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+          rateLimitCount: 100,
+          regionUrl: null,
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow(UserInputError);
+
+    await expect(
+      updateDsn.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+          rateLimitWindow: 3600,
+          rateLimitCount: 100,
+          disableRateLimit: true,
+          regionUrl: null,
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow(UserInputError);
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { mswServer } from "@sentry/mcp-server-mocks";
 import updateDsn from "./update-dsn.js";
 import { UserInputError } from "../../errors.js";
 
@@ -88,6 +90,55 @@ describe("update_dsn", () => {
     );
     expect(result).toContain("**Rate Limit**: Disabled");
     expect(result).toContain("- Updated rate limit disabled");
+  });
+
+  it("treats zero-valued API rate limit responses as disabled", async () => {
+    mswServer.use(
+      http.put(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/keys/:keyId/",
+        ({ params }) =>
+          HttpResponse.json(
+            {
+              id: String(params.keyId),
+              name: "Default",
+              dsn: {
+                public:
+                  "https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945",
+              },
+              isActive: true,
+              dateCreated: "2025-04-07T00:12:25.139394Z",
+              rateLimit: {
+                count: 0,
+                window: 3600,
+              },
+            },
+            { status: 200 },
+          ),
+        { once: true },
+      ),
+    );
+
+    const result = await updateDsn.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+        rateLimitWindow: 3600,
+        rateLimitCount: 100,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          projectSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain("**Rate Limit**: Disabled");
+    expect(result).toContain("- Updated rate limit to 100 events per 3600s");
   });
 
   it("disables rate limit entirely", async () => {

--- a/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
@@ -67,7 +67,7 @@ describe("update_dsn", () => {
     expect(result).toContain("- Updated rate limit to 100 events per 3600s");
   });
 
-  it("reports zero-valued rate limit updates consistently", async () => {
+  it("treats zero-valued rate limit updates as disabled", async () => {
     const result = await updateDsn.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -86,8 +86,8 @@ describe("update_dsn", () => {
         userId: "1",
       },
     );
-    expect(result).toContain("**Rate Limit**: 0 events per 3600 seconds");
-    expect(result).toContain("- Updated rate limit to 0 events per 3600s");
+    expect(result).toContain("**Rate Limit**: Disabled");
+    expect(result).toContain("- Updated rate limit disabled");
   });
 
   it("disables rate limit entirely", async () => {

--- a/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
@@ -67,6 +67,29 @@ describe("update_dsn", () => {
     expect(result).toContain("- Updated rate limit to 100 events per 3600s");
   });
 
+  it("reports zero-valued rate limit updates consistently", async () => {
+    const result = await updateDsn.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+        rateLimitWindow: 3600,
+        rateLimitCount: 0,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          projectSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+    expect(result).toContain("**Rate Limit**: 0 events per 3600 seconds");
+    expect(result).toContain("- Updated rate limit to 0 events per 3600s");
+  });
+
   it("disables rate limit entirely", async () => {
     const result = await updateDsn.handler(
       {

--- a/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.test.ts
@@ -117,6 +117,24 @@ describe("update_dsn", () => {
     expect(result).toContain("- Updated loader options updated");
   });
 
+  it("throws when no update fields are provided", async () => {
+    await expect(
+      updateDsn.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlug: "cloudflare-mcp",
+          keyId: "d20df0a1ab5031c7f3c7edca9c02814d",
+          regionUrl: null,
+        },
+        {
+          constraints: { organizationSlug: null, projectSlug: null },
+          accessToken: "access-token",
+          userId: "1",
+        },
+      ),
+    ).rejects.toThrow(UserInputError);
+  });
+
   it("validates rate limit input combinations", async () => {
     const mockContext = {
       constraints: { organizationSlug: null, projectSlug: null },

--- a/packages/mcp-core/src/tools/catalog/update-dsn.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.ts
@@ -1,0 +1,234 @@
+import { z } from "zod";
+import { setTag } from "@sentry/core";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { UserInputError } from "../../errors";
+import type { ServerContext } from "../../types";
+import {
+  ParamOrganizationSlug,
+  ParamRegionUrl,
+  ParamProjectSlug,
+} from "../../schema";
+
+export default defineTool({
+  name: "update_dsn",
+  skills: ["project-management"], // DSN management is part of project setup
+  requiredScopes: ["project:write"],
+  description: [
+    "Update settings for an existing DSN (client key) in a project, such as name, active status, rate limit, and loader script options.",
+    "",
+    "USE THIS TOOL WHEN:",
+    "- Deactivating or activating a DSN/client key",
+    "- Setting or removing DSN rate limits ('set rate limit of 1000 per hour on DSN X')",
+    "- Renaming a DSN ('rename DSN X to Production')",
+    "- Configuring Javascript SDK loader script options (session replay, performance, debug, feedback, etc.)",
+    "",
+    "Be careful when using this tool!",
+    "",
+    "<examples>",
+    "### Rename DSN and set rate limit",
+    "```",
+    "update_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', name='Production Key', rateLimitWindow=3600, rateLimitCount=500)",
+    "```",
+    "",
+    "### Deactivate a DSN",
+    "```",
+    "update_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', isActive=false)",
+    "```",
+    "",
+    "### Disable rate limit entirely",
+    "```",
+    "update_dsn(organizationSlug='my-organization', projectSlug='my-project', keyId='d20df0a1ab5031c7f3c7edca9c02814d', disableRateLimit=true)",
+    "```",
+    "</examples>",
+    "",
+    "<hints>",
+    "- Use `find_dsns()` first to find the `keyId` for the DSN you want to update.",
+    "- Both `rateLimitWindow` (seconds) and `rateLimitCount` (error cap) must be provided together to set a rate limit.",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug,
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    projectSlug: ParamProjectSlug,
+    keyId: z
+      .string()
+      .trim()
+      .describe("The ID of the DSN (client key) to update. Use find_dsns() to retrieve this ID first."),
+    name: z
+      .string()
+      .trim()
+      .describe("The new name for the DSN.")
+      .optional(),
+    isActive: z
+      .boolean()
+      .describe("Activate or deactivate the DSN.")
+      .optional(),
+    rateLimitWindow: z
+      .number()
+      .int()
+      .positive()
+      .describe("The time window in seconds for the rate limit.")
+      .optional(),
+    rateLimitCount: z
+      .number()
+      .int()
+      .positive()
+      .describe("The maximum number of errors allowed within the rate limit window.")
+      .optional(),
+    disableRateLimit: z
+      .boolean()
+      .describe("Set to true to disable the rate limit entirely (removes the cap).")
+      .optional(),
+    browserSdkVersion: z
+      .string()
+      .trim()
+      .describe("The Sentry Javascript SDK version to use (e.g. 'latest', '7.x').")
+      .optional(),
+    loaderHasReplay: z
+      .boolean()
+      .describe("Configure Session Replay for the Javascript Loader Script.")
+      .optional(),
+    loaderHasPerformance: z
+      .boolean()
+      .describe("Configure Performance Monitoring for the Javascript Loader Script.")
+      .optional(),
+    loaderHasDebug: z
+      .boolean()
+      .describe("Configure Debug Bundles & Logging for the Javascript Loader Script.")
+      .optional(),
+    loaderHasFeedback: z
+      .boolean()
+      .describe("Configure User Feedback for the Javascript Loader Script.")
+      .optional(),
+    loaderHasLogsAndMetrics: z
+      .boolean()
+      .describe("Configure Logs and Metrics for the Javascript Loader Script (requires SDK >= 10.0.0).")
+      .optional(),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? undefined,
+    });
+    const organizationSlug = params.organizationSlug;
+
+    setTag("organization.slug", organizationSlug);
+    setTag("project.slug", params.projectSlug);
+
+    // Validate rate limit input combinations
+    if (
+      (params.rateLimitWindow !== undefined && params.rateLimitCount === undefined) ||
+      (params.rateLimitWindow === undefined && params.rateLimitCount !== undefined)
+    ) {
+      throw new UserInputError("Both rateLimitWindow and rateLimitCount must be provided together to set a rate limit.");
+    }
+
+    if (params.disableRateLimit && (params.rateLimitWindow !== undefined || params.rateLimitCount !== undefined)) {
+      throw new UserInputError("Cannot both set a rate limit and disable it at the same time.");
+    }
+
+    let rateLimit: { window: number; count: number } | null | undefined = undefined;
+    if (params.disableRateLimit === true) {
+      rateLimit = null;
+    } else if (params.rateLimitWindow !== undefined && params.rateLimitCount !== undefined) {
+      rateLimit = {
+        window: params.rateLimitWindow,
+        count: params.rateLimitCount,
+      };
+    }
+
+    let dynamicSdkLoaderOptions: {
+      hasReplay?: boolean;
+      hasPerformance?: boolean;
+      hasDebug?: boolean;
+      hasFeedback?: boolean;
+      hasLogsAndMetrics?: boolean;
+    } | undefined = undefined;
+
+    if (
+      params.loaderHasReplay !== undefined ||
+      params.loaderHasPerformance !== undefined ||
+      params.loaderHasDebug !== undefined ||
+      params.loaderHasFeedback !== undefined ||
+      params.loaderHasLogsAndMetrics !== undefined
+    ) {
+      dynamicSdkLoaderOptions = {};
+      if (params.loaderHasReplay !== undefined) dynamicSdkLoaderOptions.hasReplay = params.loaderHasReplay;
+      if (params.loaderHasPerformance !== undefined) dynamicSdkLoaderOptions.hasPerformance = params.loaderHasPerformance;
+      if (params.loaderHasDebug !== undefined) dynamicSdkLoaderOptions.hasDebug = params.loaderHasDebug;
+      if (params.loaderHasFeedback !== undefined) dynamicSdkLoaderOptions.hasFeedback = params.loaderHasFeedback;
+      if (params.loaderHasLogsAndMetrics !== undefined) dynamicSdkLoaderOptions.hasLogsAndMetrics = params.loaderHasLogsAndMetrics;
+    }
+
+    const clientKey = await apiService.updateClientKey({
+      organizationSlug,
+      projectSlug: params.projectSlug,
+      keyId: params.keyId,
+      name: params.name,
+      isActive: params.isActive,
+      rateLimit,
+      browserSdkVersion: params.browserSdkVersion,
+      dynamicSdkLoaderOptions,
+    });
+
+    let output = `# Updated DSN in **${organizationSlug}/${params.projectSlug}**\n\n`;
+    output += `**DSN ID**: ${clientKey.id}\n`;
+    output += `**DSN**: ${clientKey.dsn.public}\n`;
+    output += `**Name**: ${clientKey.name}\n`;
+    output += `**Status**: ${clientKey.isActive ? "Active" : "Inactive"}\n`;
+
+    if (clientKey.rateLimit) {
+      output += `**Rate Limit**: ${clientKey.rateLimit.count} events per ${clientKey.rateLimit.window} seconds\n`;
+    } else {
+      output += `**Rate Limit**: Disabled\n`;
+    }
+
+    if (clientKey.browserSdkVersion) {
+      output += `**Browser SDK Version**: ${clientKey.browserSdkVersion}\n`;
+    }
+
+    if (clientKey.dynamicSdkLoaderOptions) {
+      const loader = clientKey.dynamicSdkLoaderOptions;
+      const optionsStr = [
+        `Replay: ${loader.hasReplay ? "Enabled" : "Disabled"}`,
+        `Performance: ${loader.hasPerformance ? "Enabled" : "Disabled"}`,
+        `Debug: ${loader.hasDebug ? "Enabled" : "Disabled"}`,
+        loader.hasFeedback !== undefined ? `Feedback: ${loader.hasFeedback ? "Enabled" : "Disabled"}` : null,
+        loader.hasLogsAndMetrics !== undefined ? `Logs & Metrics: ${loader.hasLogsAndMetrics ? "Enabled" : "Disabled"}` : null,
+      ]
+        .filter((val): val is string => val !== null)
+        .join(", ");
+      output += `**Loader Options**: ${optionsStr}\n`;
+    }
+
+    // Display what was updated
+    const updates: string[] = [];
+    if (params.name) updates.push(`name to "${params.name}"`);
+    if (params.isActive !== undefined) updates.push(`status to ${params.isActive ? "active" : "inactive"}`);
+    if (params.disableRateLimit) updates.push("rate limit disabled");
+    else if (params.rateLimitWindow !== undefined) {
+      updates.push(`rate limit to ${params.rateLimitCount} events per ${params.rateLimitWindow}s`);
+    }
+    if (params.browserSdkVersion) updates.push(`browser SDK version to "${params.browserSdkVersion}"`);
+    if (dynamicSdkLoaderOptions) {
+      updates.push("loader options updated");
+    }
+
+    if (updates.length > 0) {
+      output += `\n## Updates Applied\n`;
+      output += updates.map((update) => `- Updated ${update}`).join("\n");
+      output += `\n`;
+    }
+
+    output += "\n## Response Notes\n\n";
+    output += "- Please tell the user the updated DSN settings.\n";
+
+    return output;
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/update-dsn.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.ts
@@ -177,9 +177,14 @@ export default defineTool({
       );
     }
 
+    const zeroRateLimit =
+      params.rateLimitWindow !== undefined &&
+      params.rateLimitCount !== undefined &&
+      (params.rateLimitWindow === 0 || params.rateLimitCount === 0);
+
     let rateLimit: { window: number; count: number } | null | undefined =
       undefined;
-    if (params.disableRateLimit === true) {
+    if (params.disableRateLimit === true || zeroRateLimit) {
       rateLimit = null;
     } else if (
       params.rateLimitWindow !== undefined &&
@@ -241,8 +246,6 @@ export default defineTool({
 
     if (clientKey.rateLimit) {
       output += `**Rate Limit**: ${clientKey.rateLimit.count} events per ${clientKey.rateLimit.window} seconds\n`;
-    } else if (rateLimit && (rateLimit.count === 0 || rateLimit.window === 0)) {
-      output += `**Rate Limit**: ${rateLimit.count} events per ${rateLimit.window} seconds\n`;
     } else {
       output += `**Rate Limit**: Disabled\n`;
     }
@@ -273,7 +276,8 @@ export default defineTool({
     if (params.name) updates.push(`name to "${params.name}"`);
     if (params.isActive !== undefined)
       updates.push(`status to ${params.isActive ? "active" : "inactive"}`);
-    if (params.disableRateLimit) updates.push("rate limit disabled");
+    if (params.disableRateLimit || zeroRateLimit)
+      updates.push("rate limit disabled");
     else if (params.rateLimitWindow !== undefined) {
       updates.push(
         `rate limit to ${params.rateLimitCount} events per ${params.rateLimitWindow}s`,

--- a/packages/mcp-core/src/tools/catalog/update-dsn.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.ts
@@ -54,10 +54,13 @@ export default defineTool({
     keyId: z
       .string()
       .trim()
-      .describe("The ID of the DSN (client key) to update. Use find_dsns() to retrieve this ID first."),
+      .describe(
+        "The ID of the DSN (client key) to update. Use find_dsns() to retrieve this ID first.",
+      ),
     name: z
       .string()
       .trim()
+      .max(64)
       .describe("The new name for the DSN.")
       .optional(),
     isActive: z
@@ -67,23 +70,30 @@ export default defineTool({
     rateLimitWindow: z
       .number()
       .int()
-      .positive()
+      .min(0)
+      .max(60 * 60 * 24)
       .describe("The time window in seconds for the rate limit.")
       .optional(),
     rateLimitCount: z
       .number()
       .int()
-      .positive()
-      .describe("The maximum number of errors allowed within the rate limit window.")
+      .min(0)
+      .describe(
+        "The maximum number of errors allowed within the rate limit window.",
+      )
       .optional(),
     disableRateLimit: z
       .boolean()
-      .describe("Set to true to disable the rate limit entirely (removes the cap).")
+      .describe(
+        "Set to true to disable the rate limit entirely (removes the cap).",
+      )
       .optional(),
     browserSdkVersion: z
       .string()
       .trim()
-      .describe("The Sentry Javascript SDK version to use (e.g. 'latest', '7.x').")
+      .describe(
+        "The Sentry Javascript SDK version to use (e.g. 'latest', '7.x').",
+      )
       .optional(),
     loaderHasReplay: z
       .boolean()
@@ -91,11 +101,15 @@ export default defineTool({
       .optional(),
     loaderHasPerformance: z
       .boolean()
-      .describe("Configure Performance Monitoring for the Javascript Loader Script.")
+      .describe(
+        "Configure Performance Monitoring for the Javascript Loader Script.",
+      )
       .optional(),
     loaderHasDebug: z
       .boolean()
-      .describe("Configure Debug Bundles & Logging for the Javascript Loader Script.")
+      .describe(
+        "Configure Debug Bundles & Logging for the Javascript Loader Script.",
+      )
       .optional(),
     loaderHasFeedback: z
       .boolean()
@@ -103,7 +117,9 @@ export default defineTool({
       .optional(),
     loaderHasLogsAndMetrics: z
       .boolean()
-      .describe("Configure Logs and Metrics for the Javascript Loader Script (requires SDK >= 10.0.0).")
+      .describe(
+        "Configure Logs and Metrics for the Javascript Loader Script (requires SDK >= 10.0.0).",
+      )
       .optional(),
   },
   annotations: {
@@ -121,7 +137,6 @@ export default defineTool({
     setTag("organization.slug", organizationSlug);
     setTag("project.slug", params.projectSlug);
 
-    // Require at least one field to update
     const hasUpdates =
       params.name !== undefined ||
       params.isActive !== undefined ||
@@ -141,35 +156,50 @@ export default defineTool({
       );
     }
 
-    // Validate rate limit input combinations
     if (
-      (params.rateLimitWindow !== undefined && params.rateLimitCount === undefined) ||
-      (params.rateLimitWindow === undefined && params.rateLimitCount !== undefined)
+      (params.rateLimitWindow !== undefined &&
+        params.rateLimitCount === undefined) ||
+      (params.rateLimitWindow === undefined &&
+        params.rateLimitCount !== undefined)
     ) {
-      throw new UserInputError("Both rateLimitWindow and rateLimitCount must be provided together to set a rate limit.");
+      throw new UserInputError(
+        "Both rateLimitWindow and rateLimitCount must be provided together to set a rate limit.",
+      );
     }
 
-    if (params.disableRateLimit && (params.rateLimitWindow !== undefined || params.rateLimitCount !== undefined)) {
-      throw new UserInputError("Cannot both set a rate limit and disable it at the same time.");
+    if (
+      params.disableRateLimit &&
+      (params.rateLimitWindow !== undefined ||
+        params.rateLimitCount !== undefined)
+    ) {
+      throw new UserInputError(
+        "Cannot both set a rate limit and disable it at the same time.",
+      );
     }
 
-    let rateLimit: { window: number; count: number } | null | undefined = undefined;
+    let rateLimit: { window: number; count: number } | null | undefined =
+      undefined;
     if (params.disableRateLimit === true) {
       rateLimit = null;
-    } else if (params.rateLimitWindow !== undefined && params.rateLimitCount !== undefined) {
+    } else if (
+      params.rateLimitWindow !== undefined &&
+      params.rateLimitCount !== undefined
+    ) {
       rateLimit = {
         window: params.rateLimitWindow,
         count: params.rateLimitCount,
       };
     }
 
-    let dynamicSdkLoaderOptions: {
-      hasReplay?: boolean;
-      hasPerformance?: boolean;
-      hasDebug?: boolean;
-      hasFeedback?: boolean;
-      hasLogsAndMetrics?: boolean;
-    } | undefined = undefined;
+    let dynamicSdkLoaderOptions:
+      | {
+          hasReplay?: boolean;
+          hasPerformance?: boolean;
+          hasDebug?: boolean;
+          hasFeedback?: boolean;
+          hasLogsAndMetrics?: boolean;
+        }
+      | undefined = undefined;
 
     if (
       params.loaderHasReplay !== undefined ||
@@ -179,11 +209,17 @@ export default defineTool({
       params.loaderHasLogsAndMetrics !== undefined
     ) {
       dynamicSdkLoaderOptions = {};
-      if (params.loaderHasReplay !== undefined) dynamicSdkLoaderOptions.hasReplay = params.loaderHasReplay;
-      if (params.loaderHasPerformance !== undefined) dynamicSdkLoaderOptions.hasPerformance = params.loaderHasPerformance;
-      if (params.loaderHasDebug !== undefined) dynamicSdkLoaderOptions.hasDebug = params.loaderHasDebug;
-      if (params.loaderHasFeedback !== undefined) dynamicSdkLoaderOptions.hasFeedback = params.loaderHasFeedback;
-      if (params.loaderHasLogsAndMetrics !== undefined) dynamicSdkLoaderOptions.hasLogsAndMetrics = params.loaderHasLogsAndMetrics;
+      if (params.loaderHasReplay !== undefined)
+        dynamicSdkLoaderOptions.hasReplay = params.loaderHasReplay;
+      if (params.loaderHasPerformance !== undefined)
+        dynamicSdkLoaderOptions.hasPerformance = params.loaderHasPerformance;
+      if (params.loaderHasDebug !== undefined)
+        dynamicSdkLoaderOptions.hasDebug = params.loaderHasDebug;
+      if (params.loaderHasFeedback !== undefined)
+        dynamicSdkLoaderOptions.hasFeedback = params.loaderHasFeedback;
+      if (params.loaderHasLogsAndMetrics !== undefined)
+        dynamicSdkLoaderOptions.hasLogsAndMetrics =
+          params.loaderHasLogsAndMetrics;
     }
 
     const clientKey = await apiService.updateClientKey({
@@ -205,6 +241,8 @@ export default defineTool({
 
     if (clientKey.rateLimit) {
       output += `**Rate Limit**: ${clientKey.rateLimit.count} events per ${clientKey.rateLimit.window} seconds\n`;
+    } else if (rateLimit && (rateLimit.count === 0 || rateLimit.window === 0)) {
+      output += `**Rate Limit**: ${rateLimit.count} events per ${rateLimit.window} seconds\n`;
     } else {
       output += `**Rate Limit**: Disabled\n`;
     }
@@ -219,23 +257,30 @@ export default defineTool({
         `Replay: ${loader.hasReplay ? "Enabled" : "Disabled"}`,
         `Performance: ${loader.hasPerformance ? "Enabled" : "Disabled"}`,
         `Debug: ${loader.hasDebug ? "Enabled" : "Disabled"}`,
-        loader.hasFeedback !== undefined ? `Feedback: ${loader.hasFeedback ? "Enabled" : "Disabled"}` : null,
-        loader.hasLogsAndMetrics !== undefined ? `Logs & Metrics: ${loader.hasLogsAndMetrics ? "Enabled" : "Disabled"}` : null,
+        loader.hasFeedback !== undefined
+          ? `Feedback: ${loader.hasFeedback ? "Enabled" : "Disabled"}`
+          : null,
+        loader.hasLogsAndMetrics !== undefined
+          ? `Logs & Metrics: ${loader.hasLogsAndMetrics ? "Enabled" : "Disabled"}`
+          : null,
       ]
         .filter((val): val is string => val !== null)
         .join(", ");
       output += `**Loader Options**: ${optionsStr}\n`;
     }
 
-    // Display what was updated
     const updates: string[] = [];
     if (params.name) updates.push(`name to "${params.name}"`);
-    if (params.isActive !== undefined) updates.push(`status to ${params.isActive ? "active" : "inactive"}`);
+    if (params.isActive !== undefined)
+      updates.push(`status to ${params.isActive ? "active" : "inactive"}`);
     if (params.disableRateLimit) updates.push("rate limit disabled");
     else if (params.rateLimitWindow !== undefined) {
-      updates.push(`rate limit to ${params.rateLimitCount} events per ${params.rateLimitWindow}s`);
+      updates.push(
+        `rate limit to ${params.rateLimitCount} events per ${params.rateLimitWindow}s`,
+      );
     }
-    if (params.browserSdkVersion) updates.push(`browser SDK version to "${params.browserSdkVersion}"`);
+    if (params.browserSdkVersion)
+      updates.push(`browser SDK version to "${params.browserSdkVersion}"`);
     if (dynamicSdkLoaderOptions) {
       updates.push("loader options updated");
     }

--- a/packages/mcp-core/src/tools/catalog/update-dsn.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.ts
@@ -244,7 +244,11 @@ export default defineTool({
     output += `**Name**: ${clientKey.name}\n`;
     output += `**Status**: ${clientKey.isActive ? "Active" : "Inactive"}\n`;
 
-    if (clientKey.rateLimit) {
+    if (
+      clientKey.rateLimit &&
+      clientKey.rateLimit.count > 0 &&
+      clientKey.rateLimit.window > 0
+    ) {
       output += `**Rate Limit**: ${clientKey.rateLimit.count} events per ${clientKey.rateLimit.window} seconds\n`;
     } else {
       output += `**Rate Limit**: Disabled\n`;

--- a/packages/mcp-core/src/tools/catalog/update-dsn.ts
+++ b/packages/mcp-core/src/tools/catalog/update-dsn.ts
@@ -121,6 +121,26 @@ export default defineTool({
     setTag("organization.slug", organizationSlug);
     setTag("project.slug", params.projectSlug);
 
+    // Require at least one field to update
+    const hasUpdates =
+      params.name !== undefined ||
+      params.isActive !== undefined ||
+      params.disableRateLimit !== undefined ||
+      params.rateLimitWindow !== undefined ||
+      params.rateLimitCount !== undefined ||
+      params.browserSdkVersion !== undefined ||
+      params.loaderHasReplay !== undefined ||
+      params.loaderHasPerformance !== undefined ||
+      params.loaderHasDebug !== undefined ||
+      params.loaderHasFeedback !== undefined ||
+      params.loaderHasLogsAndMetrics !== undefined;
+
+    if (!hasUpdates) {
+      throw new UserInputError(
+        "At least one setting must be provided to update. Provide one or more of: name, isActive, rateLimitWindow + rateLimitCount, disableRateLimit, browserSdkVersion, or loader options.",
+      );
+    }
+
     // Validate rate limit input combinations
     if (
       (params.rateLimitWindow !== undefined && params.rateLimitCount === undefined) ||

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -220,6 +220,20 @@ type IssueUpdateBody = {
   substatus?: string;
 };
 
+type ClientKeyUpdateBody = {
+  name?: string;
+  isActive?: boolean;
+  rateLimit?: { window: number; count: number } | null;
+  browserSdkVersion?: string;
+  dynamicSdkLoaderOptions?: {
+    hasReplay?: boolean;
+    hasPerformance?: boolean;
+    hasDebug?: boolean;
+    hasFeedback?: boolean;
+    hasLogsAndMetrics?: boolean;
+  };
+};
+
 function buildMockIgnoredStatusDetails(
   body: IssueUpdateBody,
   substatus: string | null | undefined,
@@ -519,14 +533,23 @@ export const restHandlers = buildHandlers([
     method: "put",
     path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/keys/:keyId/",
     fetch: async ({ request, params }) => {
-      const body = (await request.json()) as any;
+      const body = (await request.json()) as ClientKeyUpdateBody;
+      const rateLimit =
+        body.rateLimit && body.rateLimit.count > 0 && body.rateLimit.window > 0
+          ? body.rateLimit
+          : null;
       return HttpResponse.json({
         ...clientKeyFixture,
         id: params.keyId,
         name: body.name ?? clientKeyFixture.name,
-        isActive: body.isActive !== undefined ? body.isActive : clientKeyFixture.isActive,
-        rateLimit: body.rateLimit !== undefined ? body.rateLimit : clientKeyFixture.rateLimit,
-        browserSdkVersion: body.browserSdkVersion ?? clientKeyFixture.browserSdkVersion,
+        isActive:
+          body.isActive !== undefined
+            ? body.isActive
+            : clientKeyFixture.isActive,
+        rateLimit:
+          body.rateLimit !== undefined ? rateLimit : clientKeyFixture.rateLimit,
+        browserSdkVersion:
+          body.browserSdkVersion ?? clientKeyFixture.browserSdkVersion,
         dynamicSdkLoaderOptions: {
           ...clientKeyFixture.dynamicSdkLoaderOptions,
           ...body.dynamicSdkLoaderOptions,

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -516,6 +516,25 @@ export const restHandlers = buildHandlers([
     },
   },
   {
+    method: "put",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/keys/:keyId/",
+    fetch: async ({ request, params }) => {
+      const body = (await request.json()) as any;
+      return HttpResponse.json({
+        ...clientKeyFixture,
+        id: params.keyId,
+        name: body.name ?? clientKeyFixture.name,
+        isActive: body.isActive !== undefined ? body.isActive : clientKeyFixture.isActive,
+        rateLimit: body.rateLimit !== undefined ? body.rateLimit : clientKeyFixture.rateLimit,
+        browserSdkVersion: body.browserSdkVersion ?? clientKeyFixture.browserSdkVersion,
+        dynamicSdkLoaderOptions: {
+          ...clientKeyFixture.dynamicSdkLoaderOptions,
+          ...body.dynamicSdkLoaderOptions,
+        },
+      });
+    },
+  },
+  {
     method: "get",
     path: "/api/0/organizations/sentry-mcp-evals/events/",
     fetch: async ({ request }) => {


### PR DESCRIPTION
## Summary

Adds a new `update_dsn` MCP tool that enables AI assistants to update Sentry DSN (client key) configuration for a project. This fills a gap where DSN keys could be read via `get_dsn_details` but not modified.

### Key Changes
- **New `update_dsn` tool**: Allows updating rate limits, browser SDK version, and dynamic SDK loader options on a Sentry client key
- **Extended `ClientKeySchema`**: Added `rateLimit`, `browserSdkVersion`, and `dynamicSdkLoaderOptions` fields to support the full PUT response shape
- **New `updateClientKey` API method**: PUT request to `/projects/:org/:project/keys/:keyId/` endpoint
- **MSW mock handler**: Added PUT mock for the client key endpoint for test coverage
- **Comprehensive tests**: Covers success cases (rate limit, SDK version, loader options, combined updates) and input validation errors

### Capabilities

The tool accepts the following update parameters (all optional, at least one required):
- `rateLimitCount` + `rateLimitWindow`: Set per-DSN rate limits (or pass `0` to clear)
- `browserSdkVersion`: Pin a specific Sentry Browser SDK version
- `dynamicSdkLoaderOptions`: Toggle performance monitoring, session replay, and debug mode on the CDN loader

### Breaking Changes
- None