### PR TITLE
fix(profiling): Accept current Sentry profile schemas

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -4055,9 +4055,9 @@ export class SentryApiService {
     const path = `/organizations/${organizationSlug}/profiling/chunks/?${queryParams.toString()}`;
     const body = await this.requestJSON(path, undefined, opts);
 
-    // Response wraps chunks in {chunks: []}
+    // Normalize the Sentry {chunk: ...} wrapper to the internal chunks array.
     const response = ProfileChunkResponseSchema.parse(body);
-    if (!response.chunks || response.chunks.length === 0) {
+    if (response.chunks.length === 0) {
       throw new ApiNotFoundError(
         `No profile chunk found for profiler_id ${profilerId}`,
         undefined,
@@ -4065,7 +4065,12 @@ export class SentryApiService {
       );
     }
 
-    return response.chunks[0];
+    return {
+      ...response.chunks[0],
+      // Sentry's frontend does the same query-param backfill for continuous
+      // profile chunks because profiling-service may omit profiler_id.
+      profiler_id: response.chunks[0].profiler_id ?? profilerId,
+    };
   }
 
   getPreprodSnapshotUrl(organizationSlug: string, snapshotId: string): string {

--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -15,6 +15,7 @@ import {
   FlamegraphSchema,
   IssueSchema,
   IssueTagValuesSchema,
+  ProfileChunkResponseSchema,
   ProfileChunkSampleSchema,
   ProfileChunkSchema,
   ProfileFrameSchema,
@@ -746,6 +747,107 @@ describe("FlamegraphSchema", () => {
     expect(flamegraph.profiles[0]?.sample_durations_ns).toEqual([]);
     expect(flamegraph.profiles[0]?.sample_counts).toEqual([]);
   });
+
+  it("parses sparse empty flamegraph responses so tools can return no-data output", () => {
+    const flamegraph = FlamegraphSchema.parse({
+      metadata: {
+        platform: "javascript",
+        projectID: 1,
+        transactionName: "POST /checkout",
+      },
+    });
+
+    expect(flamegraph.platform).toBe("javascript");
+    expect(flamegraph.projectID).toBe(1);
+    expect(flamegraph.transactionName).toBe("POST /checkout");
+    expect(flamegraph.profiles).toEqual([]);
+    expect(flamegraph.shared.frames).toEqual([]);
+    expect(flamegraph.shared.frame_infos).toEqual([]);
+    expect(flamegraph.shared.profiles).toEqual([]);
+  });
+
+  it("parses continuous profile references returned in aggregate flamegraphs", () => {
+    const flamegraph = FlamegraphSchema.parse({
+      platform: "javascript",
+      projectID: 1,
+      profiles: [],
+      shared: {
+        frames: [],
+        profiles: [
+          {
+            project_id: 1,
+            profiler_id: "041bde57b9844e36b8b7e5734efae5f7",
+            chunk_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+            thread_id: "12345",
+            start: "1710958503629000000",
+            end: "1710958504629000000",
+            transaction_id: null,
+          },
+        ],
+      },
+    });
+
+    expect(flamegraph.shared.profiles).toHaveLength(1);
+    expect(flamegraph.shared.profiles[0]).toMatchObject({
+      project_id: 1,
+      profiler_id: "041bde57b9844e36b8b7e5734efae5f7",
+      chunk_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+      thread_id: "12345",
+      start: "1710958503629000000",
+      end: "1710958504629000000",
+      transaction_id: null,
+    });
+  });
+
+  it("parses fallback continuous profile references without optional timing or thread fields", () => {
+    const flamegraph = FlamegraphSchema.parse({
+      platform: "javascript",
+      projectID: 1,
+      profiles: [],
+      shared: {
+        frames: [],
+        profiles: [
+          {
+            project_id: 1,
+            profiler_id: "041bde57b9844e36b8b7e5734efae5f7",
+            chunk_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+          },
+        ],
+      },
+    });
+
+    expect(flamegraph.shared.profiles).toHaveLength(1);
+    expect(flamegraph.shared.profiles[0]).toMatchObject({
+      project_id: 1,
+      profiler_id: "041bde57b9844e36b8b7e5734efae5f7",
+      chunk_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    });
+  });
+
+  it("parses upstream frame infos without weight and string profile references", () => {
+    const flamegraph = FlamegraphSchema.parse({
+      platform: "javascript",
+      projectID: 1,
+      profiles: [],
+      shared: {
+        frames: [],
+        frame_infos: [
+          {
+            count: 3,
+            sumDuration: 42,
+            sumSelfTime: 12,
+            p75Duration: 20,
+            p95Duration: 30,
+            p99Duration: 40,
+          },
+        ],
+        profiles: ["transaction-profile-id"],
+      },
+    });
+
+    expect(flamegraph.shared.frame_infos[0]?.weight).toBe(42);
+    expect(flamegraph.shared.profiles[0]).toBe("transaction-profile-id");
+  });
 });
 
 describe("ProfileChunkSampleSchema", () => {
@@ -863,7 +965,7 @@ describe("profile fixtures", () => {
     // profile-chunk.json mirrors the continuous profiler output: string
     // thread_id, absolute timestamp per sample, no transaction block.
     const chunk = ProfileChunkSchema.parse(
-      structuredClone(profileChunkFixture.chunks[0]),
+      structuredClone(profileChunkFixture.chunk),
     );
 
     expect(
@@ -876,6 +978,42 @@ describe("profile fixtures", () => {
         (sample) => typeof sample.timestamp === "number",
       ),
     ).toBe(true);
+  });
+
+  it("parses continuous profile thread metadata entries without names", () => {
+    const chunk = ProfileChunkSchema.parse({
+      ...structuredClone(profileChunkFixture.chunk),
+      profile: {
+        ...structuredClone(profileChunkFixture.chunk.profile),
+        thread_metadata: {
+          "1": { priority: 10 },
+        },
+      },
+    });
+
+    expect(chunk.profile.thread_metadata["1"]?.priority).toBe(10);
+  });
+
+  it("parses Sentry's singular profile chunk response wrapper", () => {
+    const response = ProfileChunkResponseSchema.parse(
+      structuredClone(profileChunkFixture),
+    );
+
+    expect(response.chunks).toHaveLength(1);
+    expect(response.chunks[0]?.chunk_id).toBe(
+      profileChunkFixture.chunk.chunk_id,
+    );
+  });
+
+  it("still parses the legacy plural profile chunk response wrapper", () => {
+    const response = ProfileChunkResponseSchema.parse({
+      chunks: [structuredClone(profileChunkFixture.chunk)],
+    });
+
+    expect(response.chunks).toHaveLength(1);
+    expect(response.chunks[0]?.chunk_id).toBe(
+      profileChunkFixture.chunk.chunk_id,
+    );
   });
 });
 

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1431,13 +1431,13 @@ export const AIConversationSpanListSchema = z.array(AIConversationSpanSchema);
  */
 export const FlamegraphFrameSchema = z
   .object({
-    file: z.string(),
+    file: z.preprocess((value) => value ?? "", z.string()),
     image: z.string().optional(),
-    is_application: z.boolean(),
-    line: z.number(),
-    name: z.string(),
+    is_application: z.preprocess((value) => value ?? false, z.boolean()),
+    line: z.preprocess((value) => value ?? 0, z.number()),
+    name: z.preprocess((value) => value ?? "(unknown)", z.string()),
     path: z.string().optional(),
-    fingerprint: z.number(),
+    fingerprint: z.preprocess((value) => value ?? 0, z.number()),
   })
   .passthrough();
 
@@ -1450,28 +1450,52 @@ export const FlamegraphFrameSchema = z
 export const FlamegraphFrameInfoSchema = z
   .object({
     count: z.number(),
-    weight: z.number(),
+    weight: z.number().optional(),
     sumDuration: z.number(),
     sumSelfTime: z.number(),
     p75Duration: z.number(),
     p95Duration: z.number(),
     p99Duration: z.number(),
   })
-  .passthrough();
+  .passthrough()
+  .transform((frameInfo) => ({
+    ...frameInfo,
+    weight: frameInfo.weight ?? frameInfo.sumDuration,
+  }));
 
 /**
  * Schema for profile metadata within a flamegraph response.
  *
- * Links to individual profile IDs and their time ranges.
+ * Links flamegraph samples back to transaction profile IDs or continuous
+ * profile chunks. References can also be raw profile ID strings in older
+ * speedscope-compatible payloads. Timing fields are optional because Sentry's
+ * continuous candidate sources do not all populate the same reference metadata.
  */
-export const FlamegraphProfileMetadataSchema = z
-  .object({
-    project_id: z.number(),
-    profile_id: z.string(),
-    start: z.number(),
-    end: z.number(),
-  })
-  .passthrough();
+export const FlamegraphProfileMetadataSchema = z.union([
+  z.string(),
+  z
+    .object({
+      project_id: z.number(),
+      profile_id: z.string(),
+      start: z.union([z.number(), z.string()]).optional(),
+      end: z.union([z.number(), z.string()]).optional(),
+    })
+    .passthrough(),
+  // Compatibility with getsentry/sentry `ContinuousProfileCandidate`:
+  // continuous flamegraph refs may come from transaction/spans/functions paths,
+  // so only project_id/profiler_id/chunk_id are always present.
+  z
+    .object({
+      project_id: z.number(),
+      profiler_id: z.string(),
+      chunk_id: z.string(),
+      thread_id: z.string().optional(),
+      start: z.union([z.number(), z.string()]).optional(),
+      end: z.union([z.number(), z.string()]).optional(),
+      transaction_id: z.string().nullable().optional(),
+    })
+    .passthrough(),
+]);
 
 /**
  * Schema for a single profile within a flamegraph (typically one per thread).
@@ -1509,28 +1533,61 @@ export const FlamegraphProfileSchema = z
  * This is the primary data source for profile analysis as it's
  * already aggregated and includes percentile calculations.
  */
-export const FlamegraphSchema = z
-  .object({
-    activeProfileIndex: z.preprocess((value) => value ?? 0, z.number()),
-    metadata: z.record(z.unknown()).optional(),
-    platform: z.string(),
-    profiles: z.array(FlamegraphProfileSchema),
-    projectID: z.number(),
-    shared: z.object({
-      frames: z.array(FlamegraphFrameSchema),
-      frame_infos: z.preprocess(
-        (value) => value ?? [],
-        z.array(FlamegraphFrameInfoSchema),
-      ),
+export const FlamegraphSchema = z.preprocess(
+  (value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return value;
+    }
+
+    // Sparse no-data flamegraph responses can carry only `metadata`; keep them
+    // parseable so tools can render the explicit no-profile-data result.
+    const body = value as Record<string, unknown>;
+    const metadata =
+      body.metadata && typeof body.metadata === "object"
+        ? (body.metadata as Record<string, unknown>)
+        : {};
+
+    return {
+      ...body,
+      platform: body.platform ?? metadata.platform,
+      projectID: body.projectID ?? metadata.projectID,
+      transactionName: body.transactionName ?? metadata.transactionName,
+    };
+  },
+  z
+    .object({
+      activeProfileIndex: z.preprocess((value) => value ?? 0, z.number()),
+      metadata: z.record(z.unknown()).optional(),
+      platform: z.string(),
       profiles: z.preprocess(
         (value) => value ?? [],
-        z.array(FlamegraphProfileMetadataSchema),
+        z.array(FlamegraphProfileSchema),
       ),
-    }),
-    transactionName: z.string().optional(),
-    metrics: z.unknown().optional(),
-  })
-  .passthrough();
+      projectID: z.number(),
+      shared: z.preprocess(
+        (value) => value ?? {},
+        z
+          .object({
+            frames: z.preprocess(
+              (value) => value ?? [],
+              z.array(FlamegraphFrameSchema),
+            ),
+            frame_infos: z.preprocess(
+              (value) => value ?? [],
+              z.array(FlamegraphFrameInfoSchema),
+            ),
+            profiles: z.preprocess(
+              (value) => value ?? [],
+              z.array(FlamegraphProfileMetadataSchema),
+            ),
+          })
+          .passthrough(),
+      ),
+      transactionName: z.string().optional(),
+      metrics: z.unknown().optional(),
+    })
+    .passthrough(),
+);
 
 /**
  * Schema for individual frames in raw profile chunk data.
@@ -1570,7 +1627,9 @@ export const ProfileFrameSchema = z
 const ProfileThreadMetadataSchema = z.record(
   z
     .object({
-      name: z.string().nullable(),
+      // Matches Sentry's `Profiling.ContinuousProfile.thread_metadata` type,
+      // where metadata entries may include only priority.
+      name: z.string().nullable().optional(),
       priority: z.number().nullable().optional(),
     })
     .passthrough(),
@@ -1634,17 +1693,20 @@ export const TransactionProfileSampleSchema = z
 export const ProfileChunkSchema = z
   .object({
     chunk_id: z.string(),
-    profiler_id: z.string(),
+    profiler_id: z.string().optional(),
     event_id: z.string().optional(),
-    environment: z.string().nullable(),
-    platform: z.string(),
-    release: z.string(),
-    version: z.string(),
+    environment: z.preprocess((value) => value ?? null, z.string().nullable()),
+    platform: z.preprocess((value) => value ?? "unknown", z.string()),
+    release: z.preprocess((value) => value ?? "unknown", z.string()),
+    version: z.preprocess((value) => value ?? "2", z.string()),
     profile: z.object({
       frames: z.array(ProfileFrameSchema),
       samples: z.array(ProfileChunkSampleSchema),
       stacks: z.array(z.array(z.number())),
-      thread_metadata: ProfileThreadMetadataSchema,
+      thread_metadata: z.preprocess(
+        (value) => value ?? {},
+        ProfileThreadMetadataSchema,
+      ),
     }),
   })
   .passthrough();
@@ -1652,13 +1714,29 @@ export const ProfileChunkSchema = z
 /**
  * Schema for profile chunks API response wrapper.
  *
- * The API returns chunks in an array wrapper, even for single chunk requests.
+ * Sentry returns a singular `chunk` wrapper for single chunk requests. The
+ * frontend also backfills profiler_id from the query because profiling-service
+ * chunks may omit it. The legacy plural `chunks` wrapper remains accepted for
+ * older fixtures and mocks.
  */
-export const ProfileChunkResponseSchema = z
-  .object({
-    chunks: z.array(ProfileChunkSchema),
-  })
-  .passthrough();
+export const ProfileChunkResponseSchema = z.union([
+  z
+    .object({
+      chunk: ProfileChunkSchema.nullable(),
+    })
+    .passthrough()
+    .transform((response) => ({
+      chunks: response.chunk ? [response.chunk] : [],
+    })),
+  z
+    .object({
+      chunks: z.array(ProfileChunkSchema),
+    })
+    .passthrough()
+    .transform((response) => ({
+      chunks: response.chunks,
+    })),
+]);
 
 const ProfileReleaseSchema = z
   .union([

--- a/packages/mcp-core/src/tools/catalog/get-profile-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-profile-details.test.ts
@@ -1,5 +1,6 @@
 import {
   mswServer,
+  profileChunkFixture,
   transactionProfileV1MissingFunctionFixture,
   transactionProfileV1Fixture,
 } from "@sentry/mcp-server-mocks";
@@ -184,6 +185,44 @@ describe("get_profile_details", () => {
       expect(result).toContain("## Summary");
       expect(result).toContain("## Raw Sample Analysis");
       expect(result).toContain("## Top Frames by Occurrence");
+    });
+
+    it("copies profilerId from the request when the chunk payload omits it", async () => {
+      const chunk = {
+        ...structuredClone(profileChunkFixture.chunk),
+        profiler_id: undefined,
+      };
+
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/projects/sentry-mcp-evals/backend/",
+          () =>
+            HttpResponse.json({ id: 12345, slug: "backend", name: "Backend" }),
+          { once: true },
+        ),
+        http.get(
+          "https://sentry.io/api/0/organizations/sentry-mcp-evals/profiling/chunks/",
+          () => HttpResponse.json({ chunk }),
+          { once: true },
+        ),
+      );
+
+      const result = await getProfileDetails.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlugOrId: "backend",
+          profilerId: "041bde57b9844e36b8b7e5734efae5f7",
+          start: "2024-01-01T00:00:00Z",
+          end: "2024-01-01T01:00:00Z",
+          regionUrl: null,
+          focusOnUserCode: true,
+        },
+        baseContext,
+      );
+
+      expect(result).toContain(
+        "- **Profiler ID**: 041bde57b9844e36b8b7e5734efae5f7",
+      );
     });
 
     it("rejects incomplete continuous profile URLs", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-profile.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-profile.test.ts
@@ -1,3 +1,5 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
 import getProfile from "./get-profile";
 
@@ -143,6 +145,47 @@ describe("get_profile", () => {
         - Try a longer time period (e.g., '30d')
         - Check if profiling is enabled for this project"
       `);
+    });
+
+    it("returns no data message when Sentry returns a sparse empty flamegraph", async () => {
+      mswServer.use(
+        http.get(
+          "https://sentry.io/api/0/organizations/sentry-mcp-evals/profiling/flamegraph/",
+          () =>
+            HttpResponse.json({
+              metadata: {
+                platform: "javascript",
+                projectID: 4509062593708032,
+                transactionName: "/api/sparse",
+              },
+            }),
+          { once: true },
+        ),
+      );
+
+      const result = await getProfile.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          projectSlugOrId: 4509062593708032,
+          transactionName: "/api/sparse",
+          statsPeriod: "7d",
+          focusOnUserCode: true,
+          maxHotPaths: 5,
+          regionUrl: null,
+        },
+        {
+          constraints: {
+            organizationSlug: null,
+          },
+          accessToken: "access-token",
+          userId: "1",
+        },
+      );
+
+      expect(result).toContain("## No Profile Data Found");
+      expect(result).toContain(
+        "No profiling data found for transaction **/api/sparse** in the last 7d.",
+      );
     });
 
     it("works with numeric project ID", async () => {

--- a/packages/mcp-server-mocks/src/fixtures/profile-chunk.json
+++ b/packages/mcp-server-mocks/src/fixtures/profile-chunk.json
@@ -1,103 +1,101 @@
 {
-  "chunks": [
-    {
-      "chunk_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
-      "profiler_id": "041bde57b9844e36b8b7e5734efae5f7",
-      "event_id": "f8e7d6c5b4a3f8e7d6c5b4a3f8e7d6c5",
-      "environment": "production",
-      "platform": "python",
-      "release": "backend@1.2.3",
-      "version": "2",
-      "profile": {
-        "frames": [
-          {
-            "filename": "main.py",
-            "function": "handle_request",
-            "in_app": true,
-            "lineno": 42,
-            "colno": 8,
-            "module": "app.main",
-            "abs_path": "/app/src/main.py",
-            "platform": "python",
-            "lang": "python"
-          },
-          {
-            "filename": "db.py",
-            "function": "execute_query",
-            "in_app": true,
-            "lineno": 118,
-            "colno": 12,
-            "module": "app.db",
-            "abs_path": "/app/src/db.py",
-            "platform": "python",
-            "lang": "python"
-          },
-          {
-            "filename": "serializers.py",
-            "function": "serialize_response",
-            "in_app": true,
-            "lineno": 55,
-            "colno": 4,
-            "module": "app.serializers",
-            "abs_path": "/app/src/serializers.py",
-            "platform": "python",
-            "lang": "python"
-          },
-          {
-            "filename": null,
-            "function": "PyObject_Call",
-            "in_app": false,
-            "lineno": null,
-            "module": "cpython",
-            "abs_path": null,
-            "platform": "python",
-            "instruction_addr": "0x7f3a2b1c4d5e",
-            "symbol": "PyObject_Call"
-          },
-          {
-            "filename": "connection.py",
-            "function": "cursor.execute",
-            "in_app": false,
-            "lineno": 230,
-            "module": "psycopg2.extensions",
-            "abs_path": "/usr/lib/python3.11/site-packages/psycopg2/extensions.py",
-            "platform": "python",
-            "lang": "python"
-          },
-          {
-            "filename": "UserService.java",
-            "function": "getUsers",
-            "in_app": true,
-            "lineno": 87,
-            "module": "com.example.service",
-            "abs_path": "com/example/service/UserService.java",
-            "platform": "java",
-            "class_name": "UserService",
-            "raw_function": "com.example.service.UserService.getUsers",
-            "lang": "java"
-          }
-        ],
-        "samples": [
-          { "stack_id": 0, "thread_id": "1", "timestamp": 1700000000.0 },
-          { "stack_id": 1, "thread_id": "1", "timestamp": 1700000000.01 },
-          { "stack_id": 2, "thread_id": "1", "timestamp": 1700000000.02 },
-          { "stack_id": 1, "thread_id": "1", "timestamp": 1700000000.03 },
-          { "stack_id": 3, "thread_id": "2", "timestamp": 1700000000.0 },
-          { "stack_id": 0, "thread_id": "1", "timestamp": 1700000000.04 },
-          { "stack_id": 1, "thread_id": "1", "timestamp": 1700000000.05 },
-          { "stack_id": 2, "thread_id": "1", "timestamp": 1700000000.06 }
-        ],
-        "stacks": [
-          [0, 3],
-          [0, 1, 4],
-          [0, 2],
-          [0, 1, 4, 3]
-        ],
-        "thread_metadata": {
-          "1": { "name": "MainThread", "priority": 10 },
-          "2": { "name": "BackgroundWorker", "priority": 5 }
+  "chunk": {
+    "chunk_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "profiler_id": "041bde57b9844e36b8b7e5734efae5f7",
+    "event_id": "f8e7d6c5b4a3f8e7d6c5b4a3f8e7d6c5",
+    "environment": "production",
+    "platform": "python",
+    "release": "backend@1.2.3",
+    "version": "2",
+    "profile": {
+      "frames": [
+        {
+          "filename": "main.py",
+          "function": "handle_request",
+          "in_app": true,
+          "lineno": 42,
+          "colno": 8,
+          "module": "app.main",
+          "abs_path": "/app/src/main.py",
+          "platform": "python",
+          "lang": "python"
+        },
+        {
+          "filename": "db.py",
+          "function": "execute_query",
+          "in_app": true,
+          "lineno": 118,
+          "colno": 12,
+          "module": "app.db",
+          "abs_path": "/app/src/db.py",
+          "platform": "python",
+          "lang": "python"
+        },
+        {
+          "filename": "serializers.py",
+          "function": "serialize_response",
+          "in_app": true,
+          "lineno": 55,
+          "colno": 4,
+          "module": "app.serializers",
+          "abs_path": "/app/src/serializers.py",
+          "platform": "python",
+          "lang": "python"
+        },
+        {
+          "filename": null,
+          "function": "PyObject_Call",
+          "in_app": false,
+          "lineno": null,
+          "module": "cpython",
+          "abs_path": null,
+          "platform": "python",
+          "instruction_addr": "0x7f3a2b1c4d5e",
+          "symbol": "PyObject_Call"
+        },
+        {
+          "filename": "connection.py",
+          "function": "cursor.execute",
+          "in_app": false,
+          "lineno": 230,
+          "module": "psycopg2.extensions",
+          "abs_path": "/usr/lib/python3.11/site-packages/psycopg2/extensions.py",
+          "platform": "python",
+          "lang": "python"
+        },
+        {
+          "filename": "UserService.java",
+          "function": "getUsers",
+          "in_app": true,
+          "lineno": 87,
+          "module": "com.example.service",
+          "abs_path": "com/example/service/UserService.java",
+          "platform": "java",
+          "class_name": "UserService",
+          "raw_function": "com.example.service.UserService.getUsers",
+          "lang": "java"
         }
+      ],
+      "samples": [
+        { "stack_id": 0, "thread_id": "1", "timestamp": 1700000000.0 },
+        { "stack_id": 1, "thread_id": "1", "timestamp": 1700000000.01 },
+        { "stack_id": 2, "thread_id": "1", "timestamp": 1700000000.02 },
+        { "stack_id": 1, "thread_id": "1", "timestamp": 1700000000.03 },
+        { "stack_id": 3, "thread_id": "2", "timestamp": 1700000000.0 },
+        { "stack_id": 0, "thread_id": "1", "timestamp": 1700000000.04 },
+        { "stack_id": 1, "thread_id": "1", "timestamp": 1700000000.05 },
+        { "stack_id": 2, "thread_id": "1", "timestamp": 1700000000.06 }
+      ],
+      "stacks": [
+        [0, 3],
+        [0, 1, 4],
+        [0, 2],
+        [0, 1, 4, 3]
+      ],
+      "thread_metadata": {
+        "1": { "name": "MainThread", "priority": 10 },
+        "2": { "name": "BackgroundWorker", "priority": 5 }
       }
     }
-  ]
+  }
 }


### PR DESCRIPTION
Sentry MCP now accepts the current profiling payload shapes used by Sentry for aggregate flamegraphs and continuous profile chunks. Sparse flamegraph responses can reach the intended no-data output instead of failing Zod parsing, continuous chunk responses normalize from Sentry's singular `{chunk}` wrapper, and omitted chunk `profiler_id` values are backfilled from the request like Sentry's frontend does.

The schema drift came from several upstream Sentry profiling changes: getsentry/sentry#74463 and getsentry/sentry#75200 introduced continuous flamegraph candidates with optional timing/thread metadata, getsentry/sentry#95873 added a chunked candidate path that can omit `thread_id`, getsentry/sentry#74087 made continuous chunk thread metadata names optional, getsentry/sentry#83338 made the UI consume `/profiling/chunks/` as `{chunk}`, getsentry/sentry#86435 added the frontend `profiler_id` backfill, and getsentry/sentry#99553 / getsentry/sentry#100332 changed frame info metadata so `weight` is not required. This PR mirrors those contracts in MCP while keeping legacy `{chunks}` fixtures accepted as input only.

Fixes #1107

Validation:
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm run test`
