### PR TITLE
fix: surface user identity in AI conversations and default error search fields

### DIFF
--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -223,6 +223,8 @@ Current expected behavior:
   default `statsPeriod` or explicit `start` and `end` values.
 - User and assistant message events are extracted from GenAI input/output
   fields.
+- User message events include `userEmail` when the source span has
+  `user.email`.
 - Tool call events are represented as first-class timeline events, not nested
   under a synthetic turn.
 - Each timeline event includes enough trace context to debug it, including

--- a/docs/specs/search-events.md
+++ b/docs/specs/search-events.md
@@ -69,6 +69,7 @@ search_events({
 4. **Executes** discover endpoint: `/organizations/{org}/events/` with:
    - Translated query string
    - Dataset-specific field selection
+   - Default error field selection includes `user.email` and `user.id`
    - Numeric project ID (converted from slug if provided)
    - Public dataset normalization (`metrics` maps to the current API dataset `tracemetrics`)
 5. **Returns** formatted results with:

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -837,6 +837,9 @@
                   "traceId": {
                     "type": "string"
                   },
+                  "userEmail": {
+                    "type": "string"
+                  },
                   "metadata": {
                     "type": "object",
                     "properties": {

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
@@ -140,6 +140,7 @@ describe("get_ai_conversation_details", () => {
             "timestamp": 1713805400000,
             "traceId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "type": "message",
+            "userEmail": "dev@example.com",
           },
           {
             "content": "The checkout worker is timing out.",
@@ -197,6 +198,33 @@ describe("get_ai_conversation_details", () => {
         "url": "https://test-org.sentry.io/explore/conversations/conv-123/",
       }
     `);
+  });
+
+  it("omits userEmail from user messages when span has no user.email", async () => {
+    const spansWithoutEmail = conversationSpans.map((span) => {
+      const { "user.email": _userEmail, ...rest } = span;
+      return rest;
+    });
+    mockConversationEndpoint("test-org", "conv-123", spansWithoutEmail);
+
+    const result = await getAIConversationDetails.handler(
+      {
+        organizationSlug: "test-org",
+        conversationId: "conv-123",
+      },
+      baseContext,
+    );
+
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    const userMessages = structuredContent.timeline.filter(
+      (event: { type: string; role?: string }) =>
+        event.type === "message" && event.role === "user",
+    );
+    expect(userMessages).toHaveLength(2);
+    for (const message of userMessages) {
+      expect(message).not.toHaveProperty("userEmail");
+    }
   });
 
   it("resolves an Explore conversation URL through get_sentry_resource", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
@@ -200,9 +200,12 @@ describe("get_ai_conversation_details", () => {
     `);
   });
 
-  it("omits userEmail from user messages when span has no user.email", async () => {
+  it("omits userEmail from user messages when span has no user.email or null user.email", async () => {
     const spansWithoutEmail = conversationSpans.map((span) => {
       const { "user.email": _userEmail, ...rest } = span;
+      if ("user.email" in span) {
+        return { ...rest, "user.email": null };
+      }
       return rest;
     });
     mockConversationEndpoint("test-org", "conv-123", spansWithoutEmail);
@@ -216,10 +219,11 @@ describe("get_ai_conversation_details", () => {
     );
 
     assertStructuredOnlyResult(result);
-    const structuredContent = getStructuredContent(result);
+    const structuredContent = getStructuredContent<{
+      timeline: Array<{ type: string; role?: string; userEmail?: string }>;
+    }>(result);
     const userMessages = structuredContent.timeline.filter(
-      (event: { type: string; role?: string }) =>
-        event.type === "message" && event.role === "user",
+      (event) => event.type === "message" && event.role === "user",
     );
     expect(userMessages).toHaveLength(2);
     for (const message of userMessages) {

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.ts
@@ -30,6 +30,7 @@ type ConversationMessage = {
   timestamp: number;
   spanId: string;
   traceId: string;
+  userEmail?: string;
   metadata?: {
     agentName?: string;
     model?: string;
@@ -71,6 +72,7 @@ const conversationMessageSchema = z.object({
   timestamp: z.number(),
   spanId: z.string(),
   traceId: z.string(),
+  userEmail: z.string().optional(),
   metadata: z
     .object({
       agentName: z.string().optional(),
@@ -314,6 +316,7 @@ function buildMessageEvents(span: AIConversationSpan): ConversationMessage[] {
         timestamp: timestampMs(span["precise.start_ts"]),
         spanId: span.span_id,
         traceId: span.trace,
+        userEmail: span["user.email"],
         metadata: undefined,
       }),
     );

--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -3,7 +3,6 @@ import { http, HttpResponse } from "msw";
 import { mswServer } from "@sentry/mcp-server-mocks";
 import searchEvents from "./search-events";
 import { MAX_EVENTS_VALIDATION_ATTEMPTS } from "../support/search-events/utils";
-import { RECOMMENDED_FIELDS } from "../support/search-events/config";
 import { generateText } from "ai";
 import { UserInputError } from "../../errors";
 
@@ -28,12 +27,6 @@ vi.mock("ai", async (importOriginal) => {
 
 describe("search_events", () => {
   const mockGenerateText = vi.mocked(generateText);
-
-  it("includes user identity in the default errors field set", () => {
-    expect(RECOMMENDED_FIELDS.errors.basic).toEqual(
-      expect.arrayContaining(["user.email", "user.id"]),
-    );
-  });
 
   // Helper to create AI response for different datasets
   const mockAIResponse = (
@@ -1536,6 +1529,12 @@ describe("search_events", () => {
         ({ request }) => {
           const url = new URL(request.url);
           expect(url.searchParams.get("dataset")).toBe("errors");
+          expect(url.searchParams.getAll("field")).toEqual([
+            "issue",
+            "title",
+            "level",
+            "timestamp",
+          ]);
           return HttpResponse.json({
             data: [
               {
@@ -1578,6 +1577,63 @@ describe("search_events", () => {
     expect(mockGenerateText).toHaveBeenCalled();
     expect(result).toContain("Database Connection Error");
     expect(result).toContain("PROJ-123");
+  });
+
+  it("includes user identity in default error search fields", async () => {
+    mockGenerateText.mockResolvedValueOnce(
+      mockAIResponse("errors", "level:error", []),
+    );
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("errors");
+          expect(url.searchParams.getAll("field")).toEqual(
+            expect.arrayContaining(["user.email", "user.id"]),
+          );
+          return HttpResponse.json({
+            data: [
+              {
+                id: "error1",
+                issue: "PROJ-123",
+                title: "Database Connection Error",
+                "user.email": "dev@example.com",
+                "user.id": "123",
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query: "database errors",
+        dataset: "errors",
+        fields: null,
+        sort: "-timestamp",
+        statsPeriod: "14d",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toContain("dev@example.com");
+    expect(result).toContain("user.id");
   });
 
   it("should format object fields without [object Object] output", async () => {

--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw";
 import { mswServer } from "@sentry/mcp-server-mocks";
 import searchEvents from "./search-events";
 import { MAX_EVENTS_VALIDATION_ATTEMPTS } from "../support/search-events/utils";
+import { RECOMMENDED_FIELDS } from "../support/search-events/config";
 import { generateText } from "ai";
 import { UserInputError } from "../../errors";
 
@@ -27,6 +28,12 @@ vi.mock("ai", async (importOriginal) => {
 
 describe("search_events", () => {
   const mockGenerateText = vi.mocked(generateText);
+
+  it("includes user identity in the default errors field set", () => {
+    expect(RECOMMENDED_FIELDS.errors.basic).toEqual(
+      expect.arrayContaining(["user.email", "user.id"]),
+    );
+  });
 
   // Helper to create AI response for different datasets
   const mockAIResponse = (

--- a/packages/mcp-core/src/tools/support/search-events/config.ts
+++ b/packages/mcp-core/src/tools/support/search-events/config.ts
@@ -853,6 +853,8 @@ export const RECOMMENDED_FIELDS = {
       "message",
       "error.type",
       "culprit",
+      "user.email",
+      "user.id",
     ],
     description:
       "Basic error information including issue ID, title, timestamp, severity, and location",


### PR DESCRIPTION
## Summary

Expose `user.email` on user timeline messages in `get_ai_conversation_details`, and include `user.email` / `user.id` in the default `search_events` error field set.

## Motivation

When debugging AI agent runs (e.g. Seer), maintainers could not tie failures back to specific users because:

1. `get_ai_conversation_details` collected `user.email` from spans but did not project it into the timeline messages agents actually read.
2. `search_events` default error fields omitted user identity, so error listings lacked user context unless explicitly requested.

Fixes #1033

## Changes

- Add optional `userEmail` to conversation timeline user messages (from `span["user.email"]`, omitted when absent).
- Extend `RECOMMENDED_FIELDS.errors.basic` with `user.email` and `user.id`.
- Regenerate `toolDefinitions.json` for the updated output schema.
- Add regression tests and snapshot update.

## Tests

```bash
pnpm --filter @sentry/mcp-core test -- src/tools/catalog/get-ai-conversation-details.test.ts src/tools/catalog/search-events.test.ts
```

Result: **1212 passed** (mcp-core suite)

## Notes

- `userEmail` is only included when present on the span; no placeholder values.
- This restores debugging context already available in Sentry spans under existing `event:read` scopes.
