### PR TITLE
fix(schema): accept relative permalinks from self-hosted Sentry

### DIFF
--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -702,7 +702,7 @@ export const IssueSchema = z
     lastSeen: z.string().datetime().nullable(),
     count: z.union([z.string(), z.number()]),
     userCount: z.union([z.string(), z.number()]),
-    permalink: z.string().url(),
+    permalink: z.string(), // relative on self-hosted Sentry; .url() rejects it (permalink is display-only)
     project: ProjectSchema,
     platform: z.string().nullable().optional(),
     status: z.string(),


### PR DESCRIPTION
## Problem
`IssueSchema.permalink` is validated with `z.string().url()`. Self-hosted Sentry returns **relative** permalinks (e.g. `/organizations/<org>/issues/<id>/`) rather than absolute URLs, so validation throws `Invalid url` on the `permalink` path. This makes `search_issues` (and any tool returning issues) fail entirely against self-hosted instances (e.g. `--host localhost:9000 --insecure-http`).

## Fix
Relax `permalink` to `z.string()`. The field is display-only and never parsed as a URL, so URL validation adds no value while breaking self-hosted users.

## Testing
Verified against a self-hosted Sentry instance: `search_issues` returns results instead of erroring on permalink validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)