### PR TITLE
feat(agents): Add OpenRouter provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,14 @@
 # This file provides default environment variables for all packages.
 # Individual packages can override these values with their own .env files.
 
-# OpenAI API key for AI-powered search tools (search_events, search_issues)
-# Get yours at: https://platform.openai.com/api-keys
+# OpenRouter API key for AI-powered search tools (search_events, search_issues)
+# Get yours at: https://openrouter.ai/settings/keys
 # Required for natural language query translation features
-OPENAI_API_KEY=sk-proj-agenerate-this
+OPENROUTER_API_KEY=sk-or-generate-this
+
+# OpenAI is also supported if you prefer to use it directly.
+# Get yours at: https://platform.openai.com/api-keys
+# OPENAI_API_KEY=sk-proj-generate-this
 
 # For mcp-test-client: Anthropic API key for Claude access
 # ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ claude plugin install sentry-mcp@sentry-mcp-experimental
 
 While this repository is focused on acting as an MCP service, we also support a `stdio` transport. This is still a work in progress, but is the easiest way to adapt run the MCP against a self-hosted Sentry install.
 
-**Note:** The AI-powered search tools (`search_events`, `search_issues`, etc.) require an LLM provider (OpenAI or Anthropic). These tools use natural language processing to translate queries into Sentry's query syntax. Without a configured provider, these specific tools will be unavailable, but all other tools will function normally.
+**Note:** The AI-powered search tools (`search_events`, `search_issues`, etc.) require an LLM provider (OpenAI, Azure OpenAI, Anthropic, or OpenRouter). These tools use natural language processing to translate queries into Sentry's query syntax. Without a configured provider, these specific tools will be unavailable, but all other tools will function normally.
 
 To utilize the `stdio` transport, you'll need to create an User Auth Token in Sentry with the necessary scopes. As of writing this is:
 
@@ -76,9 +76,11 @@ npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.internal:9000 -
 SENTRY_ACCESS_TOKEN=         # Required: Your Sentry auth token
 
 # LLM Provider Configuration (required for AI-powered search tools)
-EMBEDDED_AGENT_PROVIDER=     # Required: 'openai' or 'anthropic'
+EMBEDDED_AGENT_PROVIDER=     # Required when multiple provider keys are set: 'openai', 'azure-openai', 'anthropic', or 'openrouter'
 OPENAI_API_KEY=              # Required if using OpenAI
 ANTHROPIC_API_KEY=           # Required if using Anthropic
+OPENROUTER_API_KEY=          # Required if using OpenRouter
+OPENROUTER_MODEL=            # Optional OpenRouter model, defaults to 'openai/gpt-5'
 
 # Optional overrides
 SENTRY_HOST=                 # For self-hosted deployments
@@ -162,7 +164,7 @@ To contribute changes, you'll need to set up your local environment:
 
 3. **Configure your credentials:**
 
-   - Edit `.env` in the root directory and add your `OPENAI_API_KEY`
+   - Edit `.env` in the root directory and add either `OPENAI_API_KEY` or `OPENROUTER_API_KEY`
    - Edit `packages/mcp-cloudflare/.env` and add:
      - `SENTRY_CLIENT_ID=your_development_sentry_client_id`
      - `SENTRY_CLIENT_SECRET=your_development_sentry_client_secret`
@@ -198,7 +200,8 @@ pnpm test
 
 ```shell
 # .env (in project root)
-OPENAI_API_KEY=  # Also required for AI-powered search tools in production
+OPENAI_API_KEY=      # Use OpenAI-backed AI-powered tools
+OPENROUTER_API_KEY=  # Or use OpenRouter-backed AI-powered tools
 ```
 
 Note: The root `.env` file provides defaults for all packages. Individual packages can have their own `.env` files to override these defaults during development.

--- a/docs/operations/embedded-agents.md
+++ b/docs/operations/embedded-agents.md
@@ -10,7 +10,7 @@ Sentry MCP uses embedded AI agents for the following tools:
 - `search_issue_events` - Search events within a specific issue
 - `use_sentry` - Unified natural language interface to all Sentry operations
 
-These tools require an LLM provider (OpenAI, Azure OpenAI, or Anthropic) to be configured.
+These tools require an LLM provider (OpenAI, Azure OpenAI, Anthropic, or OpenRouter) to be configured.
 
 ## Provider Selection
 
@@ -19,7 +19,7 @@ These tools require an LLM provider (OpenAI, Azure OpenAI, or Anthropic) to be c
 Always set `EMBEDDED_AGENT_PROVIDER` to explicitly specify your LLM provider:
 
 ```bash
-export EMBEDDED_AGENT_PROVIDER=openai   # or 'azure-openai' / 'anthropic'
+export EMBEDDED_AGENT_PROVIDER=openai   # or 'azure-openai' / 'anthropic' / 'openrouter'
 export OPENAI_API_KEY=sk-...            # corresponding API key
 ```
 
@@ -34,12 +34,13 @@ Sentry MCP resolves the LLM provider in this order:
    - `--agent-provider` CLI flag
 
 2. **Conflict detection**
-   - If both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are set without explicit provider selection, an error is thrown
+   - If multiple provider keys are set without explicit provider selection, an error is thrown
    - This prevents silent bugs when external tools inject API keys
 
 3. **Auto-detection** (lowest priority, **deprecated**)
    - If only `ANTHROPIC_API_KEY` is set → use Anthropic
    - If only `OPENAI_API_KEY` is set → use OpenAI
+   - If only `OPENROUTER_API_KEY` is set → use OpenRouter
    - A deprecation warning is logged when this fallback is used
 
 ### Configuration Methods
@@ -66,6 +67,16 @@ Or:
 ```bash
 export EMBEDDED_AGENT_PROVIDER=anthropic
 export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+For OpenRouter:
+
+```bash
+export OPENROUTER_API_KEY=sk-or-...
+# Optional; defaults to openai/gpt-5
+export OPENROUTER_MODEL=openai/gpt-5
+# Recommended, and required when multiple provider keys are set
+export EMBEDDED_AGENT_PROVIDER=openrouter
 ```
 
 #### Method 2: CLI Flag
@@ -136,12 +147,12 @@ Always set `EMBEDDED_AGENT_PROVIDER` when multiple API keys might be present:
 
 ## Error Messages
 
-### "Both API keys are set"
+### "Multiple LLM API keys are set"
 
 ```
-Error: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set.
+Error: Multiple LLM API keys are set.
 Please specify which provider to use by setting the EMBEDDED_AGENT_PROVIDER
-environment variable to 'openai', 'azure-openai', or 'anthropic'.
+environment variable to 'openai', 'azure-openai', 'anthropic', or 'openrouter'.
 ```
 
 **Cause:** Multiple API keys detected without explicit provider selection.
@@ -163,7 +174,7 @@ Please set the API key environment variable.
 
 ```
 Error: No embedded agent provider configured.
-Set OPENAI_API_KEY or ANTHROPIC_API_KEY environment variable,
+Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY environment variable,
 or use --agent-provider flag to specify a provider.
 ```
 
@@ -208,6 +219,9 @@ export OPENAI_MODEL=gpt-4
 
 # Anthropic (default: claude-opus-4-5-20251101)
 export ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+
+# OpenRouter (default: openai/gpt-5)
+export OPENROUTER_MODEL=anthropic/claude-sonnet-4
 ```
 
 ### Verify Configuration
@@ -228,6 +242,11 @@ Or:
 Using anthropic for AI-powered search tools (auto-detected).
 ```
 
+Or:
+```
+Using openrouter for AI-powered search tools (auto-detected).
+```
+
 ## Troubleshooting
 
 ### Provider not detected
@@ -236,12 +255,14 @@ Using anthropic for AI-powered search tools (auto-detected).
 ```bash
 echo $ANTHROPIC_API_KEY
 echo $OPENAI_API_KEY
+echo $OPENROUTER_API_KEY
 echo $EMBEDDED_AGENT_PROVIDER
 ```
 
 **Verify API key format:**
 - OpenAI: `sk-...` (starts with `sk-`)
 - Anthropic: `sk-ant-...` (starts with `sk-ant-`)
+- OpenRouter: `sk-or-...` (starts with `sk-or-`)
 
 ### External tool conflicts
 

--- a/docs/specs/search-events.md
+++ b/docs/specs/search-events.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A unified search tool that accepts natural language queries and translates them to Sentry's discover endpoint parameters using OpenAI GPT-5. Replaces `find_errors` and `find_transactions` with a single, more flexible interface.
+A unified search tool that accepts natural language queries and translates them to Sentry's discover endpoint parameters using the configured embedded LLM provider. Replaces `find_errors` and `find_transactions` with a single, more flexible interface.
 
 ## Motivation
 
@@ -62,7 +62,7 @@ search_events({
 2. **Fetches searchable attributes** based on dataset:
    - For `spans`/`logs`/`metrics`: Uses `/organizations/{org}/trace-items/attributes/` endpoint with parallel calls for string and number attribute types
    - For `errors`: Uses `/organizations/{org}/tags/` endpoint (legacy, will migrate when new API supports errors)
-3. **OpenAI GPT-5 translates** natural language to Sentry query syntax using:
+3. **Configured LLM provider translates** natural language to Sentry query syntax using:
    - Comprehensive system prompt with Sentry query syntax rules
    - Dataset-specific field mappings and query patterns
    - Organization's custom attributes (fetched in step 2)
@@ -78,11 +78,11 @@ search_events({
 
 ## Key Implementation Details
 
-### OpenAI Integration
+### Embedded Agent Provider
 
-- **Model**: GPT-5 for natural language to Sentry query translation (configurable via `configureOpenAIProvider`)
+- **Default model**: GPT-5 for natural language to Sentry query translation
 - **System prompt**: Contains comprehensive Sentry query syntax, dataset-specific rules, and available fields
-- **Environment**: Requires `OPENAI_API_KEY` environment variable
+- **Environment**: Requires a configured embedded agent provider, such as `OPENAI_API_KEY` or `OPENROUTER_API_KEY`
 - **Custom attributes**: Automatically fetched and included in system prompt for each organization
 
 ### Dataset-Specific Translation
@@ -150,7 +150,7 @@ search_events({
 4. **Error Handling**:
    - ✅ Enhanced error messages with Sentry event IDs for debugging
    - ✅ Graceful handling of missing projects, API failures
-   - ✅ Clear error messages for missing OpenAI API key
+   - ✅ Clear error messages for missing embedded agent provider key
 
 5. **Output Formatting**:
    - ✅ Dataset-specific rendering instructions for AI agents
@@ -173,6 +173,6 @@ search_events({
 
 ## Dependencies
 
-- **Runtime**: OpenAI API key required (`OPENAI_API_KEY` environment variable)
+- **Runtime**: Embedded agent provider key required, such as `OPENAI_API_KEY` or `OPENROUTER_API_KEY`
 - **Build**: @ai-sdk/openai, ai packages added to dependencies
-- **Testing**: Comprehensive mocks for OpenAI and Sentry APIs
+- **Testing**: Comprehensive mocks for LLM provider and Sentry APIs

--- a/packages/mcp-cloudflare/.env.example
+++ b/packages/mcp-cloudflare/.env.example
@@ -13,10 +13,14 @@ SENTRY_CLIENT_SECRET=
 # Example: openssl rand -base64 32
 COOKIE_SECRET=thisisasecret
 
-# OpenAI API key for AI-powered search tools (search_events, search_issues)
-# Get yours at: https://platform.openai.com/api-keys
+# OpenRouter API key for AI-powered search tools (search_events, search_issues)
+# Get yours at: https://openrouter.ai/settings/keys
 # Required for natural language query translation features
-OPENAI_API_KEY=sk-proj-generate-this
+OPENROUTER_API_KEY=sk-or-generate-this
+
+# OpenAI is also supported if you prefer to use it directly.
+# Get yours at: https://platform.openai.com/api-keys
+# OPENAI_API_KEY=sk-proj-generate-this
 
 # The URL where your MCP server is hosted
 # Local development: http://localhost:5173

--- a/packages/mcp-core/README.md
+++ b/packages/mcp-core/README.md
@@ -7,7 +7,7 @@ This package is primarily for running the `stdio` MCP server. If you do not know
 <https://mcp.sentry.dev>
 
 **Note:** Some tools require additional configuration:
-- **AI-powered search tools** (`search_events` and `search_issues`): These tools use OpenAI to translate natural language queries into Sentry's query syntax. They require an `OPENAI_API_KEY` environment variable. Without this key, these specific tools will be unavailable, but all other tools will function normally.
+- **AI-powered search tools** (`search_events` and `search_issues`): These tools use a configured LLM provider to translate natural language queries into Sentry's query syntax. Set one provider key, such as `OPENAI_API_KEY` or `OPENROUTER_API_KEY`. Without a provider key, these specific tools will be unavailable, but all other tools will function normally.
 
 ## Authorization
 
@@ -75,9 +75,11 @@ MCP_SKILLS=inspect,docs,triage         # Limit to specific skills
 MCP_SCOPES=org:read,event:read         # Override default scopes (replaces defaults) - DEPRECATED, use MCP_SKILLS
 MCP_ADD_SCOPES=event:write             # Add to default scopes (keeps defaults) - DEPRECATED, use MCP_SKILLS
 
-# OpenAI configuration for AI-powered search tools
-OPENAI_API_KEY=your-openai-key         # Required for AI-powered search tools (search_events, search_issues)
+# LLM provider configuration for AI-powered search tools
+OPENAI_API_KEY=your-openai-key         # Use OpenAI for AI-powered search tools
 OPENAI_MODEL=gpt-5                     # OpenAI model to use (default: "gpt-5")
+OPENROUTER_API_KEY=your-openrouter-key # Or use OpenRouter for AI-powered search tools
+OPENROUTER_MODEL=openai/gpt-5          # OpenRouter model to use (default: "openai/gpt-5")
 OPENAI_REASONING_EFFORT=low            # Reasoning effort for o1 models: "low", "medium", "high", or "" to disable (default: "low")
 
 # No environment variable exists for the OpenAI base URL override; use --openai-base-url instead.

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -117,6 +117,10 @@
       "types": "./dist/internal/agents/anthropic-provider.d.ts",
       "default": "./dist/internal/agents/anthropic-provider.js"
     },
+    "./internal/agents/openrouter-provider": {
+      "types": "./dist/internal/agents/openrouter-provider.d.ts",
+      "default": "./dist/internal/agents/openrouter-provider.js"
+    },
     "./internal/agents/provider-factory": {
       "types": "./dist/internal/agents/provider-factory.d.ts",
       "default": "./dist/internal/agents/provider-factory.js"

--- a/packages/mcp-core/src/internal/agents/azure-openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/azure-openai-provider.test.ts
@@ -11,12 +11,15 @@ import {
 describe("azure-openai-provider", () => {
   const originalModel = process.env.OPENAI_MODEL;
   const originalApiKey = process.env.OPENAI_API_KEY;
+  const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
   const originalApiVersion = process.env.OPENAI_API_VERSION;
 
   beforeEach(() => {
     setAzureOpenAIBaseUrl(undefined);
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.OPENAI_MODEL;
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENROUTER_API_KEY;
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.OPENAI_API_VERSION;
   });
@@ -34,6 +37,13 @@ describe("azure-openai-provider", () => {
       delete process.env.OPENAI_API_KEY;
     } else {
       process.env.OPENAI_API_KEY = originalApiKey;
+    }
+
+    if (originalOpenRouterApiKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
     }
 
     if (originalApiVersion === undefined) {

--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
@@ -36,6 +36,7 @@ describe("callEmbeddedAgent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENROUTER_API_KEY = "";
   });
 
   it("throws LLMProviderError for OpenAI region restriction", async () => {

--- a/packages/mcp-core/src/internal/agents/openai-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openai-provider.test.ts
@@ -6,12 +6,15 @@ import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider.js";
 describe("openai-provider", () => {
   const originalModel = process.env.OPENAI_MODEL;
   const originalApiKey = process.env.OPENAI_API_KEY;
+  const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
   const originalApiVersion = process.env.OPENAI_API_VERSION;
 
   beforeEach(() => {
     setOpenAIBaseUrl(undefined);
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.OPENAI_MODEL;
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENROUTER_API_KEY;
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.OPENAI_API_VERSION;
   });
@@ -29,6 +32,13 @@ describe("openai-provider", () => {
       delete process.env.OPENAI_API_KEY;
     } else {
       process.env.OPENAI_API_KEY = originalApiKey;
+    }
+
+    if (originalOpenRouterApiKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
     }
 
     if (originalApiVersion === undefined) {

--- a/packages/mcp-core/src/internal/agents/openrouter-provider.test.ts
+++ b/packages/mcp-core/src/internal/agents/openrouter-provider.test.ts
@@ -1,0 +1,92 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { generateText } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getOpenRouterModel } from "./openrouter-provider.js";
+
+describe("openrouter-provider", () => {
+  const originalApiKey = process.env.OPENROUTER_API_KEY;
+  const originalModel = process.env.OPENROUTER_MODEL;
+
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENROUTER_MODEL;
+  });
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalApiKey;
+    }
+
+    if (originalModel === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_MODEL;
+    } else {
+      process.env.OPENROUTER_MODEL = originalModel;
+    }
+
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the OpenRouter chat completions endpoint", async () => {
+    let requestUrl: string | undefined;
+    let authorization: string | null = null;
+
+    const fetchMock = vi.fn(
+      async (input: Request | URL | string, init?: RequestInit) => {
+        const request =
+          input instanceof Request
+            ? new Request(input, init)
+            : new Request(input.toString(), init);
+        requestUrl = request.url;
+        authorization = request.headers.get("authorization");
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "boom",
+              type: "invalid_request_error",
+              param: null,
+              code: "bad_request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      generateText({
+        model: getOpenRouterModel(),
+        prompt: "hello",
+      }),
+    ).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(requestUrl).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(authorization).toBe("Bearer test-openrouter-key");
+  });
+
+  it("uses default and configured models", () => {
+    expect((getOpenRouterModel() as LanguageModelV3).modelId).toBe(
+      "openai/gpt-5",
+    );
+
+    process.env.OPENROUTER_MODEL = "anthropic/claude-sonnet-4";
+
+    expect((getOpenRouterModel() as LanguageModelV3).modelId).toBe(
+      "anthropic/claude-sonnet-4",
+    );
+    expect(
+      (getOpenRouterModel("google/gemini-2.5-pro") as LanguageModelV3).modelId,
+    ).toBe("google/gemini-2.5-pro");
+  });
+});

--- a/packages/mcp-core/src/internal/agents/openrouter-provider.ts
+++ b/packages/mcp-core/src/internal/agents/openrouter-provider.ts
@@ -1,0 +1,25 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
+import { USER_AGENT } from "../../version";
+
+const DEFAULT_OPENROUTER_MODEL = "openai/gpt-5";
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+/**
+ * Builds an OpenRouter chat-completions model for embedded agent calls.
+ */
+export function getOpenRouterModel(model?: string): LanguageModel {
+  const factory = createOpenAI({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseURL: OPENROUTER_BASE_URL,
+    headers: {
+      "User-Agent": USER_AGENT,
+      "HTTP-Referer": "https://github.com/getsentry/sentry-mcp",
+      "X-OpenRouter-Title": "Sentry MCP",
+    },
+  });
+
+  return factory.chat(
+    model ?? process.env.OPENROUTER_MODEL ?? DEFAULT_OPENROUTER_MODEL,
+  );
+}

--- a/packages/mcp-core/src/internal/agents/provider-factory.test.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.test.ts
@@ -10,6 +10,7 @@ import { ConfigurationError } from "../../errors.js";
 describe("provider-factory", () => {
   const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
   const originalOpenAIKey = process.env.OPENAI_API_KEY;
+  const originalOpenRouterKey = process.env.OPENROUTER_API_KEY;
   const originalProviderEnv = process.env.EMBEDDED_AGENT_PROVIDER;
 
   beforeEach(() => {
@@ -21,6 +22,8 @@ describe("provider-factory", () => {
     delete process.env.ANTHROPIC_API_KEY;
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.OPENAI_API_KEY;
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENROUTER_API_KEY;
     // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
     delete process.env.EMBEDDED_AGENT_PROVIDER;
   });
@@ -38,6 +41,12 @@ describe("provider-factory", () => {
       delete process.env.OPENAI_API_KEY;
     } else {
       process.env.OPENAI_API_KEY = originalOpenAIKey;
+    }
+    if (originalOpenRouterKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterKey;
     }
     if (originalProviderEnv === undefined) {
       // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
@@ -62,6 +71,13 @@ describe("provider-factory", () => {
 
       const provider = getAgentProvider();
       expect(provider.type).toBe("openai");
+    });
+
+    it("detects openrouter when only OPENROUTER_API_KEY is set", () => {
+      process.env.OPENROUTER_API_KEY = "sk-or-test";
+
+      const provider = getAgentProvider();
+      expect(provider.type).toBe("openrouter");
     });
 
     it("returns undefined from getResolvedProviderType when no API keys", () => {
@@ -106,6 +122,16 @@ describe("provider-factory", () => {
       expect(provider.type).toBe("azure-openai");
     });
 
+    it("uses openrouter when multiple keys are present and EMBEDDED_AGENT_PROVIDER=openrouter", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+      process.env.OPENAI_API_KEY = "sk-test";
+      process.env.OPENROUTER_API_KEY = "sk-or-test";
+      process.env.EMBEDDED_AGENT_PROVIDER = "openrouter";
+
+      const provider = getAgentProvider();
+      expect(provider.type).toBe("openrouter");
+    });
+
     it("uses openai when both keys present and setAgentProvider called", () => {
       process.env.ANTHROPIC_API_KEY = "sk-ant-test";
       process.env.OPENAI_API_KEY = "sk-test";
@@ -137,14 +163,12 @@ describe("provider-factory", () => {
       process.env.ANTHROPIC_API_KEY = "sk-ant-test";
       process.env.OPENAI_API_KEY = "sk-test";
 
-      expect(() => getAgentProvider()).toThrow(
-        /Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set/,
-      );
+      expect(() => getAgentProvider()).toThrow(/Multiple LLM API keys are set/);
       expect(() => getAgentProvider()).toThrow(
         /EMBEDDED_AGENT_PROVIDER environment variable/,
       );
       expect(() => getAgentProvider()).toThrow(
-        /'openai', 'azure-openai', or 'anthropic'/,
+        /'openai', 'azure-openai', 'anthropic', or 'openrouter'/,
       );
     });
 
@@ -172,6 +196,13 @@ describe("provider-factory", () => {
 
       const providerType = getResolvedProviderType();
       expect(providerType).toBeUndefined();
+    });
+
+    it("throws ConfigurationError when explicit openrouter lacks API key", () => {
+      process.env.EMBEDDED_AGENT_PROVIDER = "openrouter";
+
+      expect(() => getAgentProvider()).toThrow(ConfigurationError);
+      expect(() => getAgentProvider()).toThrow(/OPENROUTER_API_KEY is not set/);
     });
 
     it("throws ConfigurationError when azure-openai lacks a supported base URL", () => {
@@ -245,6 +276,13 @@ describe("provider-factory", () => {
 
       const provider = getAgentProvider();
       expect(provider.label).toBe("azure-openai chat completions API");
+    });
+
+    it("labels openrouter", () => {
+      process.env.OPENROUTER_API_KEY = "sk-or-test";
+
+      const provider = getAgentProvider();
+      expect(provider.label).toBe("openrouter");
     });
   });
 });

--- a/packages/mcp-core/src/internal/agents/provider-factory.ts
+++ b/packages/mcp-core/src/internal/agents/provider-factory.ts
@@ -6,6 +6,7 @@ import {
 } from "./azure-openai-provider";
 import { getOpenAIModel, setOpenAIBaseUrl } from "./openai-provider";
 import { getAnthropicModel, setAnthropicBaseUrl } from "./anthropic-provider";
+import { getOpenRouterModel } from "./openrouter-provider";
 import { ConfigurationError } from "../../errors";
 
 // Module-level state for explicit provider selection
@@ -38,8 +39,11 @@ export function setProviderBaseUrls(config: {
  */
 function detectProviderConflict(): boolean {
   return (
-    Boolean(process.env.ANTHROPIC_API_KEY) &&
-    Boolean(process.env.OPENAI_API_KEY)
+    [
+      process.env.ANTHROPIC_API_KEY,
+      process.env.OPENAI_API_KEY,
+      process.env.OPENROUTER_API_KEY,
+    ].filter(Boolean).length > 1
   );
 }
 
@@ -53,6 +57,8 @@ function hasApiKeyForProvider(type: AgentProviderType): boolean {
     case "openai":
     case "azure-openai":
       return Boolean(process.env.OPENAI_API_KEY);
+    case "openrouter":
+      return Boolean(process.env.OPENROUTER_API_KEY);
   }
 }
 
@@ -66,6 +72,8 @@ function getApiKeyName(type: AgentProviderType): string {
     case "openai":
     case "azure-openai":
       return "OPENAI_API_KEY";
+    case "openrouter":
+      return "OPENROUTER_API_KEY";
   }
 }
 
@@ -115,6 +123,18 @@ function buildProvider(type: AgentProviderType): EmbeddedAgentProvider {
         }),
       };
     }
+    case "openrouter":
+      return {
+        type: "openrouter",
+        label: "openrouter",
+        getModel: getOpenRouterModel,
+        getProviderOptions: () => ({
+          openai: {
+            structuredOutputs: false,
+            strictJsonSchema: false,
+          },
+        }),
+      };
   }
 }
 
@@ -133,7 +153,8 @@ function resolveProviderType(): AgentProviderType | undefined {
   if (
     envProvider === "openai" ||
     envProvider === "azure-openai" ||
-    envProvider === "anthropic"
+    envProvider === "anthropic" ||
+    envProvider === "openrouter"
   ) {
     return envProvider;
   }
@@ -146,6 +167,7 @@ function resolveProviderType(): AgentProviderType | undefined {
   // 4. Auto-detect
   if (process.env.ANTHROPIC_API_KEY) return "anthropic";
   if (process.env.OPENAI_API_KEY) return "openai";
+  if (process.env.OPENROUTER_API_KEY) return "openrouter";
 
   return undefined;
 }
@@ -173,8 +195,8 @@ export function getAgentProvider(): EmbeddedAgentProvider {
   // Check for conflicts when both API keys are present
   if (!providerType && detectProviderConflict()) {
     throw new ConfigurationError(
-      "Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set. " +
-        "Please specify which provider to use by setting the EMBEDDED_AGENT_PROVIDER environment variable to 'openai', 'azure-openai', or 'anthropic'.",
+      "Multiple LLM API keys are set. " +
+        "Please specify which provider to use by setting the EMBEDDED_AGENT_PROVIDER environment variable to 'openai', 'azure-openai', 'anthropic', or 'openrouter'.",
     );
   }
 
@@ -182,7 +204,7 @@ export function getAgentProvider(): EmbeddedAgentProvider {
   if (!providerType) {
     throw new ConfigurationError(
       "No embedded agent provider configured. " +
-        "Set OPENAI_API_KEY or ANTHROPIC_API_KEY environment variable, " +
+        "Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY environment variable, " +
         "or use --agent-provider flag to specify a provider.",
     );
   }

--- a/packages/mcp-core/src/internal/agents/types.ts
+++ b/packages/mcp-core/src/internal/agents/types.ts
@@ -8,7 +8,11 @@ export type ProviderOptions = Record<string, Record<string, JSONValue>>;
 /**
  * Supported embedded agent provider types.
  */
-export type AgentProviderType = "openai" | "azure-openai" | "anthropic";
+export type AgentProviderType =
+  | "openai"
+  | "azure-openai"
+  | "anthropic"
+  | "openrouter";
 
 /**
  * Interface for embedded agent providers.

--- a/packages/mcp-core/src/tools/catalog/get-sentry-resource.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-sentry-resource.test.ts
@@ -15,6 +15,7 @@ import getSentryResource from "./get-sentry-resource.js";
 
 const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
 const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 const originalEmbeddedAgentProvider = process.env.EMBEDDED_AGENT_PROVIDER;
 
 const baseContext = {
@@ -117,6 +118,7 @@ describe("get_sentry_resource", () => {
   beforeEach(() => {
     Reflect.deleteProperty(process.env, "OPENAI_API_KEY");
     Reflect.deleteProperty(process.env, "ANTHROPIC_API_KEY");
+    Reflect.deleteProperty(process.env, "OPENROUTER_API_KEY");
     Reflect.deleteProperty(process.env, "EMBEDDED_AGENT_PROVIDER");
   });
 
@@ -131,6 +133,12 @@ describe("get_sentry_resource", () => {
       Reflect.deleteProperty(process.env, "ANTHROPIC_API_KEY");
     } else {
       process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+    }
+
+    if (originalOpenRouterApiKey === undefined) {
+      Reflect.deleteProperty(process.env, "OPENROUTER_API_KEY");
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
     }
 
     if (originalEmbeddedAgentProvider === undefined) {

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
@@ -11,6 +11,7 @@ import getTraceDetails from "./get-trace-details.js";
 
 const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
 const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 const originalEmbeddedAgentProvider = process.env.EMBEDDED_AGENT_PROVIDER;
 
 /** Register the same handler on sentry.io and us.sentry.io (org fixture resolves region). */
@@ -106,6 +107,7 @@ describe("get_trace_details", () => {
   beforeEach(() => {
     process.env.OPENAI_API_KEY = "test-key";
     Reflect.deleteProperty(process.env, "ANTHROPIC_API_KEY");
+    Reflect.deleteProperty(process.env, "OPENROUTER_API_KEY");
     Reflect.deleteProperty(process.env, "EMBEDDED_AGENT_PROVIDER");
   });
 
@@ -120,6 +122,12 @@ describe("get_trace_details", () => {
       Reflect.deleteProperty(process.env, "ANTHROPIC_API_KEY");
     } else {
       process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+    }
+
+    if (originalOpenRouterApiKey === undefined) {
+      Reflect.deleteProperty(process.env, "OPENROUTER_API_KEY");
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
     }
 
     if (originalEmbeddedAgentProvider === undefined) {
@@ -242,6 +250,7 @@ describe("get_trace_details", () => {
   it("falls back to direct search_events guidance when agent search is unavailable", async () => {
     Reflect.deleteProperty(process.env, "OPENAI_API_KEY");
     Reflect.deleteProperty(process.env, "ANTHROPIC_API_KEY");
+    Reflect.deleteProperty(process.env, "OPENROUTER_API_KEY");
     Reflect.deleteProperty(process.env, "EMBEDDED_AGENT_PROVIDER");
 
     const result = await getTraceDetails.handler(
@@ -267,6 +276,7 @@ describe("get_trace_details", () => {
   it("does not show trace next-step tool calls when search_events is unavailable", async () => {
     Reflect.deleteProperty(process.env, "OPENAI_API_KEY");
     Reflect.deleteProperty(process.env, "ANTHROPIC_API_KEY");
+    Reflect.deleteProperty(process.env, "OPENROUTER_API_KEY");
     Reflect.deleteProperty(process.env, "EMBEDDED_AGENT_PROVIDER");
 
     const result = await getTraceDetails.handler(

--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -122,6 +122,7 @@ describe("search_events", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENROUTER_API_KEY = "";
     mockGenerateText.mockResolvedValue(mockAIResponse("errors"));
     mockValidEventsValidation();
   });
@@ -2281,6 +2282,7 @@ describe("search_events", () => {
   it("should search events with direct query syntax (no agent)", async () => {
     process.env.OPENAI_API_KEY = "";
     process.env.ANTHROPIC_API_KEY = "";
+    process.env.OPENROUTER_API_KEY = "";
 
     mswServer.use(
       http.get(
@@ -2767,6 +2769,7 @@ describe("search_events", () => {
   it("rejects search immediately when validation fails without an agent provider", async () => {
     process.env.OPENAI_API_KEY = "";
     process.env.ANTHROPIC_API_KEY = "";
+    process.env.OPENROUTER_API_KEY = "";
 
     mswServer.use(
       http.get(

--- a/packages/mcp-core/src/tools/catalog/search-issue-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-issue-events.test.ts
@@ -82,6 +82,7 @@ describe("search_issue_events", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENROUTER_API_KEY = "";
     mockGenerateText.mockResolvedValue(mockAIResponse());
   });
 
@@ -649,6 +650,7 @@ describe("search_issue_events", () => {
   it("should search events with direct query syntax (no agent)", async () => {
     process.env.OPENAI_API_KEY = "";
     process.env.ANTHROPIC_API_KEY = "";
+    process.env.OPENROUTER_API_KEY = "";
 
     mswServer.use(
       http.get("*/api/0/organizations/*/issues/*/events/", ({ request }) => {

--- a/packages/mcp-core/src/tools/catalog/search-issues.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-issues.test.ts
@@ -67,6 +67,7 @@ describe("search_issues", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENROUTER_API_KEY = "";
     mockGenerateText.mockResolvedValue(mockAIResponse());
   });
 
@@ -147,6 +148,7 @@ describe("search_issues", () => {
   it("should search issues with direct query syntax (no agent)", async () => {
     process.env.OPENAI_API_KEY = "";
     process.env.ANTHROPIC_API_KEY = "";
+    process.env.OPENROUTER_API_KEY = "";
 
     mswServer.use(
       http.get("*/api/0/organizations/*/issues/", ({ request }) => {
@@ -199,6 +201,7 @@ describe("search_issues", () => {
   it("omits update_issue guidance when update_issue is unavailable in the session", async () => {
     process.env.OPENAI_API_KEY = "";
     process.env.ANTHROPIC_API_KEY = "";
+    process.env.OPENROUTER_API_KEY = "";
 
     mswServer.use(
       http.get("*/api/0/organizations/*/issues/", ({ request }) => {

--- a/packages/mcp-server/src/cli/parse.test.ts
+++ b/packages/mcp-server/src/cli/parse.test.ts
@@ -57,6 +57,14 @@ describe("cli/parseArgv", () => {
     expect(parsed.agentProvider).toBe("azure-openai");
   });
 
+  it("parses --agent-provider=openrouter", () => {
+    const parsed = parseArgv([
+      "--access-token=tok",
+      "--agent-provider=openrouter",
+    ]);
+    expect(parsed.agentProvider).toBe("openrouter");
+  });
+
   it("collects unknown args", () => {
     const parsed = parseArgv(["--unknown", "--another=1"]);
     expect(parsed.unknownArgs.length).toBeGreaterThan(0);

--- a/packages/mcp-server/src/cli/resolve.test.ts
+++ b/packages/mcp-server/src/cli/resolve.test.ts
@@ -73,14 +73,23 @@ describe("cli/finalize", () => {
     expect(cfg.agentProvider).toBe("azure-openai");
   });
 
+  it("accepts openrouter as a valid explicit provider", () => {
+    const cfg = finalize({
+      accessToken: "tok",
+      agentProvider: "openrouter",
+      unknownArgs: [],
+    });
+    expect(cfg.agentProvider).toBe("openrouter");
+  });
+
   it("rejects invalid explicit provider values", () => {
     expect(() =>
       finalize({
         accessToken: "tok",
-        agentProvider: "openrouter",
+        agentProvider: "bad-provider",
         unknownArgs: [],
       }),
-    ).toThrow(/Must be "openai", "azure-openai", or "anthropic"/);
+    ).toThrow(/Must be "openai", "azure-openai", "anthropic", or "openrouter"/);
   });
 
   it("throws on non-https URL", () => {

--- a/packages/mcp-server/src/cli/resolve.ts
+++ b/packages/mcp-server/src/cli/resolve.ts
@@ -115,17 +115,22 @@ export function finalize(input: MergedArgs): PartiallyResolvedConfig {
     : undefined;
 
   // Validate agent provider if explicitly set
-  let agentProvider: "openai" | "azure-openai" | "anthropic" | undefined =
-    undefined;
+  let agentProvider:
+    | "openai"
+    | "azure-openai"
+    | "anthropic"
+    | "openrouter"
+    | undefined = undefined;
   if (input.agentProvider) {
     const provider = input.agentProvider.toLowerCase();
     if (
       provider !== "openai" &&
       provider !== "azure-openai" &&
-      provider !== "anthropic"
+      provider !== "anthropic" &&
+      provider !== "openrouter"
     ) {
       throw new Error(
-        `Error: Invalid agent provider "${input.agentProvider}". Must be "openai", "azure-openai", or "anthropic".`,
+        `Error: Invalid agent provider "${input.agentProvider}". Must be "openai", "azure-openai", "anthropic", or "openrouter".`,
       );
     }
     agentProvider = provider;

--- a/packages/mcp-server/src/cli/types.ts
+++ b/packages/mcp-server/src/cli/types.ts
@@ -62,6 +62,12 @@ export type MergedArgs = {
   unknownArgs: string[];
 };
 
+export type CliAgentProvider =
+  | "openai"
+  | "azure-openai"
+  | "anthropic"
+  | "openrouter";
+
 /**
  * Partially resolved config — accessToken may not yet be available
  * (will be resolved via device code flow or cache).
@@ -77,7 +83,7 @@ export type PartiallyResolvedConfig = {
   openaiModel?: string;
   anthropicBaseUrl?: string;
   anthropicModel?: string;
-  agentProvider?: "openai" | "azure-openai" | "anthropic";
+  agentProvider?: CliAgentProvider;
   /** Skills granted for this session (always populated by finalize()) */
   finalSkills: Set<Skill>;
   organizationSlug?: string;

--- a/packages/mcp-server/src/cli/usage.ts
+++ b/packages/mcp-server/src/cli/usage.ts
@@ -25,7 +25,7 @@ Common optional flags:
   --experimental          Enable forward-looking tool variants and experimental features
 
 Embedded agent configuration:
-  --agent-provider <provider>   LLM provider: openai, azure-openai, or anthropic (auto-detects from API keys)
+  --agent-provider <provider>   LLM provider: openai, azure-openai, anthropic, or openrouter (auto-detects from API keys)
   --openai-base-url <url>       Override OpenAI API base URL
   --openai-model <model>        Override OpenAI model (default: gpt-5)
   --anthropic-base-url <url>    Override Anthropic API base URL
@@ -46,7 +46,9 @@ Environment variables:
   SENTRY_CLIENT_ID        Override OAuth client ID for device code flow
   OPENAI_API_KEY          OpenAI API key for AI-powered search tools
   ANTHROPIC_API_KEY       Anthropic API key for AI-powered search tools
-  EMBEDDED_AGENT_PROVIDER Provider override: openai, azure-openai, or anthropic
+  OPENROUTER_API_KEY      OpenRouter API key for AI-powered search tools
+  OPENROUTER_MODEL        OpenRouter model (default: openai/gpt-5)
+  EMBEDDED_AGENT_PROVIDER Provider override: openai, azure-openai, anthropic, or openrouter
   MCP_DISABLE_SKILLS      Disable specific skills (comma-separated)
 
 Examples:
@@ -57,5 +59,6 @@ Examples:
   ${packageName} --access-token=TOKEN --host=sentry.internal:9000 --insecure-http
   ${packageName} --access-token=TOKEN --host=sentry.example.com --disable-skills=seer
   ${packageName} --access-token=TOKEN --agent-provider=azure-openai --openai-base-url=https://example.openai.azure.com/openai/v1/
-  ${packageName} --access-token=TOKEN --agent-provider=anthropic`;
+  ${packageName} --access-token=TOKEN --agent-provider=anthropic
+  ${packageName} --access-token=TOKEN --agent-provider=openrouter`;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -93,9 +93,7 @@ async function main() {
 
   // Configure embedded agent provider
   if (cfg.agentProvider) {
-    setAgentProvider(
-      cfg.agentProvider as Parameters<typeof setAgentProvider>[0],
-    );
+    setAgentProvider(cfg.agentProvider);
   }
   setProviderBaseUrls({
     openaiBaseUrl: cfg.openaiBaseUrl,
@@ -110,11 +108,14 @@ async function main() {
 
   // Helper functions for provider status messages
   function hasProviderConflict(): boolean {
-    const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
-    const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
+    const providerKeyCount = [
+      process.env.ANTHROPIC_API_KEY,
+      process.env.OPENAI_API_KEY,
+      process.env.OPENROUTER_API_KEY,
+    ].filter(Boolean).length;
     const hasExplicitProvider =
       cfg.agentProvider || process.env.EMBEDDED_AGENT_PROVIDER;
-    return hasAnthropic && hasOpenAI && !hasExplicitProvider;
+    return providerKeyCount > 1 && !hasExplicitProvider;
   }
 
   function getConfiguredProvider(): string | undefined {
@@ -133,24 +134,42 @@ async function main() {
 
     const hasAnthropic = Boolean(process.env.ANTHROPIC_API_KEY);
     const hasOpenAI = Boolean(process.env.OPENAI_API_KEY);
+    const hasOpenRouter = Boolean(process.env.OPENROUTER_API_KEY);
 
     // Check if configured provider's key is missing but other key is present
     if (
       (configured === "openai" || configured === "azure-openai") &&
       !hasOpenAI &&
-      hasAnthropic
+      (hasAnthropic || hasOpenRouter)
     ) {
       return {
         mismatch: true,
         configured,
-        availableKey: "ANTHROPIC_API_KEY",
+        availableKey: hasOpenRouter
+          ? "OPENROUTER_API_KEY"
+          : "ANTHROPIC_API_KEY",
       };
     }
-    if (configured === "anthropic" && !hasAnthropic && hasOpenAI) {
+    if (
+      configured === "anthropic" &&
+      !hasAnthropic &&
+      (hasOpenAI || hasOpenRouter)
+    ) {
       return {
         mismatch: true,
         configured: "anthropic",
-        availableKey: "OPENAI_API_KEY",
+        availableKey: hasOpenRouter ? "OPENROUTER_API_KEY" : "OPENAI_API_KEY",
+      };
+    }
+    if (
+      configured === "openrouter" &&
+      !hasOpenRouter &&
+      (hasOpenAI || hasAnthropic)
+    ) {
+      return {
+        mismatch: true,
+        configured: "openrouter",
+        availableKey: hasOpenAI ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY",
       };
     }
 
@@ -171,6 +190,7 @@ async function main() {
     | "openai"
     | "azure-openai"
     | "anthropic"
+    | "openrouter"
     | undefined;
 
   if (!resolvedProvider) {
@@ -185,10 +205,10 @@ async function main() {
 
     if (hasProviderConflict()) {
       console.warn(
-        "Warning: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are set, but no provider is explicitly configured.",
+        "Warning: Multiple LLM API keys are set, but no provider is explicitly configured.",
       );
       console.warn(
-        "Please set EMBEDDED_AGENT_PROVIDER='openai', 'azure-openai', or 'anthropic' to specify which provider to use.",
+        "Please set EMBEDDED_AGENT_PROVIDER='openai', 'azure-openai', 'anthropic', or 'openrouter' to specify which provider to use.",
       );
       console.warn(
         "AI-powered search tools will be unavailable until a provider is selected.",
@@ -198,7 +218,9 @@ async function main() {
         mismatchInfo.configured === "openai" ||
         mismatchInfo.configured === "azure-openai"
           ? "OPENAI_API_KEY"
-          : "ANTHROPIC_API_KEY";
+          : mismatchInfo.configured === "openrouter"
+            ? "OPENROUTER_API_KEY"
+            : "ANTHROPIC_API_KEY";
       const configuredViaCliFlag = Boolean(cli.agentProvider);
       const providerSetting = configuredViaCliFlag
         ? `--agent-provider=${mismatchInfo.configured}`
@@ -227,7 +249,7 @@ async function main() {
       );
     } else {
       console.warn(
-        "Warning: No LLM API key found (OPENAI_API_KEY or ANTHROPIC_API_KEY).",
+        "Warning: No LLM API key found (OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY).",
       );
       console.warn("Agent-assisted search and use_sentry will be unavailable.");
       console.warn(

--- a/packages/mcp-test-client/README.md
+++ b/packages/mcp-test-client/README.md
@@ -4,7 +4,7 @@ A simple CLI tool to test the Sentry MCP server using stdio transport with an AI
 
 ## Features
 
-- 🤖 AI-powered interaction with Sentry MCP tools using GPT-4
+- 🤖 AI-powered interaction with Sentry MCP tools using OpenAI or OpenRouter
 - 🔧 Full access to all MCP server tools
 - 💬 Interactive mode by default when no prompt provided
 - 🎨 Colorized output for better readability
@@ -16,7 +16,7 @@ A simple CLI tool to test the Sentry MCP server using stdio transport with an AI
 
 - Node.js >= 22.13
 - pnpm package manager
-- OpenAI API key for prompt/agent mode
+- OpenAI or OpenRouter API key for prompt/agent mode
 - Sentry access token with appropriate permissions for token-based stdio mode
 
 ## Installation
@@ -51,8 +51,9 @@ The OAuth flow uses PKCE (Proof Key for Code Exchange) and doesn't require a cli
 Create a `.env` file in the package directory:
 
 ```env
-# Required
+# Required for prompt/agent mode; set exactly one provider key
 OPENAI_API_KEY=your_openai_api_key
+OPENROUTER_API_KEY=your_openrouter_api_key
 
 # Required - Sentry access token with appropriate permissions
 SENTRY_ACCESS_TOKEN=your_sentry_access_token
@@ -61,7 +62,7 @@ SENTRY_ACCESS_TOKEN=your_sentry_access_token
 # Leave unset to target the SaaS host
 SENTRY_HOST=sentry.example.com  # Hostname only
 MCP_URL=https://mcp.sentry.dev  # MCP server host (defaults to production)
-MCP_MODEL=gpt-4o  # Override default model (GPT-4)
+MCP_MODEL=openai/gpt-5  # Override default model
 
 # Optional - Error tracking
 SENTRY_DSN=your_sentry_dsn  # Error tracking for the client itself
@@ -121,7 +122,7 @@ Use the local stdio transport explicitly:
 # Test stdio with an explicit token
 SENTRY_ACCESS_TOKEN=your_token pnpm mcp-test-client --transport stdio
 
-# Test stdio auth/tool discovery without OPENAI_API_KEY
+# Test stdio auth/tool discovery without an LLM provider key
 pnpm mcp-test-client --transport stdio --list-tools
 ```
 
@@ -209,13 +210,13 @@ If you see "Failed to connect to MCP server":
 
 If you get authentication errors:
 
-1. Verify your OPENAI_API_KEY is set correctly
+1. Verify your `OPENAI_API_KEY` or `OPENROUTER_API_KEY` is set correctly
 2. Check that your SENTRY_ACCESS_TOKEN has the required permissions
 3. For self-hosted Sentry, ensure SENTRY_HOST is set
 
 ### Testing Auth Without an LLM
 
-To verify stdio auth behavior without `OPENAI_API_KEY`, use:
+To verify stdio auth behavior without an LLM provider key, use:
 
 ```bash
 pnpm mcp-test-client --transport stdio --list-tools
@@ -277,8 +278,8 @@ After installation, you can verify everything is working:
 # Check CLI is installed
 pnpm mcp-test-client --help
 
-# Test basic functionality (no API keys required)
-SENTRY_ACCESS_TOKEN=dummy OPENAI_API_KEY=dummy pnpm mcp-test-client --help
+# Test basic functionality (no real API keys required)
+SENTRY_ACCESS_TOKEN=dummy OPENROUTER_API_KEY=dummy pnpm mcp-test-client --help
 
 # Run the test script (requires valid credentials)
 ./examples/test-connection.sh

--- a/packages/mcp-test-client/src/agent-provider.test.ts
+++ b/packages/mcp-test-client/src/agent-provider.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentProvider } from "./agent-provider.js";
+
+describe("resolveAgentProvider", () => {
+  it("detects openrouter when only OPENROUTER_API_KEY is set", () => {
+    expect(
+      resolveAgentProvider({
+        OPENROUTER_API_KEY: "sk-or-test",
+      }),
+    ).toBe("openrouter");
+  });
+
+  it("requires an explicit provider when multiple provider keys are set", () => {
+    expect(
+      resolveAgentProvider({
+        OPENAI_API_KEY: "sk-test",
+        OPENROUTER_API_KEY: "sk-or-test",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("treats Anthropic as a conflicting provider key", () => {
+    expect(
+      resolveAgentProvider({
+        ANTHROPIC_API_KEY: "sk-ant-test",
+        OPENROUTER_API_KEY: "sk-or-test",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("honors EMBEDDED_AGENT_PROVIDER=openrouter", () => {
+    expect(
+      resolveAgentProvider({
+        EMBEDDED_AGENT_PROVIDER: "openrouter",
+        OPENAI_API_KEY: "sk-test",
+        OPENROUTER_API_KEY: "sk-or-test",
+      }),
+    ).toBe("openrouter");
+  });
+
+  it("requires the matching key for explicit providers", () => {
+    expect(
+      resolveAgentProvider({
+        EMBEDDED_AGENT_PROVIDER: "openrouter",
+        OPENAI_API_KEY: "sk-test",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveAgentProvider({
+        EMBEDDED_AGENT_PROVIDER: "openai",
+        OPENROUTER_API_KEY: "sk-or-test",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/mcp-test-client/src/agent-provider.ts
+++ b/packages/mcp-test-client/src/agent-provider.ts
@@ -1,0 +1,29 @@
+export type TestClientAgentProvider = "openai" | "openrouter";
+
+/**
+ * Resolves the test-client LLM provider from environment configuration.
+ */
+export function resolveAgentProvider(
+  env: NodeJS.ProcessEnv,
+): TestClientAgentProvider | undefined {
+  const configuredProvider = env.EMBEDDED_AGENT_PROVIDER?.toLowerCase();
+  if (configuredProvider === "openai" && env.OPENAI_API_KEY) {
+    return configuredProvider;
+  }
+  if (configuredProvider === "openrouter" && env.OPENROUTER_API_KEY) {
+    return configuredProvider;
+  }
+  if (configuredProvider) {
+    return undefined;
+  }
+
+  const providerKeys = [
+    env.ANTHROPIC_API_KEY,
+    env.OPENAI_API_KEY,
+    env.OPENROUTER_API_KEY,
+  ].filter(Boolean);
+  if (providerKeys.length > 1) return undefined;
+  if (env.OPENAI_API_KEY) return "openai";
+  if (env.OPENROUTER_API_KEY) return "openrouter";
+  return undefined;
+}

--- a/packages/mcp-test-client/src/agent.test.ts
+++ b/packages/mcp-test-client/src/agent.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAgent } from "./agent.js";
+import type { MCPConnection } from "./types.js";
+
+function createStreamingResponse() {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"openai/gpt-5","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n',
+          ),
+        );
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"openai/gpt-5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+describe("runAgent", () => {
+  const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+  const originalOpenRouterModel = process.env.OPENROUTER_MODEL;
+  const originalMcpModel = process.env.MCP_MODEL;
+
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = "sk-or-test";
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.OPENROUTER_MODEL;
+    // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+    delete process.env.MCP_MODEL;
+  });
+
+  afterEach(() => {
+    if (originalOpenRouterApiKey === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+    }
+
+    if (originalOpenRouterModel === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.OPENROUTER_MODEL;
+    } else {
+      process.env.OPENROUTER_MODEL = originalOpenRouterModel;
+    }
+
+    if (originalMcpModel === undefined) {
+      // biome-ignore lint/performance/noDelete: Required to properly unset environment variable
+      delete process.env.MCP_MODEL;
+    } else {
+      process.env.MCP_MODEL = originalMcpModel;
+    }
+
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses OpenRouter chat completions when configured", async () => {
+    let requestUrl: string | undefined;
+    let authorization: string | null = null;
+    let requestBody: unknown;
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Request | URL | string, init?: RequestInit) => {
+        const request =
+          input instanceof Request
+            ? new Request(input, init)
+            : new Request(input.toString(), init);
+        requestUrl = request.url;
+        authorization = request.headers.get("authorization");
+        requestBody = await request.json();
+
+        return createStreamingResponse();
+      }),
+    );
+
+    const connection: MCPConnection = {
+      client: {
+        tools: async () => ({}),
+      },
+      tools: new Map(),
+      disconnect: async () => {},
+      sessionId: "test-session",
+      transport: "stdio",
+    };
+
+    await runAgent(connection, "hello", {
+      provider: "openrouter",
+      maxSteps: 1,
+    });
+
+    expect(requestUrl).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(authorization).toBe("Bearer sk-or-test");
+    expect(requestBody).toMatchObject({
+      model: "openai/gpt-5",
+      stream: true,
+    });
+  });
+});

--- a/packages/mcp-test-client/src/agent.ts
+++ b/packages/mcp-test-client/src/agent.ts
@@ -1,8 +1,12 @@
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, stepCountIs } from "ai";
 import { startNewTrace, startSpan } from "@sentry/core";
 import type { MCPConnection } from "./types.js";
-import { DEFAULT_MODEL } from "./constants.js";
+import {
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_OPENROUTER_MODEL,
+  OPENROUTER_BASE_URL,
+} from "./constants.js";
 import {
   logError,
   logTool,
@@ -37,16 +41,41 @@ P.S. If you're excited about building cool developer tools and working with cutt
 export interface AgentConfig {
   model?: string;
   maxSteps?: number;
+  provider?: "openai" | "openrouter";
 }
 
+/**
+ * Runs the MCP test client agent against a connected MCP server.
+ */
 export async function runAgent(
   connection: MCPConnection,
   userPrompt: string,
   config: AgentConfig = {},
 ) {
-  const model = config.model || process.env.MCP_MODEL || DEFAULT_MODEL;
+  const provider = config.provider ?? "openai";
+  const model =
+    config.model ||
+    process.env.MCP_MODEL ||
+    (provider === "openrouter"
+      ? process.env.OPENROUTER_MODEL || DEFAULT_OPENROUTER_MODEL
+      : process.env.OPENAI_MODEL || DEFAULT_OPENAI_MODEL);
   const maxSteps = config.maxSteps || 10;
   const sessionId = connection.sessionId;
+  const modelProvider =
+    provider === "openrouter"
+      ? createOpenAI({
+          apiKey: process.env.OPENROUTER_API_KEY,
+          baseURL: OPENROUTER_BASE_URL,
+          headers: {
+            "HTTP-Referer": "https://github.com/getsentry/sentry-mcp",
+            "X-OpenRouter-Title": "Sentry MCP Test Client",
+          },
+        })
+      : createOpenAI();
+  const languageModel =
+    provider === "openrouter"
+      ? modelProvider.chat(model)
+      : modelProvider(model);
 
   // Wrap entire function in a new trace
   return await startNewTrace(async () => {
@@ -57,7 +86,7 @@ export async function runAgent(
           "service.version": LIB_VERSION,
           "gen_ai.conversation.id": sessionId,
           "gen_ai.agent.name": "sentry-mcp-agent",
-          "gen_ai.provider.name": "openai",
+          "gen_ai.provider.name": provider,
           "gen_ai.request.model": model,
           "gen_ai.operation.name": "chat",
         },
@@ -70,7 +99,7 @@ export async function runAgent(
           let isStreaming = false;
 
           const result = await streamText({
-            model: openai(model),
+            model: languageModel,
             system: SYSTEM_PROMPT,
             messages: [{ role: "user", content: userPrompt }],
             tools,

--- a/packages/mcp-test-client/src/constants.ts
+++ b/packages/mcp-test-client/src/constants.ts
@@ -1,8 +1,9 @@
 // Default MCP Server
 export const DEFAULT_MCP_URL = "https://mcp.sentry.dev";
 
-// Default AI model - using GPT-4
-export const DEFAULT_MODEL = "gpt-4o";
+export const DEFAULT_OPENAI_MODEL = "gpt-4o";
+export const DEFAULT_OPENROUTER_MODEL = "openai/gpt-5";
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 // OAuth configuration
 export const OAUTH_REDIRECT_PORT = 8765;

--- a/packages/mcp-test-client/src/index.ts
+++ b/packages/mcp-test-client/src/index.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+/**
+ * CLI entry point for MCP QA: loads env, resolves transport/provider, then runs
+ * either tool discovery or the test agent against a single MCP connection.
+ */
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { Command, Option } from "commander";
@@ -15,6 +19,7 @@ import { logError, logInfo } from "./logger.js";
 import { sentryBeforeSend } from "@sentry/mcp-core/telem/sentry";
 import type { MCPConnection } from "./types.js";
 import { resolveTransportMode } from "./transport.js";
+import { resolveAgentProvider } from "./agent-provider.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "../../../");
@@ -61,6 +66,8 @@ program
   )
   .action(async (prompt, options) => {
     try {
+      const agentProvider = resolveAgentProvider(process.env);
+
       // Initialize Sentry with CLI-provided DSN if available
       const sentryDsn =
         options.sentryDsn ||
@@ -75,7 +82,7 @@ program
         initialScope: {
           tags: {
             "gen_ai.agent.name": "sentry-mcp-agent",
-            "gen_ai.provider.name": "openai",
+            "gen_ai.provider.name": agentProvider ?? "unknown",
           },
         },
         release: process.env.SENTRY_RELEASE,
@@ -99,19 +106,26 @@ program
         options.accessToken || process.env.SENTRY_ACCESS_TOKEN;
       const sentryHost = options.host || process.env.SENTRY_HOST;
 
-      const openaiKey = process.env.OPENAI_API_KEY;
       const transport = resolveTransportMode({
         requestedTransport: options.transport,
         accessToken,
       });
       const listToolsOnly = Boolean(options.listTools);
 
-      if (!listToolsOnly && !openaiKey) {
-        logError("OPENAI_API_KEY environment variable is required");
+      if (!listToolsOnly && !agentProvider) {
+        logError("No supported LLM provider is configured");
         console.log(
-          chalk.yellow("\nPlease set it in your .env file or environment:"),
+          chalk.yellow(
+            "\nPlease set one provider in your .env file or environment:",
+          ),
         );
         console.log(chalk.gray("OPENAI_API_KEY=your_openai_api_key"));
+        console.log(chalk.gray("OPENROUTER_API_KEY=your_openrouter_api_key"));
+        console.log(
+          chalk.gray(
+            "EMBEDDED_AGENT_PROVIDER=openrouter # required if multiple provider keys are set",
+          ),
+        );
         process.exit(1);
       }
 
@@ -139,6 +153,7 @@ program
 
       const agentConfig = {
         model: options.model,
+        provider: agentProvider ?? "openai",
       };
 
       try {

--- a/turbo.json
+++ b/turbo.json
@@ -94,7 +94,10 @@
   "globalPassThroughEnv": [
     "NODE_ENV",
     "CI",
+    "EMBEDDED_AGENT_PROVIDER",
     "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_MODEL",
     "COOKIE_SECRET",
     "SENTRY_CLIENT_ID",
     "SENTRY_CLIENT_SECRET",


### PR DESCRIPTION
Adds OpenRouter as an embedded-agent provider and wires the stdio server/test client to auto-detect it when `OPENROUTER_API_KEY` is the only provider key. OpenRouter uses the OpenAI-compatible chat completions endpoint with `openai/gpt-5` as the default model, so local QA can run without setting `OPENROUTER_MODEL` or `EMBEDDED_AGENT_PROVIDER`.

The provider conflict rules now cover Anthropic, OpenAI, and OpenRouter, and Turbo passes through the provider key/model/selector env vars for workspace commands. The docs and package READMEs describe the provider-neutral setup, and regression coverage asserts the OpenRouter endpoint/auth/model contract in the test client.
