### PR TITLE
chore(warden): Ignore generated artifacts

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -4,6 +4,17 @@ version = 1
 failOn = "high"
 reportOn = "low"
 
+[defaults.ignore]
+paths = [
+  # Generated artifacts intentionally committed to the repository.
+  "pnpm-lock.yaml",
+  "packages/mcp-core/src/*Definitions.json",
+  "plugins/sentry-mcp*/agents/sentry-mcp.md",
+  "packages/mcp-cloudflare/worker-configuration.d.ts",
+  "packages/mcp-core/src/internal/agents/tools/data/*.json",
+  "!packages/mcp-core/src/internal/agents/tools/data/app.json",
+]
+
 [[skills]]
 name = "mcp-audit"
 paths = [


### PR DESCRIPTION
Add global Warden ignore patterns for generated files that are intentionally committed to the repository: MCP definition JSON, plugin agent files, Wrangler typegen, OpenTelemetry namespace data, and the lockfile.

This keeps Warden focused on hand-authored changes during reviews while still allowing the manually maintained OpenTelemetry app namespace to be reviewed via an explicit re-include pattern.

Validated the TOML parses and checked that the generated-file patterns cover the intended tracked artifacts.