### PR TITLE
fix(search_events): link to conversations page for AI conversation queries

### DIFF
--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -257,6 +257,61 @@ describe("search_events", () => {
     );
   });
 
+  it("should link directly to AI conversation details for a single conversation id filter", async () => {
+    const query = 'gen_ai.conversation.id:"14365297"';
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(query);
+
+          return HttpResponse.json({
+            data: [
+              {
+                id: "span1",
+                "span.op": "ai.pipeline",
+                "span.description": "AI conversation",
+                "span.duration": 120,
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields: ["span.op", "span.description", "span.duration"],
+        sort: "-span.duration",
+        statsPeriod: "14d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain(
+      "https://test-org.sentry.io/explore/conversations/14365297/",
+    );
+    expect(result).not.toContain("https://test-org.sentry.io/explore/traces/");
+  });
+
   it("should append environment filters for structured trace searches", async () => {
     const query =
       'transaction:"VPN connections" message:"environment: prod" tags[type]:Unified tags[country]:CN';

--- a/packages/mcp-core/src/tools/catalog/search-events.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.ts
@@ -16,6 +16,7 @@ import {
   isMetricsDataset,
   normalizeEventsDataset,
 } from "../../utils/events-datasets";
+import { extractConversationIdFromSearchQuery } from "../../utils/url-utils";
 import {
   searchEventsAgent,
   type searchEventsAgentOutputSchema,
@@ -858,20 +859,23 @@ export default defineTool({
       eventData.length,
     );
 
-    const explorerUrl = apiService.getEventsExplorerUrl(
-      organizationSlug,
-      sentryQuery,
-      projectId,
-      dataset,
-      fields,
-      sortParam,
-      aggregateFunctions,
-      groupByFields,
-      timeParams.statsPeriod,
-      timeParams.start,
-      timeParams.end,
-      eventData,
-    );
+    const conversationId = extractConversationIdFromSearchQuery(sentryQuery);
+    const explorerUrl = conversationId
+      ? apiService.getAIConversationUrl(organizationSlug, conversationId)
+      : apiService.getEventsExplorerUrl(
+          organizationSlug,
+          sentryQuery,
+          projectId,
+          dataset,
+          fields,
+          sortParam,
+          aggregateFunctions,
+          groupByFields,
+          timeParams.statsPeriod,
+          timeParams.start,
+          timeParams.end,
+          eventData,
+        );
 
     const formatParams = {
       eventData,

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -12,6 +12,7 @@ import {
   getMonitorUrl,
   getTraceUrl,
   getEventsExplorerUrl,
+  getAIConversationUrl,
   extractConversationIdFromSearchQuery,
   getTraceMetricsExploreUrl,
 } from "./url-utils";
@@ -469,6 +470,14 @@ describe("url-utils", () => {
       ).toBe("14365297");
     });
 
+    it("extracts an unquoted conversation id from a grouped filter", () => {
+      expect(
+        extractConversationIdFromSearchQuery(
+          "(gen_ai.conversation.id:14365297)",
+        ),
+      ).toBe("14365297");
+    });
+
     it("returns undefined when no conversation id is present", () => {
       expect(
         extractConversationIdFromSearchQuery("span.op:ai"),
@@ -491,6 +500,16 @@ describe("url-utils", () => {
           '!gen_ai.conversation.id:"14365297"',
         ),
       ).toBeUndefined();
+      expect(
+        extractConversationIdFromSearchQuery(
+          'NOT gen_ai.conversation.id:"14365297"',
+        ),
+      ).toBeUndefined();
+      expect(
+        extractConversationIdFromSearchQuery(
+          'NOT (gen_ai.conversation.id:"14365297")',
+        ),
+      ).toBeUndefined();
     });
 
     it("returns undefined when negated and positive conversation id filters are combined", () => {
@@ -505,6 +524,16 @@ describe("url-utils", () => {
       expect(
         extractConversationIdFromSearchQuery("gen_ai.conversation.id:[1,2]"),
       ).toBeUndefined();
+    });
+  });
+
+  describe("getAIConversationUrl", () => {
+    it("encodes conversation ids as path segments", () => {
+      expect(
+        getAIConversationUrl("us.sentry.io", "myorg", "thread/1?x=y"),
+      ).toBe(
+        "https://myorg.sentry.io/explore/conversations/thread%2F1%3Fx%3Dy/",
+      );
     });
   });
 

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -484,6 +484,20 @@ describe("url-utils", () => {
         ),
       ).toBeUndefined();
     });
+
+    it("returns undefined for negated conversation id filters", () => {
+      expect(
+        extractConversationIdFromSearchQuery(
+          '!gen_ai.conversation.id:"14365297"',
+        ),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for IN-style bracket conversation id filters", () => {
+      expect(
+        extractConversationIdFromSearchQuery("gen_ai.conversation.id:[1,2]"),
+      ).toBeUndefined();
+    });
   });
 
   describe("getTraceMetricsExploreUrl", () => {

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -493,6 +493,14 @@ describe("url-utils", () => {
       ).toBeUndefined();
     });
 
+    it("returns undefined when negated and positive conversation id filters are combined", () => {
+      expect(
+        extractConversationIdFromSearchQuery(
+          '!gen_ai.conversation.id:"1" OR gen_ai.conversation.id:"2"',
+        ),
+      ).toBeUndefined();
+    });
+
     it("returns undefined for IN-style bracket conversation id filters", () => {
       expect(
         extractConversationIdFromSearchQuery("gen_ai.conversation.id:[1,2]"),

--- a/packages/mcp-core/src/utils/url-utils.test.ts
+++ b/packages/mcp-core/src/utils/url-utils.test.ts
@@ -12,6 +12,7 @@ import {
   getMonitorUrl,
   getTraceUrl,
   getEventsExplorerUrl,
+  extractConversationIdFromSearchQuery,
   getTraceMetricsExploreUrl,
 } from "./url-utils";
 
@@ -450,6 +451,38 @@ describe("url-utils", () => {
       expect(url.searchParams.get("statsPeriod")).toBe("7d");
       expect(url.searchParams.get("sort")).toBe("-count()");
       expect(url.searchParams.getAll("field")).toEqual(["release", "count()"]);
+    });
+  });
+
+  describe("extractConversationIdFromSearchQuery", () => {
+    it("extracts a quoted conversation id", () => {
+      expect(
+        extractConversationIdFromSearchQuery(
+          'gen_ai.conversation.id:"14365297"',
+        ),
+      ).toBe("14365297");
+    });
+
+    it("extracts an unquoted conversation id", () => {
+      expect(
+        extractConversationIdFromSearchQuery("gen_ai.conversation.id:14365297"),
+      ).toBe("14365297");
+    });
+
+    it("returns undefined when no conversation id is present", () => {
+      expect(
+        extractConversationIdFromSearchQuery("span.op:ai"),
+      ).toBeUndefined();
+      expect(extractConversationIdFromSearchQuery("")).toBeUndefined();
+      expect(extractConversationIdFromSearchQuery(null)).toBeUndefined();
+    });
+
+    it("returns undefined when multiple conversation ids are present", () => {
+      expect(
+        extractConversationIdFromSearchQuery(
+          'gen_ai.conversation.id:"1" OR gen_ai.conversation.id:"2"',
+        ),
+      ).toBeUndefined();
     });
   });
 

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -606,15 +606,15 @@ export function getAIConversationUrl(
   return getSentryWebBaseUrl(
     host,
     organizationSlug,
-    `/explore/conversations/${conversationId}/`,
+    `/explore/conversations/${encodeURIComponent(conversationId)}/`,
     protocol,
   );
 }
 
 /**
- * Extract a single AI conversation ID from a Sentry search query that filters
- * on `gen_ai.conversation.id`. Returns undefined when the query does not
- * contain exactly one such filter.
+ * Extract a single non-negated AI conversation ID from a Sentry search query
+ * that filters on `gen_ai.conversation.id`. Returns undefined when the query
+ * does not contain exactly one such filter or contains a negated filter.
  */
 export function extractConversationIdFromSearchQuery(
   query: string | undefined | null,
@@ -623,11 +623,15 @@ export function extractConversationIdFromSearchQuery(
     return undefined;
   }
 
-  if (/!gen_ai\.conversation\.id:/.test(query)) {
+  if (
+    /!gen_ai\.conversation\.id:|\bNOT\s+(?:\(\s*)?gen_ai\.conversation\.id:/i.test(
+      query,
+    )
+  ) {
     return undefined;
   }
 
-  const pattern = /gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s]+))/g;
+  const pattern = /gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s)]+))/g;
   const matches = [...query.matchAll(pattern)];
   if (matches.length !== 1) {
     return undefined;

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -612,6 +612,27 @@ export function getAIConversationUrl(
 }
 
 /**
+ * Extract a single AI conversation ID from a Sentry search query that filters
+ * on `gen_ai.conversation.id`. Returns undefined when the query does not
+ * contain exactly one such filter.
+ */
+export function extractConversationIdFromSearchQuery(
+  query: string | undefined | null,
+): string | undefined {
+  if (!query) {
+    return undefined;
+  }
+
+  const pattern = /gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s]+))/g;
+  const matches = [...query.matchAll(pattern)];
+  if (matches.length !== 1) {
+    return undefined;
+  }
+
+  return matches[0][1] ?? matches[0][2];
+}
+
+/**
  * Generates a Sentry AI conversations list URL with optional search filters.
  */
 export function getAIConversationsUrl(

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -623,7 +623,11 @@ export function extractConversationIdFromSearchQuery(
     return undefined;
   }
 
-  const pattern = /(?<![!])gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s]+))/g;
+  if (/!gen_ai\.conversation\.id:/.test(query)) {
+    return undefined;
+  }
+
+  const pattern = /gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s]+))/g;
   const matches = [...query.matchAll(pattern)];
   if (matches.length !== 1) {
     return undefined;

--- a/packages/mcp-core/src/utils/url-utils.ts
+++ b/packages/mcp-core/src/utils/url-utils.ts
@@ -623,13 +623,18 @@ export function extractConversationIdFromSearchQuery(
     return undefined;
   }
 
-  const pattern = /gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s]+))/g;
+  const pattern = /(?<![!])gen_ai\.conversation\.id:(?:"([^"]+)"|([^\s]+))/g;
   const matches = [...query.matchAll(pattern)];
   if (matches.length !== 1) {
     return undefined;
   }
 
-  return matches[0][1] ?? matches[0][2];
+  const conversationId = matches[0][1] ?? matches[0][2];
+  if (conversationId.startsWith("[")) {
+    return undefined;
+  }
+
+  return conversationId;
 }
 
 /**


### PR DESCRIPTION
## Summary

When `search_events` is called with a query containing a single `gen_ai.conversation.id` filter, the "View in Sentry" link now points to the dedicated AI Conversations page (`/explore/conversations/{id}/`) instead of the generic traces explorer.

## Motivation

The `get_ai_conversation_details` tool already uses the correct conversations URL via `getAIConversationUrl()`, but `search_events` always built links through `getEventsExplorerUrl()`, producing a worse UX for AI conversation queries.

Fixes #1034

## Changes

- Add `extractConversationIdFromSearchQuery()` helper in `url-utils.ts`
- In `search-events.ts`, use `getAIConversationUrl()` when exactly one conversation ID is detected in the resolved query
- Add unit tests for the extraction helper (quoted/unquoted IDs, absent/multiple IDs)

## Tests

- `pnpm --filter @sentry/mcp-core test -- src/utils/url-utils.test.ts` — passed
- Full mcp-core suite: **1214/1214** passed

## Notes

- Only overrides the link when the query contains exactly one `gen_ai.conversation.id` filter; OR queries with multiple IDs still use the traces explorer URL
- Conversation URL intentionally omits time/project filters since the conversation page is the primary resource for this query shape