### PR TITLE
feat(search-events): Query available fields before constructing a query

### DIFF
--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -1813,6 +1813,60 @@ describe("search_events", () => {
     );
   });
 
+  it("should prefetch field catalog before agent query construction", async () => {
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse("logs", "severity:error", [
+        "timestamp",
+        "message",
+        "severity",
+      ]),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/trace-items/attributes/",
+        () =>
+          HttpResponse.json([
+            { key: "severity", name: "Severity", attributeType: "string" },
+            { key: "message", name: "Message", attributeType: "string" },
+          ]),
+      ),
+      http.get("https://sentry.io/api/0/organizations/test-org/events/", () =>
+        HttpResponse.json({ data: [] }),
+      ),
+    );
+
+    await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query: "error logs",
+        dataset: "logs",
+        fields: null,
+        sort: "-timestamp",
+        statsPeriod: "14d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    const prompt = mockGenerateText.mock.calls[0]?.[0]?.prompt;
+    expect(prompt).toContain('Prefetched field catalog for dataset "logs"');
+    expect(prompt).toContain("- severity:");
+    expect(prompt).toContain("EXAMPLE QUERIES FOR LOGS");
+    expect(prompt).toContain("error logs");
+  });
+
   it("should handle logs dataset queries", async () => {
     // Mock AI response for logs dataset
     mockGenerateText.mockResolvedValueOnce(

--- a/packages/mcp-core/src/tools/catalog/search-events.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.ts
@@ -531,6 +531,8 @@ export default defineTool({
         organizationSlug,
         apiService,
         projectId,
+        dataset: inputDataset,
+        statsPeriod: params.statsPeriod,
       });
 
       const parsed = agentResult.result;
@@ -738,6 +740,8 @@ export default defineTool({
               organizationSlug,
               apiService,
               projectId,
+              dataset,
+              ...timeParams,
             });
 
             const parsed = agentResult.result;

--- a/packages/mcp-core/src/tools/support/search-events/agent.ts
+++ b/packages/mcp-core/src/tools/support/search-events/agent.ts
@@ -4,9 +4,14 @@ import type { SentryApiService } from "../../../api-client";
 import { createOtelLookupTool } from "../../../internal/agents/tools/otel-semantics";
 import { createDatasetFieldsTool } from "../../../internal/agents/tools/dataset-fields";
 import { createWhoamiTool } from "../../../internal/agents/tools/whoami";
-import { createDatasetAttributesTool } from "./utils";
-import { systemPrompt } from "./config";
+import { logWarn } from "../../../telem/logging";
+import type { PublicEventsDataset } from "../../../utils/events-datasets";
 import { PUBLIC_EVENTS_DATASETS } from "../../../utils/events-datasets";
+import {
+  buildPrefetchedFieldCatalog,
+  createDatasetAttributesTool,
+} from "./utils";
+import { systemPrompt } from "./config";
 
 const SEARCH_EVENTS_DATASETS = [...PUBLIC_EVENTS_DATASETS, "replays"] as const;
 
@@ -81,6 +86,49 @@ export interface SearchEventsAgentOptions {
   organizationSlug: string;
   apiService: SentryApiService;
   projectId?: string;
+  dataset?: PublicEventsDataset | "replays";
+  statsPeriod?: string;
+  start?: string;
+  end?: string;
+}
+
+async function buildSearchEventsAgentPrompt(
+  options: SearchEventsAgentOptions,
+): Promise<string> {
+  const sections: string[] = [];
+
+  if (options.dataset) {
+    try {
+      const fieldCatalog = await buildPrefetchedFieldCatalog({
+        apiService: options.apiService,
+        organizationSlug: options.organizationSlug,
+        dataset: options.dataset,
+        projectId: options.projectId,
+        statsPeriod: options.statsPeriod,
+        start: options.start,
+        end: options.end,
+      });
+
+      sections.push(
+        `Prefetched field catalog for dataset "${options.dataset}":`,
+        "Construct the query using these discovered fields.",
+        "Call datasetAttributes or replayFields only for targeted substringMatch/query lookups, or if you choose a different dataset.",
+        "",
+        fieldCatalog,
+      );
+    } catch (error) {
+      logWarn(error, {
+        loggerScope: ["search-events", "prefetch-fields"],
+        extra: {
+          dataset: options.dataset,
+          organizationSlug: options.organizationSlug,
+        },
+      });
+    }
+  }
+
+  sections.push("---", "", options.query);
+  return sections.join("\n");
 }
 
 /**
@@ -112,6 +160,7 @@ export async function searchEventsAgent(
     projectId: options.projectId,
   });
   const whoamiTool = createWhoamiTool({ apiService: options.apiService });
+  const prompt = await buildSearchEventsAgentPrompt(options);
 
   // Use callEmbeddedAgent to translate the query with tool call capture
   return await callEmbeddedAgent<
@@ -119,7 +168,7 @@ export async function searchEventsAgent(
     typeof searchEventsAgentOutputSchema
   >({
     system: systemPrompt,
-    prompt: options.query,
+    prompt,
     tools: {
       datasetAttributes: datasetAttributesTool,
       replayFields: replayFieldsTool,

--- a/packages/mcp-core/src/tools/support/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.test.ts
@@ -7,6 +7,9 @@ import {
   formatEventsValidationResults,
   formatKnownUserValue,
   looksLikeSentrySearchSyntax,
+  buildDatasetAttributesCatalog,
+  buildPrefetchedFieldCatalog,
+  formatReplayFieldCatalog,
 } from "./utils";
 import { SentryApiService } from "../../../api-client";
 import * as logging from "../../../telem/logging";
@@ -689,5 +692,145 @@ Validated Query:
 Validated Query:
 - INVALID query — Invalid syntax
 `);
+  });
+});
+
+describe("buildDatasetAttributesCatalog", () => {
+  let apiService: SentryApiService;
+
+  beforeEach(() => {
+    apiService = new SentryApiService({
+      accessToken: "test-token",
+    });
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/trace-items/attributes/",
+        () =>
+          HttpResponse.json([
+            { key: "severity", name: "Severity", attributeType: "string" },
+            { key: "message", name: "Message", attributeType: "string" },
+          ]),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    mswServer.resetHandlers();
+  });
+
+  it("should include static, custom, and example fields for logs", async () => {
+    const catalog = await buildDatasetAttributesCatalog({
+      apiService,
+      organizationSlug: "test-org",
+      dataset: "logs",
+    });
+
+    expect(catalog).toContain("Dataset: logs");
+    expect(catalog).toContain("- severity: Severity");
+    expect(catalog).toContain("- message: Message");
+    expect(catalog).toContain("- severity_number: Numeric severity level");
+    expect(catalog).toContain("Recommended Fields for logs:");
+    expect(catalog).toContain("EXAMPLE QUERIES FOR LOGS");
+  });
+});
+
+describe("formatReplayFieldCatalog", () => {
+  it("should format replay fields and common query patterns", () => {
+    const catalog = formatReplayFieldCatalog({
+      dataset: "replays",
+      fields: [
+        {
+          key: "count_errors",
+          name: "Error Count",
+          totalValues: 12,
+          examples: ["0", "1", "5"],
+        },
+        {
+          key: "url",
+          name: "URL",
+          totalValues: 8,
+        },
+      ],
+      commonPatterns: [
+        {
+          pattern: "count_errors:>0",
+          description: "Replays with one or more errors",
+        },
+        {
+          pattern: "viewed_by_me:true",
+          description: "Replays viewed by the current user",
+        },
+      ],
+    });
+
+    expect(catalog).toContain("Dataset: replays");
+    expect(catalog).toContain("Available Fields (2 total):");
+    expect(catalog).toContain("- count_errors: Error Count (e.g. 0, 1, 5)");
+    expect(catalog).toContain("- url: URL");
+    expect(catalog).toContain("Common Replay Query Patterns:");
+    expect(catalog).toContain(
+      "- count_errors:>0: Replays with one or more errors",
+    );
+    expect(catalog).toContain(
+      "- viewed_by_me:true: Replays viewed by the current user",
+    );
+    expect(catalog).toContain(
+      "Use these fields and patterns when constructing the replay query.",
+    );
+  });
+
+  it("should note when more than 50 replay fields are available", () => {
+    const fields = Array.from({ length: 51 }, (_, index) => ({
+      key: `field_${index}`,
+      name: `Field ${index}`,
+      totalValues: 1,
+    }));
+
+    const catalog = formatReplayFieldCatalog({
+      dataset: "replays",
+      fields,
+      commonPatterns: [],
+    });
+
+    expect(catalog).toContain("Available Fields (51 total):");
+    expect(catalog).toContain("- field_0: Field 0");
+    expect(catalog).toContain("- field_49: Field 49");
+    expect(catalog).not.toContain("- field_50: Field 50");
+    expect(catalog).toContain("... and 1 more fields");
+  });
+});
+
+describe("buildPrefetchedFieldCatalog", () => {
+  let apiService: SentryApiService;
+
+  beforeEach(() => {
+    apiService = new SentryApiService({
+      accessToken: "test-token",
+    });
+  });
+
+  afterEach(() => {
+    mswServer.resetHandlers();
+  });
+
+  it("should build replay field catalogs from replay tags", async () => {
+    mswServer.use(
+      http.get("https://sentry.io/api/0/organizations/test-org/tags/", () =>
+        HttpResponse.json([
+          { key: "count_errors", name: "Error Count", totalValues: 12 },
+          { key: "url", name: "URL", totalValues: 8 },
+        ]),
+      ),
+    );
+
+    const catalog = await buildPrefetchedFieldCatalog({
+      apiService,
+      organizationSlug: "test-org",
+      dataset: "replays",
+    });
+
+    expect(catalog).toContain("Dataset: replays");
+    expect(catalog).toContain("- count_errors: Error Count");
+    expect(catalog).toContain("Common Replay Query Patterns:");
   });
 });

--- a/packages/mcp-core/src/tools/support/search-events/utils.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.ts
@@ -17,7 +17,12 @@ import {
   isPlainObject,
 } from "../../../internal/user-formatting";
 import {
+  discoverDatasetFields,
+  type DatasetFieldsResult,
+} from "../../../internal/agents/tools/dataset-fields";
+import {
   type EventsDataset,
+  type PublicEventsDataset,
   PUBLIC_EVENTS_DATASETS,
   normalizeEventsDataset,
 } from "../../../utils/events-datasets";
@@ -697,6 +702,173 @@ export async function assertEventsSearchIsValid(
   }
 }
 
+export function formatReplayFieldCatalog(result: DatasetFieldsResult): string {
+  const fieldLines = result.fields
+    .slice(0, 50)
+    .map((field) => {
+      const examples =
+        field.examples && field.examples.length > 0
+          ? ` (e.g. ${field.examples.join(", ")})`
+          : "";
+      return `- ${field.key}: ${field.name}${examples}`;
+    })
+    .join("\n");
+
+  const patternLines = result.commonPatterns
+    .map((pattern) => `- ${pattern.pattern}: ${pattern.description}`)
+    .join("\n");
+
+  return `Dataset: replays
+
+Available Fields (${result.fields.length} total):
+${fieldLines}
+${result.fields.length > 50 ? `\n... and ${result.fields.length - 50} more fields` : ""}
+
+Common Replay Query Patterns:
+${patternLines}
+
+Use these fields and patterns when constructing the replay query.`;
+}
+
+export async function buildDatasetAttributesCatalog(options: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  dataset: PublicEventsDataset;
+  projectId?: string;
+  statsPeriod?: string;
+  start?: string;
+  end?: string;
+  substringMatch?: string;
+  query?: string;
+  attributeTypes?: TraceItemAttributeType[];
+}): Promise<string> {
+  const {
+    BASE_COMMON_FIELDS,
+    DATASET_FIELDS,
+    RECOMMENDED_FIELDS,
+    NUMERIC_FIELDS,
+    DATASET_EXAMPLES,
+  } = await import("./config");
+
+  const {
+    apiService,
+    organizationSlug,
+    dataset,
+    projectId,
+    statsPeriod,
+    start,
+    end,
+    substringMatch,
+    query,
+    attributeTypes,
+  } = options;
+  const normalizedDataset = normalizeEventsDataset(dataset);
+  const attributeTimeParams = {
+    statsPeriod: statsPeriod ?? "14d",
+    start,
+    end,
+  };
+  const { attributes: customAttributes, fieldTypes } =
+    await fetchCustomAttributes(
+      apiService,
+      organizationSlug,
+      dataset,
+      projectId,
+      attributeTimeParams,
+      {
+        attributeTypes,
+        substringMatch,
+        query,
+      },
+    );
+
+  const allFields = {
+    ...BASE_COMMON_FIELDS,
+    ...DATASET_FIELDS[normalizedDataset],
+    ...customAttributes,
+  };
+  const fieldCount = Object.keys(allFields).length;
+
+  const recommendedFields = RECOMMENDED_FIELDS[normalizedDataset];
+
+  const allFieldTypes: Record<string, TraceItemAttributeType> = {
+    ...fieldTypes,
+  };
+  const staticNumericFields = NUMERIC_FIELDS[normalizedDataset] || new Set();
+  for (const field of staticNumericFields) {
+    allFieldTypes[field] = "number";
+  }
+
+  recordAgentToolResultCount(fieldCount);
+
+  return `Dataset: ${dataset}
+
+Available Fields (${fieldCount} total):
+${Object.entries(allFields)
+  .slice(0, 50) // Limit to first 50 to avoid overwhelming the agent
+  .map(([key, desc]) => `- ${key}: ${desc}`)
+  .join("\n")}
+${fieldCount > 50 ? `\n... and ${fieldCount - 50} more fields` : ""}
+
+Recommended Fields for ${dataset}:
+${recommendedFields.basic.map((f) => `- ${f}`).join("\n")}
+
+Field Types (CRITICAL for aggregate functions):
+${Object.entries(allFieldTypes)
+  .slice(0, 30) // Show more field types since this is critical for aggregate functions
+  .map(([key, type]) => `- ${key}: ${type}`)
+  .join("\n")}
+${Object.keys(allFieldTypes).length > 30 ? `\n... and ${Object.keys(allFieldTypes).length - 30} more fields` : ""}
+
+IMPORTANT: Only use numeric aggregate functions (avg, sum, min, max, percentiles) with numeric fields. Use count() or count_unique() for non-numeric fields.
+
+EXAMPLE QUERIES FOR ${dataset.toUpperCase()}:
+${DATASET_EXAMPLES[normalizedDataset]
+  .map((ex) => `- "${ex.description}" →\n  ${JSON.stringify(ex.output)}`)
+  .join("\n\n")}
+
+Use these examples as patterns for constructing your query.`;
+}
+
+export async function buildPrefetchedFieldCatalog(options: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  dataset: PublicEventsDataset | "replays";
+  projectId?: string;
+  statsPeriod?: string;
+  start?: string;
+  end?: string;
+  substringMatch?: string;
+  query?: string;
+  attributeTypes?: TraceItemAttributeType[];
+}): Promise<string> {
+  // Replays are not events-dataset searches: they use replay tag discovery with
+  // built-in click/tap fields and replay query patterns, not trace-items
+  // attributes or DATASET_FIELDS/DATASET_EXAMPLES from config.
+  if (options.dataset === "replays") {
+    const replayFields = await discoverDatasetFields(
+      options.apiService,
+      options.organizationSlug,
+      "replays",
+      { projectId: options.projectId },
+    );
+    return formatReplayFieldCatalog(replayFields);
+  }
+
+  return buildDatasetAttributesCatalog({
+    apiService: options.apiService,
+    organizationSlug: options.organizationSlug,
+    dataset: options.dataset,
+    projectId: options.projectId,
+    statsPeriod: options.statsPeriod,
+    start: options.start,
+    end: options.end,
+    substringMatch: options.substringMatch,
+    query: options.query,
+    attributeTypes: options.attributeTypes,
+  });
+}
+
 /**
  * Create a tool for the agent to query available attributes by dataset
  * The tool is pre-bound with the API service and organization configured for the appropriate region
@@ -739,83 +911,18 @@ export function createDatasetAttributesTool(options: {
         ),
     }),
     execute: async ({ dataset, substringMatch, query, attributeTypes }) => {
-      const {
-        BASE_COMMON_FIELDS,
-        DATASET_FIELDS,
-        RECOMMENDED_FIELDS,
-        NUMERIC_FIELDS,
-        DATASET_EXAMPLES,
-      } = await import("./config");
-
-      // Get custom attributes for this dataset
       // IMPORTANT: Let ALL errors bubble up to wrapAgentToolExecute
       // UserInputError will be converted to error string for the AI agent
       // Other errors will bubble up to be captured by Sentry
-      const normalizedDataset = normalizeEventsDataset(dataset);
-      const attributeTimeParams = { statsPeriod: "14d" };
-      const { attributes: customAttributes, fieldTypes } =
-        await fetchCustomAttributes(
-          apiService,
-          organizationSlug,
-          dataset,
-          projectId,
-          attributeTimeParams,
-          {
-            attributeTypes,
-            substringMatch,
-            query,
-          },
-        );
-
-      // Combine all available fields
-      const allFields = {
-        ...BASE_COMMON_FIELDS,
-        ...DATASET_FIELDS[normalizedDataset],
-        ...customAttributes,
-      };
-      const fieldCount = Object.keys(allFields).length;
-
-      const recommendedFields = RECOMMENDED_FIELDS[normalizedDataset];
-
-      // Combine field types from both static config and dynamic API
-      const allFieldTypes: Record<string, TraceItemAttributeType> = {
-        ...fieldTypes,
-      };
-      const staticNumericFields =
-        NUMERIC_FIELDS[normalizedDataset] || new Set();
-      for (const field of staticNumericFields) {
-        allFieldTypes[field] = "number";
-      }
-
-      recordAgentToolResultCount(fieldCount);
-
-      return `Dataset: ${dataset}
-
-Available Fields (${fieldCount} total):
-${Object.entries(allFields)
-  .slice(0, 50) // Limit to first 50 to avoid overwhelming the agent
-  .map(([key, desc]) => `- ${key}: ${desc}`)
-  .join("\n")}
-${fieldCount > 50 ? `\n... and ${fieldCount - 50} more fields` : ""}
-
-Recommended Fields for ${dataset}:
-${recommendedFields.basic.map((f) => `- ${f}`).join("\n")}
-
-Field Types (CRITICAL for aggregate functions):
-${Object.entries(allFieldTypes)
-  .slice(0, 30) // Show more field types since this is critical for aggregate functions
-  .map(([key, type]) => `- ${key}: ${type}`)
-  .join("\n")}
-${Object.keys(allFieldTypes).length > 30 ? `\n... and ${Object.keys(allFieldTypes).length - 30} more fields` : ""}
-
-IMPORTANT: Only use numeric aggregate functions (avg, sum, min, max, percentiles) with numeric fields. Use count() or count_unique() for non-numeric fields.
-
-EXAMPLE QUERIES FOR ${dataset.toUpperCase()}:
-${DATASET_EXAMPLES[normalizedDataset]
-  .map((ex) => `- "${ex.description}" →\n  ${JSON.stringify(ex.output)}`)
-  .join("\n\n")}
-
-Use these examples as patterns for constructing your query.`;
+      return buildDatasetAttributesCatalog({
+        apiService,
+        organizationSlug,
+        dataset,
+        projectId,
+        substringMatch,
+        query,
+        attributeTypes,
+      });
     },
   });
 }


### PR DESCRIPTION
- Queries aren't fetching fields first before constructing a query which is leading to a decent number of the invalid queries beind sent to /validate
- Query available fields first to see if this improves valid queries