### PR TITLE
chore: Generate definitions before commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "biome lint && pnpm run lint:ast-grep",
     "lint:ast-grep": "ast-grep scan && ast-grep test --skip-snapshot-tests",
     "lint:fix": "biome lint --fix",
+    "pre-commit:generated": "node scripts/pre-commit-generated.mjs",
     "inspector": "pnpx @modelcontextprotocol/inspector@latest",
     "inspector:stdio": "pnpx @modelcontextprotocol/inspector@latest -- tsx packages/mcp-server/src/index.ts",
     "measure-tokens": "pnpm run --filter ./packages/mcp-core measure-tokens",
@@ -61,7 +62,7 @@
     "vitest-evals": "catalog:"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm exec lint-staged --concurrent false"
+    "pre-commit": "pnpm run pre-commit:generated && pnpm exec lint-staged --concurrent false"
   },
   "lint-staged": {
     "*": [

--- a/scripts/pre-commit-generated.mjs
+++ b/scripts/pre-commit-generated.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const GENERATED_TASKS = [
+  {
+    name: "MCP tool and skill definitions",
+    command: ["pnpm", "--filter", "@sentry/mcp-core", "generate-definitions"],
+    inputs: [
+      /^packages\/mcp-core\/src\/tools\/(?!.*\.test\.ts$).*\.ts$/,
+      /^packages\/mcp-core\/src\/skills\.ts$/,
+      /^packages\/mcp-core\/src\/tools\/surfaces\.ts$/,
+      /^packages\/mcp-core\/src\/tools\/types\.ts$/,
+      /^packages\/mcp-core\/src\/internal\/tool-helpers\/tool-call-formatting\.ts$/,
+      /^packages\/mcp-core\/scripts\/generate-definitions\.ts$/,
+      /^plugins\/sentry-mcp\/agents\/sentry-mcp\.md$/,
+      /^plugins\/sentry-mcp-experimental\/agents\/sentry-mcp\.md$/,
+    ],
+    outputs: [
+      "packages/mcp-core/src/toolDefinitions.json",
+      "packages/mcp-core/src/skillDefinitions.json",
+      "plugins/sentry-mcp/agents/sentry-mcp.md",
+      "plugins/sentry-mcp-experimental/agents/sentry-mcp.md",
+    ],
+  },
+];
+
+function run(command, options = {}) {
+  execFileSync(command[0], command.slice(1), {
+    stdio: options.stdio ?? "inherit",
+  });
+}
+
+function getStagedFiles() {
+  const output = execFileSync(
+    "git",
+    ["diff", "--cached", "--name-only", "--diff-filter=ACMRD"],
+    { encoding: "utf8" },
+  );
+
+  return output.split("\n").filter(Boolean);
+}
+
+const stagedFiles = getStagedFiles();
+
+if (stagedFiles.length === 0) {
+  process.exit(0);
+}
+
+let ranTask = false;
+
+for (const task of GENERATED_TASKS) {
+  const shouldRun = stagedFiles.some((file) =>
+    task.inputs.some((pattern) => pattern.test(file)),
+  );
+
+  if (!shouldRun) {
+    continue;
+  }
+
+  console.log(`Generating ${task.name}...`);
+  run(task.command);
+  run(["git", "add", ...task.outputs]);
+  ranTask = true;
+}
+
+if (!ranTask) {
+  console.log("No generated files need updating for staged changes.");
+}

--- a/scripts/pre-commit-generated.mjs
+++ b/scripts/pre-commit-generated.mjs
@@ -89,7 +89,18 @@ for (const task of GENERATED_TASKS) {
   }
 
   console.log(`Generating ${task.name}...`);
-  const dirtyOutputsBeforeGeneration = new Set(getDirtyFiles(task.outputs));
+  const dirtyOutputsBeforeGeneration = getDirtyFiles(task.outputs);
+  if (dirtyOutputsBeforeGeneration.length > 0) {
+    console.error(
+      [
+        `Cannot generate ${task.name} with unstaged changes in generated outputs:`,
+        ...dirtyOutputsBeforeGeneration.map((file) => `  - ${file}`),
+        "Stage or discard those changes before committing.",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+
   run(task.command);
 
   // Only stage outputs that exist on disk, were clean before generation, and
@@ -99,7 +110,6 @@ for (const task of GENERATED_TASKS) {
   // previously dirty files avoids staging unrelated working-tree edits.
   const outputsToStage = task.outputs.filter((output) => {
     if (!existsSync(output)) return false;
-    if (dirtyOutputsBeforeGeneration.has(output)) return false;
     return hasWorkingTreeChanges(output);
   });
   if (outputsToStage.length > 0) {

--- a/scripts/pre-commit-generated.mjs
+++ b/scripts/pre-commit-generated.mjs
@@ -62,10 +62,10 @@ for (const task of GENERATED_TASKS) {
   console.log(`Generating ${task.name}...`);
   run(task.command);
 
-  // Only stage outputs that exist on disk and were actually changed by
-  // generation. Skipping missing files avoids a crash when an agent .md
-  // output is staged for deletion; skipping unchanged files avoids
-  // accidentally staging unrelated working-tree edits.
+  // Only stage outputs that exist on disk and currently differ from the index.
+  // Skipping missing files avoids a crash when an output is staged for deletion
+  // (e.g. via git rm) and the generator does not recreate it. Skipping clean
+  // files avoids unnecessary git-add calls when generation was a no-op.
   const outputsToStage = task.outputs.filter((output) => {
     if (!existsSync(output)) return false;
     try {

--- a/scripts/pre-commit-generated.mjs
+++ b/scripts/pre-commit-generated.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 
 const GENERATED_TASKS = [
   {
@@ -60,7 +61,23 @@ for (const task of GENERATED_TASKS) {
 
   console.log(`Generating ${task.name}...`);
   run(task.command);
-  run(["git", "add", ...task.outputs]);
+
+  // Only stage outputs that exist on disk and were actually changed by
+  // generation. Skipping missing files avoids a crash when an agent .md
+  // output is staged for deletion; skipping unchanged files avoids
+  // accidentally staging unrelated working-tree edits.
+  const outputsToStage = task.outputs.filter((output) => {
+    if (!existsSync(output)) return false;
+    try {
+      execFileSync("git", ["diff", "--quiet", output], { stdio: "pipe" });
+      return false; // no working-tree changes vs index
+    } catch {
+      return true; // has changes
+    }
+  });
+  if (outputsToStage.length > 0) {
+    run(["git", "add", ...outputsToStage]);
+  }
   ranTask = true;
 }
 

--- a/scripts/pre-commit-generated.mjs
+++ b/scripts/pre-commit-generated.mjs
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// Pre-commit generated-output dispatcher. It runs before lint-staged, owns
+// staging generated artifacts for staged generator inputs, refuses partially
+// staged inputs, and only stages generated outputs that were clean beforehand.
+
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 
@@ -10,8 +14,6 @@ const GENERATED_TASKS = [
     inputs: [
       /^packages\/mcp-core\/src\/tools\/(?!.*\.test\.ts$).*\.ts$/,
       /^packages\/mcp-core\/src\/skills\.ts$/,
-      /^packages\/mcp-core\/src\/tools\/surfaces\.ts$/,
-      /^packages\/mcp-core\/src\/tools\/types\.ts$/,
       /^packages\/mcp-core\/src\/internal\/tool-helpers\/tool-call-formatting\.ts$/,
       /^packages\/mcp-core\/scripts\/generate-definitions\.ts$/,
       /^plugins\/sentry-mcp\/agents\/sentry-mcp\.md$/,
@@ -26,9 +28,9 @@ const GENERATED_TASKS = [
   },
 ];
 
-function run(command, options = {}) {
+function run(command) {
   execFileSync(command[0], command.slice(1), {
-    stdio: options.stdio ?? "inherit",
+    stdio: "inherit",
   });
 }
 
@@ -42,6 +44,21 @@ function getStagedFiles() {
   return output.split("\n").filter(Boolean);
 }
 
+function hasWorkingTreeChanges(path) {
+  try {
+    execFileSync("git", ["diff", "--quiet", path], { stdio: "pipe" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function getDirtyFiles(files) {
+  return files.filter(
+    (file) => existsSync(file) && hasWorkingTreeChanges(file),
+  );
+}
+
 const stagedFiles = getStagedFiles();
 
 if (stagedFiles.length === 0) {
@@ -51,29 +68,39 @@ if (stagedFiles.length === 0) {
 let ranTask = false;
 
 for (const task of GENERATED_TASKS) {
-  const shouldRun = stagedFiles.some((file) =>
+  const stagedInputs = stagedFiles.filter((file) =>
     task.inputs.some((pattern) => pattern.test(file)),
   );
 
-  if (!shouldRun) {
+  if (stagedInputs.length === 0) {
     continue;
   }
 
+  const dirtyStagedInputs = getDirtyFiles(stagedInputs);
+  if (dirtyStagedInputs.length > 0) {
+    console.error(
+      [
+        `Cannot generate ${task.name} with unstaged changes in staged inputs:`,
+        ...dirtyStagedInputs.map((file) => `  - ${file}`),
+        "Stage or discard those changes before committing.",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+
   console.log(`Generating ${task.name}...`);
+  const dirtyOutputsBeforeGeneration = new Set(getDirtyFiles(task.outputs));
   run(task.command);
 
-  // Only stage outputs that exist on disk and currently differ from the index.
+  // Only stage outputs that exist on disk, were clean before generation, and
+  // currently differ from the index.
   // Skipping missing files avoids a crash when an output is staged for deletion
-  // (e.g. via git rm) and the generator does not recreate it. Skipping clean
-  // files avoids unnecessary git-add calls when generation was a no-op.
+  // (e.g. via git rm) and the generator does not recreate it. Skipping
+  // previously dirty files avoids staging unrelated working-tree edits.
   const outputsToStage = task.outputs.filter((output) => {
     if (!existsSync(output)) return false;
-    try {
-      execFileSync("git", ["diff", "--quiet", output], { stdio: "pipe" });
-      return false; // no working-tree changes vs index
-    } catch {
-      return true; // has changes
-    }
+    if (dirtyOutputsBeforeGeneration.has(output)) return false;
+    return hasWorkingTreeChanges(output);
   });
   if (outputsToStage.length > 0) {
     run(["git", "add", ...outputsToStage]);


### PR DESCRIPTION
Pre-commit now runs a generated-file dispatcher before lint-staged. When staged changes touch MCP tool, skill, definition-generator, or plugin agent prompt inputs, it regenerates the MCP tool and skill definitions and stages the known generated outputs so commits do not drift from the generated artifacts.

## What changed

- Added `scripts/pre-commit-generated.mjs` — the dispatcher that runs before lint-staged
- Hooked it into `package.json` pre-commit config alongside lint-staged
- Outputs are staged selectively: only paths that exist on disk **and** have actual changes vs the index are passed to `git add`, which fixes two edge cases:
  - **Crash on deleted agent files**: previously `git add` would be called on a path that no longer existed after a `git rm`, blocking the commit
  - **Accidental staging of unrelated edits**: previously all outputs were staged even when generation was a no-op, which could pull in unrelated working-tree changes

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B595QDZLL%3A1782495931.070289%22)