### PR TITLE
feat(oauth): Select all active skills by default

### DIFF
--- a/docs/specs/remembered-oauth-skills.md
+++ b/docs/specs/remembered-oauth-skills.md
@@ -13,12 +13,10 @@ validated during the callback before becoming `grantedSkills`.
 ## Motivation
 
 Users frequently re-authorize the same MCP client after token expiry, local
-client resets, or auth cache cleanup. The current approval screen always starts
-from built-in `defaultEnabled` skills, so users who intentionally enabled
-optional skills must reselect them each time.
-
-Remembering prior selections reduces repeated consent work without changing the
-authorization model.
+client resets, or auth cache cleanup. Remembering prior selections reduces
+repeated consent work without changing the authorization model. When a client
+has no remembered preference, the approval screen starts with all active
+approvable skills selected.
 
 ## Design
 
@@ -62,7 +60,7 @@ On read and write:
 - Ignore deprecated skills.
 
 Invalid cookie data must not block authorization. It only falls back to the
-built-in skill defaults.
+all-active-skills approval default.
 
 ## Interface
 
@@ -78,7 +76,7 @@ interface ApprovalDialogOptions {
 Checkbox selection order:
 
 1. Use remembered skills for the current `clientId`, when present.
-2. Otherwise use existing `skill.defaultEnabled` values.
+2. Otherwise select all active approvable skills.
 
 ## OAuth Flow
 
@@ -136,7 +134,7 @@ Implementation steps:
 
 Add focused unit tests for:
 
-- No preference cookie falls back to built-in defaults.
+- No preference cookie falls back to all active approvable skills.
 - Remembered skills pre-check the approval form.
 - Unknown, malformed, and deprecated skills are ignored.
 - POST writes both cookies.
@@ -146,9 +144,9 @@ Add focused unit tests for:
 
 ## Migration
 
-No migration is required. Existing users without the new cookie continue to see
-the current built-in defaults. Existing `mcp-approved-clients` cookies remain
-valid and unchanged.
+No migration is required. Existing users without the preference cookie see all
+active approvable skills selected. Existing `mcp-approved-clients` cookies
+remain valid and unchanged.
 
 ## Future Work
 

--- a/docs/testing/remote.md
+++ b/docs/testing/remote.md
@@ -369,9 +369,9 @@ pnpm -w run cli "list organizations"
 ### 2. Test Skills Permissions
 
 **In OAuth approval screen, test:**
-- Minimal skills (inspect, docs only)
-- Default skills (inspect, seer)
-- All skills (inspect, seer, docs, triage, project-management)
+- Default selection: all active skills (inspect, seer, triage, project-management)
+- Minimal custom selection (inspect only)
+- Write-capable custom selection (triage, project-management)
 
 **Verify tools reflect the current session grant:**
 ```bash

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.test.ts
@@ -66,7 +66,7 @@ describe("approval-dialog", () => {
       expect(html).toContain('value="');
     });
 
-    it("uses built-in skill defaults when no remembered defaults are provided", async () => {
+    it("selects all approvable skills when no remembered defaults are provided", async () => {
       const response = await renderApprovalDialog(
         new Request("https://example.com/oauth/authorize"),
         {
@@ -80,8 +80,8 @@ describe("approval-dialog", () => {
 
       expectSkillChecked(html, "inspect");
       expectSkillChecked(html, "seer");
-      expectSkillUnchecked(html, "triage");
-      expectSkillUnchecked(html, "project-management");
+      expectSkillChecked(html, "triage");
+      expectSkillChecked(html, "project-management");
     });
 
     it("uses remembered skill defaults when provided", async () => {

--- a/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
+++ b/packages/mcp-cloudflare/src/server/lib/approval-dialog.ts
@@ -382,7 +382,7 @@ export interface ApprovalDialogOptions {
    */
   cookieSecret: string;
   /**
-   * Skill IDs to preselect. When omitted, built-in defaultEnabled values apply.
+   * Skill IDs to preselect. When omitted, all approvable skills are selected.
    */
   defaultSkills?: string[];
 }
@@ -463,11 +463,7 @@ export async function renderApprovalDialog(
   } = options;
   const defaultSkillIds =
     defaultSkills === undefined
-      ? new Set(
-          APPROVABLE_SKILLS.filter((skill) => skill.defaultEnabled).map(
-            (skill) => skill.id,
-          ),
-        )
+      ? new Set(APPROVABLE_SKILLS.map((skill) => skill.id))
       : new Set(filterApprovableSkillIds(defaultSkills));
 
   // Use static skill definitions bundled at build time

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -256,10 +256,11 @@ describe("oauth authorize routes", () => {
       expect(response.status).toBe(200);
       expectSkillChecked(html, "inspect");
       expectSkillChecked(html, "seer");
-      expectSkillUnchecked(html, "triage");
+      expectSkillChecked(html, "triage");
+      expectSkillChecked(html, "project-management");
     });
 
-    it("ignores tampered remembered skill cookies and falls back to built-in defaults", async () => {
+    it("ignores tampered remembered skill cookies and falls back to all approvable skills", async () => {
       mockOAuthProvider.parseAuthRequest.mockResolvedValueOnce({
         clientId: "test-client",
         redirectUri: "https://example.com/callback",
@@ -291,7 +292,8 @@ describe("oauth authorize routes", () => {
       expect(response.status).toBe(200);
       expectSkillChecked(html, "inspect");
       expectSkillChecked(html, "seer");
-      expectSkillUnchecked(html, "triage");
+      expectSkillChecked(html, "triage");
+      expectSkillChecked(html, "project-management");
     });
   });
 


### PR DESCRIPTION
Hosted OAuth consent now starts new approvals with every active approvable skill selected. Client-specific remembered preferences still take precedence, so users who previously saved a non-empty custom subset keep seeing that subset instead of being reset to the all-skills fallback.

The docs and remote QA notes now describe the active-skill default, and the OAuth approval tests cover both the new fallback and the remembered-selection override. Validation passed with `pnpm run tsc && pnpm run lint && pnpm run test`.