### PR TITLE
feat(cloudflare): Add Sentry-Bearer direct auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ For self-hosted instances without TLS:
 npx @sentry/mcp-server@latest --access-token=TOKEN --host=sentry.internal:9000 --insecure-http
 ```
 
+#### Remote with an Explicit Sentry Token
+
+Remote clients that support custom HTTP headers can pass an upstream Sentry API
+token directly to the Cloudflare transport:
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp",
+      "headers": {
+        "Authorization": "Sentry-Bearer ${SENTRY_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+`Sentry-Bearer` is intentionally separate from `Bearer`: `Bearer` is reserved
+for MCP OAuth access tokens. With `Sentry-Bearer`, the worker does not store,
+validate, exchange, or refresh the upstream token. It forwards the token through
+the same Sentry API calls used by OAuth-backed sessions, and the client or
+upstream provider remains responsible for token lifetime and refresh.
+
+Direct remote auth defaults to all active MCP skills. You can narrow the exposed
+tools with `?skills=inspect,triage` or `?disable-skills=seer`.
+
 #### Environment Variables
 
 ```shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ canonical workflow and required docs live in [../AGENTS.md](../AGENTS.md)
 - [specs/embedded-agent-openai-routing.md](specs/embedded-agent-openai-routing.md) - Embedded agent OpenAI routing spec
 - [specs/remembered-oauth-skills.md](specs/remembered-oauth-skills.md) - Remembered OAuth skill defaults spec
 - [specs/search-events.md](specs/search-events.md) - Search Events spec
+- [specs/sentry-bearer-cloudflare-auth.md](specs/sentry-bearer-cloudflare-auth.md) - Direct Sentry token auth for the Cloudflare transport
 - [specs/subpath-constraints.md](specs/subpath-constraints.md) - Subpath constraints spec
 
 ### Releases

--- a/docs/cloudflare/oauth-architecture.md
+++ b/docs/cloudflare/oauth-architecture.md
@@ -86,6 +86,7 @@ sequenceDiagram
 | **MCP Refresh Token** | MCP OAuth Provider | MCP Clients | Grant reference | Refresh MCP access tokens |
 | **Sentry Access Token** | Sentry OAuth | MCP Server | User credentials | Call Sentry API |
 | **Sentry Refresh Token** | Sentry OAuth | MCP OAuth Provider | Refresh credentials | Refresh Sentry tokens |
+| **Explicit Sentry API Token** | External client or provider | MCP Server | Opaque Sentry API token | Direct remote auth with `Sentry-Bearer` |
 
 ### Not a Simple Proxy
 
@@ -370,6 +371,29 @@ When a constrained OAuth request includes `resource=/mcp/{org}` or
 user as a "Session scope" banner before permissions are granted.
 
 Note: These describe the MCP OAuth server, not Sentry's OAuth endpoints.
+
+## Direct Sentry-Bearer Mode
+
+Cloudflare `/mcp` also supports an explicit upstream Sentry API token:
+
+```http
+Authorization: Sentry-Bearer <sentry_api_token>
+```
+
+This is not part of the dual OAuth flow. The worker handles the request before
+the MCP OAuth provider, builds `ServerContext` with the provided token, and uses
+the same Sentry API client calls as OAuth-backed sessions.
+
+Direct mode intentionally does not:
+
+- validate the token before initializing the MCP server
+- store the token in KV
+- mint or refresh MCP OAuth tokens
+- refresh upstream Sentry tokens
+- revoke MCP grants when Sentry rejects the upstream token
+
+The caller owns token lifetime and refresh. `Authorization: Bearer ...` remains
+reserved for MCP OAuth access tokens.
 
 ## Integration Between MCP OAuth and MCP Server
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -4,7 +4,7 @@ Authentication and security patterns for the Sentry MCP server.
 
 ## Remote HTTP Auth Model
 
-The remote HTTP deployment uses two separate authorization layers:
+The default remote HTTP deployment uses two separate authorization layers:
 
 ```
 MCP Client → MCP OAuth (our server) → Sentry OAuth → Sentry API
@@ -14,7 +14,20 @@ This is not just "OAuth to Sentry, then proxy requests back." The Cloudflare
 deployment issues its own MCP access token to the client, and that token wraps
 the upstream Sentry credentials the server needs to make API calls.
 
+There is also an explicit direct-token mode for trusted clients that already
+manage an upstream Sentry API token:
+
+```http
+Authorization: Sentry-Bearer <sentry_api_token>
+```
+
+That mode bypasses MCP OAuth. The token is not stored, exchanged, refreshed, or
+pre-validated by the worker; it is passed through as the upstream Sentry API
+token for the request.
+
 ### Two Distinct Tokens
+
+For OAuth-backed remote sessions, there are two distinct tokens:
 
 1. **Upstream Sentry token**
    - Issued by Sentry's OAuth server
@@ -92,6 +105,10 @@ Today, runtime authorization for remote HTTP sessions is driven primarily by:
 `grantedScopes` still exists on tokens for backward compatibility with older
 clients, but it is transitional. Skills are the primary authorization model.
 
+Direct `Sentry-Bearer` sessions default to all active skills and can be narrowed
+with `skills` or `disable-skills` query parameters. They do not get OAuth
+consent-screen skill selection.
+
 ## Security Model
 
 The remote deployment intentionally separates trust boundaries:
@@ -119,6 +136,11 @@ The remote deployment intentionally separates trust boundaries:
 3. **Each session can be path-scoped**: `/mcp/:org` and `/mcp/:org/:project` produce tokens that only work for that scoped MCP URL.
 4. **Refresh does not widen access**: MCP refresh reuses the same stored grant props and does not ask Sentry for broader permissions.
 5. **Stale or invalid grants fail closed**: missing props, invalid skills, or rejected upstream tokens are revoked or require re-authentication. Already-issued Cloudflare grants with the old `preprod` skill are treated as `inspect`.
+
+For direct `Sentry-Bearer` sessions, the client intentionally provides the raw
+Sentry token. The worker still enforces MCP tool exposure and passes URL
+constraints into tool context, but token lifetime, refresh, and revocation are
+owned by the caller and upstream Sentry API behavior.
 
 ## OAuth Architecture
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -3,6 +3,15 @@
 This directory contains detailed specifications for features in the Sentry MCP
 server. Each spec should live in a single Markdown file under `docs/specs/`.
 
+## Specs
+
+- [AI Conversations](ai-conversations.md)
+- [Embedded Agent OpenAI Routing](embedded-agent-openai-routing.md)
+- [Remembered OAuth Skill Defaults](remembered-oauth-skills.md)
+- [Search Events](search-events.md)
+- [Sentry-Bearer Cloudflare Auth](sentry-bearer-cloudflare-auth.md)
+- [Subpath Constraints](subpath-constraints.md)
+
 ## Purpose
 
 Feature specifications serve to:

--- a/docs/specs/sentry-bearer-cloudflare-auth.md
+++ b/docs/specs/sentry-bearer-cloudflare-auth.md
@@ -1,0 +1,148 @@
+# Sentry-Bearer Cloudflare Auth
+
+## Overview
+
+The Cloudflare HTTP transport supports an explicit upstream Sentry API token in
+the MCP request `Authorization` header:
+
+```http
+Authorization: Sentry-Bearer <sentry_api_token>
+```
+
+This mode lets trusted clients that already manage Sentry API tokens use the
+remote MCP transport without first completing the MCP OAuth flow.
+
+## Motivation
+
+Before this feature, explicit Sentry API tokens were only usable with the
+stdio transport. Remote HTTP clients had to use MCP OAuth, even when an
+upstream provider had already obtained and refreshed a Sentry token.
+
+The goal is to add a remote equivalent of stdio `--access-token`: the worker
+does not validate, store, exchange, or refresh the token. It forwards the token
+through the normal MCP server context, and the existing Sentry API client uses
+it for upstream API calls.
+
+## Design
+
+`Authorization: Sentry-Bearer <token>` is an explicit direct-auth signal. The
+Cloudflare entrypoint handles matching `/mcp...` requests before invoking the
+MCP OAuth provider.
+
+Direct-auth requests:
+
+- skip MCP OAuth token validation
+- skip grant lookup and grant revocation
+- skip upstream Sentry token refresh paths
+- do not store the token in KV
+- do not pre-validate the token against Sentry
+- use the token as `ServerContext.accessToken`
+- rely on Sentry API responses for token validity and permissions
+
+`Authorization: Bearer <token>` keeps its existing meaning as a downstream MCP
+OAuth access token. Missing auth keeps returning the normal OAuth challenge.
+Malformed `Sentry-Bearer` auth returns a direct `401` instead of falling back
+to OAuth.
+
+## Interface
+
+### Header
+
+```http
+Authorization: Sentry-Bearer <sentry_api_token>
+```
+
+The token value must be a single non-empty header token. The worker treats it
+as opaque.
+
+### URL
+
+The direct mode uses the same MCP endpoint shapes as OAuth:
+
+```text
+/mcp
+/mcp/:organizationSlug
+/mcp/:organizationSlug/:projectSlug
+```
+
+The URL path is still injected into `ServerContext.constraints`. Unlike OAuth,
+direct mode does not pre-verify that the token can access the constrained
+organization or project before initializing the MCP server. The upstream
+Sentry API remains the permission boundary for actual tool calls.
+
+### Skills
+
+Direct mode defaults to all active MCP skills. Clients can narrow tool
+exposure with query parameters:
+
+```text
+/mcp?skills=inspect,triage
+/mcp?disable-skills=seer
+```
+
+Invalid skill names return `400`. At least one valid skill must remain enabled.
+
+## Examples
+
+Direct remote MCP configuration for clients that support custom HTTP headers:
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp",
+      "headers": {
+        "Authorization": "Sentry-Bearer ${SENTRY_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Manual MCP request:
+
+```bash
+curl https://mcp.sentry.dev/mcp \
+  -H "Authorization: Sentry-Bearer $SENTRY_ACCESS_TOKEN" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+## Implementation
+
+1. Detect `Sentry-Bearer` authorization at the Cloudflare entrypoint before
+   routing to the OAuth provider.
+2. Reject missing or malformed direct tokens with `401` and a
+   `WWW-Authenticate: Sentry-Bearer ...` challenge.
+3. Build the MCP server with the provided token, resolved skills, parsed URL
+   constraints, and direct-auth telemetry.
+4. Reuse the existing Sentry API client paths through `ServerContext`.
+5. Keep OAuth refresh, grant lifecycle, and upstream-401 revocation logic scoped
+   to OAuth-authenticated requests.
+
+## Testing
+
+Coverage should verify:
+
+- direct `Sentry-Bearer` requests reach the MCP handler without OAuth props
+- `Bearer` requests still route through MCP OAuth
+- malformed `Sentry-Bearer` requests return `401` without invoking OAuth
+- direct mode applies token-scoped rate limiting with hashed token keys
+- direct mode supports skill narrowing and rejects invalid skills
+- direct mode does not pre-verify URL constraints
+- OAuth stale-grant and upstream-401 revocation behavior remains unchanged
+
+## Migration
+
+This is additive. Existing OAuth clients continue using `Authorization:
+Bearer <mcp_access_token>`, OAuth discovery, and token refresh unchanged.
+Existing stdio clients continue using `--access-token` or
+`SENTRY_ACCESS_TOKEN`.
+
+## Future Work
+
+- Add first-class test-client support for custom remote headers if remote
+  direct-token QA becomes common.
+- Consider a dedicated rate-limiter binding for direct upstream tokens if the
+  traffic profile diverges from authenticated OAuth users.

--- a/docs/testing/remote.md
+++ b/docs/testing/remote.md
@@ -8,15 +8,15 @@ The remote MCP server runs on Cloudflare Workers and provides HTTP-based access 
 
 **When to use remote:**
 - Testing OAuth flows
+- Testing explicit Sentry API token auth over HTTP
 - Testing constraint-based access control (org/project filtering)
 - Testing the web chat interface
 - Production-like environment testing
 - Multi-user scenarios
 
 **When to use stdio instead:**
-- Self-hosted Sentry without OAuth
+- Self-hosted Sentry without a Cloudflare deployment
 - IDE integration testing
-- Direct API token authentication
 - Local development without network
 
 ## Prerequisites
@@ -194,6 +194,42 @@ pnpm -w run cli "who am I?"
 - Tokens stored in `~/.sentry-mcp-tokens.json`
 - Automatically refreshed when expired
 - To force re-auth: delete the token file
+
+### Direct Sentry Token Testing
+
+Remote `/mcp` also accepts explicit upstream Sentry API tokens with a separate
+authorization scheme:
+
+```bash
+curl http://localhost:5173/mcp \
+  -H "Authorization: Sentry-Bearer $SENTRY_ACCESS_TOKEN" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Use this path when the client or an upstream provider already owns the Sentry
+token lifecycle. The worker does not use MCP OAuth, store the token, validate it
+up front, refresh it, or revoke a grant when Sentry later rejects it.
+
+`Authorization: Bearer ...` remains the MCP OAuth token format. A malformed
+`Sentry-Bearer` header returns `401` directly instead of falling back to OAuth.
+
+Direct-token sessions default to all active skills. Narrow the exposed tools
+with query parameters:
+
+```bash
+curl "http://localhost:5173/mcp?skills=inspect,triage" \
+  -H "Authorization: Sentry-Bearer $SENTRY_ACCESS_TOKEN" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Constrained URLs still set MCP org/project constraints, for example
+`/mcp/sentry/javascript`, but direct-token mode does not pre-verify those
+constraints during initialization. Tool calls rely on the upstream Sentry API to
+accept or reject the provided token for the requested org/project.
 
 ### Testing with Constraints
 
@@ -641,11 +677,11 @@ Key differences to verify:
 
 | Feature | Stdio | Remote |
 |---------|-------|--------|
-| Authentication | Access token | OAuth |
+| Authentication | Access token | OAuth, or `Sentry-Bearer` access token |
 | Constraints | Via CLI flags | Via URL path |
 | Transport | stdin/stdout | HTTP/SSE |
 | Multi-user | No | Yes |
-| Token refresh | N/A | Automatic |
+| Token refresh | N/A | OAuth only; direct tokens are caller-managed |
 | Web UI | No | Yes |
 | Performance | Faster (no network) | Network latency |
 

--- a/packages/mcp-cloudflare/src/server/index.test.ts
+++ b/packages/mcp-cloudflare/src/server/index.test.ts
@@ -5,6 +5,7 @@ import type { Env } from "./types";
 const {
   MockOAuthProvider,
   mockOAuthProviderFetch,
+  mockHandleSentryBearerMcpRequest,
   mockGetClientIp,
   mockCheckRateLimit,
   mockActiveSpan,
@@ -21,6 +22,7 @@ const {
   return {
     MockOAuthProvider,
     mockOAuthProviderFetch,
+    mockHandleSentryBearerMcpRequest: vi.fn(),
     mockGetClientIp,
     mockCheckRateLimit: vi.fn(),
     mockActiveSpan: {
@@ -49,6 +51,7 @@ vi.mock("./app", () => ({
 
 vi.mock("./lib/mcp-handler", () => ({
   default: { fetch: vi.fn() },
+  handleSentryBearerMcpRequest: mockHandleSentryBearerMcpRequest,
 }));
 
 vi.mock("./oauth", () => ({
@@ -183,6 +186,68 @@ describe("worker entrypoint", () => {
     );
 
     expect(response.status).toBe(200);
+  });
+
+  it("routes Sentry-Bearer MCP requests directly without OAuth", async () => {
+    mockHandleSentryBearerMcpRequest.mockResolvedValueOnce(new Response("ok"));
+
+    const request = new Request("https://mcp.sentry.dev/mcp", {
+      method: "POST",
+      headers: {
+        Authorization: "Sentry-Bearer sntryu_test-token",
+        "User-Agent": "Claude-Code/1.0",
+      },
+    });
+
+    const response = await handler.fetch!(request, env, ctx);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    expect(mockHandleSentryBearerMcpRequest).toHaveBeenCalledWith(
+      request,
+      env,
+      ctx,
+      "sntryu_test-token",
+    );
+    expect(MockOAuthProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed Sentry-Bearer MCP authorization without OAuth", async () => {
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: "Sentry-Bearer",
+        },
+      }),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toContain("Missing or invalid");
+    expect(response.headers.get("WWW-Authenticate")).toContain("Sentry-Bearer");
+    expect(mockHandleSentryBearerMcpRequest).not.toHaveBeenCalled();
+    expect(MockOAuthProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects Sentry-Bearer MCP authorization with extra credentials without OAuth", async () => {
+    const response = await handler.fetch!(
+      new Request("https://mcp.sentry.dev/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: "Sentry-Bearer sntryu_test-token extra",
+        },
+      }),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toContain("Missing or invalid");
+    expect(response.headers.get("WWW-Authenticate")).toContain("Sentry-Bearer");
+    expect(mockHandleSentryBearerMcpRequest).not.toHaveBeenCalled();
+    expect(MockOAuthProvider).not.toHaveBeenCalled();
   });
 
   it("returns 429 when MCP/OAuth IP limiting blocks the request", async () => {

--- a/packages/mcp-cloudflare/src/server/index.ts
+++ b/packages/mcp-cloudflare/src/server/index.ts
@@ -9,7 +9,9 @@ import {
 } from "./lib/attribution";
 import { resolveClientFamily } from "./lib/client-family";
 import { redirectUriHasUserInfo } from "./lib/html-utils";
-import sentryMcpHandler from "./lib/mcp-handler";
+import sentryMcpHandler, {
+  handleSentryBearerMcpRequest,
+} from "./lib/mcp-handler";
 import {
   type RateLimitScope,
   annotateTrackedRequestSpan,
@@ -40,6 +42,35 @@ import { setSentryUserFromRequest } from "./utils/sentry-user";
 const AUTH_PARAM_SEPARATOR = /,\s*(?=[A-Za-z_][A-Za-z0-9_-]*\s*=)/;
 const AUTH_CHALLENGE = /^(\S+)(?:\s+(.+))?$/;
 const RESOURCE_METADATA_PARAM = /^resource_metadata\s*=/i;
+const SENTRY_BEARER_SCHEME = /^Sentry-Bearer\b/i;
+const SENTRY_BEARER_AUTH = /^Sentry-Bearer\s+(\S+)$/i;
+
+type SentryBearerAuth = { matched: false } | { matched: true; token?: string };
+
+/**
+ * Detects the direct-token Authorization scheme without consuming normal
+ * OAuth `Bearer` tokens. Malformed Sentry-Bearer headers still return
+ * `matched: true` without a token so callers can fail directly before OAuth.
+ */
+function parseSentryBearerAuthorization(
+  header: string | null,
+): SentryBearerAuth {
+  if (!header) {
+    return { matched: false };
+  }
+
+  const trimmedHeader = header.trim();
+  if (!SENTRY_BEARER_SCHEME.test(trimmedHeader)) {
+    return { matched: false };
+  }
+
+  const match = SENTRY_BEARER_AUTH.exec(trimmedHeader);
+  if (!match) {
+    return { matched: true };
+  }
+
+  return match[1] ? { matched: true, token: match[1] } : { matched: true };
+}
 
 function replaceResourceMetadataParam(
   headerValue: string,
@@ -127,8 +158,9 @@ async function finalizeResponse(
 // The OAuth provider manages several routes directly and may attach its own
 // CORS headers to the responses it handles. We wrap it to:
 //   1. Intercept OPTIONS before the library — return our own preflight response.
-//   2. Let the library handle the actual request normally.
-//   3. On the way out, apply our CORS policy:
+//   2. Route explicit Sentry-Bearer `/mcp` requests before OAuth.
+//   3. Let the library handle the remaining request normally.
+//   4. On the way out, apply our CORS policy:
 //      - Public metadata endpoints → restrictive read-only CORS (`*`, GET only)
 //      - Everything else → strip all CORS headers the library added
 const wrappedOAuthProvider = {
@@ -201,6 +233,38 @@ const wrappedOAuthProvider = {
       const utmSource = resolveUtmSourceFromUrl(url);
       if (utmSource) {
         activeSpan?.setAttribute(UTM_SOURCE_ATTRIBUTE, utmSource);
+      }
+    }
+
+    if (url.pathname.startsWith("/mcp")) {
+      const sentryBearerAuth = parseSentryBearerAuthorization(
+        request.headers.get("Authorization"),
+      );
+
+      if (sentryBearerAuth.matched) {
+        activeSpan?.setAttribute("app.auth.kind", "sentry-bearer");
+
+        if (!sentryBearerAuth.token) {
+          return finalizeResponse(
+            request,
+            url,
+            new Response("Missing or invalid Sentry-Bearer token", {
+              status: 401,
+              headers: {
+                "WWW-Authenticate":
+                  'Sentry-Bearer realm="Sentry MCP", error="invalid_token", error_description="Missing or invalid Sentry-Bearer token"',
+              },
+            }),
+          );
+        }
+
+        const response = await handleSentryBearerMcpRequest(
+          request,
+          env,
+          ctx,
+          sentryBearerAuth.token,
+        );
+        return finalizeResponse(request, url, response);
       }
     }
 

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -1,5 +1,6 @@
 import type { ExecutionContext, RateLimit } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DIRECT_AUTH_ASSERTION_TOKEN } from "../../test-utils/fetch-mock-setup";
 import type { Env } from "../types";
 
 const { sentryMetricsCount, sentrySetUser } = vi.hoisted(() => ({
@@ -15,7 +16,7 @@ vi.mock("@sentry/cloudflare", () => ({
   setUser: sentrySetUser,
 }));
 
-import mcpHandler from "./mcp-handler";
+import mcpHandler, { handleSentryBearerMcpRequest } from "./mcp-handler";
 
 interface OAuthProps {
   id: string;
@@ -311,6 +312,213 @@ describe("MCP Handler", () => {
       expect(response.status).toBe(429);
       expect(await response.text()).toContain("Rate limit exceeded");
     });
+
+    it("accepts Sentry-Bearer direct tokens without OAuth props or refresh tokens", async () => {
+      const request = createMcpRequest("tools/list");
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(200);
+      const body = await parseSSEResponse<{
+        result?: { tools: Array<{ name: string }> };
+      }>(response);
+      const toolNames = body.result?.tools.map((tool) => tool.name) ?? [];
+
+      expect(toolNames).toContain("search_events");
+      expect(toolNames).toContain("update_issue");
+    });
+
+    it("passes Sentry-Bearer direct tokens to upstream Sentry API calls", async () => {
+      const request = createMcpRequest("tools/call", {
+        name: "execute_sentry_tool",
+        arguments: {
+          name: "whoami",
+          arguments: {},
+        },
+      });
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+      const env = createTestEnv();
+      env.SENTRY_HOST = "direct-token.test";
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        env,
+        ctx,
+        DIRECT_AUTH_ASSERTION_TOKEN,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await parseSSEResponse<{
+        result?: { content?: Array<{ text?: string }> };
+      }>(response);
+      const text = body.result?.content?.map((item) => item.text).join("\n");
+
+      expect(text).toContain("You are authenticated as");
+    });
+
+    it("applies the Sentry-Bearer MCP rate limit per token", async () => {
+      const mockTokenRateLimiter = {
+        limit: vi.fn().mockResolvedValue({ success: true }),
+      } as unknown as RateLimit;
+      const request = createMcpRequest("tools/list");
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+      const env = createTestEnv();
+      env.MCP_USER_RATE_LIMITER = mockTokenRateLimiter;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        env,
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockTokenRateLimiter.limit).toHaveBeenCalledWith({
+        key: expect.stringMatching(/^mcp:sentry-token:[0-9a-f]{16}$/),
+      });
+    });
+
+    it("returns 429 with Sentry-Bearer scope when a direct token exceeds the MCP rate limit", async () => {
+      const request = createMcpRequest("tools/list");
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+      const env = createTestEnv();
+      env.MCP_USER_RATE_LIMITER = {
+        limit: vi.fn().mockResolvedValue({ success: false }),
+      } as unknown as RateLimit;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        env,
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(429);
+      expect(await response.text()).toContain("Rate limit exceeded");
+      expect(response.headers.get("x-sentry-rate-limit-scope")).toBe(
+        "sentry-token",
+      );
+    });
+
+    it("narrows Sentry-Bearer tools with direct skills query params", async () => {
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        { path: "/mcp?skills=inspect" },
+      );
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(200);
+      const body = await parseSSEResponse<{
+        result?: { tools: Array<{ name: string }> };
+      }>(response);
+      const toolNames = body.result?.tools.map((tool) => tool.name) ?? [];
+
+      expect(toolNames).toContain("search_events");
+      expect(toolNames).not.toContain("update_issue");
+    });
+
+    it("removes Sentry-Bearer tools with direct disable-skills query params", async () => {
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        { path: "/mcp?disable-skills=triage" },
+      );
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(200);
+      const body = await parseSSEResponse<{
+        result?: { tools: Array<{ name: string }> };
+      }>(response);
+      const toolNames = body.result?.tools.map((tool) => tool.name) ?? [];
+
+      expect(toolNames).toContain("search_events");
+      expect(toolNames).not.toContain("update_issue");
+    });
+
+    it("rejects invalid Sentry-Bearer skills query params", async () => {
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        { path: "/mcp?skills=bogus" },
+      );
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("invalid skills");
+    });
+
+    it("rejects empty Sentry-Bearer skills query params", async () => {
+      const request = createMcpRequest(
+        "tools/list",
+        {},
+        { path: "/mcp?skills=" },
+      );
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain(
+        "skills must include at least one valid skill",
+      );
+    });
   });
 
   describe("URL constraints", () => {
@@ -381,6 +589,35 @@ describe("MCP Handler", () => {
 
       expect(response.status).toBe(404);
       expect(await response.text()).toContain("not found");
+    });
+
+    it("does not pre-verify Sentry-Bearer URL constraints", async () => {
+      const request = createMcpRequest(
+        "initialize",
+        {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+        { path: "/mcp/nonexistent-org" },
+      );
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(200);
+      const body = await parseSSEResponse<{
+        result?: { protocolVersion: string };
+      }>(response);
+      expect(body.result?.protocolVersion).toBeDefined();
     });
 
     it("returns 403 when the token is org-scoped but the MCP URL uses a different organization", async () => {

--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.ts
@@ -3,16 +3,24 @@
  *
  * Stateless request handling approach:
  * - Uses createMcpHandler to wrap the MCP server
- * - Extracts auth props directly from ExecutionContext (set by OAuth provider)
+ * - OAuth requests extract auth props from ExecutionContext (set by OAuth provider)
+ * - Sentry-Bearer requests pass an explicit upstream token directly
  * - Context captured in tool handler closures during buildServer()
  * - No session state required - each request is independent
+ *
+ * Direct Sentry-Bearer mode intentionally does not validate, store, refresh,
+ * or revoke the upstream token. It only supplies that token to ServerContext.
  */
 
 import type { ExportedHandler } from "@cloudflare/workers-types";
 import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
 import * as Sentry from "@sentry/cloudflare";
 import { buildServer } from "@sentry/mcp-core/server";
-import { parseSkills } from "@sentry/mcp-core/skills";
+import {
+  ACTIVE_SKILLS,
+  parseSkills,
+  type Skill,
+} from "@sentry/mcp-core/skills";
 import { logWarn } from "@sentry/mcp-core/telem/logging";
 import type { ServerContext } from "@sentry/mcp-core/types";
 import { createMcpHandler } from "agents/mcp";
@@ -38,6 +46,26 @@ import { verifyConstraintsAccess } from "./constraint-utils";
 type OAuthExecutionContext = ExecutionContext & {
   props?: Record<string, unknown>;
 };
+
+type OAuthMcpContext = {
+  kind: "oauth";
+  accessToken: string;
+  grantedSkills: Set<Skill>;
+  userId: string;
+  clientId: string;
+  clientName?: string;
+  tokenConstraintOrganizationSlug?: string | null;
+  tokenConstraintProjectSlug?: string | null;
+  onUpstreamUnauthorized: () => void | Promise<void>;
+};
+
+type SentryBearerMcpContext = {
+  kind: "sentry-bearer";
+  accessToken: string;
+  grantedSkills: Set<Skill>;
+};
+
+type AuthenticatedMcpContext = OAuthMcpContext | SentryBearerMcpContext;
 
 function getSkillGrantedAttributeName(skill: string): string {
   return `app.consent.skill.${skill.replaceAll("-", "_")}.granted`;
@@ -167,6 +195,277 @@ function revokeStaleGrant(
   );
 }
 
+function formatInvalidSkills(invalid: string[], source: string): string {
+  return `${source} provided invalid skills: ${invalid.join(", ")}`;
+}
+
+/**
+ * Resolves direct-mode skill exposure from URL query parameters.
+ *
+ * Direct requests default to all active skills. `skills` replaces that set,
+ * while `disable-skills` removes entries from it. Empty or invalid inputs fail
+ * before the MCP server is built so direct callers do not silently widen access.
+ */
+function resolveDirectGrantedSkills(
+  url: URL,
+): { ok: true; grantedSkills: Set<Skill> } | { ok: false; response: Response } {
+  const skillsParam = url.searchParams.get("skills");
+  const disableSkillsParam = url.searchParams.get("disable-skills");
+
+  let grantedSkills: Set<Skill>;
+  if (url.searchParams.has("skills")) {
+    const { valid, invalid } = parseSkills(skillsParam);
+    if (invalid.length > 0) {
+      return {
+        ok: false,
+        response: new Response(formatInvalidSkills(invalid, "skills"), {
+          status: 400,
+        }),
+      };
+    }
+    if (valid.size === 0) {
+      return {
+        ok: false,
+        response: new Response("skills must include at least one valid skill", {
+          status: 400,
+        }),
+      };
+    }
+    grantedSkills = valid;
+  } else {
+    grantedSkills = new Set(ACTIVE_SKILLS);
+  }
+
+  if (disableSkillsParam) {
+    const { valid, invalid } = parseSkills(disableSkillsParam);
+    if (invalid.length > 0) {
+      return {
+        ok: false,
+        response: new Response(formatInvalidSkills(invalid, "disable-skills"), {
+          status: 400,
+        }),
+      };
+    }
+    for (const skill of valid) {
+      grantedSkills.delete(skill);
+    }
+    if (grantedSkills.size === 0) {
+      return {
+        ok: false,
+        response: new Response(
+          "disable-skills removed all available skills; at least one skill must remain enabled",
+          { status: 400 },
+        ),
+      };
+    }
+  }
+
+  return { ok: true, grantedSkills };
+}
+
+/**
+ * Builds a direct MCP request context from an explicit upstream Sentry token.
+ *
+ * This bypasses OAuth entirely: no grant props, token validation, token
+ * storage, upstream refresh, or grant revocation are used for direct mode.
+ */
+export async function handleSentryBearerMcpRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  accessToken: string,
+): Promise<Response> {
+  const skills = resolveDirectGrantedSkills(new URL(request.url));
+  if (!skills.ok) {
+    return skills.response;
+  }
+
+  return handleAuthenticatedMcpRequest(request, env, ctx, {
+    kind: "sentry-bearer",
+    accessToken,
+    grantedSkills: skills.grantedSkills,
+  });
+}
+
+/**
+ * Shared MCP server builder for OAuth-backed and direct-token requests.
+ *
+ * OAuth mode verifies URL constraints and owns upstream-401 grant revocation.
+ * Direct mode only parses URL constraints into context and leaves upstream
+ * token validity, refresh, and revocation to the caller/provider.
+ */
+async function handleAuthenticatedMcpRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  auth: AuthenticatedMcpContext,
+): Promise<Response> {
+  const url = new URL(request.url);
+
+  // Parse constraints from URL pattern /mcp/:org?/:project?
+  const pattern = new URLPattern({ pathname: "/mcp/:org?/:project?" });
+  const result = pattern.exec(url);
+
+  if (!result) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const { groups } = result.pathname;
+  const organizationSlug = groups?.org || null;
+  const projectSlug = groups?.project || null;
+
+  // Check for agent mode query parameter
+  const isAgentMode = url.searchParams.get("agent") === "1";
+
+  // Check for experimental mode query parameter
+  const isExperimentalMode = url.searchParams.get("experimental") === "1";
+
+  // Read utm_source for attribution tracking
+  const utmSource = resolveUtmSourceFromUrl(url);
+
+  const sentryHost = env.SENTRY_HOST || "sentry.io";
+  const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
+  const { ip_address: userIpAddress } = setSentryUserFromRequest(
+    request,
+    auth.kind === "oauth" ? auth.userId : undefined,
+  );
+
+  const activeSpan = Sentry.getActiveSpan();
+  activeSpan?.setAttribute("app.transport", "http");
+  activeSpan?.setAttribute("app.auth.kind", auth.kind);
+  activeSpan?.setAttribute("app.client.family", clientFamily);
+  activeSpan?.setAttribute("app.server.mode.agent", isAgentMode);
+  activeSpan?.setAttribute("app.server.mode.experimental", isExperimentalMode);
+  if (utmSource) {
+    activeSpan?.setAttribute(UTM_SOURCE_ATTRIBUTE, utmSource);
+  }
+
+  if (auth.kind === "oauth") {
+    for (const skill of Array.from(auth.grantedSkills).sort()) {
+      activeSpan?.setAttribute(getSkillGrantedAttributeName(skill), true);
+    }
+  }
+
+  const rateLimitConfig =
+    auth.kind === "oauth"
+      ? {
+          identifier: auth.userId,
+          keyPrefix: "mcp:user" as const,
+          scope: "user" as const,
+        }
+      : {
+          identifier: auth.accessToken,
+          keyPrefix: "mcp:sentry-token" as const,
+          scope: "sentry-token" as const,
+        };
+  const rateLimitResult = await checkRateLimit(
+    rateLimitConfig.identifier,
+    env.MCP_USER_RATE_LIMITER ?? env.MCP_RATE_LIMITER,
+    {
+      keyPrefix: rateLimitConfig.keyPrefix,
+      errorMessage: MCP_RATE_LIMIT_EXCEEDED_MESSAGE,
+    },
+  );
+
+  if (!rateLimitResult.allowed) {
+    return annotateResponseMetric(
+      new Response(rateLimitResult.errorMessage, {
+        status: 429,
+      }),
+      {
+        responseReason: "local_rate_limit",
+        rateLimitScope: rateLimitConfig.scope,
+      },
+    );
+  }
+
+  if (auth.kind === "oauth") {
+    const tokenOrg = auth.tokenConstraintOrganizationSlug?.trim() || null;
+    const tokenProject = auth.tokenConstraintProjectSlug?.trim() || null;
+    if (tokenOrg && organizationSlug !== tokenOrg) {
+      return new Response(
+        "This token is scoped to an organization. Use the MCP URL for the organization you authorized.",
+        { status: 403 },
+      );
+    }
+    if (tokenProject) {
+      if (!projectSlug || projectSlug !== tokenProject) {
+        return new Response(
+          "This token is scoped to a project. Use the MCP URL that includes that project (for example /mcp/<org>/<project>).",
+          { status: 403 },
+        );
+      }
+    }
+  }
+
+  const constraints =
+    auth.kind === "oauth"
+      ? await (async () => {
+          const verification = await verifyConstraintsAccess(
+            { organizationSlug, projectSlug },
+            {
+              accessToken: auth.accessToken,
+              sentryHost,
+              cache: {
+                kv: env.MCP_CACHE,
+                userId: auth.userId,
+              },
+            },
+          );
+
+          if (!verification.ok) {
+            return new Response(verification.message, {
+              status: verification.status ?? 500,
+            });
+          }
+
+          return verification.constraints;
+        })()
+      : {
+          organizationSlug,
+          projectSlug,
+          regionUrl: null,
+          projectCapabilities: null,
+        };
+
+  if (constraints instanceof Response) {
+    return constraints;
+  }
+
+  const serverContext: ServerContext = {
+    userId: auth.kind === "oauth" ? auth.userId : undefined,
+    userIpAddress,
+    clientId: auth.kind === "oauth" ? auth.clientId : undefined,
+    clientName: auth.kind === "oauth" ? auth.clientName : undefined,
+    clientFamily,
+    accessToken: auth.accessToken,
+    grantedSkills: auth.grantedSkills,
+    constraints,
+    sentryHost,
+    mcpUrl: env.MCP_URL,
+    agentMode: isAgentMode,
+    experimentalMode: isExperimentalMode,
+    transport: "http",
+    onUpstreamUnauthorized:
+      auth.kind === "oauth" ? auth.onUpstreamUnauthorized : undefined,
+  };
+
+  // Create and configure MCP server with tools filtered by context
+  // Context is captured in tool handler closures during buildServer()
+  // Use CfWorkerJsonSchemaValidator for Cloudflare Workers (ajv is not compatible with workerd)
+  const server = buildServer({
+    context: serverContext,
+    agentMode: isAgentMode,
+    experimentalMode: isExperimentalMode,
+    jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+  });
+
+  // Run MCP handler - context already captured in closures
+  return createMcpHandler(server, {
+    route: url.pathname,
+  })(request, env, ctx);
+}
+
 /**
  * Main request handler that:
  * 1. Extracts auth props from ExecutionContext
@@ -183,29 +482,6 @@ const mcpHandler: ExportedHandler<Env> = {
     env: Env,
     ctx: ExecutionContext,
   ): Promise<Response> {
-    const url = new URL(request.url);
-
-    // Parse constraints from URL pattern /mcp/:org?/:project?
-    const pattern = new URLPattern({ pathname: "/mcp/:org?/:project?" });
-    const result = pattern.exec(url);
-
-    if (!result) {
-      return new Response("Not found", { status: 404 });
-    }
-
-    const { groups } = result.pathname;
-    const organizationSlug = groups?.org || null;
-    const projectSlug = groups?.project || null;
-
-    // Check for agent mode query parameter
-    const isAgentMode = url.searchParams.get("agent") === "1";
-
-    // Check for experimental mode query parameter
-    const isExperimentalMode = url.searchParams.get("experimental") === "1";
-
-    // Read utm_source for attribution tracking
-    const utmSource = resolveUtmSourceFromUrl(url);
-
     // Extract OAuth props from ExecutionContext (set by OAuth provider)
     const oauthCtx = ctx as OAuthExecutionContext;
 
@@ -219,26 +495,10 @@ const mcpHandler: ExportedHandler<Env> = {
     const accessToken = rawProps.accessToken as string;
     const clientId = rawProps.clientId as string;
     const clientName = rawProps.clientName;
-    const sentryHost = env.SENTRY_HOST || "sentry.io";
     const clientFamily = resolveClientFamily(request.headers.get("user-agent"));
     const requestGrantId = getRequestGrantId(request);
     const lifecycleTelemetry = getOAuthGrantLifecycleTelemetry(rawProps);
-    const { ip_address: userIpAddress } = setSentryUserFromRequest(
-      request,
-      userId,
-    );
-
-    const activeSpan = Sentry.getActiveSpan();
-    activeSpan?.setAttribute("app.transport", "http");
-    activeSpan?.setAttribute("app.client.family", clientFamily);
-    activeSpan?.setAttribute("app.server.mode.agent", isAgentMode);
-    activeSpan?.setAttribute(
-      "app.server.mode.experimental",
-      isExperimentalMode,
-    );
-    if (utmSource) {
-      activeSpan?.setAttribute(UTM_SOURCE_ATTRIBUTE, utmSource);
-    }
+    setSentryUserFromRequest(request, userId);
 
     // Parse and validate granted skills (primary authorization method)
     // Legacy tokens without grantedSkills are no longer supported
@@ -324,87 +584,18 @@ const mcpHandler: ExportedHandler<Env> = {
       );
     }
 
-    for (const skill of Array.from(validSkills).sort()) {
-      activeSpan?.setAttribute(getSkillGrantedAttributeName(skill), true);
-    }
-
-    const rateLimitResult = await checkRateLimit(
-      userId,
-      env.MCP_USER_RATE_LIMITER ?? env.MCP_RATE_LIMITER,
-      {
-        keyPrefix: "mcp:user",
-        errorMessage: MCP_RATE_LIMIT_EXCEEDED_MESSAGE,
-      },
-    );
-
-    if (!rateLimitResult.allowed) {
-      return annotateResponseMetric(
-        new Response(rateLimitResult.errorMessage, {
-          status: 429,
-        }),
-        {
-          responseReason: "local_rate_limit",
-          rateLimitScope: "user",
-        },
-      );
-    }
-
-    const tokenOrg = rawProps.constraintOrganizationSlug?.trim() || null;
-    const tokenProject = rawProps.constraintProjectSlug?.trim() || null;
-    if (tokenOrg && organizationSlug !== tokenOrg) {
-      return new Response(
-        "This token is scoped to an organization. Use the MCP URL for the organization you authorized.",
-        { status: 403 },
-      );
-    }
-    if (tokenProject) {
-      if (!projectSlug || projectSlug !== tokenProject) {
-        return new Response(
-          "This token is scoped to a project. Use the MCP URL that includes that project (for example /mcp/<org>/<project>).",
-          { status: 403 },
-        );
-      }
-    }
-
-    // Verify user has access to the requested org/project
-    // Cache verification results in KV to avoid repeated API calls
-    const verification = await verifyConstraintsAccess(
-      { organizationSlug, projectSlug },
-      {
-        accessToken,
-        sentryHost,
-        cache: {
-          kv: env.MCP_CACHE,
-          userId,
-        },
-      },
-    );
-
-    if (!verification.ok) {
-      return new Response(verification.message, {
-        status: verification.status ?? 500,
-      });
-    }
-
-    const constraints = verification.constraints;
-
-    // Build complete ServerContext from OAuth props + verified constraints.
     // Latched so use_sentry's multi-tool runs revoke at most once per request.
     let upstreamUnauthorizedHandled = false;
-    const serverContext: ServerContext = {
+
+    return handleAuthenticatedMcpRequest(request, env, ctx, {
+      kind: "oauth",
       userId,
-      userIpAddress,
       clientId,
       clientName,
-      clientFamily,
       accessToken,
       grantedSkills: validSkills,
-      constraints,
-      sentryHost,
-      mcpUrl: env.MCP_URL,
-      agentMode: isAgentMode,
-      experimentalMode: isExperimentalMode,
-      transport: "http",
+      tokenConstraintOrganizationSlug: rawProps.constraintOrganizationSlug,
+      tokenConstraintProjectSlug: rawProps.constraintProjectSlug,
       onUpstreamUnauthorized: () => {
         if (upstreamUnauthorizedHandled) return;
         upstreamUnauthorizedHandled = true;
@@ -448,22 +639,7 @@ const mcpHandler: ExportedHandler<Env> = {
           })(),
         );
       },
-    };
-
-    // Create and configure MCP server with tools filtered by context
-    // Context is captured in tool handler closures during buildServer()
-    // Use CfWorkerJsonSchemaValidator for Cloudflare Workers (ajv is not compatible with workerd)
-    const server = buildServer({
-      context: serverContext,
-      agentMode: isAgentMode,
-      experimentalMode: isExperimentalMode,
-      jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
     });
-
-    // Run MCP handler - context already captured in closures
-    return createMcpHandler(server, {
-      route: url.pathname,
-    })(request, env, ctx);
   },
 };
 

--- a/packages/mcp-cloudflare/src/server/metrics.ts
+++ b/packages/mcp-cloudflare/src/server/metrics.ts
@@ -6,7 +6,7 @@ import {
 import { resolveClientFamily } from "./lib/client-family";
 import type { OAuthErrorTelemetry } from "./oauth/telemetry";
 
-export type RateLimitScope = "ip" | "user";
+export type RateLimitScope = "ip" | "user" | "sentry-token";
 type ResponseReason = "local_rate_limit";
 
 type TrackedRoute = {
@@ -261,7 +261,9 @@ export function extractResponseMetricOptions(
     responseReason:
       responseReason === "local_rate_limit" ? responseReason : undefined,
     rateLimitScope:
-      rateLimitScope === "ip" || rateLimitScope === "user"
+      rateLimitScope === "ip" ||
+      rateLimitScope === "user" ||
+      rateLimitScope === "sentry-token"
         ? rateLimitScope
         : undefined,
   };

--- a/packages/mcp-cloudflare/src/test-utils/fetch-mock-setup.ts
+++ b/packages/mcp-cloudflare/src/test-utils/fetch-mock-setup.ts
@@ -30,13 +30,33 @@ import {
 } from "@sentry/mcp-server-mocks/payloads";
 
 // Sentry hosts to mock
-const SENTRY_HOSTS = ["https://sentry.io", "https://us.sentry.io"];
+const SENTRY_HOSTS = [
+  "https://sentry.io",
+  "https://us.sentry.io",
+  "https://direct-token.test",
+];
+
+export const DIRECT_AUTH_ASSERTION_TOKEN = "sntryu_assert-direct-token";
 
 // Standard JSON response headers
 const JSON_HEADERS = { "Content-Type": "application/json" };
 
 function normalizeQuery(query: string | null): string | null {
   return query ? query.split(" ").sort().join(" ") : query;
+}
+
+function getMockRequestHeader(
+  headers: Headers | Record<string, string> | undefined,
+  name: string,
+): string | null {
+  if (!headers) {
+    return null;
+  }
+  if ("get" in headers && typeof headers.get === "function") {
+    return headers.get(name);
+  }
+
+  return headers[name] ?? headers[name.toLowerCase()] ?? null;
 }
 
 const VALID_ERROR_EVENT_QUERIES = new Set<string | null>(
@@ -103,6 +123,31 @@ export function registerFetchMockInterceptors(fetchMock: FetchMockLike) {
           { regions: [{ name: "us", url: "https://us.sentry.io" }] },
           { headers: JSON_HEADERS },
         )
+        .persist();
+    }
+
+    if (host === "https://direct-token.test") {
+      pool
+        .intercept({ path: "/api/0/auth/" })
+        .reply((req) => {
+          const authorization = getMockRequestHeader(
+            req.headers,
+            "authorization",
+          );
+          if (authorization !== `Bearer ${DIRECT_AUTH_ASSERTION_TOKEN}`) {
+            return {
+              statusCode: 401,
+              data: { detail: "Unexpected direct-token Authorization header" },
+              responseOptions: { headers: JSON_HEADERS },
+            };
+          }
+
+          return {
+            statusCode: 200,
+            data: userFixture,
+            responseOptions: { headers: JSON_HEADERS },
+          };
+        })
         .persist();
     }
 


### PR DESCRIPTION
Cloudflare `/mcp` now accepts `Authorization: Sentry-Bearer <token>` as a direct upstream Sentry API token path. The entrypoint routes that scheme before MCP OAuth, keeps `Authorization: Bearer` on the existing OAuth path, and rejects malformed `Sentry-Bearer` headers with a direct 401 instead of falling through to OAuth.

Direct sessions do not create or inspect OAuth grants, store or refresh tokens, or revoke grants on upstream 401s. They build the same MCP server context with the provided token, token-scoped rate limiting, optional skill narrowing, and URL constraints passed through for existing Sentry API calls. The README, remote testing docs, security docs, and a feature spec document the contract.