### PR TITLE
ci: Add deterministic project guardrails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run build
         run: pnpm build
 
+      - name: Check generated definitions
+        run: pnpm run check:generated
+
       - name: Run type checking
         run: pnpm -w run tsc
 

--- a/ast-grep-rule-tests/no-stdio-stdout-test.yml
+++ b/ast-grep-rule-tests/no-stdio-stdout-test.yml
@@ -1,0 +1,15 @@
+id: no-stdio-stdout
+valid:
+  - |
+    logInfo("MCP server started", {
+      loggerScope: ["server", "lifecycle"],
+    });
+  - |
+    console.error("Error: Invalid argument");
+invalid:
+  - |
+    console.log("MCP server started");
+  - |
+    console.info("transport connected");
+  - |
+    console.debug("raw frame", frame);

--- a/ast-grep-rules/no-stdio-stdout.yml
+++ b/ast-grep-rules/no-stdio-stdout.yml
@@ -1,0 +1,17 @@
+id: no-stdio-stdout
+language: TypeScript
+severity: error
+message: Do not write to stdout from MCP stdio-reachable runtime code.
+note: stdout is reserved for MCP JSON-RPC frames. Use logging helpers that route to stderr, or keep output in explicit CLI-only code.
+rule:
+  any:
+    - pattern: console.log($$$ARGS)
+    - pattern: console.info($$$ARGS)
+    - pattern: console.debug($$$ARGS)
+files:
+  - packages/mcp-core/src/**/*.ts
+  - packages/mcp-server/src/**/*.ts
+ignores:
+  - packages/mcp-server/src/cli/**
+  - "**/*.test.ts"
+  - "**/*.d.ts"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "dev": "dotenv -e .env -e .env.local -- turbo dev --filter=!@sentry/mcp-server",
     "dev:stdio": "dotenv -e .env -e .env.local -- turbo dev --filter=!@sentry/mcp-cloudflare",
     "build": "turbo build after-build",
+    "check:generated": "pnpm --filter @sentry/mcp-core generate-definitions && git diff --exit-code -- packages/mcp-core/src/toolDefinitions.json packages/mcp-core/src/skillDefinitions.json plugins/sentry-mcp/agents/sentry-mcp.md plugins/sentry-mcp-experimental/agents/sentry-mcp.md",
     "deploy": "turbo deploy",
     "eval": "dotenv -e .env -e .env.local -- turbo eval",
     "eval:ci": "CI=true dotenv -e .env -e .env.local -- pnpm --stream -r run eval:ci",
     "format": "biome format --write",
-    "lint": "biome lint",
+    "lint": "biome lint && pnpm run lint:ast-grep",
+    "lint:ast-grep": "ast-grep scan && ast-grep test --skip-snapshot-tests",
     "lint:fix": "biome lint --fix",
     "inspector": "pnpx @modelcontextprotocol/inspector@latest",
     "inspector:stdio": "pnpx @modelcontextprotocol/inspector@latest -- tsx packages/mcp-server/src/index.ts",
@@ -43,6 +45,7 @@
     "tsc": "turbo tsc"
   },
   "dependencies": {
+    "@ast-grep/cli": "catalog:",
     "@biomejs/biome": "catalog:",
     "@types/node": "catalog:",
     "dotenv": "catalog:",
@@ -68,6 +71,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@ast-grep/cli",
       "@biomejs/biome",
       "better-sqlite3",
       "esbuild",

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -11,9 +11,7 @@
   "author": "Sentry",
   "description": "Sentry MCP Core - Shared code for MCP transports",
   "homepage": "https://github.com/getsentry/sentry-mcp",
-  "keywords": [
-    "sentry"
-  ],
+  "keywords": ["sentry"],
   "bugs": {
     "url": "https://github.com/getsentry/sentry-mcp/issues"
   },
@@ -21,9 +19,7 @@
     "type": "git",
     "url": "git@github.com:getsentry/sentry-mcp.git"
   },
-  "files": [
-    "./dist/*"
-  ],
+  "files": ["./dist/*"],
   "exports": {
     "./api-client": {
       "types": "./dist/api-client/index.d.ts",
@@ -142,8 +138,8 @@
     "prebuild": "pnpm run generate-definitions",
     "build": "tsdown",
     "pretest": "pnpm run generate-definitions",
-    "test": "vitest run",
-    "test:ci": "pnpm run generate-definitions && vitest run --reporter=default --reporter=junit --outputFile=tests.junit.xml",
+    "test": "pnpm run validate-skills && vitest run",
+    "test:ci": "pnpm run generate-definitions && pnpm run validate-skills && vitest run --reporter=default --reporter=junit --outputFile=tests.junit.xml",
     "test:watch": "pnpm run generate-definitions && vitest",
     "tsc": "tsc --noEmit",
     "generate-definitions": "tsx scripts/generate-definitions.ts && biome format --write src/toolDefinitions.json src/skillDefinitions.json",

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1985,4 +1985,97 @@ describe("API query builders", () => {
       expect(result.source).toBe("manual");
     });
   });
+
+  describe("project identifier request shape regressions", () => {
+    let apiService: SentryApiService;
+
+    beforeEach(() => {
+      apiService = new SentryApiService({
+        host: "sentry.io",
+        accessToken: "test-token",
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("preserves replay project slugs in path parameters", async () => {
+      let requestUrl: string | undefined;
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        requestUrl = url;
+        return Promise.resolve({
+          ok: true,
+          headers: {
+            get: (key: string) =>
+              key === "content-type" ? "application/json" : null,
+          },
+          json: () => Promise.resolve([["segment-1"]]),
+        });
+      });
+
+      await apiService.getReplayRecordingSegments({
+        organizationSlug: "test-org",
+        projectSlugOrId: "frontend",
+        replayId: "replay-123",
+      });
+
+      expect(requestUrl).toContain(
+        "/projects/test-org/frontend/replays/replay-123/recording-segments/",
+      );
+      expect(requestUrl).not.toContain("NaN");
+    });
+
+    it("uses projectSlug for release deploy slug filters", async () => {
+      let requestUrl: string | undefined;
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        requestUrl = url;
+        return Promise.resolve({
+          ok: true,
+          headers: {
+            get: (key: string) =>
+              key === "content-type" ? "application/json" : null,
+          },
+          json: () => Promise.resolve([]),
+        });
+      });
+
+      await apiService.listReleaseDeploys({
+        organizationSlug: "test-org",
+        releaseVersion: "frontend@1.0.0",
+        projectSlugOrId: "frontend",
+      });
+
+      const params = new URL(String(requestUrl)).searchParams;
+      expect(params.get("projectSlug")).toBe("frontend");
+      expect(params.get("project")).toBeNull();
+      expect(requestUrl).not.toContain("NaN");
+    });
+
+    it("uses project for release deploy numeric ID filters", async () => {
+      let requestUrl: string | undefined;
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        requestUrl = url;
+        return Promise.resolve({
+          ok: true,
+          headers: {
+            get: (key: string) =>
+              key === "content-type" ? "application/json" : null,
+          },
+          json: () => Promise.resolve([]),
+        });
+      });
+
+      await apiService.listReleaseDeploys({
+        organizationSlug: "test-org",
+        releaseVersion: "frontend@1.0.0",
+        projectSlugOrId: "12345",
+      });
+
+      const params = new URL(String(requestUrl)).searchParams;
+      expect(params.get("project")).toBe("12345");
+      expect(params.get("projectSlug")).toBeNull();
+      expect(requestUrl).not.toContain("NaN");
+    });
+  });
 });

--- a/packages/mcp-server/src/cli/output.ts
+++ b/packages/mcp-server/src/cli/output.ts
@@ -1,0 +1,3 @@
+export function printCliLine(message: string): void {
+  console.log(message);
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -25,6 +25,7 @@ import { startStdio } from "./transports/stdio";
 import * as Sentry from "@sentry/node";
 import { LIB_VERSION } from "@sentry/mcp-core/version";
 import { buildUsage } from "./cli/usage";
+import { printCliLine } from "./cli/output";
 import { parseArgv, parseEnv, merge } from "./cli/parse";
 import { finalize } from "./cli/resolve";
 import { resolveAccessToken } from "./auth/resolve-token";
@@ -61,11 +62,11 @@ async function main() {
 
   const cli = parseArgv(rawArgs);
   if (cli.help) {
-    console.log(usageText);
+    printCliLine(usageText);
     process.exit(0);
   }
   if (cli.version) {
-    console.log(`${packageName} ${LIB_VERSION}`);
+    printCliLine(`${packageName} ${LIB_VERSION}`);
     process.exit(0);
   }
   if (cli.unknownArgs.length > 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@ai-sdk/react':
       specifier: ^3.0.66
       version: 3.0.66
+    '@ast-grep/cli':
+      specifier: ^0.43.0
+      version: 0.43.0
     '@biomejs/biome':
       specifier: ^1.9.4
       version: 1.9.4
@@ -181,6 +184,9 @@ importers:
 
   .:
     dependencies:
+      '@ast-grep/cli':
+        specifier: 'catalog:'
+        version: 0.43.0
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
@@ -663,6 +669,53 @@ packages:
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
+
+  '@ast-grep/cli-darwin-arm64@0.43.0':
+    resolution: {integrity: sha512-0i63gSBbgriPaRpFsbP3yETxolHPK2JAZbpcGbFOytB7QTnKAguwhlKmIOkUGKfsCzYiEq1awY0EBmvjMONXOg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.43.0':
+    resolution: {integrity: sha512-SPkj00HGKpYdqReUmso2ftG5Xgd+bWNFH4i9fubLxsWzn4ey2G6sotPruaOtcrzxb9xH+8kmhN7KJfm1k8Atzg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.43.0':
+    resolution: {integrity: sha512-U8+2fkcY8sBxNHHBYZ33vTa7C97GFAB+Kj6gFzVMSqK8Ve1Aw+DxhVWD4i/PBryDdmWb4/erjGSkTQtdhVa2vg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ast-grep/cli-linux-x64-gnu@0.43.0':
+    resolution: {integrity: sha512-r/o9Mag6OZmGevY9OJjatuUKDOX1rSvgo29qSfxpMbIciiH3hkzEW/2w1xTPZI8xnM7iC+k+CkGoknmoXVTYGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.43.0':
+    resolution: {integrity: sha512-oHa4ruD87xccnqFuR+Pmx6F/suHV0YtibuyZ6SxUqgpNJAFZiUNAiFblzhEgQ5gp03e8B012P/Yy/7GYOvxOLg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.43.0':
+    resolution: {integrity: sha512-RSzz9bKzSEutWgX7/g84guudEp75Q990CYpG/TBasdJP+U27zX8aA9d5p1+o/lF0hw3UoTYuFCGG8PU/QelfNQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.43.0':
+    resolution: {integrity: sha512-/5dDD9B65vVuHCdVHN5+tIDquhE5s43S5CgEn88w1BgQaoayf+nRnUO4ZFez6SqyCGqAfa/yZdoaOQ9N2ySa1w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.43.0':
+    resolution: {integrity: sha512-DGi6xXAOBJubGg9QWqTeW8PzKSGHWEOa3uxXspEfYf532yb3lHmNJAcKMl1d+O9Xs9bTcNeDLC8se+O+tirEFQ==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -5027,6 +5080,39 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
+
+  '@ast-grep/cli-darwin-arm64@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/cli@0.43.0':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.43.0
+      '@ast-grep/cli-darwin-x64': 0.43.0
+      '@ast-grep/cli-linux-arm64-gnu': 0.43.0
+      '@ast-grep/cli-linux-x64-gnu': 0.43.0
+      '@ast-grep/cli-win32-arm64-msvc': 0.43.0
+      '@ast-grep/cli-win32-ia32-msvc': 0.43.0
+      '@ast-grep/cli-win32-x64-msvc': 0.43.0
 
   '@babel/code-frame@7.27.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
 
 catalog:
+  "@ast-grep/cli": ^0.43.0
   "@ai-sdk/anthropic": ^3.0.33
   "@ai-sdk/mcp": ^1.0.16
   "@ai-sdk/openai": ^3.0.23

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - ast-grep-rules
+testConfigs:
+  - testDir: ast-grep-rule-tests

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,14 @@
     },
     "lint": {
       "dependsOn": ["^build"],
-      "inputs": ["**/*.{ts,tsx,js,jsx}", "biome.json", "package.json"],
+      "inputs": [
+        "**/*.{ts,tsx,js,jsx}",
+        "ast-grep-rule-tests/**/*.yml",
+        "ast-grep-rules/**/*.yml",
+        "biome.json",
+        "package.json",
+        "sgconfig.yml"
+      ],
       "cache": true
     },
     "test": {

--- a/turbo.json
+++ b/turbo.json
@@ -50,6 +50,7 @@
     "test": {
       "dependsOn": ["^build"],
       "inputs": [
+        "scripts/**/*.ts",
         "src/**/*.ts",
         "**/*.test.ts",
         "**/*.spec.ts",


### PR DESCRIPTION
This adds deterministic checks for the failure patterns identified by Odie: stdio stdout usage is now covered by ast-grep and wired into `pnpm lint`, generated definitions are checked in CI, and MCP core tests now validate skill mappings before running Vitest. It also adds request-shape regression coverage for project slug and numeric project ID handling in Sentry API client calls.

The stdout rule intentionally uses ast-grep fixtures instead of a one-off script so it fits the existing lint runner. The generated-definition check runs after build in CI, and the API regressions assert against outgoing request URLs to catch accidental `NaN` or wrong parameter names. Validated locally with `pnpm run check:generated`, `pnpm lint`, `pnpm run tsc`, and `pnpm test`.