### PR TITLE
feat(validation): Update to new validation endpoint

### DIFF
--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1409,7 +1409,7 @@ describe("API query builders", () => {
       ).toEqual(["string", "boolean"]);
     });
 
-    it("should validate exact trace item attributes", async () => {
+    it("should validate events requests via the validate endpoint", async () => {
       const apiService = new SentryApiService({
         host: "sentry.io",
         accessToken: "test-token",
@@ -1423,46 +1423,104 @@ describe("API query builders", () => {
           requestUrl = url;
           requestOptions = options;
           return Promise.resolve({
-            ok: true,
+            ok: false,
+            status: 400,
             headers: {
               get: (key: string) =>
                 key === "content-type" ? "application/json" : null,
             },
             json: () =>
               Promise.resolve({
-                attributes: {
-                  "tags[type]": { valid: true, type: "string" },
-                  "tags[missing]": {
-                    valid: false,
-                    error: "Unknown attribute: tags[missing]",
+                valid: false,
+                projects: [],
+                dataset: [],
+                environment: [],
+                field: [
+                  {
+                    name: "tags[type]",
+                    valid: true,
+                    attrType: "string",
+                    error: null,
                   },
-                },
+                  {
+                    name: "tags[missing]",
+                    valid: false,
+                    attrType: null,
+                    error: "Unknown attribute",
+                  },
+                ],
+                query: [
+                  {
+                    valid: false,
+                    error: "Invalid syntax",
+                  },
+                  {
+                    name: "transaction",
+                    valid: true,
+                    attrType: "string",
+                    error: null,
+                  },
+                ],
+                orderby: [
+                  {
+                    name: "-span.duration",
+                    valid: false,
+                    attrType: null,
+                    error: "Orderby must also be a selected field",
+                  },
+                ],
               }),
           });
         });
 
-      const result = await apiService.validateTraceItemAttributes({
+      const result = await apiService.validateEvents({
         organizationSlug: "test-org",
-        itemType: "spans",
-        attributes: ["tags[type]", "tags[missing]"],
+        dataset: "spans",
+        fields: ["tags[type]", "tags[missing]"],
+        query: 'transaction:"VPN connections"',
+        orderby: ["-span.duration"],
+        environment: ["production", "staging"],
         project: "123",
         statsPeriod: "7d",
       });
 
       expect(result).toEqual({
-        "tags[type]": { valid: true, type: "string" },
-        "tags[missing]": {
-          valid: false,
-          error: "Unknown attribute: tags[missing]",
-        },
+        valid: false,
+        projects: [],
+        dataset: [],
+        environment: [],
+        field: [
+          { name: "tags[type]", valid: true, type: "string" },
+          {
+            name: "tags[missing]",
+            valid: false,
+            error: "Unknown attribute",
+          },
+        ],
+        query: [
+          { valid: false, error: "Invalid syntax" },
+          { name: "transaction", valid: true, type: "string" },
+        ],
+        orderby: [
+          {
+            name: "-span.duration",
+            valid: false,
+            error: "Orderby must also be a selected field",
+          },
+        ],
       });
       expect(requestUrl).toContain(
-        "/api/0/organizations/test-org/trace-items/attributes/validate/?itemType=spans&project=123&statsPeriod=7d",
+        "/api/0/organizations/test-org/events/validate/?",
       );
-      expect(requestOptions?.method).toBe("POST");
-      expect(JSON.parse(String(requestOptions?.body))).toEqual({
-        attributes: ["tags[type]", "tags[missing]"],
-      });
+      const params = new URL(String(requestUrl)).searchParams;
+      expect(params.get("dataset")).toBe("spans");
+      expect(params.get("project")).toBe("123");
+      expect(params.get("statsPeriod")).toBe("7d");
+      expect(params.get("query")).toBe('transaction:"VPN connections"');
+      expect(params.getAll("field")).toEqual(["tags[type]", "tags[missing]"]);
+      expect(params.getAll("orderby")).toEqual(["-span.duration"]);
+      expect(params.getAll("environment")).toEqual(["production", "staging"]);
+      expect(requestOptions?.method).toBeUndefined();
     });
   });
 

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1449,18 +1449,18 @@ describe("API query builders", () => {
                     error: "Unknown attribute",
                   },
                 ],
-                query: [
-                  {
-                    valid: false,
-                    error: "Invalid syntax",
-                  },
-                  {
-                    name: "transaction",
-                    valid: true,
-                    attrType: "string",
-                    error: null,
-                  },
-                ],
+                query: {
+                  valid: false,
+                  error: "Invalid syntax",
+                  fields: [
+                    {
+                      name: "transaction",
+                      valid: true,
+                      attrType: "string",
+                      error: null,
+                    },
+                  ],
+                },
                 orderby: [
                   {
                     name: "-span.duration",
@@ -1497,10 +1497,11 @@ describe("API query builders", () => {
             error: "Unknown attribute",
           },
         ],
-        query: [
-          { valid: false, error: "Invalid syntax" },
-          { name: "transaction", valid: true, type: "string" },
-        ],
+        query: {
+          valid: false,
+          error: "Invalid syntax",
+          fields: [{ name: "transaction", valid: true, type: "string" }],
+        },
         orderby: [
           {
             name: "-span.duration",

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -266,6 +266,12 @@ export type EventsValidationIssue = {
   error?: string;
 };
 
+export type EventsNamedValidationIssue = {
+  name: string;
+  valid: boolean;
+  error?: string;
+};
+
 export type EventsAttributeValidationResult = {
   name: string;
   valid: boolean;
@@ -273,17 +279,19 @@ export type EventsAttributeValidationResult = {
   error?: string;
 };
 
-export type EventsQueryValidationItem =
-  | EventsValidationIssue
-  | EventsAttributeValidationResult;
+export type EventsQueryValidation = {
+  valid: boolean;
+  error?: string;
+  fields: EventsAttributeValidationResult[];
+};
 
 export type EventsValidationResult = {
   valid: boolean;
   projects: EventsValidationIssue[];
-  dataset: EventsValidationIssue[];
+  dataset: EventsNamedValidationIssue[];
   environment: EventsValidationIssue[];
   field: EventsAttributeValidationResult[];
-  query: EventsQueryValidationItem[];
+  query: EventsQueryValidation;
   orderby: EventsAttributeValidationResult[];
 };
 
@@ -323,18 +331,6 @@ function parseEventsAttributeValidation(
   return result;
 }
 
-function parseEventsQueryValidation(
-  value: unknown,
-): EventsQueryValidationItem | null {
-  if (!isRecord(value) || typeof value.valid !== "boolean") {
-    return null;
-  }
-  if (typeof value.name === "string") {
-    return parseEventsAttributeValidation(value);
-  }
-  return parseEventsValidationIssue(value);
-}
-
 function parseEventsValidationIssues(value: unknown): EventsValidationIssue[] {
   if (!Array.isArray(value)) {
     return [];
@@ -355,15 +351,49 @@ function parseEventsAttributeValidations(
     .filter((item): item is EventsAttributeValidationResult => item !== null);
 }
 
-function parseEventsQueryValidations(
+function parseEventsNamedValidationIssue(
   value: unknown,
-): EventsQueryValidationItem[] {
+): EventsNamedValidationIssue | null {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    typeof value.valid !== "boolean"
+  ) {
+    return null;
+  }
+  const issue: EventsNamedValidationIssue = {
+    name: value.name,
+    valid: value.valid,
+  };
+  if (typeof value.error === "string" && value.error.length > 0) {
+    issue.error = value.error;
+  }
+  return issue;
+}
+
+function parseEventsNamedValidationIssues(
+  value: unknown,
+): EventsNamedValidationIssue[] {
   if (!Array.isArray(value)) {
     return [];
   }
   return value
-    .map(parseEventsQueryValidation)
-    .filter((item): item is EventsQueryValidationItem => item !== null);
+    .map(parseEventsNamedValidationIssue)
+    .filter((issue): issue is EventsNamedValidationIssue => issue !== null);
+}
+
+function parseEventsQueryValidation(value: unknown): EventsQueryValidation {
+  if (!isRecord(value) || typeof value.valid !== "boolean") {
+    return { valid: false, fields: [] };
+  }
+  const query: EventsQueryValidation = {
+    valid: value.valid,
+    fields: parseEventsAttributeValidations(value.fields),
+  };
+  if (typeof value.error === "string" && value.error.length > 0) {
+    query.error = value.error;
+  }
+  return query;
 }
 
 function parseEventsValidationResponse(body: unknown): EventsValidationResult {
@@ -374,7 +404,7 @@ function parseEventsValidationResponse(body: unknown): EventsValidationResult {
       dataset: [],
       environment: [],
       field: [],
-      query: [],
+      query: { valid: false, fields: [] },
       orderby: [],
     };
   }
@@ -382,10 +412,10 @@ function parseEventsValidationResponse(body: unknown): EventsValidationResult {
   return {
     valid: typeof body.valid === "boolean" ? body.valid : false,
     projects: parseEventsValidationIssues(body.projects),
-    dataset: parseEventsValidationIssues(body.dataset),
+    dataset: parseEventsNamedValidationIssues(body.dataset),
     environment: parseEventsValidationIssues(body.environment),
     field: parseEventsAttributeValidations(body.field),
-    query: parseEventsQueryValidations(body.query),
+    query: parseEventsQueryValidation(body.query),
     orderby: parseEventsAttributeValidations(body.orderby),
   };
 }

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -261,6 +261,135 @@ export type TraceItemAttributeValidationResult = {
   error?: string;
 };
 
+export type EventsValidationIssue = {
+  valid: boolean;
+  error?: string;
+};
+
+export type EventsAttributeValidationResult = {
+  name: string;
+  valid: boolean;
+  type?: TraceItemAttributeType;
+  error?: string;
+};
+
+export type EventsQueryValidationItem =
+  | EventsValidationIssue
+  | EventsAttributeValidationResult;
+
+export type EventsValidationResult = {
+  valid: boolean;
+  projects: EventsValidationIssue[];
+  dataset: EventsValidationIssue[];
+  environment: EventsValidationIssue[];
+  field: EventsAttributeValidationResult[];
+  query: EventsQueryValidationItem[];
+  orderby: EventsAttributeValidationResult[];
+};
+
+function parseEventsValidationIssue(
+  value: unknown,
+): EventsValidationIssue | null {
+  if (!isRecord(value) || typeof value.valid !== "boolean") {
+    return null;
+  }
+  const issue: EventsValidationIssue = { valid: value.valid };
+  if (typeof value.error === "string" && value.error.length > 0) {
+    issue.error = value.error;
+  }
+  return issue;
+}
+
+function parseEventsAttributeValidation(
+  value: unknown,
+): EventsAttributeValidationResult | null {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    typeof value.valid !== "boolean"
+  ) {
+    return null;
+  }
+  const result: EventsAttributeValidationResult = {
+    name: value.name,
+    valid: value.valid,
+  };
+  if (isTraceItemAttributeType(value.attrType)) {
+    result.type = value.attrType;
+  }
+  if (typeof value.error === "string" && value.error.length > 0) {
+    result.error = value.error;
+  }
+  return result;
+}
+
+function parseEventsQueryValidation(
+  value: unknown,
+): EventsQueryValidationItem | null {
+  if (!isRecord(value) || typeof value.valid !== "boolean") {
+    return null;
+  }
+  if (typeof value.name === "string") {
+    return parseEventsAttributeValidation(value);
+  }
+  return parseEventsValidationIssue(value);
+}
+
+function parseEventsValidationIssues(value: unknown): EventsValidationIssue[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map(parseEventsValidationIssue)
+    .filter((issue): issue is EventsValidationIssue => issue !== null);
+}
+
+function parseEventsAttributeValidations(
+  value: unknown,
+): EventsAttributeValidationResult[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map(parseEventsAttributeValidation)
+    .filter((item): item is EventsAttributeValidationResult => item !== null);
+}
+
+function parseEventsQueryValidations(
+  value: unknown,
+): EventsQueryValidationItem[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map(parseEventsQueryValidation)
+    .filter((item): item is EventsQueryValidationItem => item !== null);
+}
+
+function parseEventsValidationResponse(body: unknown): EventsValidationResult {
+  if (!isRecord(body)) {
+    return {
+      valid: false,
+      projects: [],
+      dataset: [],
+      environment: [],
+      field: [],
+      query: [],
+      orderby: [],
+    };
+  }
+
+  return {
+    valid: typeof body.valid === "boolean" ? body.valid : false,
+    projects: parseEventsValidationIssues(body.projects),
+    dataset: parseEventsValidationIssues(body.dataset),
+    environment: parseEventsValidationIssues(body.environment),
+    field: parseEventsAttributeValidations(body.field),
+    query: parseEventsQueryValidations(body.query),
+    orderby: parseEventsAttributeValidations(body.orderby),
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -566,7 +695,7 @@ export class SentryApiService {
   private async request(
     path: string,
     options: RequestInit = {},
-    { host }: { host?: string } = {},
+    { host, allowStatuses }: { host?: string; allowStatuses?: number[] } = {},
   ): Promise<Response> {
     const url = host
       ? `${this.protocol}://${host}/api/0${path}`
@@ -642,6 +771,9 @@ export class SentryApiService {
 
     // Handle error responses generically
     if (!response.ok) {
+      if (allowStatuses?.includes(response.status)) {
+        return response;
+      }
       const errorText = await response.text();
       let parsed: unknown | undefined;
       try {
@@ -2692,63 +2824,63 @@ export class SentryApiService {
     return attributeResponses.flat();
   }
 
-  async validateTraceItemAttributes(
+  async validateEvents(
     {
       organizationSlug,
-      itemType = "spans",
-      attributes,
+      dataset = "spans",
+      fields,
+      query,
+      orderby,
       project,
+      environment,
       statsPeriod,
       start,
       end,
     }: {
       organizationSlug: string;
-      itemType?: TraceItemType;
-      attributes: string[];
+      dataset?: EventsDataset;
+      fields?: string[];
+      query?: string;
+      orderby?: string[];
       project?: string;
+      environment?: string | string[];
       statsPeriod?: string;
       start?: string;
       end?: string;
     },
     opts?: RequestOptions,
-  ): Promise<Record<string, TraceItemAttributeValidationResult>> {
+  ): Promise<EventsValidationResult> {
     const queryParams = new URLSearchParams();
-    queryParams.set("itemType", itemType);
+    queryParams.set("dataset", normalizeEventsDataset(dataset));
     if (project) {
       queryParams.set("project", project);
     }
+    if (query) {
+      queryParams.set("query", query);
+    }
+    if (environment) {
+      const environments = Array.isArray(environment)
+        ? environment
+        : [environment];
+      for (const value of environments) {
+        queryParams.append("environment", value);
+      }
+    }
     this.applyTimeParams(queryParams, statsPeriod, start, end);
+    for (const field of fields ?? []) {
+      queryParams.append("field", field);
+    }
+    for (const value of orderby ?? []) {
+      queryParams.append("orderby", value);
+    }
 
-    const body = await this.requestJSON(
-      `/organizations/${organizationSlug}/trace-items/attributes/validate/?${queryParams.toString()}`,
-      {
-        method: "POST",
-        body: JSON.stringify({ attributes }),
-      },
-      opts,
+    const response = await this.request(
+      `/organizations/${organizationSlug}/events/validate/?${queryParams.toString()}`,
+      undefined,
+      { ...opts, allowStatuses: [400] },
     );
-
-    if (!isRecord(body) || !isRecord(body.attributes)) {
-      return {};
-    }
-
-    const results: Record<string, TraceItemAttributeValidationResult> = {};
-    for (const [attribute, value] of Object.entries(body.attributes)) {
-      if (!isRecord(value) || typeof value.valid !== "boolean") {
-        continue;
-      }
-      const validationResult: TraceItemAttributeValidationResult = {
-        valid: value.valid,
-      };
-      if (isTraceItemAttributeType(value.type)) {
-        validationResult.type = value.type;
-      }
-      if (typeof value.error === "string") {
-        validationResult.error = value.error;
-      }
-      results[attribute] = validationResult;
-    }
-    return results;
+    const body = await this.parseJsonResponse(response);
+    return parseEventsValidationResponse(body);
   }
 
   private async fetchTraceItemAttributesByType(

--- a/packages/mcp-core/src/tools/support/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.test.ts
@@ -587,7 +587,7 @@ describe("formatEventsValidationResults", () => {
         dataset: [],
         environment: [],
         field: [],
-        query: [],
+        query: { valid: true, fields: [] },
         orderby: [],
       }),
     ).toBe("");
@@ -600,6 +600,7 @@ describe("formatEventsValidationResults", () => {
         projects: [{ valid: true }],
         dataset: [
           {
+            name: "spans",
             valid: false,
             error: "dataset must be one of: spans, errors",
           },
@@ -613,38 +614,99 @@ describe("formatEventsValidationResults", () => {
             error: "Unknown attribute",
           },
         ],
-        query: [
-          { valid: false, error: "Invalid syntax" },
-          { name: "transaction", valid: true, type: "string" },
-        ],
+        query: {
+          valid: false,
+          error: "Invalid syntax",
+          fields: [{ name: "transaction", valid: true, type: "string" }],
+        },
         orderby: [
           {
-            name: "-span.duration",
+            name: "-spon.duration",
             valid: false,
             error: "Orderby must also be a selected field",
           },
         ],
       }),
     ).toBe(`Validation Result: invalid
-Validated Projects:
-- valid
-
 Validated Dataset:
-- invalid (dataset must be one of: spans, errors)
-
-Validated Environment:
-- valid
+- INVALID spans — dataset must be one of: spans, errors
 
 Validated Fields:
-- span.duration: valid (number)
-- tags[missing]: invalid (Unknown attribute)
+- INVALID tags[missing] — Unknown attribute
 
 Validated Query:
-- query syntax: invalid (Invalid syntax)
-- transaction: valid (string)
+- INVALID query — Invalid syntax
 
 Validated Order By:
-- -span.duration: invalid (Orderby must also be a selected field)
+- INVALID -spon.duration — Orderby must also be a selected field
+`);
+  });
+
+  it("formats invalid query with invalid query fields", () => {
+    expect(
+      formatEventsValidationResults({
+        valid: false,
+        projects: [],
+        dataset: [],
+        environment: [],
+        field: [],
+        query: {
+          valid: false,
+          error: 'quotes are not closed at "VPN connections',
+          fields: [
+            { name: "hello", valid: false, error: "Unknown attribute" },
+            { name: "tags[fake]", valid: false, error: "Unknown attribute" },
+          ],
+        },
+        orderby: [],
+      }),
+    ).toBe(`Validation Result: invalid
+Validated Query:
+- INVALID query — quotes are not closed at "VPN connections
+  - INVALID hello — Unknown attribute
+  - INVALID tags[fake] — Unknown attribute
+`);
+  });
+
+  it("formats valid query field details when validation passes", () => {
+    expect(
+      formatEventsValidationResults({
+        valid: true,
+        projects: [],
+        dataset: [],
+        environment: [],
+        field: [],
+        query: {
+          valid: true,
+          fields: [{ name: "transaction", valid: true, type: "string" }],
+        },
+        orderby: [],
+      }),
+    ).toBe(`Validation Result: valid
+Validated Query:
+- OK query
+  - OK transaction — type: string
+`);
+  });
+
+  it("formats query-only validation failure", () => {
+    expect(
+      formatEventsValidationResults({
+        valid: false,
+        projects: [],
+        dataset: [],
+        environment: [],
+        field: [],
+        query: {
+          valid: false,
+          error: "Invalid syntax",
+          fields: [],
+        },
+        orderby: [],
+      }),
+    ).toBe(`Validation Result: invalid
+Validated Query:
+- INVALID query — Invalid syntax
 `);
   });
 });

--- a/packages/mcp-core/src/tools/support/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.test.ts
@@ -4,6 +4,7 @@ import { mswServer } from "@sentry/mcp-server-mocks";
 import {
   fetchCustomAttributes,
   formatEventValue,
+  formatEventsValidationResults,
   formatKnownUserValue,
   looksLikeSentrySearchSyntax,
 } from "./utils";
@@ -574,5 +575,76 @@ describe("fetchCustomAttributes", () => {
         },
       });
     });
+  });
+});
+
+describe("formatEventsValidationResults", () => {
+  it("returns an empty string when there are no validation sections", () => {
+    expect(
+      formatEventsValidationResults({
+        valid: true,
+        projects: [],
+        dataset: [],
+        environment: [],
+        field: [],
+        query: [],
+        orderby: [],
+      }),
+    ).toBe("");
+  });
+
+  it("formats all validation sections for a mixed result", () => {
+    expect(
+      formatEventsValidationResults({
+        valid: false,
+        projects: [{ valid: true }],
+        dataset: [
+          {
+            valid: false,
+            error: "dataset must be one of: spans, errors",
+          },
+        ],
+        environment: [{ valid: true }],
+        field: [
+          { name: "span.duration", valid: true, type: "number" },
+          {
+            name: "tags[missing]",
+            valid: false,
+            error: "Unknown attribute",
+          },
+        ],
+        query: [
+          { valid: false, error: "Invalid syntax" },
+          { name: "transaction", valid: true, type: "string" },
+        ],
+        orderby: [
+          {
+            name: "-span.duration",
+            valid: false,
+            error: "Orderby must also be a selected field",
+          },
+        ],
+      }),
+    ).toBe(`Validation Result: invalid
+Validated Projects:
+- valid
+
+Validated Dataset:
+- invalid (dataset must be one of: spans, errors)
+
+Validated Environment:
+- valid
+
+Validated Fields:
+- span.duration: valid (number)
+- tags[missing]: invalid (Unknown attribute)
+
+Validated Query:
+- query syntax: invalid (Invalid syntax)
+- transaction: valid (string)
+
+Validated Order By:
+- -span.duration: invalid (Orderby must also be a selected field)
+`);
   });
 });

--- a/packages/mcp-core/src/tools/support/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import type {
   SentryApiService,
   TraceItemAttributeType,
-  TraceItemAttributeValidationResult,
+  EventsAttributeValidationResult,
+  EventsQueryValidationItem,
+  EventsValidationIssue,
+  EventsValidationResult,
   TraceItemType,
 } from "../../../api-client";
 import {
@@ -423,24 +426,74 @@ function getTraceItemType(dataset: EventsDataset): TraceItemType | null {
   return null;
 }
 
-function formatValidationResults(
-  validationResults: Record<string, TraceItemAttributeValidationResult>,
+function formatAttributeValidationLine(
+  item: EventsAttributeValidationResult,
 ): string {
-  const entries = Object.entries(validationResults);
-  if (entries.length === 0) {
+  if (item.valid) {
+    return `- ${item.name}: valid${item.type ? ` (${item.type})` : ""}`;
+  }
+  return `- ${item.name}: invalid${item.error ? ` (${item.error})` : ""}`;
+}
+
+function formatValidationIssueLine(issue: EventsValidationIssue): string {
+  if (issue.valid) {
+    return "- valid";
+  }
+  return `- invalid${issue.error ? ` (${issue.error})` : ""}`;
+}
+
+function formatQueryValidationLine(item: EventsQueryValidationItem): string {
+  if ("name" in item && item.name) {
+    return formatAttributeValidationLine(item);
+  }
+  if (item.valid) {
+    return "- query syntax: valid";
+  }
+  return `- query syntax: invalid${item.error ? ` (${item.error})` : ""}`;
+}
+
+export function formatEventsValidationResults(
+  validationResults: EventsValidationResult,
+): string {
+  const sections: string[] = [];
+
+  if (validationResults.projects.length > 0) {
+    sections.push(
+      `Validated Projects:\n${validationResults.projects.map(formatValidationIssueLine).join("\n")}`,
+    );
+  }
+  if (validationResults.dataset.length > 0) {
+    sections.push(
+      `Validated Dataset:\n${validationResults.dataset.map(formatValidationIssueLine).join("\n")}`,
+    );
+  }
+  if (validationResults.environment.length > 0) {
+    sections.push(
+      `Validated Environment:\n${validationResults.environment.map(formatValidationIssueLine).join("\n")}`,
+    );
+  }
+  if (validationResults.field.length > 0) {
+    sections.push(
+      `Validated Fields:\n${validationResults.field.map(formatAttributeValidationLine).join("\n")}`,
+    );
+  }
+  if (validationResults.query.length > 0) {
+    sections.push(
+      `Validated Query:\n${validationResults.query.map(formatQueryValidationLine).join("\n")}`,
+    );
+  }
+  if (validationResults.orderby.length > 0) {
+    sections.push(
+      `Validated Order By:\n${validationResults.orderby.map(formatAttributeValidationLine).join("\n")}`,
+    );
+  }
+
+  if (sections.length === 0) {
     return "";
   }
 
-  return `Validated Attributes:
-${entries
-  .map(([attribute, result]) => {
-    if (result.valid) {
-      return `- ${attribute}: valid${result.type ? ` (${result.type})` : ""}`;
-    }
-    return `- ${attribute}: invalid${result.error ? ` (${result.error})` : ""}`;
-  })
-  .join("\n")}
-`;
+  const overall = validationResults.valid ? "valid" : "invalid";
+  return `Validation Result: ${overall}\n${sections.join("\n\n")}\n`;
 }
 
 /**
@@ -488,7 +541,23 @@ export function createDatasetAttributesTool(options: {
         .min(1)
         .optional()
         .describe(
-          "Optional exact attribute keys to validate, such as ['tags[type]', 'span.duration']",
+          "Optional exact field names to validate, such as ['tags[type]', 'span.duration']",
+        ),
+      orderby: z
+        .array(z.string().trim().min(1))
+        .min(1)
+        .optional()
+        .describe(
+          "Optional sort fields to validate against the selected fields, such as ['-span.duration']",
+        ),
+      environment: z
+        .union([
+          z.string().trim().min(1),
+          z.array(z.string().trim().min(1)).min(1),
+        ])
+        .optional()
+        .describe(
+          "Optional environment filter to validate, as a string or array of environment names",
         ),
     }),
     execute: async ({
@@ -497,6 +566,8 @@ export function createDatasetAttributesTool(options: {
       query,
       attributeTypes,
       attributes,
+      orderby,
+      environment,
     }) => {
       const {
         BASE_COMMON_FIELDS,
@@ -511,18 +582,17 @@ export function createDatasetAttributesTool(options: {
       // UserInputError will be converted to error string for the AI agent
       // Other errors will bubble up to be captured by Sentry
       const normalizedDataset = normalizeEventsDataset(dataset);
-      const traceItemType = getTraceItemType(normalizedDataset);
       const attributeTimeParams = { statsPeriod: "14d" };
-      const validationResults =
-        traceItemType && attributes?.length
-          ? await apiService.validateTraceItemAttributes({
-              organizationSlug,
-              itemType: traceItemType,
-              attributes,
-              project: projectId,
-              ...attributeTimeParams,
-            })
-          : {};
+      const validationResults = await apiService.validateEvents({
+        organizationSlug,
+        dataset,
+        fields: attributes,
+        query,
+        orderby,
+        environment,
+        project: projectId,
+        ...attributeTimeParams,
+      });
       const { attributes: customAttributes, fieldTypes } =
         await fetchCustomAttributes(
           apiService,
@@ -560,7 +630,7 @@ export function createDatasetAttributesTool(options: {
       recordAgentToolResultCount(fieldCount);
 
       return `Dataset: ${dataset}
-${formatValidationResults(validationResults)}
+${validationResults ? formatEventsValidationResults(validationResults) : ""}
 
 Available Fields (${fieldCount} total):
 ${Object.entries(allFields)

--- a/packages/mcp-core/src/tools/support/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.ts
@@ -2,9 +2,7 @@ import { z } from "zod";
 import type {
   SentryApiService,
   TraceItemAttributeType,
-  EventsAttributeValidationResult,
-  EventsQueryValidationItem,
-  EventsValidationIssue,
+  EventsQueryValidation,
   EventsValidationResult,
   TraceItemType,
 } from "../../../api-client";
@@ -426,74 +424,143 @@ function getTraceItemType(dataset: EventsDataset): TraceItemType | null {
   return null;
 }
 
-function formatAttributeValidationLine(
-  item: EventsAttributeValidationResult,
-): string {
-  if (item.valid) {
-    return `- ${item.name}: valid${item.type ? ` (${item.type})` : ""}`;
+function formatValidationStatusLine({
+  valid,
+  name,
+  type,
+  error,
+  indent = 0,
+}: {
+  valid: boolean;
+  name?: string;
+  type?: string;
+  error?: string;
+  indent?: number;
+}): string {
+  const status = valid ? "OK" : "INVALID";
+  const label = name ? ` ${name}` : "";
+  const prefix = `${" ".repeat(indent)}- ${status}${label}`;
+
+  if (valid && type) {
+    return `${prefix} — type: ${type}`;
   }
-  return `- ${item.name}: invalid${item.error ? ` (${item.error})` : ""}`;
+  if (error) {
+    return `${prefix} — ${error}`;
+  }
+  return prefix;
 }
 
-function formatValidationIssueLine(issue: EventsValidationIssue): string {
-  if (issue.valid) {
-    return "- valid";
+function formatQueryValidation(
+  query: EventsQueryValidation,
+  failuresOnly: boolean,
+): string[] {
+  const invalidFields = query.fields.filter((field) => !field.valid);
+  const visibleFields = failuresOnly ? invalidFields : query.fields;
+  const showQueryLine = failuresOnly
+    ? !query.valid || invalidFields.length > 0
+    : !query.valid || query.fields.length > 0;
+
+  if (!showQueryLine) {
+    return [];
   }
-  return `- invalid${issue.error ? ` (${issue.error})` : ""}`;
+
+  const lines: string[] = [];
+  if (!query.valid) {
+    lines.push(
+      formatValidationStatusLine({
+        valid: false,
+        name: "query",
+        error: query.error,
+      }),
+    );
+  } else {
+    lines.push(formatValidationStatusLine({ valid: true, name: "query" }));
+  }
+
+  lines.push(
+    ...visibleFields.map((field) =>
+      formatValidationStatusLine({ ...field, indent: 2 }),
+    ),
+  );
+  return lines;
 }
 
-function formatQueryValidationLine(item: EventsQueryValidationItem): string {
-  if ("name" in item && item.name) {
-    return formatAttributeValidationLine(item);
+function pushValidationSection(
+  sections: string[],
+  title: string,
+  items: ReadonlyArray<{
+    valid: boolean;
+    name?: string;
+    type?: string;
+    error?: string;
+  }>,
+  failuresOnly: boolean,
+): void {
+  const visibleItems = failuresOnly
+    ? items.filter((item) => !item.valid)
+    : items;
+  if (visibleItems.length === 0) {
+    return;
   }
-  if (item.valid) {
-    return "- query syntax: valid";
-  }
-  return `- query syntax: invalid${item.error ? ` (${item.error})` : ""}`;
+
+  sections.push(
+    `Validated ${title}:\n${visibleItems.map((item) => formatValidationStatusLine(item)).join("\n")}`,
+  );
 }
 
 export function formatEventsValidationResults(
   validationResults: EventsValidationResult,
 ): string {
+  const failuresOnly = !validationResults.valid;
   const sections: string[] = [];
 
-  if (validationResults.projects.length > 0) {
-    sections.push(
-      `Validated Projects:\n${validationResults.projects.map(formatValidationIssueLine).join("\n")}`,
-    );
+  pushValidationSection(
+    sections,
+    "Projects",
+    validationResults.projects,
+    failuresOnly,
+  );
+  pushValidationSection(
+    sections,
+    "Dataset",
+    validationResults.dataset,
+    failuresOnly,
+  );
+  pushValidationSection(
+    sections,
+    "Environment",
+    validationResults.environment,
+    failuresOnly,
+  );
+  pushValidationSection(
+    sections,
+    "Fields",
+    validationResults.field,
+    failuresOnly,
+  );
+
+  const queryLines = formatQueryValidation(
+    validationResults.query,
+    failuresOnly,
+  );
+  if (queryLines.length > 0) {
+    sections.push(`Validated Query:\n${queryLines.join("\n")}`);
   }
-  if (validationResults.dataset.length > 0) {
-    sections.push(
-      `Validated Dataset:\n${validationResults.dataset.map(formatValidationIssueLine).join("\n")}`,
-    );
-  }
-  if (validationResults.environment.length > 0) {
-    sections.push(
-      `Validated Environment:\n${validationResults.environment.map(formatValidationIssueLine).join("\n")}`,
-    );
-  }
-  if (validationResults.field.length > 0) {
-    sections.push(
-      `Validated Fields:\n${validationResults.field.map(formatAttributeValidationLine).join("\n")}`,
-    );
-  }
-  if (validationResults.query.length > 0) {
-    sections.push(
-      `Validated Query:\n${validationResults.query.map(formatQueryValidationLine).join("\n")}`,
-    );
-  }
-  if (validationResults.orderby.length > 0) {
-    sections.push(
-      `Validated Order By:\n${validationResults.orderby.map(formatAttributeValidationLine).join("\n")}`,
-    );
-  }
+
+  pushValidationSection(
+    sections,
+    "Order By",
+    validationResults.orderby,
+    failuresOnly,
+  );
 
   if (sections.length === 0) {
     return "";
   }
 
   const overall = validationResults.valid ? "valid" : "invalid";
-  return `Validation Result: ${overall}\n${sections.join("\n\n")}\n`;
+  const details = sections.join("\n\n");
+  return `Validation Result: ${overall}\n${details}\n`;
 }
 
 /**

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -1016,7 +1016,7 @@ export const restHandlers = buildHandlers([
         error: null,
       }));
 
-      const queryResults = query
+      const queryFieldResults = query
         ? [
             {
               name: "transaction",
@@ -1043,14 +1043,18 @@ export const restHandlers = buildHandlers([
       return HttpResponse.json({
         valid:
           fieldResults.every((field) => field.valid) &&
-          queryResults.every((item) => item.valid) &&
+          queryFieldResults.every((item) => item.valid) &&
           orderbyResults.every((item) => item.valid) &&
           environmentResults.every((item) => item.valid),
         projects: [],
         dataset: [],
         environment: environmentResults,
         field: fieldResults,
-        query: queryResults,
+        query: {
+          valid: queryFieldResults.every((item) => item.valid),
+          error: null,
+          fields: queryFieldResults,
+        },
         orderby: orderbyResults,
       });
     },

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -995,35 +995,63 @@ export const restHandlers = buildHandlers([
     fetch: () => HttpResponse.json(tagsFixture),
   },
   {
-    method: "post",
-    path: "/api/0/organizations/sentry-mcp-evals/trace-items/attributes/validate/",
-    fetch: async ({ request }) => {
-      const body = (await request.json().catch(() => null)) as unknown;
-      const attributesValue =
-        typeof body === "object" && body !== null && "attributes" in body
-          ? body.attributes
-          : undefined;
-      const attributes = Array.isArray(attributesValue)
-        ? attributesValue.filter(
-            (attribute): attribute is string => typeof attribute === "string",
-          )
+    method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/events/validate/",
+    fetch: ({ request }) => {
+      const url = new URL(request.url);
+      const fields = url.searchParams.getAll("field");
+      const query = url.searchParams.get("query");
+      const orderby = url.searchParams.getAll("orderby");
+      const environments = url.searchParams.getAll("environment");
+
+      const fieldResults = fields.map((field) => ({
+        name: field,
+        valid: true,
+        attrType:
+          field.includes("sequence") ||
+          field.includes("count") ||
+          field.includes("duration")
+            ? "number"
+            : "string",
+        error: null,
+      }));
+
+      const queryResults = query
+        ? [
+            {
+              name: "transaction",
+              valid: true,
+              attrType: "string",
+              error: null,
+            },
+          ]
         : [];
 
+      const orderbyResults = orderby.map((value) => ({
+        name: value,
+        valid: fields.length > 0,
+        attrType: null,
+        error:
+          fields.length > 0 ? null : "Orderby must also be a selected field",
+      }));
+
+      const environmentResults = environments.map((environment) => ({
+        valid: true,
+        error: null,
+      }));
+
       return HttpResponse.json({
-        attributes: Object.fromEntries(
-          attributes.map((attribute) => [
-            attribute,
-            {
-              valid: true,
-              type:
-                attribute.includes("sequence") ||
-                attribute.includes("count") ||
-                attribute.includes("duration")
-                  ? "number"
-                  : "string",
-            },
-          ]),
-        ),
+        valid:
+          fieldResults.every((field) => field.valid) &&
+          queryResults.every((item) => item.valid) &&
+          orderbyResults.every((item) => item.valid) &&
+          environmentResults.every((item) => item.valid),
+        projects: [],
+        dataset: [],
+        environment: environmentResults,
+        field: fieldResults,
+        query: queryResults,
+        orderby: orderbyResults,
       });
     },
   },


### PR DESCRIPTION
- This updates the `trace-items/attribute/validate` to the new `/events/validate` endpoint which checks the query and other field params as well
- Code was written by Cursor