### PR TITLE
fix(docs): use native url transport for Codex and Zed cloud MCP config

### DIFF
--- a/packages/mcp-cloudflare/src/client/components/fragments/instructions/codex-cli.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/instructions/codex-cli.tsx
@@ -1,5 +1,4 @@
 import CodeSnippet from "../../ui/code-snippet";
-import { NPM_REMOTE_NAME } from "../../../../constants";
 
 interface CodexCLIInstructionsProps {
   transport: "cloud" | "stdio";
@@ -8,14 +7,9 @@ interface CodexCLIInstructionsProps {
 export function CodexCLIInstructions({ transport }: CodexCLIInstructionsProps) {
   if (transport === "cloud") {
     const endpoint = new URL("/mcp", window.location.href).href;
-    const coreConfig = {
-      command: "npx",
-      args: ["-y", `${NPM_REMOTE_NAME}@latest`, endpoint],
-    };
     const codexRemoteConfigToml = [
       "[mcp_servers.sentry]",
-      'command = "npx"',
-      `args = ["-y", "${NPM_REMOTE_NAME}@latest", "${endpoint}"]`,
+      `url = "${endpoint}"`,
     ].join("\n");
 
     return (
@@ -25,9 +19,7 @@ export function CodexCLIInstructions({ transport }: CodexCLIInstructionsProps) {
           <li>
             <CodeSnippet
               noMargin
-              snippet={`codex mcp add sentry -- ${
-                coreConfig.command
-              } ${coreConfig.args.join(" ")}`}
+              snippet={`codex mcp add sentry --url ${endpoint}`}
             />
           </li>
           <li>

--- a/packages/mcp-cloudflare/src/client/components/fragments/instructions/zed.tsx
+++ b/packages/mcp-cloudflare/src/client/components/fragments/instructions/zed.tsx
@@ -1,6 +1,5 @@
 import CodeSnippet from "../../ui/code-snippet";
 import { KeyIcon } from "../../ui/key-icon";
-import { NPM_REMOTE_NAME } from "../../../../constants";
 
 interface ZedInstructionsProps {
   transport: "cloud" | "stdio";
@@ -11,14 +10,12 @@ export function ZedInstructions({ transport }: ZedInstructionsProps) {
 
   if (transport === "cloud") {
     const endpoint = new URL("/mcp", window.location.href).href;
-    const coreConfig = {
-      command: "npx",
-      args: ["-y", `${NPM_REMOTE_NAME}@latest`, endpoint],
-    };
     const zedInstructions = JSON.stringify(
       {
         context_servers: {
-          [mcpServerName]: coreConfig,
+          [mcpServerName]: {
+            url: endpoint,
+          },
           settings: {},
         },
       },


### PR DESCRIPTION
## Problem

Codex and Zed cloud transport instructions on mcp.sentry.dev both use `mcp-remote` as a proxy, but both clients support native HTTP/OAuth MCP transport — making `mcp-remote` unnecessary and actively broken.

Reported: Codex with the `mcp-remote` config fails with:
```
⚠ MCP client for `sentry` failed to start: MCP startup failed: handshaking with MCP server failed: connection closed: initialize response
```

While the native URL config works:
```toml
[mcp_servers.sentry]
url = "https://mcp.sentry.dev/mcp"
```

(The repo's own `.codex/config.toml` already uses this format.)

## Changes

**Codex (`codex-cli.tsx`):**
- CLI snippet: `codex mcp add sentry -- npx -y mcp-remote@latest ...` → `codex mcp add sentry --url <endpoint>`
- TOML snippet: `command/args` with `mcp-remote` → `url = "..."`
- Removed unused `NPM_REMOTE_NAME` import

**Zed (`zed.tsx`):**
- `context_servers` snippet: `command/args` with `mcp-remote` → `{ url: "..." }`
- Zed docs confirm: when no `Authorization` header is set, Zed triggers standard MCP OAuth flow automatically
- Removed unused `NPM_REMOTE_NAME` import

## Not changed

**Warp and Windsurf** still use `mcp-remote` — pending confirmation that their local agents handle the MCP OAuth PKCE flow when given a bare `url`. Warp cloud agents explicitly do not support OAuth MCP. Windsurf docs only show PAT auth for HTTP transport. These need field testing before changing.

## Verified
- Codex: user-reported working config matches the fix
- Zed: [docs confirm](https://zed.dev/docs/ai/mcp.html) native OAuth for `url`-only remote servers
- Codex: [GitHub MCP install guide](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-codex.md) confirms `url` field and `--url` flag work

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC08J1NSPU6S%3A1782555198.040859%22)