### PR TITLE
build: Update pnpm and Node baseline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/.github/workflows/mcp-server-package.yml
+++ b/.github/workflows/mcp-server-package.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         name: Install pnpm

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/.github/workflows/token-cost.yml
+++ b/.github/workflows/token-cost.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/docs/contributing/documentation-style-guide.md
+++ b/docs/contributing/documentation-style-guide.md
@@ -181,7 +181,7 @@ all dependencies. Make sure to create your .env file with the required variables
 ```markdown
 ## Environment Setup
 
-Required: Node.js 20+, pnpm
+Required: Node.js 22.13+, pnpm
 
 ```bash
 pnpm install

--- a/docs/testing/remote.md
+++ b/docs/testing/remote.md
@@ -21,7 +21,7 @@ The remote MCP server runs on Cloudflare Workers and provides HTTP-based access 
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22.13+
 - pnpm installed
 - Wrangler CLI (for Cloudflare deployment)
 - Sentry OAuth application credentials

--- a/docs/testing/stdio.md
+++ b/docs/testing/stdio.md
@@ -20,7 +20,7 @@ The stdio transport runs the MCP server as a subprocess that communicates via st
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22.13+
 - pnpm installed
 - Sentry access token with appropriate scopes
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@11.8.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "license": "FSL-1.1-ALv2",
   "author": "Sentry",
@@ -68,22 +68,6 @@
       "biome format --write --no-errors-on-unmatched --files-ignore-unknown=true",
       "biome lint --fix --no-errors-on-unmatched --files-ignore-unknown=true"
     ]
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@ast-grep/cli",
-      "@biomejs/biome",
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "simple-git-hooks",
-      "workerd"
-    ],
-    "overrides": {
-      "@modelcontextprotocol/sdk": "^1.26.0",
-      "fast-xml-parser": "5.7.2",
-      "undici": "^7.24.4"
-    }
   },
   "devDependencies": {
     "@types/json-schema": "^7.0.15"

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -3,9 +3,9 @@
   "version": "0.36.0",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@10.8.1",
+  "packageManager": "pnpm@11.8.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "license": "FSL-1.1-ALv2",
   "author": "Sentry",

--- a/packages/mcp-server-evals/package.json
+++ b/packages/mcp-server-evals/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "license": "FSL-1.1-ALv2",
   "scripts": {

--- a/packages/mcp-server-mocks/package.json
+++ b/packages/mcp-server-mocks/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "license": "FSL-1.1-ALv2",
   "exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -3,9 +3,9 @@
   "mcpName": "io.github.getsentry/sentry-mcp",
   "version": "0.36.0",
   "type": "module",
-  "packageManager": "pnpm@10.8.1",
+  "packageManager": "pnpm@11.8.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "publishConfig": {
     "access": "public"
@@ -13,11 +13,7 @@
   "license": "FSL-1.1-ALv2",
   "author": "Sentry",
   "homepage": "https://github.com/getsentry/sentry-mcp",
-  "keywords": [
-    "sentry",
-    "mcp",
-    "model-context-protocol"
-  ],
+  "keywords": ["sentry", "mcp", "model-context-protocol"],
   "bugs": {
     "url": "https://github.com/getsentry/sentry-mcp/issues"
   },
@@ -28,9 +24,7 @@
   "bin": {
     "sentry-mcp": "./dist/index.js"
   },
-  "files": [
-    "./dist/*"
-  ],
+  "files": ["./dist/*"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -14,7 +14,7 @@ A simple CLI tool to test the Sentry MCP server using stdio transport with an AI
 
 ## Prerequisites
 
-- Node.js >= 20
+- Node.js >= 22.13
 - pnpm package manager
 - OpenAI API key for prompt/agent mode
 - Sentry access token with appropriate permissions for token-based stdio mode

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,26 @@
 packages:
   - packages/*
 
+allowBuilds:
+  "@ast-grep/cli": true
+  "@biomejs/biome": true
+  "@sentry/cli": false
+  "@tailwindcss/oxide": false
+  better-sqlite3: true
+  core-js: false
+  core-js-pure: false
+  esbuild: true
+  msw: false
+  sharp: true
+  simple-git-hooks: true
+  vitest-evals: false
+  workerd: true
+
+overrides:
+  "@modelcontextprotocol/sdk": ^1.26.0
+  fast-xml-parser: 5.7.2
+  undici: ^7.24.4
+
 catalog:
   "@ast-grep/cli": ^0.43.0
   "@ai-sdk/anthropic": ^3.0.33


### PR DESCRIPTION
Move the workspace to pnpm 11.8.0 and Node 22.13+ so the package-manager runtime requirement matches the repository baseline. pnpm 11 no longer reads the root package.json pnpm block, so the workspace overrides and build-script policy now live in pnpm-workspace.yaml.

CI workflows now use Node 22, and the setup/testing docs advertise the same Node 22.13+ prerequisite. The lockfile is unchanged; this is a tooling baseline and configuration migration rather than a dependency version refresh.

Validation: pnpm install --lockfile-only, pnpm run tsc, pnpm run lint, pnpm run test, pnpm run docs:check.