### PR TITLE
feat(ai): Expose GenAI fields in conversation details

### DIFF
--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -230,6 +230,19 @@ Current expected behavior:
 - Each timeline event includes enough trace context to debug it, including
   `spanId`, `traceId`, timestamp, status or duration when available, and compact
   tool input/argument fields when useful.
+- Timeline events expose a stable `genAi` block for relevant GenAI attributes,
+  including operation type, agent name, request/response model, token totals,
+  raw message attributes, response fields, and tool definitions when available.
+  Tool call timeline events expose their payloads through the event-level
+  `arguments` and `input` fields; exact `gen_ai.tool.*` attribute names remain
+  available on span summaries.
+- Large raw GenAI message and tool payload attributes are truncated in the MCP
+  response. Truncated `genAi` fields are listed in `genAi.truncatedFields`; use
+  the event or span summary `spanId` and `traceId` to query the underlying span
+  when the full value is needed.
+- Output includes chronological span summaries with `spanId`, `traceId`,
+  parent span ID, project, timestamp, duration, span name/op/description/status,
+  transaction, and the same stable `genAi` attribute projection.
 - Conversation-level context includes trace IDs, projects, token totals, and
   summary counts.
 - A structured JSON artifact is included.

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -810,6 +810,122 @@
         "totalTokens": {
           "type": "number"
         },
+        "spanSummaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "spanId": {
+                "type": "string"
+              },
+              "traceId": {
+                "type": "string"
+              },
+              "parentSpanId": {
+                "type": ["string", "null"]
+              },
+              "project": {
+                "type": "string"
+              },
+              "projectId": {
+                "type": ["string", "number"]
+              },
+              "timestamp": {
+                "type": "number"
+              },
+              "durationMs": {
+                "type": "number"
+              },
+              "spanName": {
+                "type": "string"
+              },
+              "spanOp": {
+                "type": "string"
+              },
+              "spanDescription": {
+                "type": "string"
+              },
+              "spanStatus": {
+                "type": "string"
+              },
+              "transaction": {
+                "type": "string"
+              },
+              "isTransaction": {
+                "type": "boolean"
+              },
+              "genAi": {
+                "type": "object",
+                "properties": {
+                  "operationType": {
+                    "type": "string"
+                  },
+                  "agentName": {
+                    "type": "string"
+                  },
+                  "requestModel": {
+                    "type": "string"
+                  },
+                  "responseModel": {
+                    "type": "string"
+                  },
+                  "usageTotalTokens": {
+                    "type": "number"
+                  },
+                  "costTotalTokens": {
+                    "type": "number"
+                  },
+                  "systemInstructions": {
+                    "type": "string"
+                  },
+                  "inputMessages": {
+                    "type": "string"
+                  },
+                  "outputMessages": {
+                    "type": "string"
+                  },
+                  "requestMessages": {
+                    "type": "string"
+                  },
+                  "responseText": {
+                    "type": "string"
+                  },
+                  "responseObject": {
+                    "type": "string"
+                  },
+                  "toolDefinitions": {
+                    "type": "string"
+                  },
+                  "toolName": {
+                    "type": "string"
+                  },
+                  "toolCallArguments": {
+                    "type": "string"
+                  },
+                  "toolInput": {
+                    "type": "string"
+                  },
+                  "truncatedFields": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "spanId",
+              "traceId",
+              "project",
+              "projectId",
+              "timestamp",
+              "durationMs"
+            ],
+            "additionalProperties": false
+          }
+        },
         "timeline": {
           "type": "array",
           "items": {
@@ -861,6 +977,66 @@
                     },
                     "required": ["totalTokens", "durationMs"],
                     "additionalProperties": false
+                  },
+                  "genAi": {
+                    "type": "object",
+                    "properties": {
+                      "operationType": {
+                        "type": "string"
+                      },
+                      "agentName": {
+                        "type": "string"
+                      },
+                      "requestModel": {
+                        "type": "string"
+                      },
+                      "responseModel": {
+                        "type": "string"
+                      },
+                      "usageTotalTokens": {
+                        "type": "number"
+                      },
+                      "costTotalTokens": {
+                        "type": "number"
+                      },
+                      "systemInstructions": {
+                        "type": "string"
+                      },
+                      "inputMessages": {
+                        "type": "string"
+                      },
+                      "outputMessages": {
+                        "type": "string"
+                      },
+                      "requestMessages": {
+                        "type": "string"
+                      },
+                      "responseText": {
+                        "type": "string"
+                      },
+                      "responseObject": {
+                        "type": "string"
+                      },
+                      "toolDefinitions": {
+                        "type": "string"
+                      },
+                      "toolName": {
+                        "type": "string"
+                      },
+                      "toolCallArguments": {
+                        "type": "string"
+                      },
+                      "toolInput": {
+                        "type": "string"
+                      },
+                      "truncatedFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "required": [
@@ -903,6 +1079,51 @@
                   },
                   "input": {
                     "type": "string"
+                  },
+                  "genAi": {
+                    "type": "object",
+                    "properties": {
+                      "operationType": {
+                        "type": "string"
+                      },
+                      "agentName": {
+                        "type": "string"
+                      },
+                      "requestModel": {
+                        "type": "string"
+                      },
+                      "responseModel": {
+                        "type": "string"
+                      },
+                      "usageTotalTokens": {
+                        "type": "number"
+                      },
+                      "costTotalTokens": {
+                        "type": "number"
+                      },
+                      "systemInstructions": {
+                        "type": "string"
+                      },
+                      "inputMessages": {
+                        "type": "string"
+                      },
+                      "outputMessages": {
+                        "type": "string"
+                      },
+                      "requestMessages": {
+                        "type": "string"
+                      },
+                      "responseText": {
+                        "type": "string"
+                      },
+                      "responseObject": {
+                        "type": "string"
+                      },
+                      "toolDefinitions": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "required": [
@@ -933,6 +1154,7 @@
         "messageCount",
         "toolCallCount",
         "totalTokens",
+        "spanSummaries",
         "timeline"
       ],
       "additionalProperties": false,

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
@@ -16,6 +16,23 @@ const baseContext = {
   userId: "1",
 };
 
+type ConversationDetailsForTest = {
+  timeline: Array<{
+    type: string;
+    spanId: string;
+    traceId: string;
+    genAi?: Record<string, unknown>;
+  }>;
+  spanSummaries: Array<{
+    spanId: string;
+    traceId: string;
+    spanOp?: string;
+    spanDescription?: string;
+    transaction?: string;
+    genAi?: Record<string, unknown>;
+  }>;
+} & Record<string, unknown>;
+
 const conversationSpans: Array<Record<string, unknown>> = [
   {
     "gen_ai.conversation.id": "conv-123",
@@ -25,9 +42,12 @@ const conversationSpans: Array<Record<string, unknown>> = [
     project: "mcp-server",
     "project.id": 4509109107622913,
     "span.name": "gen_ai.chat",
+    "span.op": "gen_ai.chat",
+    "span.description": "chat completion",
     "span.status": "ok",
     span_id: "1111111111111111",
     trace: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    transaction: "POST /api/internal/agent/continue",
     "gen_ai.operation.type": "ai_client",
     "gen_ai.input.messages": JSON.stringify([
       { role: "system", content: "You are a helpful assistant." },
@@ -36,6 +56,8 @@ const conversationSpans: Array<Record<string, unknown>> = [
     "gen_ai.output.messages": JSON.stringify([
       { role: "assistant", content: "The checkout worker is timing out." },
     ]),
+    "gen_ai.system_instructions": "Respond with concise diagnostics.",
+    "gen_ai.cost.total_tokens": 42,
     "gen_ai.request.model": "gpt-5-mini",
     "gen_ai.response.model": "gpt-5-mini-2026-05-01",
     "gen_ai.usage.total_tokens": 42,
@@ -50,9 +72,12 @@ const conversationSpans: Array<Record<string, unknown>> = [
     project: "mcp-server",
     "project.id": 4509109107622913,
     "span.name": "gen_ai.execute_tool",
+    "span.op": "gen_ai.execute_tool",
+    "span.description": "search_events",
     "span.status": "ok",
     span_id: "2222222222222222",
     trace: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    transaction: "POST /api/internal/agent/continue",
     "gen_ai.operation.type": "tool",
     "gen_ai.tool.name": "search_events",
     "gen_ai.tool.call.arguments": JSON.stringify({
@@ -68,6 +93,8 @@ const conversationSpans: Array<Record<string, unknown>> = [
     project: "mcp-server",
     "project.id": 4509109107622913,
     "span.name": "gen_ai.chat",
+    "span.op": "gen_ai.chat",
+    "span.description": "chat completion",
     "span.status": "ok",
     span_id: "3333333333333333",
     trace: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -112,11 +139,47 @@ describe("get_ai_conversation_details", () => {
     );
 
     assertStructuredOnlyResult(result);
-    const structuredContent = getStructuredContent(result);
+    const structuredContent =
+      getStructuredContent<ConversationDetailsForTest>(result);
     expect(structuredContent).not.toHaveProperty("focusedSpanId");
     expect(structuredContent).not.toHaveProperty("focusedSpanPresent");
     expect(structuredContent).not.toHaveProperty("messages");
     expect(structuredContent).not.toHaveProperty("spanIds");
+    expect(structuredContent.timeline[0].genAi).toMatchObject({
+      operationType: "ai_client",
+      requestModel: "gpt-5-mini",
+      responseModel: "gpt-5-mini-2026-05-01",
+      usageTotalTokens: 42,
+      costTotalTokens: 42,
+      agentName: "triage-agent",
+    });
+    expect(structuredContent.timeline[2].genAi).toMatchObject({
+      operationType: "tool",
+    });
+    expect(structuredContent.timeline[2].genAi).not.toHaveProperty("toolName");
+    expect(structuredContent.timeline[2].genAi).not.toHaveProperty(
+      "toolCallArguments",
+    );
+    expect(structuredContent.timeline[2].genAi).not.toHaveProperty("toolInput");
+    expect(structuredContent.spanSummaries[0]).toMatchObject({
+      spanId: "1111111111111111",
+      spanOp: "gen_ai.chat",
+      spanDescription: "chat completion",
+      transaction: "POST /api/internal/agent/continue",
+      genAi: expect.objectContaining({
+        operationType: "ai_client",
+        inputMessages: JSON.stringify([
+          { role: "system", content: "You are a helpful assistant." },
+          { role: "user", content: "What failed in production?" },
+        ]),
+        outputMessages: JSON.stringify([
+          {
+            role: "assistant",
+            content: "The checkout worker is timing out.",
+          },
+        ]),
+      }),
+    });
     expect(structuredContent).toMatchInlineSnapshot(`
       {
         "aiCallCount": 2,
@@ -131,10 +194,87 @@ describe("get_ai_conversation_details", () => {
           "mcp-server",
         ],
         "spanCount": 3,
+        "spanSummaries": [
+          {
+            "durationMs": 1500,
+            "genAi": {
+              "agentName": "triage-agent",
+              "costTotalTokens": 42,
+              "inputMessages": "[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What failed in production?"}]",
+              "operationType": "ai_client",
+              "outputMessages": "[{"role":"assistant","content":"The checkout worker is timing out."}]",
+              "requestModel": "gpt-5-mini",
+              "responseModel": "gpt-5-mini-2026-05-01",
+              "systemInstructions": "Respond with concise diagnostics.",
+              "usageTotalTokens": 42,
+            },
+            "parentSpanId": null,
+            "project": "mcp-server",
+            "projectId": 4509109107622913,
+            "spanDescription": "chat completion",
+            "spanId": "1111111111111111",
+            "spanName": "gen_ai.chat",
+            "spanOp": "gen_ai.chat",
+            "spanStatus": "ok",
+            "timestamp": 1713805400000,
+            "traceId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "transaction": "POST /api/internal/agent/continue",
+          },
+          {
+            "durationMs": 300,
+            "genAi": {
+              "operationType": "tool",
+              "toolCallArguments": "{"query":"level:error"}",
+              "toolInput": "{"organizationSlug":"test-org"}",
+              "toolName": "search_events",
+            },
+            "parentSpanId": "1111111111111111",
+            "project": "mcp-server",
+            "projectId": 4509109107622913,
+            "spanDescription": "search_events",
+            "spanId": "2222222222222222",
+            "spanName": "gen_ai.execute_tool",
+            "spanOp": "gen_ai.execute_tool",
+            "spanStatus": "ok",
+            "timestamp": 1713805401700,
+            "traceId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "transaction": "POST /api/internal/agent/continue",
+          },
+          {
+            "durationMs": 1000,
+            "genAi": {
+              "inputMessages": "[{"role":"user","content":"Can you inspect the failing event?"}]",
+              "operationType": "ai_client",
+              "responseText": "I found the timeout stack trace.",
+              "usageTotalTokens": 58,
+            },
+            "parentSpanId": null,
+            "project": "mcp-server",
+            "projectId": 4509109107622913,
+            "spanDescription": "chat completion",
+            "spanId": "3333333333333333",
+            "spanName": "gen_ai.chat",
+            "spanOp": "gen_ai.chat",
+            "spanStatus": "ok",
+            "timestamp": 1713805404000,
+            "traceId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          },
+        ],
         "startTimestamp": 1713805400000,
         "timeline": [
           {
             "content": "What failed in production?",
+            "genAi": {
+              "agentName": "triage-agent",
+              "costTotalTokens": 42,
+              "inputMessages": "[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What failed in production?"}]",
+              "operationType": "ai_client",
+              "outputMessages": "[{"role":"assistant","content":"The checkout worker is timing out."}]",
+              "requestModel": "gpt-5-mini",
+              "responseModel": "gpt-5-mini-2026-05-01",
+              "systemInstructions": "Respond with concise diagnostics.",
+              "usageTotalTokens": 42,
+            },
             "role": "user",
             "spanId": "1111111111111111",
             "timestamp": 1713805400000,
@@ -144,6 +284,17 @@ describe("get_ai_conversation_details", () => {
           },
           {
             "content": "The checkout worker is timing out.",
+            "genAi": {
+              "agentName": "triage-agent",
+              "costTotalTokens": 42,
+              "inputMessages": "[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What failed in production?"}]",
+              "operationType": "ai_client",
+              "outputMessages": "[{"role":"assistant","content":"The checkout worker is timing out."}]",
+              "requestModel": "gpt-5-mini",
+              "responseModel": "gpt-5-mini-2026-05-01",
+              "systemInstructions": "Respond with concise diagnostics.",
+              "usageTotalTokens": 42,
+            },
             "metadata": {
               "agentName": "triage-agent",
               "durationMs": 1500,
@@ -160,6 +311,9 @@ describe("get_ai_conversation_details", () => {
           {
             "arguments": "{"query":"level:error"}",
             "durationMs": 300,
+            "genAi": {
+              "operationType": "tool",
+            },
             "input": "{"organizationSlug":"test-org"}",
             "name": "search_events",
             "spanId": "2222222222222222",
@@ -170,6 +324,12 @@ describe("get_ai_conversation_details", () => {
           },
           {
             "content": "Can you inspect the failing event?",
+            "genAi": {
+              "inputMessages": "[{"role":"user","content":"Can you inspect the failing event?"}]",
+              "operationType": "ai_client",
+              "responseText": "I found the timeout stack trace.",
+              "usageTotalTokens": 58,
+            },
             "role": "user",
             "spanId": "3333333333333333",
             "timestamp": 1713805404000,
@@ -178,6 +338,12 @@ describe("get_ai_conversation_details", () => {
           },
           {
             "content": "I found the timeout stack trace.",
+            "genAi": {
+              "inputMessages": "[{"role":"user","content":"Can you inspect the failing event?"}]",
+              "operationType": "ai_client",
+              "responseText": "I found the timeout stack trace.",
+              "usageTotalTokens": 58,
+            },
             "metadata": {
               "durationMs": 1000,
               "status": "ok",
@@ -229,6 +395,112 @@ describe("get_ai_conversation_details", () => {
     for (const message of userMessages) {
       expect(message).not.toHaveProperty("userEmail");
     }
+  });
+
+  it("truncates large GenAI message and tool payload attributes while preserving span IDs", async () => {
+    const longValue = "x".repeat(4100);
+    mockConversationEndpoint("test-org", "conv-large-attrs", [
+      {
+        ...conversationSpans[0],
+        "gen_ai.conversation.id": "conv-large-attrs",
+        span_id: "large-ai-1",
+        "gen_ai.input.messages": longValue,
+      },
+      {
+        ...conversationSpans[1],
+        "gen_ai.conversation.id": "conv-large-attrs",
+        span_id: "large-tool-1",
+        "gen_ai.tool.call.arguments": longValue,
+        "gen_ai.tool.input": longValue,
+      },
+    ]);
+
+    const result = await getAIConversationDetails.handler(
+      {
+        organizationSlug: "test-org",
+        conversationId: "conv-large-attrs",
+      },
+      baseContext,
+    );
+
+    const structuredContent =
+      getStructuredContent<ConversationDetailsForTest>(result);
+    expect(structuredContent.timeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "message",
+          spanId: "large-ai-1",
+          traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          genAi: expect.objectContaining({
+            inputMessages: expect.stringMatching(/\.\.\. \[truncated\]$/),
+            truncatedFields: ["inputMessages"],
+          }),
+        }),
+        expect.objectContaining({
+          type: "tool_call",
+          spanId: "large-tool-1",
+          traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          arguments: expect.stringMatching(/\.\.\. \[truncated\]$/),
+          input: expect.stringMatching(/\.\.\. \[truncated\]$/),
+          genAi: expect.objectContaining({
+            operationType: "tool",
+          }),
+        }),
+      ]),
+    );
+    expect(structuredContent.spanSummaries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          spanId: "large-ai-1",
+          traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          genAi: expect.objectContaining({
+            inputMessages: expect.stringMatching(/\.\.\. \[truncated\]$/),
+            truncatedFields: ["inputMessages"],
+          }),
+        }),
+        expect.objectContaining({
+          spanId: "large-tool-1",
+          traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          genAi: expect.objectContaining({
+            toolCallArguments: expect.stringMatching(/\.\.\. \[truncated\]$/),
+            toolInput: expect.stringMatching(/\.\.\. \[truncated\]$/),
+            truncatedFields: ["toolCallArguments", "toolInput"],
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("omits empty GenAI projections from span summaries", async () => {
+    mockConversationEndpoint("test-org", "conv-no-gen-ai-attrs", [
+      {
+        "gen_ai.conversation.id": "conv-no-gen-ai-attrs",
+        parent_span: null,
+        "precise.finish_ts": 1713805401,
+        "precise.start_ts": 1713805400,
+        project: "mcp-server",
+        "project.id": 4509109107622913,
+        span_id: "no-gen-ai-attrs-1",
+        trace: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+    ]);
+
+    const result = await getAIConversationDetails.handler(
+      {
+        organizationSlug: "test-org",
+        conversationId: "conv-no-gen-ai-attrs",
+      },
+      baseContext,
+    );
+
+    const structuredContent =
+      getStructuredContent<ConversationDetailsForTest>(result);
+    expect(structuredContent.timeline).toEqual([]);
+    expect(structuredContent.spanSummaries[0]).toMatchObject({
+      spanId: "no-gen-ai-attrs-1",
+      traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+    expect(structuredContent.spanSummaries[0]).not.toHaveProperty("genAi");
   });
 
   it("resolves an Explore conversation URL through get_sentry_resource", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.ts
@@ -21,6 +21,7 @@ type ToolCall = {
   status?: string;
   arguments?: string;
   input?: string;
+  genAi?: GenAIAttributes;
 };
 
 type ConversationMessage = {
@@ -38,6 +39,7 @@ type ConversationMessage = {
     status?: string;
     durationMs: number;
   };
+  genAi?: GenAIAttributes;
 };
 
 type TimelineEvent = ConversationMessage | ToolCall;
@@ -46,12 +48,78 @@ type LookupWindow = {
   start?: string;
   end?: string;
 };
+type GenAIAttributes = {
+  operationType?: string;
+  agentName?: string;
+  requestModel?: string;
+  responseModel?: string;
+  usageTotalTokens?: number;
+  costTotalTokens?: number;
+  systemInstructions?: string;
+  inputMessages?: string;
+  outputMessages?: string;
+  requestMessages?: string;
+  responseText?: string;
+  responseObject?: string;
+  toolDefinitions?: string;
+  toolName?: string;
+  toolCallArguments?: string;
+  toolInput?: string;
+  truncatedFields?: string[];
+};
+type ToolCallGenAIAttributes = Omit<
+  GenAIAttributes,
+  "toolName" | "toolCallArguments" | "toolInput" | "truncatedFields"
+>;
+type SpanSummary = {
+  spanId: string;
+  traceId: string;
+  parentSpanId?: string | null;
+  project: string;
+  projectId: string | number;
+  timestamp: number;
+  durationMs: number;
+  spanName?: string;
+  spanOp?: string;
+  spanDescription?: string;
+  spanStatus?: string;
+  transaction?: string;
+  isTransaction?: boolean;
+  genAi?: GenAIAttributes;
+};
 
 function withoutUndefined<T extends Record<string, unknown>>(value: T): T {
   return Object.fromEntries(
     Object.entries(value).filter(([, item]) => item !== undefined),
   ) as T;
 }
+
+const genAiAttributesSchema = z.object({
+  operationType: z.string().optional(),
+  agentName: z.string().optional(),
+  requestModel: z.string().optional(),
+  responseModel: z.string().optional(),
+  usageTotalTokens: z.number().optional(),
+  costTotalTokens: z.number().optional(),
+  systemInstructions: z.string().optional(),
+  inputMessages: z.string().optional(),
+  outputMessages: z.string().optional(),
+  requestMessages: z.string().optional(),
+  responseText: z.string().optional(),
+  responseObject: z.string().optional(),
+  toolDefinitions: z.string().optional(),
+  toolName: z.string().optional(),
+  toolCallArguments: z.string().optional(),
+  toolInput: z.string().optional(),
+  truncatedFields: z.array(z.string()).optional(),
+});
+
+const toolCallGenAiAttributesSchema = genAiAttributesSchema.omit({
+  toolName: true,
+  toolCallArguments: true,
+  toolInput: true,
+  truncatedFields: true,
+});
 
 const toolCallSchema = z.object({
   type: z.literal("tool_call"),
@@ -63,6 +131,7 @@ const toolCallSchema = z.object({
   status: z.string().optional(),
   arguments: z.string().optional(),
   input: z.string().optional(),
+  genAi: toolCallGenAiAttributesSchema.optional(),
 });
 
 const conversationMessageSchema = z.object({
@@ -82,6 +151,7 @@ const conversationMessageSchema = z.object({
       durationMs: z.number(),
     })
     .optional(),
+  genAi: genAiAttributesSchema.optional(),
 });
 
 const timelineEventSchema = z.discriminatedUnion("type", [
@@ -93,6 +163,23 @@ const lookupWindowSchema = z.object({
   statsPeriod: z.string().optional(),
   start: z.string().optional(),
   end: z.string().optional(),
+});
+
+const spanSummarySchema = z.object({
+  spanId: z.string(),
+  traceId: z.string(),
+  parentSpanId: z.string().nullable().optional(),
+  project: z.string(),
+  projectId: z.union([z.string(), z.number()]),
+  timestamp: z.number(),
+  durationMs: z.number(),
+  spanName: z.string().optional(),
+  spanOp: z.string().optional(),
+  spanDescription: z.string().optional(),
+  spanStatus: z.string().optional(),
+  transaction: z.string().optional(),
+  isTransaction: z.boolean().optional(),
+  genAi: genAiAttributesSchema.optional(),
 });
 
 export const aiConversationDetailsOutputSchema = z.object({
@@ -109,6 +196,7 @@ export const aiConversationDetailsOutputSchema = z.object({
   messageCount: z.number(),
   toolCallCount: z.number(),
   totalTokens: z.number(),
+  spanSummaries: z.array(spanSummarySchema),
   timeline: z.array(timelineEventSchema),
 });
 
@@ -127,8 +215,42 @@ function numeric(value: string | number | null | undefined): number {
   return 0;
 }
 
+function optionalNumeric(
+  value: string | number | null | undefined,
+): number | undefined {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
 function timestampMs(value: number): number {
   return Math.round(value * 1000);
+}
+
+function durationMs(span: AIConversationSpan): number {
+  return Math.round(
+    (span["precise.finish_ts"] - span["precise.start_ts"]) * 1000,
+  );
+}
+
+const MAX_RAW_GEN_AI_ATTRIBUTE_LENGTH = 4000;
+
+function truncateAttribute(
+  field: string,
+  value: string | undefined,
+  truncatedFields: string[],
+): string | undefined {
+  if (value === undefined || value.length <= MAX_RAW_GEN_AI_ATTRIBUTE_LENGTH) {
+    return value;
+  }
+
+  truncatedFields.push(field);
+  return `${value.slice(0, MAX_RAW_GEN_AI_ATTRIBUTE_LENGTH)}... [truncated]`;
 }
 
 function getOperationType(span: AIConversationSpan): string | undefined {
@@ -273,11 +395,116 @@ function extractAssistantContent(span: AIConversationSpan): string | null {
   return span["gen_ai.response.text"] ?? span["gen_ai.response.object"] ?? null;
 }
 
+/** Projects documented GenAI fields into the MCP contract and marks truncated raw payloads. */
+function buildGenAIAttributes(
+  span: AIConversationSpan,
+): GenAIAttributes | undefined {
+  const truncatedFields: string[] = [];
+
+  const attributes = withoutUndefined({
+    operationType: getOperationType(span),
+    agentName: span["gen_ai.agent.name"],
+    requestModel: span["gen_ai.request.model"],
+    responseModel: span["gen_ai.response.model"],
+    usageTotalTokens: optionalNumeric(span["gen_ai.usage.total_tokens"]),
+    costTotalTokens: optionalNumeric(span["gen_ai.cost.total_tokens"]),
+    systemInstructions: truncateAttribute(
+      "systemInstructions",
+      span["gen_ai.system_instructions"],
+      truncatedFields,
+    ),
+    inputMessages: truncateAttribute(
+      "inputMessages",
+      span["gen_ai.input.messages"],
+      truncatedFields,
+    ),
+    outputMessages: truncateAttribute(
+      "outputMessages",
+      span["gen_ai.output.messages"],
+      truncatedFields,
+    ),
+    requestMessages: truncateAttribute(
+      "requestMessages",
+      span["gen_ai.request.messages"],
+      truncatedFields,
+    ),
+    responseText: truncateAttribute(
+      "responseText",
+      span["gen_ai.response.text"],
+      truncatedFields,
+    ),
+    responseObject: truncateAttribute(
+      "responseObject",
+      span["gen_ai.response.object"],
+      truncatedFields,
+    ),
+    toolDefinitions: truncateAttribute(
+      "toolDefinitions",
+      span["gen_ai.tool.definitions"],
+      truncatedFields,
+    ),
+    toolName: span["gen_ai.tool.name"],
+    toolCallArguments: truncateAttribute(
+      "toolCallArguments",
+      span["gen_ai.tool.call.arguments"],
+      truncatedFields,
+    ),
+    toolInput: truncateAttribute(
+      "toolInput",
+      span["gen_ai.tool.input"],
+      truncatedFields,
+    ),
+    truncatedFields:
+      truncatedFields.length > 0 ? truncatedFields.sort() : undefined,
+  });
+  return Object.keys(attributes).length > 0 ? attributes : undefined;
+}
+
+/** Builds the MCP-facing span summary with IDs for raw span follow-up. */
+function buildSpanSummary(span: AIConversationSpan): SpanSummary {
+  return withoutUndefined({
+    spanId: span.span_id,
+    traceId: span.trace,
+    parentSpanId: span.parent_span,
+    project: span.project,
+    projectId: span["project.id"],
+    timestamp: timestampMs(span["precise.start_ts"]),
+    durationMs: durationMs(span),
+    spanName: span["span.name"],
+    spanOp: span["span.op"],
+    spanDescription: span["span.description"],
+    spanStatus: span["span.status"],
+    transaction: span.transaction,
+    isTransaction: span.is_transaction,
+    genAi: buildGenAIAttributes(span),
+  });
+}
+
+function buildToolCallGenAIAttributes(
+  attributes: GenAIAttributes | undefined,
+): ToolCallGenAIAttributes | undefined {
+  if (!attributes) {
+    return undefined;
+  }
+
+  const {
+    toolName: _toolName,
+    toolCallArguments: _toolCallArguments,
+    toolInput: _toolInput,
+    truncatedFields: _truncatedFields,
+    ...timelineAttributes
+  } = attributes;
+  return Object.keys(timelineAttributes).length > 0
+    ? timelineAttributes
+    : undefined;
+}
+
 function buildToolCall(span: AIConversationSpan): ToolCall | null {
   const name = span["gen_ai.tool.name"];
   if (!name) {
     return null;
   }
+  const genAi = buildGenAIAttributes(span);
 
   return withoutUndefined({
     type: "tool_call" as const,
@@ -285,25 +512,23 @@ function buildToolCall(span: AIConversationSpan): ToolCall | null {
     spanId: span.span_id,
     traceId: span.trace,
     timestamp: timestampMs(span["precise.start_ts"]),
-    durationMs: Math.round(
-      (span["precise.finish_ts"] - span["precise.start_ts"]) * 1000,
-    ),
+    durationMs: durationMs(span),
     status: span["span.status"],
-    arguments: span["gen_ai.tool.call.arguments"],
-    input: span["gen_ai.tool.input"],
+    arguments: genAi?.toolCallArguments,
+    input: genAi?.toolInput,
+    genAi: buildToolCallGenAIAttributes(genAi),
   });
 }
 
 function buildMessageEvents(span: AIConversationSpan): ConversationMessage[] {
-  const durationMs = Math.round(
-    (span["precise.finish_ts"] - span["precise.start_ts"]) * 1000,
-  );
+  const spanDurationMs = durationMs(span);
+  const genAi = buildGenAIAttributes(span);
   const metadata = withoutUndefined({
     agentName: span["gen_ai.agent.name"],
     model: span["gen_ai.response.model"] ?? span["gen_ai.request.model"],
     totalTokens: numeric(span["gen_ai.usage.total_tokens"]),
     status: span["span.status"],
-    durationMs,
+    durationMs: spanDurationMs,
   });
   const events: ConversationMessage[] = [];
   const userContent = extractUserContent(span);
@@ -318,6 +543,7 @@ function buildMessageEvents(span: AIConversationSpan): ConversationMessage[] {
         traceId: span.trace,
         userEmail: span["user.email"],
         metadata: undefined,
+        genAi,
       }),
     );
   }
@@ -332,11 +558,13 @@ function buildMessageEvents(span: AIConversationSpan): ConversationMessage[] {
       spanId: span.span_id,
       traceId: span.trace,
       metadata,
+      genAi,
     });
   } else if (events.length > 0) {
     events[events.length - 1] = {
       ...events[events.length - 1]!,
       metadata,
+      genAi,
     };
   }
 
@@ -385,6 +613,13 @@ function buildConversationArtifact(
   lookupWindow: LookupWindow,
 ): AIConversationDetailsOutput {
   const timeline = extractTimeline(spans);
+  const spanSummaries = spans.map(buildSpanSummary).sort((a, b) => {
+    const timestampDiff = a.timestamp - b.timestamp;
+    if (timestampDiff !== 0) {
+      return timestampDiff;
+    }
+    return a.spanId.localeCompare(b.spanId);
+  });
   const traceIds = [...new Set(spans.map((span) => span.trace))].sort();
   const projects = [...new Set(spans.map((span) => span.project))].sort();
   const startTimestamp =
@@ -415,6 +650,7 @@ function buildConversationArtifact(
       (sum, span) => sum + numeric(span["gen_ai.usage.total_tokens"]),
       0,
     ),
+    spanSummaries,
     timeline,
   });
 }


### PR DESCRIPTION
AI conversation details now include a stable GenAI projection on transcript timeline events and chronological span summaries with span operation, description, transaction, and exact GenAI fields. Large raw message and tool payload attributes are truncated, marked, and still retain span IDs and trace IDs so agents can query raw spans when they need full values.

Tool-call timeline events keep the existing arguments/input fields for payloads, while span summaries carry the exact gen_ai.tool.* attribute names. This avoids duplicate public names on the transcript event contract.