### PR TITLE
feat(api): Add MCP referrer to search_events API calls

### DIFF
--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1058,7 +1058,7 @@ describe("API query builders", () => {
       });
 
       expect(params.toString()).toMatchInlineSnapshot(
-        `"per_page=50&query=level%3Aerror&dataset=errors&statsPeriod=24h&project=backend&sort=-count&field=title&field=project&field=count%28%29"`,
+        `"per_page=50&query=level%3Aerror&dataset=errors&statsPeriod=24h&project=backend&sort=-count&field=title&field=project&field=count%28%29&referrer=api.mcp.search-events"`,
       );
     });
 
@@ -1143,7 +1143,7 @@ describe("API query builders", () => {
       });
 
       expect(params.toString()).toMatchInlineSnapshot(
-        `"per_page=20&query=span.op%3Adb&dataset=spans&statsPeriod=1h&project=frontend&sampling=NORMAL&sort=-span.duration&field=span.op&field=span.description&field=span.duration"`,
+        `"per_page=20&query=span.op%3Adb&dataset=spans&statsPeriod=1h&project=frontend&sampling=NORMAL&sort=-span.duration&field=span.op&field=span.description&field=span.duration&referrer=api.mcp.search-events"`,
       );
     });
 
@@ -1160,7 +1160,7 @@ describe("API query builders", () => {
       });
 
       expect(params.toString()).toMatchInlineSnapshot(
-        `"per_page=30&query=severity%3Aerror&dataset=logs&sort=-timestamp&field=timestamp&field=message&field=severity"`,
+        `"per_page=30&query=severity%3Aerror&dataset=logs&sort=-timestamp&field=timestamp&field=message&field=severity&referrer=api.mcp.search-events"`,
       );
 
       // Verify sampling is not added for logs
@@ -1217,6 +1217,10 @@ describe("API query builders", () => {
         expect.stringContaining("sort=-count"),
         expect.any(Object),
       );
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("referrer=api.mcp.search-events"),
+        expect.any(Object),
+      );
     });
 
     it("should route spans dataset to EAP API builder with sampling", async () => {
@@ -1249,6 +1253,10 @@ describe("API query builders", () => {
       );
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining("sampling=NORMAL"),
+        expect.any(Object),
+      );
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("referrer=api.mcp.search-events"),
         expect.any(Object),
       );
     });

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -131,6 +131,8 @@ import type {
 // logger isnt exposed (or rather, it is, but its not the right logger)
 // import { logger } from "@sentry/node";
 
+const SENTRY_MCP_SEARCH_EVENTS_REFERRER = "api.mcp.search-events";
+
 /**
  * Mapping of common network error codes to user-friendly messages.
  * These help users understand and resolve connection issues.
@@ -3735,6 +3737,8 @@ export class SentryApiService {
       queryParams.append("field", field);
     }
 
+    queryParams.set("referrer", SENTRY_MCP_SEARCH_EVENTS_REFERRER);
+
     return queryParams;
   }
 
@@ -3801,6 +3805,8 @@ export class SentryApiService {
     for (const field of params.fields) {
       queryParams.append("field", field);
     }
+
+    queryParams.set("referrer", SENTRY_MCP_SEARCH_EVENTS_REFERRER);
 
     return queryParams;
   }

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1083,7 +1083,7 @@ export const EventsResponseSchema = z.object({
     .passthrough(),
 });
 
-// https://us.sentry.io/api/0/organizations/sentry/events/?dataset=errors&field=issue&field=title&field=project&field=timestamp&field=trace&per_page=5&query=event.type%3Aerror&referrer=sentry-mcp&sort=-timestamp&statsPeriod=1w
+// https://us.sentry.io/api/0/organizations/sentry/events/?dataset=errors&field=issue&field=title&field=project&field=timestamp&field=trace&per_page=5&query=event.type%3Aerror&referrer=api.mcp.search-events&sort=-timestamp&statsPeriod=1w
 export const ErrorsSearchResponseSchema = EventsResponseSchema.extend({
   data: z.array(
     z.object({


### PR DESCRIPTION
Set referrer=api.mcp.search-events on Discover and EAP /events/ requests so Sentry can attribute search_events traffic.