### PR TITLE
ref(api): Fetch trace item attributes in one request

### DIFF
--- a/docs/contributing/search-events-api-patterns.md
+++ b/docs/contributing/search-events-api-patterns.md
@@ -373,7 +373,7 @@ https://us.sentry.io/api/0/organizations/sentry/tags/?dataset=events&project=450
 
 **Parameters**:
 - `itemType`: Either `spans` or `logs` (plural!)
-- `attributeType`: Either `string` or `number`
+- `attributeType`: Optional filter for `string`, `number`, or `boolean`. Omit to return all types.
 - `project`: Numeric project ID (optional)
 - `statsPeriod`: Time range
 
@@ -412,10 +412,10 @@ https://us.sentry.io/api/0/organizations/sentry/trace-items/attributes/?attribut
 
 ### Implementation Strategy
 
-The tool makes parallel requests to fetch attributes efficiently:
+The tool fetches attributes with a single request per dataset:
 
 1. **For errors**: Single request to tags endpoint with optimized parameters
-2. **For spans/logs**: Single request that internally fetches both string + number attributes
+2. **For spans/logs/metrics**: Single request to trace-items attributes without `attributeType` (Sentry returns all types)
 
 ```typescript
 // For errors dataset
@@ -435,7 +435,7 @@ const attributesResponse = await apiService.listTraceItemAttributes({
 });
 ```
 
-Note: The `listTraceItemAttributes` method internally makes parallel requests for string and number attributes.
+When callers pass `attributeTypes`, `listTraceItemAttributes` filters the combined response client-side.
 
 ### Custom Attributes Integration
 

--- a/packages/mcp-cloudflare/src/test-utils/fetch-mock-setup.ts
+++ b/packages/mcp-cloudflare/src/test-utils/fetch-mock-setup.ts
@@ -349,9 +349,53 @@ export function registerFetchMockInterceptors(fetchMock: FetchMockLike) {
         const attributeType = url.searchParams.get("attributeType");
 
         if (!itemType || !attributeType) {
+          if (!itemType) {
+            return {
+              statusCode: 400,
+              data: { detail: "Missing parameters" },
+              responseOptions: { headers: JSON_HEADERS },
+            };
+          }
+
+          const normalizedItemType = itemType === "spans" ? "span" : itemType;
+
+          if (normalizedItemType === "span") {
+            return {
+              statusCode: 200,
+              data: [
+                ...traceItemsAttributesSpansStringFixture.map((attribute) => ({
+                  ...attribute,
+                  attributeType: "string",
+                })),
+                ...traceItemsAttributesSpansNumberFixture.map((attribute) => ({
+                  ...attribute,
+                  attributeType: "number",
+                })),
+              ],
+              responseOptions: { headers: JSON_HEADERS },
+            };
+          }
+
+          if (normalizedItemType === "logs") {
+            return {
+              statusCode: 200,
+              data: [
+                ...traceItemsAttributesLogsStringFixture.map((attribute) => ({
+                  ...attribute,
+                  attributeType: "string",
+                })),
+                ...traceItemsAttributesLogsNumberFixture.map((attribute) => ({
+                  ...attribute,
+                  attributeType: "number",
+                })),
+              ],
+              responseOptions: { headers: JSON_HEADERS },
+            };
+          }
+
           return {
             statusCode: 400,
-            data: { detail: "Missing parameters" },
+            data: { detail: "Invalid itemType" },
             responseOptions: { headers: JSON_HEADERS },
           };
         }

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1334,29 +1334,6 @@ describe("API query builders", () => {
 
       globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         urls.push(url);
-        const requestUrl = new URL(url);
-        const attributeType = requestUrl.searchParams.get("attributeType");
-        const body =
-          attributeType === "boolean"
-            ? [
-                {
-                  key: "tags[enabled,boolean]",
-                  name: "enabled",
-                  attributeType: "boolean",
-                  attributeSource: { source_type: "user" },
-                },
-              ]
-            : [
-                {
-                  key: "tags[type]",
-                  name: "type",
-                  attributeType: "string",
-                  attributeSource: {
-                    source_type: "sentry",
-                    is_transformed_alias: true,
-                  },
-                },
-              ];
 
         return Promise.resolve({
           ok: true,
@@ -1364,7 +1341,29 @@ describe("API query builders", () => {
             get: (key: string) =>
               key === "content-type" ? "application/json" : null,
           },
-          json: () => Promise.resolve(body),
+          json: () =>
+            Promise.resolve([
+              {
+                key: "tags[type]",
+                name: "type",
+                attributeType: "string",
+                attributeSource: {
+                  source_type: "sentry",
+                  is_transformed_alias: true,
+                },
+              },
+              {
+                key: "tags[enabled,boolean]",
+                name: "enabled",
+                attributeType: "boolean",
+                attributeSource: { source_type: "user" },
+              },
+              {
+                key: "tags[count,number]",
+                name: "count",
+                attributeType: "number",
+              },
+            ]),
         });
       });
 
@@ -1395,18 +1394,14 @@ describe("API query builders", () => {
           attributeSource: { source_type: "user" },
         },
       ]);
-      expect(urls).toHaveLength(2);
-      for (const url of urls) {
-        const params = new URL(url).searchParams;
-        expect(params.get("itemType")).toBe("spans");
-        expect(params.get("project")).toBe("123");
-        expect(params.get("statsPeriod")).toBe("7d");
-        expect(params.get("substringMatch")).toBe("tags[");
-        expect(params.get("query")).toBe('transaction:"VPN connections"');
-      }
-      expect(
-        urls.map((url) => new URL(url).searchParams.get("attributeType")),
-      ).toEqual(["string", "boolean"]);
+      expect(urls).toHaveLength(1);
+      const params = new URL(urls[0]!).searchParams;
+      expect(params.get("itemType")).toBe("spans");
+      expect(params.get("project")).toBe("123");
+      expect(params.get("statsPeriod")).toBe("7d");
+      expect(params.get("substringMatch")).toBe("tags[");
+      expect(params.get("query")).toBe('transaction:"VPN connections"');
+      expect(params.get("attributeType")).toBeNull();
     });
 
     it("should validate events requests via the validate endpoint", async () => {

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2806,6 +2806,7 @@ export class SentryApiService {
    * @param params.itemType Item type to query attributes for ("spans", "logs", or "tracemetrics")
    * @param params.project Numeric project ID to filter attributes
    * @param params.statsPeriod Time range for attribute statistics (e.g., "24h", "7d")
+   * @param params.attributeTypes Optional attribute types to keep in the response
    * @param opts Request options
    * @returns Array of available attributes with metadata including type
    */
@@ -2817,7 +2818,7 @@ export class SentryApiService {
       statsPeriod,
       start,
       end,
-      attributeTypes = ["string", "number"],
+      attributeTypes,
       substringMatch,
       query,
     }: {
@@ -2833,25 +2834,24 @@ export class SentryApiService {
     },
     opts?: RequestOptions,
   ): Promise<TraceItemAttribute[]> {
-    const uniqueAttributeTypes = Array.from(new Set(attributeTypes));
-    const attributeResponses = await Promise.all(
-      uniqueAttributeTypes.map((attributeType) =>
-        this.fetchTraceItemAttributesByType(
-          organizationSlug,
-          itemType,
-          attributeType,
-          project,
-          statsPeriod,
-          start,
-          end,
-          substringMatch,
-          query,
-          opts,
-        ),
-      ),
+    const attributes = await this.fetchTraceItemAttributes(
+      organizationSlug,
+      itemType,
+      project,
+      statsPeriod,
+      start,
+      end,
+      substringMatch,
+      query,
+      opts,
     );
 
-    return attributeResponses.flat();
+    if (!attributeTypes || attributeTypes.length === 0) {
+      return attributes;
+    }
+
+    const allowedTypes = new Set(attributeTypes);
+    return attributes.filter((attribute) => allowedTypes.has(attribute.type));
   }
 
   async validateEvents(
@@ -2913,10 +2913,9 @@ export class SentryApiService {
     return parseEventsValidationResponse(body);
   }
 
-  private async fetchTraceItemAttributesByType(
+  private async fetchTraceItemAttributes(
     organizationSlug: string,
     itemType: TraceItemType,
-    attributeType: TraceItemAttributeType,
     project?: string,
     statsPeriod?: string,
     start?: string,
@@ -2927,7 +2926,6 @@ export class SentryApiService {
   ): Promise<TraceItemAttribute[]> {
     const queryParams = new URLSearchParams();
     queryParams.set("itemType", itemType);
-    queryParams.set("attributeType", attributeType);
     if (project) {
       queryParams.set("project", project);
     }
@@ -2942,7 +2940,7 @@ export class SentryApiService {
     const url = `/organizations/${organizationSlug}/trace-items/attributes/?${queryParams.toString()}`;
 
     const body = await this.requestJSON(url, undefined, opts);
-    return parseTraceItemAttributes(body, attributeType);
+    return parseTraceItemAttributes(body, "string");
   }
 
   /**

--- a/packages/mcp-core/src/tools/support/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.test.ts
@@ -368,36 +368,33 @@ describe("fetchCustomAttributes", () => {
 
   describe("successful responses", () => {
     it("should return attributes for spans dataset", async () => {
-      // Mock with separate string and number queries as the real API does
-      // The API client makes two separate calls with attributeType parameter
       mswServer.use(
         http.get(
           "https://sentry.io/api/0/organizations/test-org/trace-items/attributes/",
           ({ request }) => {
             const url = new URL(request.url);
-            const attributeType = url.searchParams.get("attributeType");
             const itemType = url.searchParams.get("itemType");
 
-            // Validate the request has expected parameters
-            if (!attributeType || !itemType) {
+            if (!itemType) {
               return HttpResponse.json(
                 { detail: "Missing required parameters" },
                 { status: 400 },
               );
             }
 
-            if (attributeType === "string") {
-              return HttpResponse.json([
-                { key: "span.op", name: "Operation" },
-                { key: "sentry:internal", name: "Internal" }, // Should be filtered
-              ]);
-            }
-            if (attributeType === "number") {
-              return HttpResponse.json([
-                { key: "span.duration", name: "Duration" },
-              ]);
-            }
-            return HttpResponse.json([]);
+            return HttpResponse.json([
+              { key: "span.op", name: "Operation", attributeType: "string" },
+              {
+                key: "sentry:internal",
+                name: "Internal",
+                attributeType: "string",
+              },
+              {
+                key: "span.duration",
+                name: "Duration",
+                attributeType: "number",
+              },
+            ]);
           },
         ),
       );
@@ -452,25 +449,23 @@ describe("fetchCustomAttributes", () => {
           "https://sentry.io/api/0/organizations/test-org/trace-items/attributes/",
           ({ request }) => {
             const url = new URL(request.url);
-            const attributeType = url.searchParams.get("attributeType");
             const itemType = url.searchParams.get("itemType");
 
             expect(itemType).toBe("tracemetrics");
 
-            if (attributeType === "string") {
-              return HttpResponse.json([
-                { key: "metric.name", name: "Metric Name" },
-                { key: "metric.type", name: "Metric Type" },
-              ]);
-            }
-
-            if (attributeType === "number") {
-              return HttpResponse.json([
-                { key: "value", name: "Metric Value" },
-              ]);
-            }
-
-            return HttpResponse.json([]);
+            return HttpResponse.json([
+              {
+                key: "metric.name",
+                name: "Metric Name",
+                attributeType: "string",
+              },
+              {
+                key: "metric.type",
+                name: "Metric Type",
+                attributeType: "string",
+              },
+              { key: "value", name: "Metric Value", attributeType: "number" },
+            ]);
           },
         ),
       );
@@ -505,35 +500,23 @@ describe("fetchCustomAttributes", () => {
             const url = new URL(request.url);
             requests.push(url.searchParams);
 
-            const attributeType = url.searchParams.get("attributeType");
-            if (attributeType === "string") {
-              return HttpResponse.json([
-                {
-                  key: "tags[type]",
-                  name: "type",
-                  attributeType: "string",
-                },
-              ]);
-            }
-            if (attributeType === "number") {
-              return HttpResponse.json([
-                {
-                  key: "tags[sequence,number]",
-                  name: "sequence",
-                  attributeType: "number",
-                },
-              ]);
-            }
-            if (attributeType === "boolean") {
-              return HttpResponse.json([
-                {
-                  key: "tags[enabled,boolean]",
-                  name: "enabled",
-                  attributeType: "boolean",
-                },
-              ]);
-            }
-            return HttpResponse.json([]);
+            return HttpResponse.json([
+              {
+                key: "tags[type]",
+                name: "type",
+                attributeType: "string",
+              },
+              {
+                key: "tags[sequence,number]",
+                name: "sequence",
+                attributeType: "number",
+              },
+              {
+                key: "tags[enabled,boolean]",
+                name: "enabled",
+                attributeType: "boolean",
+              },
+            ]);
           },
         ),
       );
@@ -551,10 +534,8 @@ describe("fetchCustomAttributes", () => {
         },
       );
 
-      expect(requests).toHaveLength(3);
-      expect(
-        requests.map((params) => params.get("attributeType")).sort(),
-      ).toEqual(["boolean", "number", "string"]);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.get("attributeType")).toBeNull();
       for (const params of requests) {
         expect(params.get("itemType")).toBe("spans");
         expect(params.get("project")).toBe("123");

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -1075,13 +1075,6 @@ export const restHandlers = buildHandlers([
         );
       }
 
-      if (!attributeType) {
-        return HttpResponse.json(
-          { detail: "attributeType parameter is required" },
-          { status: 400 },
-        );
-      }
-
       // Validate itemType values (API accepts both singular and plural forms)
       const normalizedItemType = itemType === "spans" ? "span" : itemType;
       if (!["span", "logs", "tracemetrics"].includes(normalizedItemType)) {
@@ -1093,11 +1086,48 @@ export const restHandlers = buildHandlers([
         );
       }
 
+      if (!attributeType) {
+        if (normalizedItemType === "span") {
+          return HttpResponse.json([
+            ...traceItemsAttributesSpansStringFixture.map((attribute) => ({
+              ...attribute,
+              attributeType: "string",
+            })),
+            ...traceItemsAttributesSpansNumberFixture.map((attribute) => ({
+              ...attribute,
+              attributeType: "number",
+            })),
+          ]);
+        }
+        if (normalizedItemType === "logs") {
+          return HttpResponse.json([
+            ...traceItemsAttributesLogsStringFixture.map((attribute) => ({
+              ...attribute,
+              attributeType: "string",
+            })),
+            ...traceItemsAttributesLogsNumberFixture.map((attribute) => ({
+              ...attribute,
+              attributeType: "number",
+            })),
+          ]);
+        }
+        return HttpResponse.json([
+          ...traceItemsAttributesTraceMetricsStringFixture.map((attribute) => ({
+            ...attribute,
+            attributeType: "string",
+          })),
+          ...traceItemsAttributesTraceMetricsNumberFixture.map((attribute) => ({
+            ...attribute,
+            attributeType: "number",
+          })),
+        ]);
+      }
+
       // Validate attributeType values
-      if (!["string", "number"].includes(attributeType)) {
+      if (!["string", "number", "boolean"].includes(attributeType)) {
         return HttpResponse.json(
           {
-            detail: `Invalid attributeType '${attributeType}'. Must be 'string' or 'number'`,
+            detail: `Invalid attributeType '${attributeType}'. Must be 'string', 'number', or 'boolean'`,
           },
           { status: 400 },
         );


### PR DESCRIPTION
Omit attributeType so Sentry returns all attribute types in a single attributes call instead of fanning out per type. Filter attributeTypes client-side when callers request a subset.