### PR TITLE
fix(core): Preserve mixed-case slug parameters

### DIFF
--- a/docs/contributing/documentation-style-guide.md
+++ b/docs/contributing/documentation-style-guide.md
@@ -81,7 +81,6 @@ Link to reusable patterns: See "Error Handling" in [Common Patterns](common-patt
 // Tool parameter pattern used throughout the codebase
 export const ParamOrganizationSlug = z
   .string()
-  .toLowerCase()
   .trim()
   .describe("The organization's slug. Find using `find_organizations()` tool.");
 ```
@@ -93,10 +92,9 @@ import { z } from "zod";
 
 // Define a schema for the organization slug parameter
 // This schema will validate that the input is a string
-// It will also convert to lowercase and trim whitespace
+// It will also trim whitespace
 export const ParamOrganizationSlug = z
   .string() // Ensures the value is a string
-  .toLowerCase() // Converts to lowercase
   .trim() // Removes whitespace
   .describe("The organization's slug..."); // Adds description
 ```

--- a/packages/mcp-core/src/schema.ts
+++ b/packages/mcp-core/src/schema.ts
@@ -2,16 +2,17 @@
  * Reusable Zod parameter schemas for MCP tools.
  *
  * Shared validation schemas used across tool definitions to ensure consistent
- * parameter handling and validation. Each schema includes transformation
- * (e.g., toLowerCase, trim) and LLM-friendly descriptions.
+ * parameter handling and validation. Schemas apply minimal normalization
+ * (e.g., trim) and LLM-friendly descriptions.
  */
 import { z } from "zod";
 import { SENTRY_GUIDES } from "./constants";
 import { validateSlug } from "./utils/slug-validation";
 
+// Sentry slug lookups can be exact and case-sensitive on legacy instances.
+// Preserve caller casing for resource slugs; only trim and validate shape.
 export const ParamOrganizationSlug = z
   .string()
-  .toLowerCase()
   .trim()
   .superRefine(validateSlug)
   .describe(
@@ -20,7 +21,6 @@ export const ParamOrganizationSlug = z
 
 export const ParamTeamSlug = z
   .string()
-  .toLowerCase()
   .trim()
   .superRefine(validateSlug)
   .describe(
@@ -29,7 +29,6 @@ export const ParamTeamSlug = z
 
 export const ParamProjectSlug = z
   .string()
-  .toLowerCase()
   .trim()
   .superRefine(validateSlug)
   .describe(
@@ -38,11 +37,10 @@ export const ParamProjectSlug = z
 
 export const ParamProjectSlugOrAll = z
   .string()
-  .toLowerCase()
   .trim()
   .superRefine(validateSlug)
   .describe(
-    "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+    "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug.",
   );
 
 export const ParamSearchQuery = z

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -290,13 +290,13 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+              "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug."
             },
             {
               "type": "null"
             }
           ],
-          "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+          "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug.",
           "default": null
         },
         "query": {
@@ -475,13 +475,13 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+              "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug."
             },
             {
               "type": "null"
             }
           ],
-          "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+          "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug.",
           "default": null
         },
         "environment": {
@@ -638,13 +638,13 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+              "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug."
             },
             {
               "type": "null"
             }
           ],
-          "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+          "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug.",
           "default": null
         },
         "query": {
@@ -1197,13 +1197,13 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible."
+              "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug."
             },
             {
               "type": "null"
             }
           ],
-          "description": "The project's slug. This will default to all projects you have access to. It is encouraged to specify this when possible.",
+          "description": "The project's slug, or exact lowercase `all` when a tool supports all-projects scope. Other casing is treated as a project slug.",
           "default": null
         },
         "ruleIdOrName": {

--- a/packages/mcp-core/src/tools/catalog/find-projects.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-projects.test.ts
@@ -1,5 +1,8 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
 import findProjects from "./find-projects.js";
+import { prepareToolParams } from "../catalog-runtime/availability";
 import { getServerContext } from "../../test-setup.js";
 
 describe("find_projects", () => {
@@ -18,5 +21,39 @@ describe("find_projects", () => {
       - **cloudflare-mcp**
       "
     `);
+  });
+
+  it("preserves mixed-case organization slug in the API path", async () => {
+    const context = getServerContext();
+
+    mswServer.use(
+      http.get("*/api/0/organizations/*/projects/", ({ request }) => {
+        expect(new URL(request.url).pathname).toBe(
+          "/api/0/organizations/MyOrg/projects/",
+        );
+        return HttpResponse.json([
+          {
+            id: "1",
+            slug: "MyProject",
+            name: "My Project",
+          },
+        ]);
+      }),
+    );
+
+    const params = prepareToolParams({
+      tool: findProjects,
+      params: {
+        organizationSlug: " MyOrg ",
+        regionUrl: null,
+        query: null,
+      },
+      context,
+    }) as Parameters<typeof findProjects.handler>[0];
+
+    const result = await findProjects.handler(params, context);
+
+    expect(result).toContain("# Projects in **MyOrg**");
+    expect(result).toContain("- **MyProject**");
   });
 });

--- a/packages/mcp-core/src/tools/catalog/get-monitor-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-monitor-details.test.ts
@@ -2,6 +2,7 @@ import { mswServer } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 import getMonitorDetails from "./get-monitor-details.js";
+import { prepareToolParams } from "../catalog-runtime/availability";
 
 const context = {
   constraints: {
@@ -180,6 +181,69 @@ describe("get_monitor_details", () => {
       "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/monitors/nightly-import/",
       "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/monitors/nightly-import/checkins/",
       "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/monitors/nightly-import/stats/",
+    ]);
+  });
+
+  it("preserves mixed-case project slug in monitor detail endpoints", async () => {
+    const paths: string[] = [];
+    const monitorResponse = {
+      id: "4509100000000001",
+      slug: "nightly-import",
+      name: "Nightly Import",
+      status: "ok",
+      owner: null,
+      project: {
+        id: "4509109104082945",
+        slug: "MyProject",
+        name: "My Project",
+      },
+      config: {
+        schedule_type: "crontab",
+        schedule: ["crontab", "0 2 * * *"],
+      },
+      environments: [],
+    };
+    mswServer.use(
+      http.get(
+        "*/api/0/projects/*/*/monitors/nightly-import/",
+        ({ request }) => {
+          paths.push(new URL(request.url).pathname);
+          return HttpResponse.json(monitorResponse);
+        },
+      ),
+      http.get(
+        "*/api/0/projects/*/*/monitors/nightly-import/checkins/",
+        ({ request }) => {
+          paths.push(new URL(request.url).pathname);
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    const params = prepareToolParams({
+      tool: getMonitorDetails,
+      params: {
+        organizationSlug: " MyOrg ",
+        regionUrl: null,
+        projectSlugOrId: " MyProject ",
+        monitorSlug: "nightly-import",
+        environment: null,
+        period: "24h",
+        start: null,
+        end: null,
+        checkInLimit: 10,
+        includeStats: false,
+        rollupSeconds: null,
+      },
+      context,
+    }) as Parameters<typeof getMonitorDetails.handler>[0];
+
+    const result = await getMonitorDetails.handler(params, context);
+
+    expect(result).toContain("# Monitor Nightly Import in **MyOrg**");
+    expect(paths).toEqual([
+      "/api/0/projects/MyOrg/MyProject/monitors/nightly-import/",
+      "/api/0/projects/MyOrg/MyProject/monitors/nightly-import/checkins/",
     ]);
   });
 

--- a/packages/mcp-core/src/tools/catalog/get-monitor-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-monitor-details.ts
@@ -93,7 +93,6 @@ export default defineTool({
     regionUrl: ParamRegionUrl.nullable().default(null),
     projectSlugOrId: z
       .string()
-      .toLowerCase()
       .trim()
       .superRefine(validateSlugOrId)
       .nullable()

--- a/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.test.ts
@@ -2,6 +2,7 @@ import { mswServer, releaseFixture } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 import getReleaseDetails from "./get-release-details.js";
+import { prepareToolParams } from "../catalog-runtime/availability";
 
 const context = {
   constraints: {
@@ -242,6 +243,80 @@ describe("get_release_details", () => {
     );
     expect(new URL(commitsRequest!.url).pathname).toBe(
       `/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/${releaseVersion}/commits/`,
+    );
+  });
+
+  it("preserves mixed-case project slug in release detail endpoints", async () => {
+    const requests: Array<{
+      kind: "details" | "deploys" | "commits";
+      url: string;
+    }> = [];
+    const releaseVersion = "8ce89484-0fec-4913-a2cd-e8e2d41dee36";
+    mswServer.use(
+      http.get(
+        `https://sentry.io/api/0/projects/MyOrg/MyProject/releases/${releaseVersion}/`,
+        ({ request }) => {
+          requests.push({ kind: "details", url: request.url });
+          return HttpResponse.json(releaseFixture);
+        },
+      ),
+      http.get(
+        `https://sentry.io/api/0/organizations/MyOrg/releases/${releaseVersion}/deploys/`,
+        ({ request }) => {
+          requests.push({ kind: "deploys", url: request.url });
+          return HttpResponse.json([]);
+        },
+      ),
+      http.get(
+        `https://sentry.io/api/0/projects/MyOrg/MyProject/releases/${releaseVersion}/commits/`,
+        ({ request }) => {
+          requests.push({ kind: "commits", url: request.url });
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    const params = prepareToolParams({
+      tool: getReleaseDetails,
+      params: {
+        organizationSlug: " MyOrg ",
+        regionUrl: null,
+        releaseVersion,
+        projectSlugOrId: " MyProject ",
+        includeHealth: false,
+        includeDeploys: true,
+        includeCommits: true,
+        limit: 10,
+      },
+      context,
+    }) as Parameters<typeof getReleaseDetails.handler>[0];
+
+    await getReleaseDetails.handler(params, context);
+
+    expect(requests).toHaveLength(3);
+    const detailsRequest = requests.find(
+      (request) => request.kind === "details",
+    );
+    const deploysRequest = requests.find(
+      (request) => request.kind === "deploys",
+    );
+    const commitsRequest = requests.find(
+      (request) => request.kind === "commits",
+    );
+    expect(detailsRequest).toBeDefined();
+    expect(deploysRequest).toBeDefined();
+    expect(commitsRequest).toBeDefined();
+    expect(new URL(detailsRequest!.url).pathname).toBe(
+      `/api/0/projects/MyOrg/MyProject/releases/${releaseVersion}/`,
+    );
+    expect(new URL(deploysRequest!.url).pathname).toBe(
+      `/api/0/organizations/MyOrg/releases/${releaseVersion}/deploys/`,
+    );
+    expect(new URL(deploysRequest!.url).searchParams.get("projectSlug")).toBe(
+      "MyProject",
+    );
+    expect(new URL(commitsRequest!.url).pathname).toBe(
+      `/api/0/projects/MyOrg/MyProject/releases/${releaseVersion}/commits/`,
     );
   });
 

--- a/packages/mcp-core/src/tools/catalog/get-release-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-release-details.ts
@@ -101,7 +101,6 @@ export default defineTool({
     releaseVersion: z.string().trim().min(1).describe("Exact release version."),
     projectSlugOrId: z
       .string()
-      .toLowerCase()
       .trim()
       .superRefine(validateSlugOrId)
       .describe(

--- a/packages/mcp-core/src/tools/catalog/search-issues.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-issues.test.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import searchIssues from "./search-issues";
+import { prepareToolParams } from "../catalog-runtime/availability";
 import type { ServerContext } from "../../types";
 
 // Mock the AI SDK
@@ -322,38 +323,48 @@ describe("search_issues", () => {
   });
 
   it("should handle project slug parameter", async () => {
-    mockGenerateText.mockResolvedValue(mockAIResponse("", "date"));
+    process.env.OPENAI_API_KEY = "";
+    process.env.ANTHROPIC_API_KEY = "";
+    process.env.OPENROUTER_API_KEY = "";
 
     mswServer.use(
-      http.get("*/api/0/projects/*/my-project/", () => {
+      http.get("*/api/0/projects/*/*/", ({ request }) => {
+        expect(new URL(request.url).pathname).toBe(
+          "/api/0/projects/MyOrg/MyProject/",
+        );
         return HttpResponse.json({
           id: "789",
-          slug: "my-project",
+          slug: "MyProject",
           name: "My Project",
         });
       }),
       http.get("*/api/0/organizations/*/issues/", ({ request }) => {
         const url = new URL(request.url);
+        expect(url.pathname).toBe("/api/0/organizations/MyOrg/issues/");
         expect(url.searchParams.get("project")).toBe("789");
         expect(url.searchParams.get("statsPeriod")).toBe("30d");
         return HttpResponse.json([]);
       }),
     );
 
-    const result = await searchIssues.handler(
-      {
-        organizationSlug: "test-org",
+    const params = prepareToolParams({
+      tool: searchIssues,
+      params: {
+        organizationSlug: " MyOrg ",
         query: "all issues",
         sort: "date",
-        projectSlugOrId: "my-project",
+        projectSlugOrId: " MyProject ",
         regionUrl: null,
         limit: 10,
         period: "30d",
         includeExplanation: false,
       },
-      mockContext,
-    );
+      context: mockContext,
+    }) as Parameters<typeof searchIssues.handler>[0];
 
+    const result = await searchIssues.handler(params, mockContext);
+
+    expect(mockGenerateText).not.toHaveBeenCalled();
     expect(result).toContain("No issues found");
   });
 

--- a/packages/mcp-core/src/tools/catalog/search-issues.ts
+++ b/packages/mcp-core/src/tools/catalog/search-issues.ts
@@ -13,11 +13,7 @@ import {
   formatExplanation,
 } from "../support/search-issues/formatters";
 
-const ProjectSlugOrIdSchema = z
-  .string()
-  .toLowerCase()
-  .trim()
-  .superRefine(validateSlugOrId);
+const ProjectSlugOrIdSchema = z.string().trim().superRefine(validateSlugOrId);
 
 function buildIssueSearchRepairPrompt(params: {
   query: string;

--- a/packages/mcp-core/src/tools/catalog/slug-case.test.ts
+++ b/packages/mcp-core/src/tools/catalog/slug-case.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { prepareToolParams } from "../catalog-runtime/availability";
+import type { ToolConfig } from "../types";
+import { getServerContext } from "../../test-setup";
+import findProjects from "./find-projects";
+import getMonitorDetails from "./get-monitor-details";
+import getReleaseDetails from "./get-release-details";
+import searchIssues from "./search-issues";
+import updateProject from "./update-project";
+
+function parseToolParams(tool: ToolConfig, params: Record<string, unknown>) {
+  return prepareToolParams({
+    tool,
+    params,
+    context: getServerContext(),
+  });
+}
+
+describe("slug parameter case preservation", () => {
+  it("preserves mixed-case resource slugs during tool parameter parsing", () => {
+    expect(
+      parseToolParams(findProjects, {
+        organizationSlug: " MyOrg ",
+        regionUrl: null,
+        query: null,
+      }),
+    ).toMatchObject({
+      organizationSlug: "MyOrg",
+    });
+
+    expect(
+      parseToolParams(searchIssues, {
+        organizationSlug: "MyOrg",
+        projectSlugOrId: " MyProject ",
+      }),
+    ).toMatchObject({
+      organizationSlug: "MyOrg",
+      projectSlugOrId: "MyProject",
+    });
+
+    expect(
+      parseToolParams(getMonitorDetails, {
+        organizationSlug: "MyOrg",
+        projectSlugOrId: " MyProject ",
+        monitorSlug: "nightly-import",
+      }),
+    ).toMatchObject({
+      organizationSlug: "MyOrg",
+      projectSlugOrId: "MyProject",
+    });
+
+    expect(
+      parseToolParams(getReleaseDetails, {
+        organizationSlug: "MyOrg",
+        releaseVersion: "1.2.3",
+        projectSlugOrId: " MyProject ",
+      }),
+    ).toMatchObject({
+      organizationSlug: "MyOrg",
+      projectSlugOrId: "MyProject",
+    });
+
+    expect(
+      parseToolParams(updateProject, {
+        organizationSlug: "MyOrg",
+        projectSlug: " OldProject ",
+        name: null,
+        slug: " NewProject ",
+        platform: null,
+        teamSlug: " MyTeam ",
+        regionUrl: null,
+      }),
+    ).toMatchObject({
+      organizationSlug: "MyOrg",
+      projectSlug: "OldProject",
+      slug: "NewProject",
+      teamSlug: "MyTeam",
+    });
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/update-project.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-project.test.ts
@@ -1,5 +1,8 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
 import updateProject from "./update-project.js";
+import { prepareToolParams } from "../catalog-runtime/availability";
 
 describe("update_project", () => {
   it("updates name and platform", async () => {
@@ -76,5 +79,57 @@ describe("update_project", () => {
       - Team assignment: \`backend-team\`
       "
     `);
+  });
+
+  it("preserves mixed-case slugs in team and project update requests", async () => {
+    const paths: string[] = [];
+    let updateBody: unknown;
+    mswServer.use(
+      http.post("*/api/0/projects/*/*/teams/*/", ({ request }) => {
+        paths.push(new URL(request.url).pathname);
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.put("*/api/0/projects/*/*/", async ({ request }) => {
+        paths.push(new URL(request.url).pathname);
+        updateBody = await request.json();
+        return HttpResponse.json({
+          id: "4509109104082945",
+          slug: "NewProject",
+          name: "New Project",
+          platform: "node",
+        });
+      }),
+    );
+
+    const context = {
+      constraints: {
+        organizationSlug: null,
+      },
+      accessToken: "access-token",
+      userId: "1",
+    };
+    const params = prepareToolParams({
+      tool: updateProject,
+      params: {
+        organizationSlug: " MyOrg ",
+        regionUrl: null,
+        projectSlug: " OldProject ",
+        name: null,
+        slug: " NewProject ",
+        platform: null,
+        teamSlug: " MyTeam ",
+      },
+      context,
+    }) as Parameters<typeof updateProject.handler>[0];
+
+    const result = await updateProject.handler(params, context);
+
+    expect(paths).toEqual([
+      "/api/0/projects/MyOrg/OldProject/teams/MyTeam/",
+      "/api/0/projects/MyOrg/OldProject/",
+    ]);
+    expect(updateBody).toEqual({ slug: "NewProject" });
+    expect(result).toContain("**Slug**: NewProject");
+    expect(result).toContain('- Updated team assignment to "MyTeam"');
   });
 });

--- a/packages/mcp-core/src/tools/catalog/update-project.ts
+++ b/packages/mcp-core/src/tools/catalog/update-project.ts
@@ -66,11 +66,9 @@ export default defineTool({
       .describe("The new name for the project")
       .nullable()
       .default(null),
-    slug: z
-      .string()
-      .toLowerCase()
-      .trim()
-      .describe("The new slug for the project (must be unique)")
+    slug: ParamProjectSlug.describe(
+      "The new slug for the project (must be unique)",
+    )
       .nullable()
       .default(null),
     platform: ParamPlatform.nullable().default(null),

--- a/packages/mcp-core/src/utils/slug-validation.test.ts
+++ b/packages/mcp-core/src/utils/slug-validation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
+import {
+  ParamOrganizationSlug,
+  ParamProjectSlug,
+  ParamProjectSlugOrAll,
+  ParamTeamSlug,
+} from "../schema";
 import { validateSlug, validateSlugOrId, isNumericId } from "./slug-validation";
 
 describe("slug-validation", () => {
@@ -12,6 +18,8 @@ describe("slug-validation", () => {
         "my.project",
         "project123",
         "123project",
+        "MyOrg",
+        "My.Project_123",
         "a",
         "a-b-c-d-e-f",
         "test_123.abc-def",
@@ -151,6 +159,7 @@ describe("slug-validation", () => {
         "my_project",
         "myproject",
         "project123",
+        "MyProject",
       ];
 
       for (const slug of validSlugs) {
@@ -172,19 +181,12 @@ describe("slug-validation", () => {
   });
 
   describe("integration with ParamOrganizationSlug", () => {
-    it("should validate organization slugs with transformations", () => {
-      // Import the actual param schema to test integration
-      const ParamOrganizationSlug = z
-        .string()
-        .toLowerCase()
-        .trim()
-        .superRefine(validateSlug);
+    it("should preserve case for resource slugs", () => {
+      expect(ParamOrganizationSlug.parse("  MyOrg  ")).toBe("MyOrg");
+      expect(ParamTeamSlug.parse("MyTeam")).toBe("MyTeam");
+      expect(ParamProjectSlug.parse("My_Project")).toBe("My_Project");
+      expect(ParamProjectSlugOrAll.parse("My.Project")).toBe("My.Project");
 
-      // Should transform and validate
-      expect(ParamOrganizationSlug.parse("  MY-ORG  ")).toBe("my-org");
-      expect(ParamOrganizationSlug.parse("MY_ORG")).toBe("my_org");
-
-      // Should reject dangerous patterns after transformation
       expect(() => ParamOrganizationSlug.parse("  ../MY-ORG  ")).toThrow(
         /alphanumeric/i,
       );
@@ -219,10 +221,9 @@ describe("slug-validation", () => {
       expect(() => schema.parse("\0")).toThrow(/alphanumeric/i);
     });
 
-    it("should handle case sensitivity correctly", () => {
-      const schema = z.string().toLowerCase().trim().superRefine(validateSlug);
+    it("should reject dangerous patterns without case coercion", () => {
+      const schema = z.string().trim().superRefine(validateSlug);
 
-      // Should normalize and then validate
       expect(() => schema.parse("..AUTH")).toThrow(/alphanumeric/i);
       expect(() => schema.parse("../AUTH")).toThrow(/alphanumeric/i);
       expect(() => schema.parse("%2E%2E")).toThrow(/alphanumeric/i);

--- a/packages/mcp-core/src/utils/slug-validation.ts
+++ b/packages/mcp-core/src/utils/slug-validation.ts
@@ -37,13 +37,11 @@ const VALID_SLUG_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
  * @example
  * ```typescript
  * const OrganizationSlug = z.string()
- *   .toLowerCase()
  *   .trim()
  *   .superRefine(validateSlug)
  *   .describe("Organization slug");
  *
  * const TeamSlug = z.string()
- *   .toLowerCase()
  *   .trim()
  *   .superRefine(validateSlug)
  *   .describe("Team slug");
@@ -85,7 +83,6 @@ export function validateSlug(val: string, ctx: z.RefinementCtx): void {
  * @example
  * ```typescript
  * const ProjectSlugOrId = z.string()
- *   .toLowerCase()
  *   .trim()
  *   .superRefine(validateSlugOrId)
  *   .describe("Project slug or numeric ID");


### PR DESCRIPTION
Preserve caller casing for Sentry resource slug parameters instead of lowercasing them during MCP argument parsing.

Sentry slug lookups can be exact on legacy self-hosted instances, so mixed-case organization, project, and team slugs need to reach Sentry API paths unchanged. This restores compatibility for installs that still have mixed-case slugs.

The change keeps trimming and slug validation, leaves non-slug normalization in place, and updates the generated tool definition copy for the exact lowercase `all` sentinel. Regression coverage now asserts mixed-case parser output and API request paths/bodies for the affected tools.

Fixes #1138