### PR TITLE
feat(mcp): Add event stacktrace tool

### DIFF
--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -812,9 +812,9 @@ export const MessageEntrySchema = z
 const StacktraceSchema = z
   .object({
     frames: z.array(FrameInterface),
-    framesOmitted: z.array(z.unknown()).optional(),
+    framesOmitted: z.array(z.unknown()).nullable().optional(),
     registers: z.record(z.unknown()).nullable().optional(),
-    hasSystemFrames: z.boolean().optional(),
+    hasSystemFrames: z.boolean().nullable().optional(),
   })
   .partial()
   .extend({

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -809,18 +809,28 @@ export const MessageEntrySchema = z
   })
   .partial();
 
+const StacktraceSchema = z
+  .object({
+    frames: z.array(FrameInterface),
+    framesOmitted: z.array(z.unknown()).optional(),
+    registers: z.record(z.unknown()).nullable().optional(),
+    hasSystemFrames: z.boolean().optional(),
+  })
+  .partial()
+  .extend({
+    frames: z.array(FrameInterface),
+  });
+
 export const ThreadEntrySchema = z
   .object({
-    id: z.number().nullable(),
+    id: z.union([z.number(), z.string()]).nullable(),
     name: z.string().nullable(),
     current: z.boolean().nullable(),
     crashed: z.boolean().nullable(),
     state: z.string().nullable(),
-    stacktrace: z
-      .object({
-        frames: z.array(FrameInterface),
-      })
-      .nullable(),
+    heldLocks: z.record(z.unknown()).nullable().optional(),
+    stacktrace: StacktraceSchema.nullable(),
+    rawStacktrace: StacktraceSchema.nullable().optional(),
   })
   .partial();
 

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -714,8 +714,9 @@ export function formatThreadStacktraceOutput({
 
   parts.push("## Stacktrace");
   parts.push("");
-  if (thread.stacktrace?.framesOmitted?.length) {
-    parts.push(`**Frames Omitted**: ${thread.stacktrace.framesOmitted.length}`);
+  const framesOmitted = formatFramesOmitted(thread.stacktrace?.framesOmitted);
+  if (framesOmitted) {
+    parts.push(`**Frames Omitted**: ${framesOmitted}`);
     parts.push("");
   }
 
@@ -746,6 +747,26 @@ export function formatThreadStacktraceOutput({
   parts.push("");
 
   return parts.join("\n");
+}
+
+function formatFramesOmitted(
+  framesOmitted: unknown[] | undefined,
+): string | null {
+  if (!framesOmitted?.length) {
+    return null;
+  }
+
+  const [firstOmitted, lastOmitted] = framesOmitted;
+  if (
+    typeof firstOmitted === "number" &&
+    typeof lastOmitted === "number" &&
+    Number.isFinite(firstOmitted) &&
+    Number.isFinite(lastOmitted)
+  ) {
+    return String(Math.max(0, lastOmitted - firstOmitted));
+  }
+
+  return null;
 }
 
 /**

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -16,8 +16,9 @@ import type {
   MessageEntrySchema,
   RequestEntrySchema,
   SentryApiService,
-  ThreadsEntrySchema,
+  ThreadEntrySchema,
 } from "../api-client";
+import { ThreadsEntrySchema } from "../api-client";
 import type {
   AutofixRunState,
   Event,
@@ -229,6 +230,9 @@ export function formatEventOutput(
     (e) => e.type === "exception",
   );
   const threadsEntry = eventToRender.entries.find((e) => e.type === "threads");
+  const threadsData = threadsEntry
+    ? parseThreadsEntryData(threadsEntry.data)
+    : undefined;
   const requestEntry = eventToRender.entries.find((e) => e.type === "request");
   const spansEntry = eventToRender.entries.find((e) => e.type === "spans");
   const cspEntry = eventToRender.entries.find((e) => e.type === "csp");
@@ -247,11 +251,13 @@ export function formatEventOutput(
       eventToRender,
       exceptionEntry.data as z.infer<typeof ErrorEntrySchema>,
     );
-  } else if (threadsEntry) {
-    output += formatThreadsInterfaceOutput(
-      eventToRender,
-      threadsEntry.data as z.infer<typeof ThreadsEntrySchema>,
-    );
+  } else if (threadsData) {
+    output += formatThreadsInterfaceOutput(eventToRender, threadsData);
+  }
+
+  if (threadsData?.values && threadsData.values.length > 1) {
+    output += formatThreadList(threadsData.values);
+    output += "\n";
   }
 
   // Request info (if HTTP error)
@@ -591,6 +597,139 @@ function formatThreadsInterfaceOutput(
     parts.push("────────────────");
   } else {
     parts.push("**Stacktrace:**");
+  }
+
+  parts.push("```");
+  parts.push(
+    frames
+      .map((frame) => {
+        const header = formatFrameHeader(frame, undefined, event.platform);
+        const context = renderInlineContext(frame);
+        return `${header}${context}`;
+      })
+      .join("\n"),
+  );
+  parts.push("```");
+  parts.push("");
+
+  return parts.join("\n");
+}
+
+function getThreadDisplayValue(
+  value: string | number | boolean | null | undefined,
+): string {
+  if (value === null || value === undefined || value === "") {
+    return "-";
+  }
+  return String(value);
+}
+
+function getThreadFlags(thread: z.infer<typeof ThreadEntrySchema>): string {
+  const flags: string[] = [];
+  if (thread.crashed) {
+    flags.push("crashed");
+  }
+  if (thread.current) {
+    flags.push("current");
+  }
+  return flags.length > 0 ? flags.join(", ") : "-";
+}
+
+function formatThreadList(
+  threads: z.infer<typeof ThreadEntrySchema>[],
+): string {
+  return [
+    "### Threads",
+    "",
+    `Found ${threads.length} thread${threads.length === 1 ? "" : "s"} in this event.`,
+    "",
+    ...formatThreadTable(threads),
+    "",
+  ].join("\n");
+}
+
+function formatThreadTable(
+  threads: z.infer<typeof ThreadEntrySchema>[],
+): string[] {
+  return [
+    "| Thread ID | Name | State | Flags | Frames |",
+    "| --- | --- | --- | --- | ---: |",
+    ...threads.map((thread) => {
+      const frameCount = thread.stacktrace?.frames?.length ?? 0;
+      return `| ${getThreadDisplayValue(thread.id)} | ${getThreadDisplayValue(thread.name)} | ${getThreadDisplayValue(thread.state)} | ${getThreadFlags(thread)} | ${frameCount} |`;
+    }),
+  ];
+}
+
+export function formatAvailableThreadList(
+  threads: z.infer<typeof ThreadEntrySchema>[],
+): string {
+  return [
+    "## Available Threads",
+    "",
+    ...formatThreadTable(threads),
+    "",
+    "Pass `thread` as a numeric Thread ID or exact thread Name.",
+  ].join("\n");
+}
+
+function parseThreadsEntryData(
+  data: unknown,
+): z.infer<typeof ThreadsEntrySchema> | undefined {
+  const result = ThreadsEntrySchema.safeParse(data);
+  return result.success ? result.data : undefined;
+}
+
+/**
+ * Formats the selected thread stacktrace using the same frame rendering
+ * conventions as issue event details.
+ */
+export function formatThreadStacktraceOutput({
+  event,
+  thread,
+  selectionReason,
+}: {
+  event: Event;
+  thread: z.infer<typeof ThreadEntrySchema>;
+  selectionReason: string;
+}): string {
+  const parts: string[] = [];
+
+  parts.push("## Selected Thread");
+  parts.push("");
+  parts.push(`**Selection**: ${selectionReason}`);
+  parts.push(`**Thread ID**: ${getThreadDisplayValue(thread.id)}`);
+  parts.push(`**Name**: ${getThreadDisplayValue(thread.name)}`);
+  parts.push(`**State**: ${getThreadDisplayValue(thread.state)}`);
+  parts.push(`**Crashed**: ${getThreadDisplayValue(thread.crashed)}`);
+  parts.push(`**Current**: ${getThreadDisplayValue(thread.current)}`);
+  parts.push("");
+
+  const frames = thread.stacktrace?.frames;
+  if (!frames || frames.length === 0) {
+    parts.push("No stacktrace is available for the selected thread.");
+    parts.push("");
+    return parts.join("\n");
+  }
+
+  parts.push("## Stacktrace");
+  parts.push("");
+  if (thread.stacktrace?.framesOmitted?.length) {
+    parts.push(`**Frames Omitted**: ${thread.stacktrace.framesOmitted.length}`);
+    parts.push("");
+  }
+
+  const firstInAppFrame = findFirstInAppFrame(frames);
+  if (
+    firstInAppFrame &&
+    (firstInAppFrame.context?.length || firstInAppFrame.vars)
+  ) {
+    parts.push(renderEnhancedFrame(firstInAppFrame, event));
+    parts.push("");
+    parts.push("**Full Stacktrace:**");
+    parts.push("────────────────");
+  } else {
+    parts.push("**Full Stacktrace:**");
   }
 
   parts.push("```");
@@ -1882,6 +2021,33 @@ export function formatIssueOutput({
     fallbackInstruction: "Issue event search is not available in this session",
   });
   output += `- Issue event search: ${issueEventSearchInstruction}\n`;
+  const hasMultipleThreads = event.entries?.some((entry) => {
+    if (entry.type !== "threads") {
+      return false;
+    }
+    const threadsData = parseThreadsEntryData(entry.data);
+    return Boolean(threadsData?.values && threadsData.values.length > 1);
+  });
+  if (hasMultipleThreads) {
+    const stacktraceInstruction = formatToolCallInstruction({
+      toolName: "get_event_stacktrace",
+      arguments: {
+        organizationSlug,
+        issueId: issue.shortId,
+        eventId: event.id,
+        thread: "thread name or numeric thread ID",
+      },
+      experimentalMode: experimentalMode ?? false,
+      availableToolNames,
+      directToolNames,
+      fallbackInstruction: "",
+      purpose:
+        "to fetch a full thread stacktrace by numeric Thread ID or exact thread Name. Omit `thread` to use Sentry's default selected thread",
+    });
+    if (stacktraceInstruction) {
+      output += `- Thread stacktrace lookup: ${stacktraceInstruction}\n`;
+    }
+  }
   if (traceId) {
     const traceDetailsInstruction = formatToolCallInstruction({
       toolName: "get_sentry_resource",

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -750,7 +750,7 @@ export function formatThreadStacktraceOutput({
 }
 
 function formatFramesOmitted(
-  framesOmitted: unknown[] | undefined,
+  framesOmitted: unknown[] | null | undefined,
 ): string | null {
   if (!framesOmitted?.length) {
     return null;

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -835,6 +835,7 @@ describe("buildServer", () => {
       expect(toolNames).not.toContain("create_project");
       expect(toolNames).not.toContain("find_releases");
       expect(toolNames).not.toContain("get_event_attachment");
+      expect(toolNames).not.toContain("get_event_stacktrace");
 
       const result = await callRegisteredTool(server, "search_sentry_tools", {
         query: "create project",
@@ -1065,18 +1066,19 @@ describe("buildServer", () => {
 
       const toolNames = getRegisteredToolNames(server);
       expect(toolNames).not.toContain("get_issue_details");
+      expect(toolNames).not.toContain("get_event_stacktrace");
 
       const result = await callRegisteredTool(server, "search_sentry_tools", {
-        query: "issue details",
+        query: "event stacktrace",
         limit: 5,
       });
       const payload = getStructuredContent<{
         results: Array<{ name: string }>;
       }>(result);
 
-      expect(payload.results.map((tool) => tool.name)).toContain(
-        "get_issue_details",
-      );
+      const resultNames = payload.results.map((tool) => tool.name);
+      expect(resultNames).toContain("get_issue_details");
+      expect(resultNames).toContain("get_event_stacktrace");
     });
 
     it("search_sentry_tools includes whoami as a catalog-only foundational tool", async () => {
@@ -1254,6 +1256,27 @@ describe("buildServer", () => {
 
       expect(getTextContent(result)).toContain(
         "# Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**",
+      );
+    });
+
+    it("execute_sentry_tool dispatches to catalog-only event stacktrace", async () => {
+      const server = buildServer({
+        context: baseContext,
+      });
+
+      const toolNames = getRegisteredToolNames(server);
+      expect(toolNames).not.toContain("get_event_stacktrace");
+
+      const result = await callRegisteredTool(server, "execute_sentry_tool", {
+        name: "get_event_stacktrace",
+        arguments: {
+          organizationSlug: "sentry-mcp-evals",
+          issueId: "CLOUDFLARE-MCP-41",
+        },
+      });
+
+      expect(getTextContent(result)).toContain(
+        "# Event Stacktrace in **sentry-mcp-evals**",
       );
     });
 

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Read-only access to core Sentry data: issues, events, traces, replays, releases, monitors, profiles, documentation, and project metadata",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 30,
+    "toolCount": 31,
     "tools": [
       {
         "name": "find_alert_rules",
@@ -65,6 +65,11 @@
       {
         "name": "get_event_attachment",
         "description": "Download attachments from a Sentry event.\n\nUse this tool when you need to:\n- Download files attached to a specific event\n- Access screenshots, log files, or other attachments uploaded with an error report\n- Retrieve attachment metadata and download URLs\n\n<examples>\n### Download a specific attachment by ID\n\n```\nget_event_attachment(organizationSlug='my-organization', projectSlug='my-project', eventId='c49541c747cb4d8aa3efb70ca5aba243', attachmentId='12345')\n```\n\n### List all attachments for an event\n\n```\nget_event_attachment(organizationSlug='my-organization', projectSlug='my-project', eventId='c49541c747cb4d8aa3efb70ca5aba243')\n```\n\n</examples>\n\n<hints>\n- If `attachmentId` is provided, the specific attachment will be downloaded as an embedded resource\n- If `attachmentId` is omitted, all attachments for the event will be listed with download information\n- The `projectSlug` is required to identify which project the event belongs to\n</hints>",
+        "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "get_event_stacktrace",
+        "description": "Get a full thread stacktrace from a specific Sentry event.\n\nUse this tool when you need to:\n- Fetch the full stacktrace for a thread listed in issue details\n- Inspect a non-crashed thread from an event with multiple threads\n- Get Sentry's default selected thread stacktrace when no thread is specified\n\n<examples>\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123')\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', eventId='abc123', thread=259)\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', thread='main')\n</examples>\n\n<hints>\n- `thread` is optional. If omitted, this returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread.\n- Pass `thread` as a numeric Thread ID or exact thread Name from the issue details thread list.\n- If the issue details show only one useful thread, omit `thread`.\n</hints>",
         "requiredScopes": ["event:read"]
       },
       {
@@ -165,7 +170,7 @@
     "description": "Sentry's AI debugger that helps you analyze, root cause, and fix issues",
     "defaultEnabled": true,
     "order": 2,
-    "toolCount": 9,
+    "toolCount": 10,
     "tools": [
       {
         "name": "analyze_issue_with_seer",
@@ -186,6 +191,11 @@
         "name": "get_ai_conversation_details",
         "description": "Fetch all spans for an AI conversation by its gen_ai.conversation.id.\n\nA conversation is a set of spans sharing the same gen_ai.conversation.id. To discover conversation IDs, use search_events with dataset='spans' and query='has:gen_ai.conversation.id'.",
         "requiredScopes": ["event:read", "project:read"]
+      },
+      {
+        "name": "get_event_stacktrace",
+        "description": "Get a full thread stacktrace from a specific Sentry event.\n\nUse this tool when you need to:\n- Fetch the full stacktrace for a thread listed in issue details\n- Inspect a non-crashed thread from an event with multiple threads\n- Get Sentry's default selected thread stacktrace when no thread is specified\n\n<examples>\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123')\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', eventId='abc123', thread=259)\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', thread='main')\n</examples>\n\n<hints>\n- `thread` is optional. If omitted, this returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread.\n- Pass `thread` as a numeric Thread ID or exact thread Name from the issue details thread list.\n- If the issue details show only one useful thread, omit `thread`.\n</hints>",
+        "requiredScopes": ["event:read"]
       },
       {
         "name": "get_issue_details",
@@ -256,7 +266,7 @@
     "description": "Resolve, assign, and update issues",
     "defaultEnabled": false,
     "order": 4,
-    "toolCount": 13,
+    "toolCount": 14,
     "tools": [
       {
         "name": "add_issue_note",
@@ -282,6 +292,11 @@
         "name": "get_ai_conversation_details",
         "description": "Fetch all spans for an AI conversation by its gen_ai.conversation.id.\n\nA conversation is a set of spans sharing the same gen_ai.conversation.id. To discover conversation IDs, use search_events with dataset='spans' and query='has:gen_ai.conversation.id'.",
         "requiredScopes": ["event:read", "project:read"]
+      },
+      {
+        "name": "get_event_stacktrace",
+        "description": "Get a full thread stacktrace from a specific Sentry event.\n\nUse this tool when you need to:\n- Fetch the full stacktrace for a thread listed in issue details\n- Inspect a non-crashed thread from an event with multiple threads\n- Get Sentry's default selected thread stacktrace when no thread is specified\n\n<examples>\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123')\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', eventId='abc123', thread=259)\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', thread='main')\n</examples>\n\n<hints>\n- `thread` is optional. If omitted, this returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread.\n- Pass `thread` as a numeric Thread ID or exact thread Name from the issue details thread list.\n- If the issue details show only one useful thread, omit `thread`.\n</hints>",
+        "requiredScopes": ["event:read"]
       },
       {
         "name": "get_issue_activity",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -911,6 +911,59 @@
     "surface": "catalog"
   },
   {
+    "name": "get_event_stacktrace",
+    "description": "Get a full thread stacktrace from a specific Sentry event.\n\nUse this tool when you need to:\n- Fetch the full stacktrace for a thread listed in issue details\n- Inspect a non-crashed thread from an event with multiple threads\n- Get Sentry's default selected thread stacktrace when no thread is specified\n\n<examples>\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123')\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', eventId='abc123', thread=259)\nget_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', thread='main')\n</examples>\n\n<hints>\n- `thread` is optional. If omitted, this returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread.\n- Pass `thread` as a numeric Thread ID or exact thread Name from the issue details thread list.\n- If the issue details show only one useful thread, omit `thread`.\n</hints>",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organizationSlug": {
+          "type": "string",
+          "description": "The organization's slug. You can find a existing list of organizations you have access to using the `find_organizations()` tool."
+        },
+        "regionUrl": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The region URL for the organization you're querying, if known. For Sentry's Cloud Service (sentry.io), this is typically the region-specific URL like 'https://us.sentry.io'. For self-hosted Sentry installations, this parameter is usually not needed and should be omitted. You can find the correct regionUrl from the organization details using the `find_organizations()` tool.",
+          "default": null
+        },
+        "issueId": {
+          "type": "string",
+          "description": "The Issue ID. e.g. `PROJECT-1Z43`"
+        },
+        "eventId": {
+          "type": "string",
+          "default": "latest",
+          "description": "The event ID for the issue. Defaults to `latest`."
+        },
+        "thread": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ],
+          "description": "Optional thread selector. Pass a numeric thread ID, or an exact thread name string. If omitted, returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread."
+        }
+      },
+      "required": ["organizationSlug", "issueId"],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "requiredScopes": ["event:read"],
+    "skills": ["inspect", "triage", "seer"],
+    "surface": "catalog"
+  },
+  {
     "name": "get_issue_activity",
     "description": "Get the activity feed and comments for a Sentry issue.\n\nUse this tool when you need to:\n- Review prior comments before triaging an issue\n- Understand who resolved, ignored, assigned, or commented on an issue\n- See recent issue activity that is not included in `get_issue_details`\n\n<examples>\nget_issue_activity(organizationSlug='my-organization', issueId='PROJECT-123')\nget_issue_activity(issueUrl='https://my-organization.sentry.io/issues/PROJECT-123/')\n</examples>",
     "inputSchema": {

--- a/packages/mcp-core/src/tools/catalog/get-event-stacktrace.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-stacktrace.test.ts
@@ -46,6 +46,7 @@ const eventWithThreads = createDefaultEvent({
                   lineNo: 12,
                 },
               ],
+              framesOmitted: [10, 510],
               hasSystemFrames: false,
             },
           },
@@ -173,9 +174,57 @@ describe("get_event_stacktrace", () => {
     const result = await callHandler({ thread: 11 });
 
     expect(result).toContain("**Thread ID**: 11");
+    expect(result).toContain("**Frames Omitted**: 500");
     expect(result).toContain(
       "at com.example.Worker.waitForJob(Worker.java:12)",
     );
+  });
+
+  it("falls back to the first thread with frames when no thread crashed", async () => {
+    setupThreadMocks(
+      createDefaultEvent({
+        id: "event-with-empty-stacktrace",
+        platform: "java",
+        entries: [
+          {
+            type: "threads",
+            data: {
+              values: [
+                {
+                  id: 10,
+                  name: "empty",
+                  crashed: false,
+                  stacktrace: {
+                    frames: [],
+                  },
+                },
+                {
+                  id: 20,
+                  name: "usable",
+                  crashed: false,
+                  stacktrace: {
+                    frames: [
+                      {
+                        filename: "Worker.java",
+                        module: "com.example.Worker",
+                        function: "run",
+                        lineNo: 42,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = await callHandler();
+
+    expect(result).toContain("**Thread ID**: 20");
+    expect(result).toContain("**Name**: usable");
+    expect(result).toContain("at com.example.Worker.run(Worker.java:42)");
   });
 
   it("selects a thread by exact name", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-event-stacktrace.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-stacktrace.test.ts
@@ -1,0 +1,214 @@
+import { createDefaultEvent, mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { getServerContext } from "../../test-setup.js";
+import getEventStacktrace from "./get-event-stacktrace.js";
+
+const testIssue = {
+  id: "6507376925",
+  shortId: "THREADS-1",
+  project: {
+    id: "4509062593708032",
+    slug: "cloudflare-mcp",
+    name: "CLOUDFLARE-MCP",
+  },
+};
+
+const eventWithThreads = createDefaultEvent({
+  id: "event-with-threads",
+  title: "Application crashed",
+  message: "Application crashed",
+  platform: "java",
+  type: "error",
+  entries: [
+    {
+      type: "message",
+      data: {
+        formatted: "Application crashed",
+      },
+    },
+    {
+      type: "threads",
+      data: {
+        values: [
+          {
+            id: 11,
+            name: "worker",
+            state: "WAITING",
+            crashed: false,
+            current: false,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "Worker.java",
+                  module: "com.example.Worker",
+                  function: "waitForJob",
+                  lineNo: 12,
+                },
+              ],
+              hasSystemFrames: false,
+            },
+          },
+          {
+            id: 259,
+            name: "main",
+            state: "RUNNABLE",
+            crashed: true,
+            current: true,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "Thread.java",
+                  module: "java.lang.Thread",
+                  function: "run",
+                  lineNo: 833,
+                  inApp: false,
+                },
+                {
+                  filename: "CheckoutActivity.java",
+                  module: "com.example.CheckoutActivity",
+                  function: "submitOrder",
+                  lineNo: 42,
+                  inApp: true,
+                  context: [
+                    [40, "        Order order = buildOrder();"],
+                    [41, "        if (order == null) {"],
+                    [42, "            throw new IllegalStateException();"],
+                    [43, "        }"],
+                  ],
+                },
+              ],
+              hasSystemFrames: true,
+            },
+          },
+          {
+            id: 300,
+            name: "no-stack",
+            state: "SLEEPING",
+            crashed: false,
+            current: false,
+            stacktrace: null,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+function setupThreadMocks(event = eventWithThreads) {
+  mswServer.use(
+    http.get(
+      "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/THREADS-1/",
+      () => HttpResponse.json(testIssue),
+    ),
+    http.get(
+      "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/THREADS-1/events/latest/",
+      () => HttpResponse.json(event),
+    ),
+  );
+}
+
+function callHandler(
+  overrides: Partial<Parameters<typeof getEventStacktrace.handler>[0]> = {},
+) {
+  return getEventStacktrace.handler(
+    {
+      organizationSlug: "sentry-mcp-evals",
+      issueId: "THREADS-1",
+      eventId: "latest",
+      regionUrl: null,
+      thread: undefined,
+      ...overrides,
+    },
+    getServerContext(),
+  );
+}
+
+describe("get_event_stacktrace", () => {
+  it("returns Sentry's default selected thread stacktrace", async () => {
+    setupThreadMocks();
+
+    const result = await callHandler();
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Event Stacktrace in **sentry-mcp-evals**
+
+      **Issue ID**: THREADS-1
+      **Event ID**: event-with-threads
+
+      ## Selected Thread
+
+      **Selection**: Sentry default selection: first crashed thread, then first thread with a stacktrace, then first thread.
+      **Thread ID**: 259
+      **Name**: main
+      **State**: RUNNABLE
+      **Crashed**: true
+      **Current**: true
+
+      ## Stacktrace
+
+      **Most Relevant Frame:**
+      ─────────────────────
+      at com.example.CheckoutActivity.submitOrder(CheckoutActivity.java:42)
+
+          40 │         Order order = buildOrder();
+          41 │         if (order == null) {
+        → 42 │             throw new IllegalStateException();
+          43 │         }
+
+      **Full Stacktrace:**
+      ────────────────
+      \`\`\`
+      at java.lang.Thread.run(Thread.java:833)
+      at com.example.CheckoutActivity.submitOrder(CheckoutActivity.java:42)
+                  throw new IllegalStateException();
+      \`\`\`
+      "
+    `);
+  });
+
+  it("selects a thread by numeric ID", async () => {
+    setupThreadMocks();
+
+    const result = await callHandler({ thread: 11 });
+
+    expect(result).toContain("**Thread ID**: 11");
+    expect(result).toContain(
+      "at com.example.Worker.waitForJob(Worker.java:12)",
+    );
+  });
+
+  it("selects a thread by exact name", async () => {
+    setupThreadMocks();
+
+    const result = await callHandler({ thread: "main" });
+
+    expect(result).toContain("**Name**: main");
+    expect(result).toContain("**Thread ID**: 259");
+  });
+
+  it("reports available threads when the selector does not match", async () => {
+    setupThreadMocks();
+
+    const result = await callHandler({ thread: "missing" });
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Event Stacktrace in **sentry-mcp-evals**
+
+      **Issue ID**: THREADS-1
+      **Event ID**: event-with-threads
+
+      No thread found with name "missing".
+
+      ## Available Threads
+
+      | Thread ID | Name | State | Flags | Frames |
+      | --- | --- | --- | --- | ---: |
+      | 11 | worker | WAITING | - | 1 |
+      | 259 | main | RUNNABLE | crashed, current | 2 |
+      | 300 | no-stack | SLEEPING | - | 0 |
+
+      Pass \`thread\` as a numeric Thread ID or exact thread Name."
+    `);
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/get-event-stacktrace.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-stacktrace.test.ts
@@ -180,6 +180,46 @@ describe("get_event_stacktrace", () => {
     );
   });
 
+  it("handles nullable stacktrace metadata from Sentry", async () => {
+    setupThreadMocks(
+      createDefaultEvent({
+        id: "event-with-null-stacktrace-metadata",
+        platform: "java",
+        entries: [
+          {
+            type: "threads",
+            data: {
+              values: [
+                {
+                  id: 20,
+                  name: "main",
+                  crashed: true,
+                  stacktrace: {
+                    frames: [
+                      {
+                        filename: "Worker.java",
+                        module: "com.example.Worker",
+                        function: "run",
+                        lineNo: 42,
+                      },
+                    ],
+                    framesOmitted: null,
+                    hasSystemFrames: null,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = await callHandler();
+
+    expect(result).toContain("**Thread ID**: 20");
+    expect(result).toContain("at com.example.Worker.run(Worker.java:42)");
+  });
+
   it("falls back to the first thread with frames when no thread crashed", async () => {
     setupThreadMocks(
       createDefaultEvent({

--- a/packages/mcp-core/src/tools/catalog/get-event-stacktrace.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-stacktrace.ts
@@ -1,0 +1,94 @@
+import { setTag } from "@sentry/core";
+import { z } from "zod";
+import { ApiNotFoundError } from "../../api-client";
+import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { enhanceNotFoundError } from "../../internal/tool-helpers/enhance-error";
+import { ensureIssueWithinProjectConstraint } from "../../internal/tool-helpers/issue";
+import {
+  ParamIssueShortId,
+  ParamOrganizationSlug,
+  ParamRegionUrl,
+} from "../../schema";
+import type { ServerContext } from "../../types";
+import { fetchAndFormatEventStacktrace } from "../support/event-stacktrace";
+
+export default defineTool({
+  name: "get_event_stacktrace",
+  skills: ["inspect", "triage", "seer"],
+  requiredScopes: ["event:read"],
+  description: [
+    "Get a full thread stacktrace from a specific Sentry event.",
+    "",
+    "Use this tool when you need to:",
+    "- Fetch the full stacktrace for a thread listed in issue details",
+    "- Inspect a non-crashed thread from an event with multiple threads",
+    "- Get Sentry's default selected thread stacktrace when no thread is specified",
+    "",
+    "<examples>",
+    "get_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123')",
+    "get_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', eventId='abc123', thread=259)",
+    "get_event_stacktrace(organizationSlug='my-org', issueId='PROJECT-123', thread='main')",
+    "</examples>",
+    "",
+    "<hints>",
+    "- `thread` is optional. If omitted, this returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread.",
+    "- Pass `thread` as a numeric Thread ID or exact thread Name from the issue details thread list.",
+    "- If the issue details show only one useful thread, omit `thread`.",
+    "</hints>",
+  ].join("\n"),
+  inputSchema: {
+    organizationSlug: ParamOrganizationSlug,
+    regionUrl: ParamRegionUrl.nullable().default(null),
+    issueId: ParamIssueShortId,
+    eventId: z
+      .string()
+      .trim()
+      .default("latest")
+      .describe("The event ID for the issue. Defaults to `latest`."),
+    thread: z
+      .union([z.number().int(), z.string().trim().min(1)])
+      .optional()
+      .describe(
+        "Optional thread selector. Pass a numeric thread ID, or an exact thread name string. If omitted, returns the same default thread Sentry selects: first crashed thread, then first thread with a stacktrace, then first thread.",
+      ),
+  },
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  async handler(params, context: ServerContext) {
+    const apiService = apiServiceFromContext(context, {
+      regionUrl: params.regionUrl ?? undefined,
+    });
+
+    setTag("organization.slug", params.organizationSlug);
+    setTag("issue.id", params.issueId);
+
+    try {
+      await ensureIssueWithinProjectConstraint({
+        apiService,
+        organizationSlug: params.organizationSlug,
+        issueId: params.issueId,
+        projectSlug: context.constraints.projectSlug,
+      });
+
+      return await fetchAndFormatEventStacktrace({
+        apiService,
+        organizationSlug: params.organizationSlug,
+        issueId: params.issueId,
+        eventId: params.eventId,
+        thread: params.thread,
+      });
+    } catch (error) {
+      if (error instanceof ApiNotFoundError) {
+        throw enhanceNotFoundError(error, {
+          organizationSlug: params.organizationSlug,
+          issueId: params.issueId,
+          eventId: params.eventId,
+        });
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -350,6 +350,161 @@ describe("get_issue_details", () => {
     expect(result).toContain("**Assigned To**: Platform Team (Team)");
   });
 
+  it("lists threads and stacktrace lookup guidance only for multi-thread events", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () =>
+          HttpResponse.json(
+            createDefaultEvent({
+              id: "event-with-multiple-threads",
+              entries: [
+                {
+                  type: "message",
+                  data: {
+                    formatted: "Application crashed",
+                  },
+                },
+                {
+                  type: "threads",
+                  data: {
+                    values: [
+                      {
+                        id: 11,
+                        name: "worker",
+                        state: "WAITING",
+                        crashed: false,
+                        current: false,
+                        stacktrace: {
+                          frames: [
+                            {
+                              filename: "Worker.java",
+                              function: "waitForJob",
+                              lineNo: 12,
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        id: 259,
+                        name: "main",
+                        state: "RUNNABLE",
+                        crashed: true,
+                        current: true,
+                        stacktrace: {
+                          frames: [
+                            {
+                              filename: "CheckoutActivity.java",
+                              function: "submitOrder",
+                              lineNo: 42,
+                            },
+                            {
+                              filename: "Thread.java",
+                              function: "run",
+                              lineNo: 833,
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }),
+          ),
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    const threadSection = result
+      .slice(result.indexOf("### Threads"), result.indexOf("### Tags"))
+      .trim();
+    expect(threadSection).toMatchInlineSnapshot(`
+      "### Threads
+
+      Found 2 threads in this event.
+
+      | Thread ID | Name | State | Flags | Frames |
+      | --- | --- | --- | --- | ---: |
+      | 11 | worker | WAITING | - | 1 |
+      | 259 | main | RUNNABLE | crashed, current | 2 |"
+    `);
+    expect(result).toContain(
+      "- Thread stacktrace lookup: Use the Sentry tool `get_event_stacktrace` to fetch a full thread stacktrace by numeric Thread ID or exact thread Name. Omit `thread` to use Sentry's default selected thread",
+    );
+  });
+
+  it("omits thread list and stacktrace lookup guidance for single-thread events", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () =>
+          HttpResponse.json(
+            createDefaultEvent({
+              id: "event-with-one-thread",
+              entries: [
+                {
+                  type: "message",
+                  data: {
+                    formatted: "Application crashed",
+                  },
+                },
+                {
+                  type: "threads",
+                  data: {
+                    values: [
+                      {
+                        id: 259,
+                        name: "main",
+                        state: "RUNNABLE",
+                        crashed: true,
+                        current: true,
+                        stacktrace: {
+                          frames: [
+                            {
+                              filename: "CheckoutActivity.java",
+                              function: "submitOrder",
+                              lineNo: 42,
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }),
+          ),
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    expect(result).not.toContain("### Threads");
+    expect(result).not.toContain("Thread stacktrace lookup");
+  });
+
   it("includes attached and related replays when available", async () => {
     const attachedReplayId = "7e07485f12f9416b8b1426260799b51f";
     const attachedReplayIdWithDashes = "7e07485f-12f9-416b-8b14-26260799b51f";

--- a/packages/mcp-core/src/tools/catalog/index.ts
+++ b/packages/mcp-core/src/tools/catalog/index.ts
@@ -11,6 +11,7 @@ import getMonitorDetails from "./get-monitor-details";
 import findAlertRules from "./find-alert-rules";
 import getAlertRule from "./get-alert-rule";
 import getIssueDetails from "./get-issue-details";
+import getEventStacktrace from "./get-event-stacktrace";
 import getIssueActivity from "./get-issue-activity";
 import getIssueTagValues from "./get-issue-tag-values";
 import getTraceDetails from "./get-trace-details";
@@ -62,6 +63,7 @@ const catalogTools = {
   find_alert_rules: findAlertRules,
   get_alert_rule: getAlertRule,
   get_issue_details: getIssueDetails,
+  get_event_stacktrace: getEventStacktrace,
   get_issue_activity: getIssueActivity,
   get_issue_tag_values: getIssueTagValues,
   get_trace_details: getTraceDetails,

--- a/packages/mcp-core/src/tools/support/event-stacktrace.ts
+++ b/packages/mcp-core/src/tools/support/event-stacktrace.ts
@@ -132,9 +132,13 @@ function selectSentryDefaultThread(threads: Thread[]): Thread {
   );
   return (
     sortedThreads.find((thread) => thread.crashed) ??
-    sortedThreads.find((thread) => thread.stacktrace) ??
+    sortedThreads.find((thread) => hasFrames(thread)) ??
     sortedThreads[0]!
   );
+}
+
+function hasFrames(thread: Thread): boolean {
+  return Boolean(thread.stacktrace?.frames?.length);
 }
 
 function selectUnique(

--- a/packages/mcp-core/src/tools/support/event-stacktrace.ts
+++ b/packages/mcp-core/src/tools/support/event-stacktrace.ts
@@ -1,0 +1,161 @@
+import type { z } from "zod";
+import { ThreadsEntrySchema } from "../../api-client";
+import type { SentryApiService, ThreadEntrySchema } from "../../api-client";
+import type { Event } from "../../api-client/types";
+import {
+  formatAvailableThreadList,
+  formatThreadStacktraceOutput,
+} from "../../internal/formatting";
+
+type Thread = z.infer<typeof ThreadEntrySchema>;
+type ThreadSelector = string | number | undefined;
+
+type SelectedThread =
+  | {
+      kind: "selected";
+      thread: Thread;
+      reason: string;
+    }
+  | {
+      kind: "not_found" | "ambiguous";
+      message: string;
+    };
+
+/**
+ * Fetches an issue event and formats the selected thread stacktrace.
+ */
+export async function fetchAndFormatEventStacktrace({
+  apiService,
+  organizationSlug,
+  issueId,
+  eventId,
+  thread,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  issueId: string;
+  eventId: string;
+  thread?: string | number;
+}): Promise<string> {
+  const event = await apiService.getEventForIssue({
+    organizationSlug,
+    issueId,
+    eventId,
+  });
+
+  const threads = getThreads(event);
+
+  let output = `# Event Stacktrace in **${organizationSlug}**\n\n`;
+  output += `**Issue ID**: ${issueId}\n`;
+  output += `**Event ID**: ${event.id}\n\n`;
+
+  if (threads.length === 0) {
+    output += "No thread stacktraces were found for this event.\n";
+    return output;
+  }
+
+  const selected = selectThread(threads, thread);
+
+  if (selected.kind !== "selected") {
+    output += `${selected.message}\n\n`;
+    output += formatAvailableThreadList(threads);
+    return output;
+  }
+
+  output += formatThreadStacktraceOutput({
+    event,
+    thread: selected.thread,
+    selectionReason: selected.reason,
+  });
+  return output;
+}
+
+function getThreads(event: Event): Thread[] {
+  const threadsEntry = event.entries?.find((entry) => entry.type === "threads");
+  const result = ThreadsEntrySchema.safeParse(threadsEntry?.data);
+  return result.success ? (result.data.values ?? []) : [];
+}
+
+function selectThread(
+  threads: Thread[],
+  selector: ThreadSelector,
+): SelectedThread {
+  if (selector === undefined) {
+    const selected = selectSentryDefaultThread(threads);
+    return {
+      kind: "selected",
+      thread: selected,
+      reason:
+        "Sentry default selection: first crashed thread, then first thread with a stacktrace, then first thread.",
+    };
+  }
+
+  if (typeof selector === "number") {
+    return selectUnique(
+      threads,
+      (thread) => String(thread.id) === String(selector),
+      `No thread found with ID ${selector}.`,
+      `Multiple threads matched ID ${selector}.`,
+    );
+  }
+
+  const nameMatch = selectUnique(
+    threads,
+    (thread) => thread.name === selector,
+    "",
+    `Multiple threads matched name "${selector}".`,
+  );
+  if (nameMatch.kind !== "not_found") {
+    return nameMatch;
+  }
+
+  if (/^-?\d+$/.test(selector)) {
+    return selectUnique(
+      threads,
+      (thread) => String(thread.id) === selector,
+      `No thread found with name or ID "${selector}".`,
+      `Multiple threads matched ID ${selector}.`,
+    );
+  }
+
+  return {
+    kind: "not_found",
+    message: `No thread found with name "${selector}".`,
+  };
+}
+
+// Mirrors Sentry's thread UI default: crashed first, otherwise a thread with a
+// stacktrace, otherwise the first available thread.
+function selectSentryDefaultThread(threads: Thread[]): Thread {
+  const sortedThreads = [...threads].sort(
+    (a, b) => Number(Boolean(b.crashed)) - Number(Boolean(a.crashed)),
+  );
+  return (
+    sortedThreads.find((thread) => thread.crashed) ??
+    sortedThreads.find((thread) => thread.stacktrace) ??
+    sortedThreads[0]!
+  );
+}
+
+function selectUnique(
+  threads: Thread[],
+  predicate: (thread: Thread) => boolean,
+  notFoundMessage: string,
+  ambiguousMessage: string,
+): SelectedThread {
+  const matches = threads.filter(predicate);
+
+  if (matches.length === 0) {
+    return { kind: "not_found", message: notFoundMessage };
+  }
+
+  if (matches.length > 1) {
+    return { kind: "ambiguous", message: ambiguousMessage };
+  }
+
+  return {
+    kind: "selected",
+    thread: matches[0]!,
+    reason: "Matched the provided thread selector.",
+  };
+}


### PR DESCRIPTION
Issue details now surface a compact thread table only when the selected event has multiple threads, with a hint to fetch a full stacktrace through the catalog-only `get_event_stacktrace` tool. The new tool accepts an optional `thread` selector by numeric thread ID or exact thread name; when omitted, it mirrors Sentry UI selection by choosing the first crashed thread, then the first thread with a stacktrace, then the first thread.

The event stacktrace markdown uses the `Event Stacktrace` label and keeps the stacktrace output focused on actionable selection and frame details, omitting low-value frame-count/system-frame metadata. Inline snapshots cover the issue-details hint, selector behavior, default selection, and rendered tool output, and generated tool definitions are refreshed.

Fixes #1114