### PR TITLE
feat(ai): Surface conversations from issue traces

### DIFF
--- a/docs/contributing/tool-responses.md
+++ b/docs/contributing/tool-responses.md
@@ -124,12 +124,18 @@ defines `structuredContent` as a JSON object on `CallToolResult`, and
 `outputSchema` as the schema for that object:
 
 - Choose one response contract per tool: handwritten markdown or
-  `structuredContent`. Do not hand-write markdown and also return
-  `structuredContent` from the handler.
+  `structuredContent`. Do not hand-write markdown and also return a large
+  structured projection from the handler.
+- Exception: markdown tools may include a small `structuredContent` object for
+  documented continuation hints, such as `suggestedActions`, when the markdown
+  remains the canonical human-readable result.
 - If a tool declares `outputSchema`, every successful `structuredContent` result
   must conform to that schema.
 - Return structured results with `structuredResult(payload)`. The server
   generates `content` as a compatibility fallback from the same payload.
+- When a markdown tool also returns hint-only `structuredContent`, return a full
+  `CallToolResult` with both handwritten `content` and the hint object. Do not
+  use `structuredResult(payload)` for that mixed response.
 - Do not duplicate a large structured payload into a markdown artifact block.
 - Treat `structuredContent` as a stable product contract, not a raw upstream API
   passthrough. Map only documented fields that callers should depend on.
@@ -149,6 +155,42 @@ defines `structuredContent` as a JSON object on `CallToolResult`, and
 
 Reference: MCP 2025-11-25 Tools specification, sections "Structured Content"
 and "Output Schema".
+
+## Suggested Actions
+
+Use `suggestedActions` when a tool result reveals a concrete follow-up tool call
+that a client or agent could offer as a continuation. This is the
+machine-readable counterpart to a narrow `## Response Notes` hint.
+
+```typescript
+interface SuggestedToolAction {
+  type: "tool_call";
+  toolName: string;
+  arguments: Record<string, unknown>;
+  reason: string;
+}
+
+interface SuggestedActionsContent {
+  suggestedActions: SuggestedToolAction[];
+}
+```
+
+Guidelines:
+
+- Include only actions that are directly supported by the current result. Do not
+  include broad investigation plans or generic next steps.
+- Arguments must be complete enough to call the tool without reparsing markdown.
+- Use public MCP parameter names and values, not upstream API field names.
+- Respect tool availability in the current session. Omit actions for unavailable
+  tools.
+- Keep the list small and ordered by likely usefulness. Prefer one action; use a
+  hard cap of three.
+- Keep `reason` concise and descriptive. It should explain why the action is
+  useful, not instruct the model how to behave.
+- Mirror the action in `## Response Notes` for clients that do not read
+  `structuredContent`.
+- Do not include secrets, auth tokens, raw payloads, or sensitive user data in
+  action arguments or reasons.
 
 ## Response Notes
 

--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -119,6 +119,16 @@ GET /api/0/organizations/{organizationSlug}/ai-conversations/
 Do not implement conversation search through
 `search_events(dataset="spans")`.
 
+Issue and trace detail enrichment may still perform a bounded opportunistic
+span lookup when the caller already has a trace ID. That lookup must stay scoped
+to the trace, request only the fields needed to identify conversation IDs and
+matching spans plus any field required for result ordering, cap results to a
+small number, and route transcript follow-up through
+`get_ai_conversation_details`. It is not a replacement for
+`search_ai_conversations`. This follows Sentry's Spans-backed AI conversation
+endpoints, which select `gen_ai.conversation.id` from spans, and existing
+trace-scoped spans queries that use `trace:<trace_id>`.
+
 Expected query parameters:
 
 - `query`

--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -134,10 +134,11 @@ surface a `suggestedActions` structured-content hint when the required follow-up
 is callable in the current session. If `get_ai_conversation_details` is only
 available through the catalog, the action must call `execute_sentry_tool` with
 `name: "get_ai_conversation_details"` and the target arguments; only use the
-catalog tool name directly when it is exposed through `tools/list`. The markdown
-`Response Notes` or `AI Conversations` section remains the compatibility path
-for clients that do not read `structuredContent`. Follow the shared suggested
-action contract in
+catalog tool name directly when it is exposed through `tools/list`. Emit either
+action only when its direct tool surface is available. The markdown `Response
+Notes` or `AI Conversations` section must mirror the same callable action and
+arguments for clients that do not read `structuredContent`. Follow the shared
+suggested action contract in
 [Tool Responses](../contributing/tool-responses.md#suggested-actions).
 
 Expected query parameters:

--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -129,6 +129,14 @@ small number, and route transcript follow-up through
 endpoints, which select `gen_ai.conversation.id` from spans, and existing
 trace-scoped spans queries that use `trace:<trace_id>`.
 
+When issue or trace detail output identifies AI conversation IDs, it should
+surface a `suggestedActions` structured-content hint for
+`get_ai_conversation_details` when that tool is available in the current
+session. The markdown `Response Notes` or `AI Conversations` section remains
+the compatibility path for clients that do not read `structuredContent`. Follow
+the shared suggested action contract in
+[Tool Responses](../contributing/tool-responses.md#suggested-actions).
+
 Expected query parameters:
 
 - `query`

--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -130,11 +130,14 @@ endpoints, which select `gen_ai.conversation.id` from spans, and existing
 trace-scoped spans queries that use `trace:<trace_id>`.
 
 When issue or trace detail output identifies AI conversation IDs, it should
-surface a `suggestedActions` structured-content hint for
-`get_ai_conversation_details` when that tool is available in the current
-session. The markdown `Response Notes` or `AI Conversations` section remains
-the compatibility path for clients that do not read `structuredContent`. Follow
-the shared suggested action contract in
+surface a `suggestedActions` structured-content hint when the required follow-up
+is callable in the current session. If `get_ai_conversation_details` is only
+available through the catalog, the action must call `execute_sentry_tool` with
+`name: "get_ai_conversation_details"` and the target arguments; only use the
+catalog tool name directly when it is exposed through `tools/list`. The markdown
+`Response Notes` or `AI Conversations` section remains the compatibility path
+for clients that do not read `structuredContent`. Follow the shared suggested
+action contract in
 [Tool Responses](../contributing/tool-responses.md#suggested-actions).
 
 Expected query parameters:

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -35,6 +35,7 @@ import {
   isTerminalStatus,
 } from "./tool-helpers/seer";
 import { formatToolCallInstruction } from "./tool-helpers/tool-call-formatting";
+import type { AIConversationReference } from "./tool-helpers/ai-conversation-actions";
 import { formatUserGeoSummary } from "./user-formatting";
 
 /**
@@ -958,11 +959,6 @@ interface N1EvidenceData {
 interface SlowDbEvidenceData {
   parentSpan?: string;
   [key: string]: unknown;
-}
-
-interface AIConversationReference {
-  conversationId: string;
-  spanId?: string;
 }
 
 function normalizeSpanId(value: unknown): string | undefined {

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -35,7 +35,10 @@ import {
   isTerminalStatus,
 } from "./tool-helpers/seer";
 import { formatToolCallInstruction } from "./tool-helpers/tool-call-formatting";
-import type { AIConversationReference } from "./tool-helpers/ai-conversation-actions";
+import {
+  formatAIConversationActionInstructions,
+  type AIConversationReference,
+} from "./tool-helpers/ai-conversation-actions";
 import { formatUserGeoSummary } from "./user-formatting";
 
 /**
@@ -2108,6 +2111,17 @@ export function formatIssueOutput({
     }
     output += " to help us add support for this event type.\n";
 
+    if (aiConversations && aiConversations.length > 0) {
+      output += "\n## Response Notes\n\n";
+      output += formatAIConversationResponseNote({
+        aiConversations,
+        organizationSlug,
+        experimentalMode: experimentalMode ?? false,
+        availableToolNames,
+        directToolNames,
+      });
+    }
+
     // For unsupported event types, return early without trying to render event details
     return output;
   }
@@ -2284,41 +2298,26 @@ function formatAIConversationResponseNote({
   availableToolNames?: ReadonlySet<string>;
   directToolNames?: ReadonlySet<string>;
 }): string {
-  const instruction = formatToolCallInstruction({
-    toolName: "get_ai_conversation_details",
-    arguments: {
-      organizationSlug,
-      conversationId:
-        aiConversations.length === 1
-          ? aiConversations[0].conversationId
-          : "conversation ID",
-    },
+  const instructions = formatAIConversationActionInstructions({
+    organizationSlug,
+    aiConversations,
     experimentalMode,
     availableToolNames,
     directToolNames,
-    fallbackInstruction:
-      "AI conversation detail lookup is not available in this session",
   });
-  const transcriptInstruction = formatTranscriptInstruction(instruction);
 
   if (aiConversations.length === 1) {
     const [conversation] = aiConversations;
     const spanSuffix = conversation.spanId
       ? ` Matching span: \`${conversation.spanId}\`.`
       : "";
-    return `- AI conversation found in this trace: \`${conversation.conversationId}\`.${spanSuffix} ${transcriptInstruction}\n`;
+    return `- AI conversation found in this trace: \`${conversation.conversationId}\`.${spanSuffix}\n${instructions.map((instruction) => `- ${instruction}`).join("\n")}\n`;
   }
 
   const conversationIds = aiConversations
     .map((conversation) => `\`${conversation.conversationId}\``)
     .join(", ");
-  return `- Multiple AI conversations were found in this trace: ${conversationIds}. ${transcriptInstruction}\n`;
-}
-
-function formatTranscriptInstruction(instruction: string): string {
-  return instruction.startsWith("Use ")
-    ? `${instruction} to fetch the full transcript.`
-    : `${instruction}.`;
+  return `- Multiple AI conversations were found in this trace: ${conversationIds}.\n${instructions.map((instruction) => `- ${instruction}`).join("\n")}\n`;
 }
 
 const MAX_DISPLAY_REPLAYS = 5;

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -960,6 +960,11 @@ interface SlowDbEvidenceData {
   [key: string]: unknown;
 }
 
+interface AIConversationReference {
+  conversationId: string;
+  spanId?: string;
+}
+
 function normalizeSpanId(value: unknown): string | undefined {
   if (typeof value === "string" && value) {
     return value;
@@ -1977,6 +1982,7 @@ export function formatIssueOutput({
   performanceTrace,
   externalIssues,
   relatedReplayIds,
+  aiConversations,
   experimentalMode,
   availableToolNames,
   directToolNames,
@@ -1989,6 +1995,7 @@ export function formatIssueOutput({
   performanceTrace?: Trace;
   externalIssues?: ExternalIssueList;
   relatedReplayIds?: string[];
+  aiConversations?: AIConversationReference[];
   experimentalMode?: boolean;
   availableToolNames?: ReadonlySet<string>;
   directToolNames?: ReadonlySet<string>;
@@ -2169,6 +2176,15 @@ export function formatIssueOutput({
   output += `- Commit message issue reference: \`Fixes ${issue.shortId}\` automatically closes the issue when the commit is merged.\n`;
   output +=
     "- The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.\n";
+  if (aiConversations && aiConversations.length > 0) {
+    output += formatAIConversationResponseNote({
+      aiConversations,
+      organizationSlug,
+      experimentalMode: experimentalMode ?? false,
+      availableToolNames,
+      directToolNames,
+    });
+  }
   const issueEventSearchInstruction = formatToolCallInstruction({
     toolName: "search_issue_events",
     arguments: {
@@ -2257,6 +2273,56 @@ export function formatIssueOutput({
     output += `- Breadcrumb trail leading up to this error: \`get_sentry_resource(url='${apiService.getIssueUrl(organizationSlug, issue.shortId)}', resourceType='breadcrumbs')\`\n`;
   }
   return output;
+}
+
+function formatAIConversationResponseNote({
+  aiConversations,
+  organizationSlug,
+  experimentalMode,
+  availableToolNames,
+  directToolNames,
+}: {
+  aiConversations: AIConversationReference[];
+  organizationSlug: string;
+  experimentalMode: boolean;
+  availableToolNames?: ReadonlySet<string>;
+  directToolNames?: ReadonlySet<string>;
+}): string {
+  const instruction = formatToolCallInstruction({
+    toolName: "get_ai_conversation_details",
+    arguments: {
+      organizationSlug,
+      conversationId:
+        aiConversations.length === 1
+          ? aiConversations[0].conversationId
+          : "conversation ID",
+    },
+    experimentalMode,
+    availableToolNames,
+    directToolNames,
+    fallbackInstruction:
+      "AI conversation detail lookup is not available in this session",
+  });
+  const transcriptInstruction = formatTranscriptInstruction(instruction);
+
+  if (aiConversations.length === 1) {
+    const [conversation] = aiConversations;
+    const spanSuffix = conversation.spanId
+      ? ` Matching span: \`${conversation.spanId}\`.`
+      : "";
+    return `- AI conversation found in this trace: \`${conversation.conversationId}\`.${spanSuffix} ${transcriptInstruction}\n`;
+  }
+
+  const conversationIds = aiConversations
+    .map((conversation) => `\`${conversation.conversationId}\``)
+    .join(", ");
+  return `- Multiple AI conversations were found in this trace: ${conversationIds}. ${transcriptInstruction}\n`;
+}
+
+function formatTranscriptInstruction(instruction: string): string {
+  return instruction.startsWith("Use ")
+    ? `${instruction} to fetch the full transcript.`
+    : `${instruction}.`;
 }
 
 const MAX_DISPLAY_REPLAYS = 5;

--- a/packages/mcp-core/src/internal/tool-helpers/ai-conversation-actions.test.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/ai-conversation-actions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAIConversationActionInstructions,
+  getAIConversationSuggestedActions,
+} from "./ai-conversation-actions";
+
+const actionParams = {
+  organizationSlug: "test-org",
+  aiConversations: [{ conversationId: "conversation-123" }],
+  experimentalMode: false,
+};
+
+describe("AI conversation suggested actions", () => {
+  it("uses the public catalog gateway consistently in markdown and structured content", () => {
+    const availableToolNames = new Set([
+      "get_ai_conversation_details",
+      "execute_sentry_tool",
+    ]);
+    const directToolNames = new Set(["execute_sentry_tool"]);
+
+    expect(
+      getAIConversationSuggestedActions({
+        ...actionParams,
+        availableToolNames,
+        directToolNames,
+      }),
+    ).toEqual([
+      {
+        type: "tool_call",
+        toolName: "execute_sentry_tool",
+        arguments: {
+          name: "get_ai_conversation_details",
+          arguments: {
+            organizationSlug: "test-org",
+            conversationId: "conversation-123",
+          },
+        },
+        reason: "Fetch the full transcript for this AI conversation.",
+      },
+    ]);
+    expect(
+      formatAIConversationActionInstructions({
+        ...actionParams,
+        availableToolNames,
+        directToolNames,
+      }),
+    ).toEqual([
+      'Use the Sentry tool `execute_sentry_tool(name=\'get_ai_conversation_details\', arguments={"organizationSlug":"test-org","conversationId":"conversation-123"})` to fetch the full transcript.',
+    ]);
+  });
+
+  it("omits the action when no direct execution route is available", () => {
+    const availableToolNames = new Set([
+      "get_ai_conversation_details",
+      "execute_sentry_tool",
+    ]);
+    const directToolNames = new Set<string>();
+
+    expect(
+      getAIConversationSuggestedActions({
+        ...actionParams,
+        availableToolNames,
+        directToolNames,
+      }),
+    ).toEqual([]);
+    expect(
+      formatAIConversationActionInstructions({
+        ...actionParams,
+        availableToolNames,
+        directToolNames,
+      }),
+    ).toEqual([
+      "AI conversation detail lookup is not available in this session.",
+    ]);
+  });
+
+  it("uses the conversation tool directly when it is exposed through tools/list", () => {
+    const availableToolNames = new Set(["get_ai_conversation_details"]);
+    const directToolNames = new Set(["get_ai_conversation_details"]);
+
+    expect(
+      getAIConversationSuggestedActions({
+        ...actionParams,
+        availableToolNames,
+        directToolNames,
+      }),
+    ).toMatchObject([
+      {
+        toolName: "get_ai_conversation_details",
+        arguments: {
+          organizationSlug: "test-org",
+          conversationId: "conversation-123",
+        },
+      },
+    ]);
+    expect(
+      formatAIConversationActionInstructions({
+        ...actionParams,
+        availableToolNames,
+        directToolNames,
+      }),
+    ).toEqual([
+      "Use the Sentry tool `get_ai_conversation_details(organizationSlug='test-org', conversationId='conversation-123')` to fetch the full transcript.",
+    ]);
+  });
+});

--- a/packages/mcp-core/src/internal/tool-helpers/ai-conversation-actions.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/ai-conversation-actions.ts
@@ -1,0 +1,84 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { isToolAvailableInSession } from "./tool-call-formatting";
+import { isTopLevelToolName } from "../../tools/surfaces";
+
+const MAX_SUGGESTED_ACTIONS = 3;
+
+export interface AIConversationReference {
+  conversationId: string;
+  spanId?: string;
+}
+
+/**
+ * Adds concrete transcript follow-ups to otherwise markdown-first results.
+ * The markdown remains the compatibility path for clients that do not read
+ * structured content.
+ */
+export function addAIConversationSuggestedActions({
+  markdown,
+  organizationSlug,
+  aiConversations,
+  experimentalMode,
+  availableToolNames,
+  directToolNames,
+}: {
+  markdown: string;
+  organizationSlug: string;
+  aiConversations: AIConversationReference[];
+  experimentalMode: boolean;
+  availableToolNames?: ReadonlySet<string>;
+  directToolNames?: ReadonlySet<string>;
+}): string | CallToolResult {
+  if (
+    aiConversations.length === 0 ||
+    !isToolAvailableInSession("get_ai_conversation_details", availableToolNames)
+  ) {
+    return markdown;
+  }
+
+  const targetIsDirect = directToolNames
+    ? directToolNames.has("get_ai_conversation_details")
+    : isTopLevelToolName("get_ai_conversation_details", experimentalMode);
+  const executeToolIsDirect = directToolNames
+    ? directToolNames.has("execute_sentry_tool")
+    : isTopLevelToolName("execute_sentry_tool", experimentalMode);
+  const useCatalogGateway =
+    !targetIsDirect &&
+    executeToolIsDirect &&
+    isToolAvailableInSession("execute_sentry_tool", availableToolNames);
+
+  if (!targetIsDirect && !useCatalogGateway) {
+    return markdown;
+  }
+
+  return {
+    content: [{ type: "text", text: markdown }],
+    structuredContent: {
+      suggestedActions: aiConversations
+        .slice(0, MAX_SUGGESTED_ACTIONS)
+        .map((conversation) => {
+          const targetArguments = {
+            organizationSlug,
+            conversationId: conversation.conversationId,
+          };
+
+          return targetIsDirect
+            ? {
+                type: "tool_call",
+                toolName: "get_ai_conversation_details",
+                arguments: targetArguments,
+                reason: "Fetch the full transcript for this AI conversation.",
+              }
+            : {
+                type: "tool_call",
+                toolName: "execute_sentry_tool",
+                arguments: {
+                  name: "get_ai_conversation_details",
+                  arguments: targetArguments,
+                },
+                reason: "Fetch the full transcript for this AI conversation.",
+              };
+        }),
+    },
+  };
+}

--- a/packages/mcp-core/src/internal/tool-helpers/ai-conversation-actions.ts
+++ b/packages/mcp-core/src/internal/tool-helpers/ai-conversation-actions.ts
@@ -1,5 +1,8 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { isToolAvailableInSession } from "./tool-call-formatting";
+import {
+  formatToolCall,
+  isToolAvailableInSession,
+} from "./tool-call-formatting";
 import { isTopLevelToolName } from "../../tools/surfaces";
 
 const MAX_SUGGESTED_ACTIONS = 3;
@@ -7,6 +10,131 @@ const MAX_SUGGESTED_ACTIONS = 3;
 export interface AIConversationReference {
   conversationId: string;
   spanId?: string;
+}
+
+type SuggestedActionValue =
+  | string
+  | number
+  | boolean
+  | null
+  | SuggestedActionValue[]
+  | { [key: string]: SuggestedActionValue };
+
+/** A concrete, session-callable MCP follow-up action. */
+interface SuggestedToolAction {
+  type: "tool_call";
+  toolName: string;
+  arguments: Record<string, SuggestedActionValue>;
+  reason: string;
+}
+
+function formatInlineCode(value: string): string {
+  const backtickRuns = value.match(/`+/g) ?? [];
+  const fenceLength =
+    backtickRuns.reduce((max, run) => Math.max(max, run.length), 0) + 1;
+  const fence = "`".repeat(fenceLength);
+  const needsPadding = value.startsWith("`") || value.endsWith("`");
+  return needsPadding
+    ? `${fence} ${value} ${fence}`
+    : `${fence}${value}${fence}`;
+}
+
+/** Builds transcript actions that match the session's direct or catalog surface. */
+export function getAIConversationSuggestedActions({
+  organizationSlug,
+  aiConversations,
+  experimentalMode,
+  availableToolNames,
+  directToolNames,
+}: {
+  organizationSlug: string;
+  aiConversations: AIConversationReference[];
+  experimentalMode: boolean;
+  availableToolNames?: ReadonlySet<string>;
+  directToolNames?: ReadonlySet<string>;
+}): SuggestedToolAction[] {
+  if (
+    aiConversations.length === 0 ||
+    !isToolAvailableInSession("get_ai_conversation_details", availableToolNames)
+  ) {
+    return [];
+  }
+
+  const targetIsDirect = directToolNames
+    ? directToolNames.has("get_ai_conversation_details")
+    : isTopLevelToolName("get_ai_conversation_details", experimentalMode);
+  const executeToolIsDirect = directToolNames
+    ? directToolNames.has("execute_sentry_tool")
+    : isTopLevelToolName("execute_sentry_tool", experimentalMode);
+  const useCatalogGateway =
+    !targetIsDirect &&
+    executeToolIsDirect &&
+    isToolAvailableInSession("execute_sentry_tool", availableToolNames);
+
+  if (!targetIsDirect && !useCatalogGateway) {
+    return [];
+  }
+
+  return aiConversations.slice(0, MAX_SUGGESTED_ACTIONS).map((conversation) => {
+    const targetArguments = {
+      organizationSlug,
+      conversationId: conversation.conversationId,
+    };
+
+    return targetIsDirect
+      ? {
+          type: "tool_call",
+          toolName: "get_ai_conversation_details",
+          arguments: targetArguments,
+          reason: "Fetch the full transcript for this AI conversation.",
+        }
+      : {
+          type: "tool_call",
+          toolName: "execute_sentry_tool",
+          arguments: {
+            name: "get_ai_conversation_details",
+            arguments: targetArguments,
+          },
+          reason: "Fetch the full transcript for this AI conversation.",
+        };
+  });
+}
+
+/** Returns markdown instructions that mirror the callable structured actions. */
+export function formatAIConversationActionInstructions({
+  organizationSlug,
+  aiConversations,
+  experimentalMode,
+  availableToolNames,
+  directToolNames,
+}: {
+  organizationSlug: string;
+  aiConversations: AIConversationReference[];
+  experimentalMode: boolean;
+  availableToolNames?: ReadonlySet<string>;
+  directToolNames?: ReadonlySet<string>;
+}): string[] {
+  const actions = getAIConversationSuggestedActions({
+    organizationSlug,
+    aiConversations,
+    experimentalMode,
+    availableToolNames,
+    directToolNames,
+  });
+
+  if (actions.length === 0) {
+    return ["AI conversation detail lookup is not available in this session."];
+  }
+
+  return actions.map(
+    (action) =>
+      `Use the Sentry tool ${formatInlineCode(
+        formatToolCall({
+          toolName: action.toolName,
+          arguments: action.arguments,
+        }),
+      )} to fetch the full transcript.`,
+  );
 }
 
 /**
@@ -29,56 +157,21 @@ export function addAIConversationSuggestedActions({
   availableToolNames?: ReadonlySet<string>;
   directToolNames?: ReadonlySet<string>;
 }): string | CallToolResult {
-  if (
-    aiConversations.length === 0 ||
-    !isToolAvailableInSession("get_ai_conversation_details", availableToolNames)
-  ) {
-    return markdown;
-  }
-
-  const targetIsDirect = directToolNames
-    ? directToolNames.has("get_ai_conversation_details")
-    : isTopLevelToolName("get_ai_conversation_details", experimentalMode);
-  const executeToolIsDirect = directToolNames
-    ? directToolNames.has("execute_sentry_tool")
-    : isTopLevelToolName("execute_sentry_tool", experimentalMode);
-  const useCatalogGateway =
-    !targetIsDirect &&
-    executeToolIsDirect &&
-    isToolAvailableInSession("execute_sentry_tool", availableToolNames);
-
-  if (!targetIsDirect && !useCatalogGateway) {
+  const suggestedActions = getAIConversationSuggestedActions({
+    organizationSlug,
+    aiConversations,
+    experimentalMode,
+    availableToolNames,
+    directToolNames,
+  });
+  if (suggestedActions.length === 0) {
     return markdown;
   }
 
   return {
     content: [{ type: "text", text: markdown }],
     structuredContent: {
-      suggestedActions: aiConversations
-        .slice(0, MAX_SUGGESTED_ACTIONS)
-        .map((conversation) => {
-          const targetArguments = {
-            organizationSlug,
-            conversationId: conversation.conversationId,
-          };
-
-          return targetIsDirect
-            ? {
-                type: "tool_call",
-                toolName: "get_ai_conversation_details",
-                arguments: targetArguments,
-                reason: "Fetch the full transcript for this AI conversation.",
-              }
-            : {
-                type: "tool_call",
-                toolName: "execute_sentry_tool",
-                arguments: {
-                  name: "get_ai_conversation_details",
-                  arguments: targetArguments,
-                },
-                reason: "Fetch the full transcript for this AI conversation.",
-              };
-        }),
+      suggestedActions,
     },
   };
 }

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -325,7 +325,7 @@ describe("get_issue_details", () => {
           expect(url.searchParams.get("per_page")).toBe("3");
           expect(url.searchParams.getAll("field")).toEqual([
             "gen_ai.conversation.id",
-            "trace.span_id",
+            "span_id",
             "timestamp",
           ]);
 
@@ -333,12 +333,12 @@ describe("get_issue_details", () => {
             data: [
               {
                 "gen_ai.conversation.id": "conv-123",
-                "trace.span_id": "span-123",
+                span_id: "span-123",
                 timestamp: "2025-04-08T21:15:04+00:00",
               },
               {
                 "gen_ai.conversation.id": "conv-123",
-                "trace.span_id": "span-456",
+                span_id: "span-456",
                 timestamp: "2025-04-08T21:15:05+00:00",
               },
             ],
@@ -361,14 +361,17 @@ describe("get_issue_details", () => {
 
     const text = getTextContent(result);
     expect(text).toContain(
-      "- AI conversation found in this trace: `conv-123`. Matching span: `span-123`. Use the Sentry tool `get_ai_conversation_details` to fetch the full transcript.",
+      "- AI conversation found in this trace: `conv-123`. Matching span: `span-123`.",
+    );
+    expect(text).toContain(
+      '- Use the Sentry tool `execute_sentry_tool(name=\'get_ai_conversation_details\', arguments={"organizationSlug":"sentry-mcp-evals","conversationId":"conv-123"})` to fetch the full transcript.',
     );
     expect(
       getStructuredContent<{
         suggestedActions: Array<{
           type: string;
           toolName: string;
-          arguments: Record<string, string>;
+          arguments: Record<string, unknown>;
           reason: string;
         }>;
       }>(result),
@@ -437,7 +440,8 @@ describe("get_issue_details", () => {
 
       - Commit message issue reference: \`Fixes CLOUDFLARE-MCP-41\` automatically closes the issue when the commit is merged.
       - The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.
-      - AI conversation found in this trace: \`conv-123\`. Matching span: \`span-123\`. Use the Sentry tool \`get_ai_conversation_details\` to fetch the full transcript.
+      - AI conversation found in this trace: \`conv-123\`. Matching span: \`span-123\`.
+      - Use the Sentry tool \`execute_sentry_tool(name='get_ai_conversation_details', arguments={"organizationSlug":"sentry-mcp-evals","conversationId":"conv-123"})\` to fetch the full transcript.
       - Issue event search: Use the Sentry tool \`search_issue_events\`
       - Full distributed trace and span tree: Use the Sentry tool \`get_sentry_resource\`
       - Related span search: Use the Sentry tool \`search_events\`
@@ -1890,7 +1894,17 @@ describe("get_issue_details", () => {
 
     // Event with a type that doesn't exist yet (would never be returned by Sentry API)
     // Use the unknown event fixture factory (baseline already has future_ai_agent_trace type)
-    const unsupportedEventFixture = createUnknownEvent();
+    const traceId = "11112222333344445555666677778888";
+    const unsupportedEventFixture = {
+      ...createUnknownEvent(),
+      contexts: {
+        trace: {
+          type: "trace",
+          trace_id: traceId,
+          span_id: "error-span",
+        },
+      },
+    };
 
     mswServer.use(
       // More specific pattern for events (must come first to match before the issue pattern)
@@ -1906,6 +1920,23 @@ describe("get_issue_details", () => {
           return HttpResponse.json(unsupportedIssueFixture);
         },
       ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/events/",
+        () =>
+          HttpResponse.json({
+            data: [
+              {
+                "gen_ai.conversation.id": "conv-unsupported",
+                span_id: "span-unsupported",
+                timestamp: "2025-04-08T21:15:04+00:00",
+              },
+            ],
+          }),
+      ),
+      http.get(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/${traceId}/`,
+        () => HttpResponse.json([]),
+      ),
     );
 
     const result = await getIssueDetails.handler(
@@ -1919,12 +1950,10 @@ describe("get_issue_details", () => {
       baseContext,
     );
 
-    if (typeof result !== "string") {
-      throw new Error("Expected string result");
-    }
+    const text = typeof result === "string" ? result : getTextContent(result);
 
     // Extract the Sentry Event ID from the result (it varies per run)
-    const sentryEventIdMatch = result.match(
+    const sentryEventIdMatch = text.match(
       /Sentry Event ID \*\*([a-f0-9]{32})\*\*/,
     );
     const sentryEventId = sentryEventIdMatch
@@ -1932,10 +1961,32 @@ describe("get_issue_details", () => {
       : "SENTRY_EVENT_ID";
 
     // Replace the dynamic Sentry Event ID with a placeholder for snapshot testing
-    const normalizedResult = result.replace(
+    const normalizedResult = text.replace(
       /Sentry Event ID \*\*[a-f0-9]{32}\*\*/,
       "Sentry Event ID **<SENTRY_EVENT_ID>**",
     );
+
+    expect(
+      getStructuredContent<{
+        suggestedActions: Array<{
+          toolName: string;
+          arguments: Record<string, unknown>;
+        }>;
+      }>(result),
+    ).toMatchObject({
+      suggestedActions: [
+        {
+          toolName: "execute_sentry_tool",
+          arguments: {
+            name: "get_ai_conversation_details",
+            arguments: {
+              organizationSlug: "sentry-mcp-evals",
+              conversationId: "conv-unsupported",
+            },
+          },
+        },
+      ],
+    });
 
     expect(normalizedResult).toMatchInlineSnapshot(`
       "# Issue FUTURE-TYPE-001 in **sentry-mcp-evals**
@@ -1960,6 +2011,11 @@ describe("get_issue_details", () => {
       This event type is not yet fully supported by the MCP server. Only basic issue information is shown above.
 
       **Please report this**: Open a GitHub issue at https://github.com/getsentry/sentry-mcp/issues/new and include Event ID **ffffffffffffffffffffffffffffffff** and Sentry Event ID **<SENTRY_EVENT_ID>** to help us add support for this event type.
+
+      ## Response Notes
+
+      - AI conversation found in this trace: \`conv-unsupported\`. Matching span: \`span-unsupported\`.
+      - Use the Sentry tool \`execute_sentry_tool(name='get_ai_conversation_details', arguments={"organizationSlug":"sentry-mcp-evals","conversationId":"conv-unsupported"})\` to fetch the full transcript.
       "
     `);
 

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -292,6 +292,170 @@ describe("get_issue_details", () => {
     expect(result).not.toContain("**Culprit**: null");
   });
 
+  it("surfaces AI conversation IDs found by bounded span lookup", async () => {
+    const traceId = "11112222333344445555666677778888";
+    const event = createDefaultEvent({
+      contexts: {
+        trace: {
+          type: "trace",
+          trace_id: traceId,
+          span_id: "error-span",
+        },
+      },
+    });
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () => HttpResponse.json(event),
+        { once: true },
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/events/",
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("dataset")).toBe("spans");
+          expect(url.searchParams.get("query")).toBe(
+            `trace:${traceId} has:gen_ai.conversation.id`,
+          );
+          expect(url.searchParams.get("per_page")).toBe("3");
+          expect(url.searchParams.getAll("field")).toEqual([
+            "gen_ai.conversation.id",
+            "trace.span_id",
+            "timestamp",
+          ]);
+
+          return HttpResponse.json({
+            data: [
+              {
+                "gen_ai.conversation.id": "conv-123",
+                "trace.span_id": "span-123",
+                timestamp: "2025-04-08T21:15:04+00:00",
+              },
+              {
+                "gen_ai.conversation.id": "conv-123",
+                "trace.span_id": "span-456",
+                timestamp: "2025-04-08T21:15:05+00:00",
+              },
+            ],
+          });
+        },
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    expect(result).toContain(
+      "- AI conversation found in this trace: `conv-123`. Matching span: `span-123`. Use the Sentry tool `get_ai_conversation_details` to fetch the full transcript.",
+    );
+    expect(result).toMatchInlineSnapshot(`
+      "# Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**
+
+      **Description**: Error: Tool list_organizations is already registered
+      **Culprit**: Object.fetch(index)
+      **First Seen**: 2025-04-03T22:51:19.403Z
+      **Last Seen**: 2025-04-12T11:34:11.000Z
+      **Occurrences**: 25
+      **Users Impacted**: 1
+      **Status**: unresolved
+      **Substatus**: ongoing
+      **Assigned To**: Jane Developer (User)
+      **Issue Type**: error
+      **Issue Category**: error
+      **Platform**: javascript
+      **Project**: CLOUDFLARE-MCP
+      **URL**: https://sentry-mcp-evals.sentry.io/issues/CLOUDFLARE-MCP-41
+
+      ## Event Details
+
+      **Event ID**: abc123def456
+      **Type**: default
+      **Occurred At**: 2025-10-02T12:00:00.000Z
+      **Message**:
+      Something went wrong
+
+      ### Error
+
+      \`\`\`
+      Something went wrong
+      \`\`\`
+
+      ### Tags
+
+      **level**: error
+      **environment**: production
+
+      ### Additional Context
+
+      These are additional context provided by the user when they're instrumenting their application.
+
+      **trace**
+      trace_id: "11112222333344445555666677778888"
+      span_id: "error-span"
+
+      ## Response Notes
+
+      - Commit message issue reference: \`Fixes CLOUDFLARE-MCP-41\` automatically closes the issue when the commit is merged.
+      - The stacktrace includes first-party application code and third-party code. First-party frames are usually the best starting point for triage.
+      - AI conversation found in this trace: \`conv-123\`. Matching span: \`span-123\`. Use the Sentry tool \`get_ai_conversation_details\` to fetch the full transcript.
+      - Issue event search: Use the Sentry tool \`search_issue_events\`
+      - Full distributed trace and span tree: Use the Sentry tool \`get_sentry_resource\`
+      - Related span search: Use the Sentry tool \`search_events\`
+      - Related log search: Use the Sentry tool \`search_events\`
+      "
+    `);
+  });
+
+  it("omits AI conversation guidance when bounded span lookup finds no match", async () => {
+    const traceId = "99992222333344445555666677778888";
+    const event = createDefaultEvent({
+      contexts: {
+        trace: {
+          type: "trace",
+          trace_id: traceId,
+          span_id: "error-span",
+        },
+      },
+    });
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () => HttpResponse.json(event),
+        { once: true },
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/events/",
+        () => HttpResponse.json({ data: [] }),
+        { once: true },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    expect(result).not.toContain("AI conversation found");
+    expect(result).not.toContain("get_ai_conversation_details");
+  });
+
   it("displays team assignment correctly", async () => {
     // Override the issue fixture with a team assignment
     mswServer.use(

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -13,6 +13,10 @@ import {
 } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
+import {
+  getStructuredContent,
+  getTextContent,
+} from "../../test-utils/structured-content";
 import getIssueDetails from "./get-issue-details.js";
 
 const baseContext = {
@@ -355,10 +359,36 @@ describe("get_issue_details", () => {
       baseContext,
     );
 
-    expect(result).toContain(
+    const text = getTextContent(result);
+    expect(text).toContain(
       "- AI conversation found in this trace: `conv-123`. Matching span: `span-123`. Use the Sentry tool `get_ai_conversation_details` to fetch the full transcript.",
     );
-    expect(result).toMatchInlineSnapshot(`
+    expect(
+      getStructuredContent<{
+        suggestedActions: Array<{
+          type: string;
+          toolName: string;
+          arguments: Record<string, string>;
+          reason: string;
+        }>;
+      }>(result),
+    ).toEqual({
+      suggestedActions: [
+        {
+          type: "tool_call",
+          toolName: "execute_sentry_tool",
+          arguments: {
+            name: "get_ai_conversation_details",
+            arguments: {
+              organizationSlug: "sentry-mcp-evals",
+              conversationId: "conv-123",
+            },
+          },
+          reason: "Fetch the full transcript for this AI conversation.",
+        },
+      ],
+    });
+    expect(text).toMatchInlineSnapshot(`
       "# Issue CLOUDFLARE-MCP-41 in **sentry-mcp-evals**
 
       **Description**: Error: Tool list_organizations is already registered
@@ -454,6 +484,47 @@ describe("get_issue_details", () => {
 
     expect(result).not.toContain("AI conversation found");
     expect(result).not.toContain("get_ai_conversation_details");
+  });
+
+  it("does not query spans for an invalid event trace ID", async () => {
+    const event = createDefaultEvent({
+      contexts: {
+        trace: {
+          type: "trace",
+          trace_id: "invalid trace:has:gen_ai.conversation.id",
+          span_id: "error-span",
+        },
+      },
+    });
+    let spanLookupAttempts = 0;
+
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () => HttpResponse.json(event),
+        { once: true },
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/events/",
+        () => {
+          spanLookupAttempts += 1;
+          return HttpResponse.json({ data: [] });
+        },
+      ),
+    );
+
+    await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      baseContext,
+    );
+
+    expect(spanLookupAttempts).toBe(0);
   });
 
   it("displays team assignment correctly", async () => {
@@ -591,8 +662,9 @@ describe("get_issue_details", () => {
       baseContext,
     );
 
-    const threadSection = result
-      .slice(result.indexOf("### Threads"), result.indexOf("### Tags"))
+    const text = typeof result === "string" ? result : getTextContent(result);
+    const threadSection = text
+      .slice(text.indexOf("### Threads"), text.indexOf("### Tags"))
       .trim();
     expect(threadSection).toMatchInlineSnapshot(`
       "### Threads
@@ -604,7 +676,7 @@ describe("get_issue_details", () => {
       | 11 | worker | WAITING | - | 1 |
       | 259 | main | RUNNABLE | crashed, current | 2 |"
     `);
-    expect(result).toContain(
+    expect(text).toContain(
       "- Thread stacktrace lookup: Use the Sentry tool `get_event_stacktrace` to fetch a full thread stacktrace by numeric Thread ID or exact thread Name. Omit `thread` to use Sentry's default selected thread",
     );
   });

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -24,6 +24,10 @@ import { UserInputError } from "../../errors";
 import type { ServerContext } from "../../types";
 import { logError } from "../../telem/logging";
 import {
+  addAIConversationSuggestedActions,
+  type AIConversationReference,
+} from "../../internal/tool-helpers/ai-conversation-actions";
+import {
   ParamOrganizationSlug,
   ParamRegionUrl,
   ParamIssueShortId,
@@ -32,11 +36,7 @@ import {
 
 const MAX_AI_CONVERSATION_MATCHES = 3;
 const AI_CONVERSATION_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
-
-interface AIConversationReference {
-  conversationId: string;
-  spanId?: string;
-}
+const TRACE_ID_PATTERN = /^[0-9a-fA-F]{32}$/;
 
 export default defineTool({
   name: "get_issue_details",
@@ -166,17 +166,24 @@ export default defineTool({
         }),
       ]);
 
-      return formatIssueOutput({
+      return addAIConversationSuggestedActions({
+        markdown: formatIssueOutput({
+          organizationSlug: orgSlug,
+          issue,
+          event,
+          apiService,
+          autofixState,
+          performanceTrace,
+          externalIssues,
+          relatedReplayIds,
+          aiConversations,
+          experimentalMode: context.experimentalMode,
+          availableToolNames: context.availableToolNames,
+          directToolNames: context.directToolNames,
+        }),
         organizationSlug: orgSlug,
-        issue,
-        event,
-        apiService,
-        autofixState,
-        performanceTrace,
-        externalIssues,
-        relatedReplayIds,
         aiConversations,
-        experimentalMode: context.experimentalMode,
+        experimentalMode: context.experimentalMode ?? false,
         availableToolNames: context.availableToolNames,
         directToolNames: context.directToolNames,
       });
@@ -249,17 +256,24 @@ export default defineTool({
       }),
     ]);
 
-    return formatIssueOutput({
+    return addAIConversationSuggestedActions({
+      markdown: formatIssueOutput({
+        organizationSlug: orgSlug,
+        issue,
+        event,
+        apiService,
+        autofixState,
+        performanceTrace,
+        externalIssues,
+        relatedReplayIds,
+        aiConversations,
+        experimentalMode: context.experimentalMode,
+        availableToolNames: context.availableToolNames,
+        directToolNames: context.directToolNames,
+      }),
       organizationSlug: orgSlug,
-      issue,
-      event,
-      apiService,
-      autofixState,
-      performanceTrace,
-      externalIssues,
-      relatedReplayIds,
       aiConversations,
-      experimentalMode: context.experimentalMode,
+      experimentalMode: context.experimentalMode ?? false,
       availableToolNames: context.availableToolNames,
       directToolNames: context.directToolNames,
     });
@@ -368,7 +382,7 @@ async function maybeFindAIConversationsForIssueEvent({
   event: Event;
 }): Promise<AIConversationReference[]> {
   const traceId = getEventTraceId(event);
-  if (!traceId) {
+  if (!traceId || !TRACE_ID_PATTERN.test(traceId)) {
     return [];
   }
 

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -30,6 +30,14 @@ import {
   ParamIssueUrl,
 } from "../../schema";
 
+const MAX_AI_CONVERSATION_MATCHES = 3;
+const AI_CONVERSATION_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+interface AIConversationReference {
+  conversationId: string;
+  spanId?: string;
+}
+
 export default defineTool({
   name: "get_issue_details",
   skills: ["inspect", "triage", "seer"], // Available in inspect, triage, and seer skills
@@ -123,7 +131,7 @@ export default defineTool({
       });
       // For this call, we might want to provide context if it fails
       const [
-        { event, performanceTrace },
+        { event, performanceTrace, aiConversations },
         { autofixState, externalIssues, relatedReplayIds },
       ] = await Promise.all([
         apiService
@@ -145,11 +153,11 @@ export default defineTool({
           })
           .then(async (event) => ({
             event,
-            performanceTrace: await maybeFetchPerformanceTrace({
+            ...(await fetchEventTraceEnrichment({
               apiService,
               organizationSlug: orgSlug,
               event,
-            }),
+            })),
           })),
         fetchIssueEnrichmentData({
           apiService,
@@ -167,6 +175,7 @@ export default defineTool({
         performanceTrace,
         externalIssues,
         relatedReplayIds,
+        aiConversations,
         experimentalMode: context.experimentalMode,
         availableToolNames: context.availableToolNames,
         directToolNames: context.directToolNames,
@@ -217,7 +226,7 @@ export default defineTool({
     });
 
     const [
-      { event, performanceTrace },
+      { event, performanceTrace, aiConversations },
       { autofixState, externalIssues, relatedReplayIds },
     ] = await Promise.all([
       apiService
@@ -227,11 +236,11 @@ export default defineTool({
         })
         .then(async (event) => ({
           event,
-          performanceTrace: await maybeFetchPerformanceTrace({
+          ...(await fetchEventTraceEnrichment({
             apiService,
             organizationSlug: orgSlug,
             event,
-          }),
+          })),
         })),
       fetchIssueEnrichmentData({
         apiService,
@@ -249,12 +258,41 @@ export default defineTool({
       performanceTrace,
       externalIssues,
       relatedReplayIds,
+      aiConversations,
       experimentalMode: context.experimentalMode,
       availableToolNames: context.availableToolNames,
       directToolNames: context.directToolNames,
     });
   },
 });
+
+async function fetchEventTraceEnrichment({
+  apiService,
+  organizationSlug,
+  event,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  event: Event;
+}): Promise<{
+  performanceTrace: Trace | undefined;
+  aiConversations: AIConversationReference[];
+}> {
+  const [performanceTrace, aiConversations] = await Promise.all([
+    maybeFetchPerformanceTrace({
+      apiService,
+      organizationSlug,
+      event,
+    }),
+    maybeFindAIConversationsForIssueEvent({
+      apiService,
+      organizationSlug,
+      event,
+    }),
+  ]);
+
+  return { performanceTrace, aiConversations };
+}
 
 /**
  * Fetches supplementary data for an issue in parallel: Seer analysis and external links.
@@ -318,6 +356,131 @@ async function maybeFetchPerformanceTrace({
     logError(error);
     return undefined;
   }
+}
+
+async function maybeFindAIConversationsForIssueEvent({
+  apiService,
+  organizationSlug,
+  event,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  event: Event;
+}): Promise<AIConversationReference[]> {
+  const traceId = getEventTraceId(event);
+  if (!traceId) {
+    return [];
+  }
+
+  try {
+    return await findAIConversationsForTrace({
+      apiService,
+      organizationSlug,
+      traceId,
+      event,
+    });
+  } catch (error) {
+    logError(error);
+    return [];
+  }
+}
+
+/**
+ * Conversation IDs live on spans, not issue events. Keep this as a bounded
+ * opportunistic span match so issue details never fetch the full trace.
+ */
+async function findAIConversationsForTrace({
+  apiService,
+  organizationSlug,
+  traceId,
+  event,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  traceId: string;
+  event: Event;
+}): Promise<AIConversationReference[]> {
+  const response = await apiService.searchEvents({
+    organizationSlug,
+    dataset: "spans",
+    query: `trace:${traceId} has:gen_ai.conversation.id`,
+    fields: ["gen_ai.conversation.id", "trace.span_id", "timestamp"],
+    limit: MAX_AI_CONVERSATION_MATCHES,
+    sort: "-timestamp",
+    ...buildConversationLookupTimeParams(event),
+  });
+
+  if (
+    !response ||
+    typeof response !== "object" ||
+    !Array.isArray((response as { data?: unknown }).data)
+  ) {
+    return [];
+  }
+
+  const references = new Map<string, AIConversationReference>();
+  for (const row of (response as { data: unknown[] }).data) {
+    if (!row || typeof row !== "object") {
+      continue;
+    }
+    const record = row as Record<string, unknown>;
+    const conversationId = getString(record["gen_ai.conversation.id"]);
+    if (!conversationId || references.has(conversationId)) {
+      continue;
+    }
+
+    references.set(conversationId, {
+      conversationId,
+      spanId: getString(record["trace.span_id"]),
+    });
+
+    if (references.size >= MAX_AI_CONVERSATION_MATCHES) {
+      break;
+    }
+  }
+
+  return [...references.values()];
+}
+
+function buildConversationLookupTimeParams(event: Event): {
+  statsPeriod?: string;
+  start?: string;
+  end?: string;
+} {
+  const eventTimestamp = getEventTimestamp(event);
+  if (!eventTimestamp) {
+    return { statsPeriod: "14d" };
+  }
+
+  return {
+    start: new Date(
+      eventTimestamp.getTime() - AI_CONVERSATION_LOOKUP_WINDOW_MS,
+    ).toISOString(),
+    end: new Date(
+      eventTimestamp.getTime() + AI_CONVERSATION_LOOKUP_WINDOW_MS,
+    ).toISOString(),
+  };
+}
+
+function getEventTimestamp(event: Event): Date | null {
+  const timestamp =
+    getString((event as { dateCreated?: unknown }).dateCreated) ??
+    getString(event.dateReceived);
+  if (!timestamp) {
+    return null;
+  }
+
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getEventTraceId(event: Event): string | undefined {
+  const traceId = event.contexts?.trace?.trace_id;
+  return getString(traceId);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function isErrorEvent(event: Event): event is ErrorEvent | DefaultEvent {

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -418,7 +418,7 @@ async function findAIConversationsForTrace({
     organizationSlug,
     dataset: "spans",
     query: `trace:${traceId} has:gen_ai.conversation.id`,
-    fields: ["gen_ai.conversation.id", "trace.span_id", "timestamp"],
+    fields: ["gen_ai.conversation.id", "span_id", "timestamp"],
     limit: MAX_AI_CONVERSATION_MATCHES,
     sort: "-timestamp",
     ...buildConversationLookupTimeParams(event),
@@ -445,7 +445,7 @@ async function findAIConversationsForTrace({
 
     references.set(conversationId, {
       conversationId,
-      spanId: getString(record["trace.span_id"]),
+      spanId: getString(record.span_id),
     });
 
     if (references.size >= MAX_AI_CONVERSATION_MATCHES) {

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
@@ -709,7 +709,7 @@ describe("get_trace_details", () => {
         suggestedActions: Array<{
           type: string;
           toolName: string;
-          arguments: Record<string, string>;
+          arguments: Record<string, unknown>;
           reason: string;
         }>;
       }>(result),
@@ -759,7 +759,7 @@ describe("get_trace_details", () => {
       **Conversation ID**: \`conv-trace-snapshot\`
       **Matching Span**: \`c4d1aae7216b47ff\`
 
-      Use the Sentry tool \`get_ai_conversation_details\` to fetch the full transcript.
+      Use the Sentry tool \`execute_sentry_tool(name='get_ai_conversation_details', arguments={"organizationSlug":"sentry-mcp-evals","conversationId":"conv-trace-snapshot"})\` to fetch the full transcript.
 
       ## Next Steps
 
@@ -1171,7 +1171,7 @@ describe("get_trace_details", () => {
     expect(text).toContain("**Conversation ID**: `conv-trace-123`");
     expect(text).toContain("**Matching Span**: `2222222222222222`");
     expect(text).toContain(
-      "Use the Sentry tool `get_ai_conversation_details` to fetch the full transcript.",
+      'Use the Sentry tool `execute_sentry_tool(name=\'get_ai_conversation_details\', arguments={"organizationSlug":"sentry-mcp-evals","conversationId":"conv-trace-123"})` to fetch the full transcript.',
     );
     expect(text).toContain(
       "POST api.anthropic.com/v1/messages [http.client · 200 · 21455ms · 3333333333333333]",

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
@@ -651,6 +651,94 @@ describe("get_trace_details", () => {
     `);
   });
 
+  it("snapshots AI conversations found in loaded trace spans", async () => {
+    const traceId = "c4d1aae7216b47ff8117cf4e09ce9d0c";
+    const rootSpan = buildTraceSpanNode({
+      duration: 123,
+      eventId: "c4d1aae7216b47ff8117cf4e09ce9d0c",
+      name: "ai.generate",
+      op: "gen_ai.invoke_agent",
+      parentSpanId: null,
+      spanId: "c4d1aae7216b47ff",
+      data: {
+        "gen_ai.conversation.id": "conv-trace-snapshot",
+      },
+    });
+
+    mswServer.use(
+      ...httpGetRegional(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/trace-meta/${traceId}/`,
+        () =>
+          HttpResponse.json({
+            logs: 0,
+            errors: 0,
+            performance_issues: 0,
+            span_count: 1,
+            transaction_child_count_map: [],
+            span_count_map: {},
+          }),
+      ),
+      ...httpGetRegional(
+        `https://sentry.io/api/0/organizations/sentry-mcp-evals/trace/${traceId}/`,
+        () => HttpResponse.json([rootSpan]),
+      ),
+    );
+
+    const result = await getTraceDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        traceId,
+        regionUrl: null,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+        },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Trace \`c4d1aae7216b47ff8117cf4e09ce9d0c\` in **sentry-mcp-evals**
+
+      ## Summary
+
+      **Total Spans**: 1
+      **Errors**: 0
+      **Performance Issues**: 0
+      **Logs**: 0
+
+      ## Operation Breakdown
+
+      - **gen_ai.invoke_agent**: 1 spans (avg: 123ms, p95: 123ms)
+
+      ## Overview
+
+      trace
+         └─ ai.generate [gen_ai.invoke_agent · 123ms · c4d1aae7216b47ff]
+
+      *Overview shows 1 of 1 spans.*
+
+      ## View Full Trace
+
+      **Sentry URL**: https://sentry-mcp-evals.sentry.io/explore/traces/trace/c4d1aae7216b47ff8117cf4e09ce9d0c
+
+      ## AI Conversations
+
+      **Conversation ID**: \`conv-trace-snapshot\`
+      **Matching Span**: \`c4d1aae7216b47ff\`
+
+      Use the Sentry tool \`get_ai_conversation_details\` to fetch the full transcript.
+
+      ## Next Steps
+
+      - **Search spans**: Use the Sentry tool \`search_events\`
+      - **Search errors**: Use the Sentry tool \`search_events\`
+      - **Search logs**: Use the Sentry tool \`search_events\`"
+    `);
+  });
+
   it("renders semantic labels for common OpenTelemetry span attributes", async () => {
     const traceId = "e4d1aae7216b47ff8117cf4e09ce9d0e";
     const processSpan = buildTraceSpanNode({
@@ -750,6 +838,7 @@ describe("get_trace_details", () => {
       parentSpanId: "1111111111111111",
       spanId: "2222222222222222",
       data: {
+        "gen_ai.conversation.id": "conv-trace-123",
         "gen_ai.operation.name": "invoke_agent",
         "gen_ai.provider.name": "anthropic",
         "gen_ai.request.model": "claude-haiku-unused",
@@ -1046,6 +1135,12 @@ describe("get_trace_details", () => {
     );
     expect(result).toContain(
       "invoke_agent anthropic/claude-opus-4.6 [gen_ai.invoke_agent · 123419ms · 2222222222222222]",
+    );
+    expect(result).toContain("## AI Conversations");
+    expect(result).toContain("**Conversation ID**: `conv-trace-123`");
+    expect(result).toContain("**Matching Span**: `2222222222222222`");
+    expect(result).toContain(
+      "Use the Sentry tool `get_ai_conversation_details` to fetch the full transcript.",
     );
     expect(result).toContain(
       "POST api.anthropic.com/v1/messages [http.client · 200 · 21455ms · 3333333333333333]",

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.test.ts
@@ -7,6 +7,10 @@ import {
   traceFixture,
   traceMixedFixture,
 } from "@sentry/mcp-server-mocks";
+import {
+  getStructuredContent,
+  getTextContent,
+} from "../../test-utils/structured-content";
 import getTraceDetails from "./get-trace-details.js";
 
 const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
@@ -699,7 +703,33 @@ describe("get_trace_details", () => {
       },
     );
 
-    expect(result).toMatchInlineSnapshot(`
+    const text = getTextContent(result);
+    expect(
+      getStructuredContent<{
+        suggestedActions: Array<{
+          type: string;
+          toolName: string;
+          arguments: Record<string, string>;
+          reason: string;
+        }>;
+      }>(result),
+    ).toEqual({
+      suggestedActions: [
+        {
+          type: "tool_call",
+          toolName: "execute_sentry_tool",
+          arguments: {
+            name: "get_ai_conversation_details",
+            arguments: {
+              organizationSlug: "sentry-mcp-evals",
+              conversationId: "conv-trace-snapshot",
+            },
+          },
+          reason: "Fetch the full transcript for this AI conversation.",
+        },
+      ],
+    });
+    expect(text).toMatchInlineSnapshot(`
       "# Trace \`c4d1aae7216b47ff8117cf4e09ce9d0c\` in **sentry-mcp-evals**
 
       ## Summary
@@ -1130,83 +1160,84 @@ describe("get_trace_details", () => {
       },
     );
 
-    expect(result).toContain(
+    const text = getTextContent(result);
+    expect(text).toContain(
       "POST /api/internal/turn-resume [http.server · 201 · 3ms · 1111111111111111]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "invoke_agent anthropic/claude-opus-4.6 [gen_ai.invoke_agent · 123419ms · 2222222222222222]",
     );
-    expect(result).toContain("## AI Conversations");
-    expect(result).toContain("**Conversation ID**: `conv-trace-123`");
-    expect(result).toContain("**Matching Span**: `2222222222222222`");
-    expect(result).toContain(
+    expect(text).toContain("## AI Conversations");
+    expect(text).toContain("**Conversation ID**: `conv-trace-123`");
+    expect(text).toContain("**Matching Span**: `2222222222222222`");
+    expect(text).toContain(
       "Use the Sentry tool `get_ai_conversation_details` to fetch the full transcript.",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "POST api.anthropic.com/v1/messages [http.client · 200 · 21455ms · 3333333333333333]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "POST [http.client · 204 · 16ms · 1313131313131313]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "PROPFIND [http.client · 207 · 15ms · 1919191919191919]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "GET api.example.com:443 [http.client · 17ms · 1414141414141414]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "GET /api/v200/resources [http.client · 200 · 18ms · 1616161616161616]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "execute_tool search_events [gen_ai.execute_tool · 4107ms · 4444444444444444]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "git [process.exec · exit:0 · 4050ms · 5555555555555555]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "SELECT issues [db.query · postgresql · OK · 44ms · 6666666666666666]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "SELECT db.internal [db.query · postgresql · 41ms · 1515151515151515]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "sentry.trace.v1.TraceService/FetchTrace [rpc.client · grpc · OK · 65ms · 7777777777777777]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "bookings_workflow/Run [rpc.client · temporal · OK · 24ms · 1717171717171717]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "publish trace-events [messaging.publish · kafka · 37ms · 8888888888888888]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "tools/call search_events [mcp.request · OK · 28ms · 9999999999999999]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "query TraceDetails [graphql.execute · 31ms · aaaaaaaaaaaaaaaa]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "timer trace-worker [faas.invoke · aws · us-west-2 · coldstart · 52ms · bbbbbbbbbbbbbbbb]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "PutObject trace-artifacts/runs/abc.json [aws.s3 · us-west-2 · 73ms · cccccccccccccccc]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "com.sentry.trace.created trace/e4d1 [event.process · cloudevents:1.0 · 19ms · dddddddddddddddd]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "BUILD mcp-core [cicd.pipeline · success · 88ms · eeeeeeeeeeeeeeee]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "semantic-trace-rendering on [feature_flag.evaluate · flagsmith · targeting_match · 12ms · ffffffffffffffff]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "DynamoDB.GetItem [aws.sdk · aws-api · us-east-1 · 21ms · abababababababab]",
     );
-    expect(result).toContain(
+    expect(text).toContain(
       "job failed [exception · ValueError · 13ms · acacacacacacacac]",
     );
-    expect(result).toContain("TypeError [exception · 14ms · 1818181818181818]");
-    expect(result).toContain(
+    expect(text).toContain("TypeError [exception · 14ms · 1818181818181818]");
+    expect(text).toContain(
       "background job [internal · timeout · 11ms · 1212121212121212]",
     );
   });

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.ts
@@ -5,6 +5,7 @@ import { hasAgentProvider } from "../../internal/agents/provider-factory";
 import { formatToolCallInstruction } from "../../internal/tool-helpers/tool-call-formatting";
 import {
   addAIConversationSuggestedActions,
+  formatAIConversationActionInstructions,
   type AIConversationReference,
 } from "../../internal/tool-helpers/ai-conversation-actions";
 import { resolveRegionUrlForOrganization } from "../../internal/tool-helpers/resolve-region-url";
@@ -1203,22 +1204,13 @@ function formatAIConversationSection({
     return [];
   }
 
-  const instruction = formatToolCallInstruction({
-    toolName: "get_ai_conversation_details",
-    arguments: {
-      organizationSlug,
-      conversationId:
-        aiConversations.length === 1
-          ? aiConversations[0].conversationId
-          : "conversation ID",
-    },
+  const instructions = formatAIConversationActionInstructions({
+    organizationSlug,
+    aiConversations,
     experimentalMode,
     availableToolNames,
     directToolNames,
-    fallbackInstruction:
-      "AI conversation detail lookup is not available in this session",
   });
-  const transcriptInstruction = formatTranscriptInstruction(instruction);
 
   const lines = ["## AI Conversations", ""];
   if (aiConversations.length === 1) {
@@ -1228,7 +1220,7 @@ function formatAIConversationSection({
       lines.push(`**Matching Span**: \`${conversation.spanId}\``);
     }
     lines.push("");
-    lines.push(transcriptInstruction);
+    lines.push(...instructions);
     lines.push("");
     return lines;
   }
@@ -1240,15 +1232,9 @@ function formatAIConversationSection({
     lines.push(`- \`${conversation.conversationId}\`${spanSuffix}`);
   }
   lines.push("");
-  lines.push(transcriptInstruction);
+  lines.push(...instructions.map((instruction) => `- ${instruction}`));
   lines.push("");
   return lines;
-}
-
-function formatTranscriptInstruction(instruction: string): string {
-  return instruction.startsWith("Use ")
-    ? `${instruction} to fetch the full transcript.`
-    : `${instruction}.`;
 }
 
 function buildTraceNextSteps({

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.ts
@@ -26,6 +26,7 @@ const MAX_FOCUSED_CHILD_SPANS = 40;
 const MAX_QUEUED_CHILDREN_PER_PARENT = 24;
 const MINIMUM_DURATION_THRESHOLD_MS = 10;
 const MIN_AVG_DURATION_MS = 5;
+const MAX_AI_CONVERSATION_REFERENCES = 3;
 
 interface TraceSummary {
   spanCount: number;
@@ -51,6 +52,11 @@ interface SpanExpansionCandidate {
   parent: SelectedSpan;
   level: number;
   score: number;
+}
+
+interface AIConversationReference {
+  conversationId: string;
+  spanId?: string;
 }
 
 export default defineTool({
@@ -805,6 +811,17 @@ function formatTraceOverviewOutput({
   sections.push("");
   sections.push(`**Sentry URL**: ${traceUrl}`);
   sections.push("");
+
+  sections.push(
+    ...formatAIConversationSection({
+      aiConversations: collectAIConversationReferencesFromTrace(trace),
+      organizationSlug,
+      experimentalMode: experimentalMode ?? false,
+      availableToolNames,
+      directToolNames,
+    }),
+  );
+
   sections.push("## Next Steps");
   sections.push("");
   sections.push(
@@ -909,6 +926,15 @@ function formatFocusedSpanOutput({
   sections.push("## Attributes");
   sections.push("");
   sections.push(...formatSpanAttributeSections(focusedSpan, traceId));
+  sections.push(
+    ...formatAIConversationSection({
+      aiConversations: collectAIConversationReferencesFromTrace(trace),
+      organizationSlug,
+      experimentalMode: experimentalMode ?? false,
+      availableToolNames,
+      directToolNames,
+    }),
+  );
   sections.push("## Next Steps");
   sections.push("");
   sections.push(
@@ -1080,6 +1106,132 @@ function stripUndefined(
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
   );
+}
+
+function collectAIConversationReferencesFromTrace(
+  trace: Trace,
+): AIConversationReference[] {
+  const references = new Map<string, AIConversationReference>();
+
+  // Known gap: trace details only expose conversation IDs already present in
+  // the trace payload; unlike issue details, this path does not run a spans
+  // search enrichment lookup.
+  for (const span of getTraceSpans(trace)) {
+    collectAIConversationReferences(span, references);
+    if (references.size >= MAX_AI_CONVERSATION_REFERENCES) {
+      break;
+    }
+  }
+
+  return [...references.values()];
+}
+
+function collectAIConversationReferences(
+  span: TraceSpan,
+  references: Map<string, AIConversationReference>,
+): void {
+  const conversationId = getAIConversationIdFromSpan(span);
+  if (conversationId && !references.has(conversationId)) {
+    references.set(conversationId, {
+      conversationId,
+      spanId: getTraceSpanId(span),
+    });
+  }
+
+  if (references.size >= MAX_AI_CONVERSATION_REFERENCES) {
+    return;
+  }
+
+  for (const child of getTraceSpanChildren(span)) {
+    collectAIConversationReferences(child, references);
+    if (references.size >= MAX_AI_CONVERSATION_REFERENCES) {
+      return;
+    }
+  }
+}
+
+function getAIConversationIdFromSpan(span: TraceSpan): string | undefined {
+  return (
+    getStringRecordValue(
+      span.additional_attributes,
+      "gen_ai.conversation.id",
+    ) ??
+    getStringRecordValue(span.data, "gen_ai.conversation.id") ??
+    getStringRecordValue(span.tags, "gen_ai.conversation.id")
+  );
+}
+
+function getStringRecordValue(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function formatAIConversationSection({
+  aiConversations,
+  organizationSlug,
+  experimentalMode,
+  availableToolNames,
+  directToolNames,
+}: {
+  aiConversations: AIConversationReference[];
+  organizationSlug: string;
+  experimentalMode: boolean;
+  availableToolNames?: ReadonlySet<string>;
+  directToolNames?: ReadonlySet<string>;
+}): string[] {
+  if (aiConversations.length === 0) {
+    return [];
+  }
+
+  const instruction = formatToolCallInstruction({
+    toolName: "get_ai_conversation_details",
+    arguments: {
+      organizationSlug,
+      conversationId:
+        aiConversations.length === 1
+          ? aiConversations[0].conversationId
+          : "conversation ID",
+    },
+    experimentalMode,
+    availableToolNames,
+    directToolNames,
+    fallbackInstruction:
+      "AI conversation detail lookup is not available in this session",
+  });
+  const transcriptInstruction = formatTranscriptInstruction(instruction);
+
+  const lines = ["## AI Conversations", ""];
+  if (aiConversations.length === 1) {
+    const [conversation] = aiConversations;
+    lines.push(`**Conversation ID**: \`${conversation.conversationId}\``);
+    if (conversation.spanId) {
+      lines.push(`**Matching Span**: \`${conversation.spanId}\``);
+    }
+    lines.push("");
+    lines.push(transcriptInstruction);
+    lines.push("");
+    return lines;
+  }
+
+  for (const conversation of aiConversations) {
+    const spanSuffix = conversation.spanId
+      ? ` (matching span: \`${conversation.spanId}\`)`
+      : "";
+    lines.push(`- \`${conversation.conversationId}\`${spanSuffix}`);
+  }
+  lines.push("");
+  lines.push(transcriptInstruction);
+  lines.push("");
+  return lines;
+}
+
+function formatTranscriptInstruction(instruction: string): string {
+  return instruction.startsWith("Use ")
+    ? `${instruction} to fetch the full transcript.`
+    : `${instruction}.`;
 }
 
 function buildTraceNextSteps({

--- a/packages/mcp-core/src/tools/catalog/get-trace-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-trace-details.ts
@@ -3,6 +3,10 @@ import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
 import { hasAgentProvider } from "../../internal/agents/provider-factory";
 import { formatToolCallInstruction } from "../../internal/tool-helpers/tool-call-formatting";
+import {
+  addAIConversationSuggestedActions,
+  type AIConversationReference,
+} from "../../internal/tool-helpers/ai-conversation-actions";
 import { resolveRegionUrlForOrganization } from "../../internal/tool-helpers/resolve-region-url";
 import type { SentryApiService, Trace, TraceSpan } from "../../api-client";
 import { UserInputError } from "../../errors";
@@ -52,11 +56,6 @@ interface SpanExpansionCandidate {
   parent: SelectedSpan;
   level: number;
   score: number;
-}
-
-interface AIConversationReference {
-  conversationId: string;
-  spanId?: string;
 }
 
 export default defineTool({
@@ -176,7 +175,8 @@ export default defineTool({
       totalSpanCount: traceMeta.span_count,
     });
 
-    return formatTraceOutput({
+    const aiConversations = collectAIConversationReferencesFromTrace(trace);
+    const markdown = formatTraceOutput({
       organizationSlug: params.organizationSlug,
       traceId: params.traceId,
       spanId: params.spanId,
@@ -185,6 +185,15 @@ export default defineTool({
       traceFetchState,
       apiService,
       experimentalMode: context.experimentalMode,
+      availableToolNames: context.availableToolNames,
+      directToolNames: context.directToolNames,
+      aiConversations,
+    });
+    return addAIConversationSuggestedActions({
+      markdown,
+      organizationSlug: params.organizationSlug,
+      aiConversations,
+      experimentalMode: context.experimentalMode ?? false,
       availableToolNames: context.availableToolNames,
       directToolNames: context.directToolNames,
     });
@@ -690,6 +699,7 @@ function formatTraceOutput({
   experimentalMode,
   availableToolNames,
   directToolNames,
+  aiConversations,
 }: {
   organizationSlug: string;
   traceId: string;
@@ -701,6 +711,7 @@ function formatTraceOutput({
   experimentalMode?: boolean;
   availableToolNames?: ReadonlySet<string>;
   directToolNames?: ReadonlySet<string>;
+  aiConversations: AIConversationReference[];
 }): string {
   if (spanId) {
     return formatFocusedSpanOutput({
@@ -714,6 +725,7 @@ function formatTraceOutput({
       experimentalMode,
       availableToolNames,
       directToolNames,
+      aiConversations,
     });
   }
 
@@ -726,6 +738,7 @@ function formatTraceOutput({
     experimentalMode,
     availableToolNames,
     directToolNames,
+    aiConversations,
   });
 }
 
@@ -738,6 +751,7 @@ function formatTraceOverviewOutput({
   experimentalMode,
   availableToolNames,
   directToolNames,
+  aiConversations,
 }: {
   organizationSlug: string;
   traceId: string;
@@ -747,6 +761,7 @@ function formatTraceOverviewOutput({
   experimentalMode?: boolean;
   availableToolNames?: ReadonlySet<string>;
   directToolNames?: ReadonlySet<string>;
+  aiConversations: AIConversationReference[];
 }): string {
   const sections: string[] = [];
 
@@ -814,7 +829,7 @@ function formatTraceOverviewOutput({
 
   sections.push(
     ...formatAIConversationSection({
-      aiConversations: collectAIConversationReferencesFromTrace(trace),
+      aiConversations,
       organizationSlug,
       experimentalMode: experimentalMode ?? false,
       availableToolNames,
@@ -848,6 +863,7 @@ function formatFocusedSpanOutput({
   experimentalMode,
   availableToolNames,
   directToolNames,
+  aiConversations,
 }: {
   organizationSlug: string;
   traceId: string;
@@ -859,6 +875,7 @@ function formatFocusedSpanOutput({
   experimentalMode?: boolean;
   availableToolNames?: ReadonlySet<string>;
   directToolNames?: ReadonlySet<string>;
+  aiConversations: AIConversationReference[];
 }): string {
   const focusedSpan = findTraceSpan(trace, spanId);
   if (!focusedSpan) {
@@ -928,7 +945,7 @@ function formatFocusedSpanOutput({
   sections.push(...formatSpanAttributeSections(focusedSpan, traceId));
   sections.push(
     ...formatAIConversationSection({
-      aiConversations: collectAIConversationReferencesFromTrace(trace),
+      aiConversations,
       organizationSlug,
       experimentalMode: experimentalMode ?? false,
       availableToolNames,


### PR DESCRIPTION
Issue details now perform a bounded, trace-scoped spans lookup to find AI conversation IDs without loading the full trace. Event-provided trace IDs are validated before use, the lookup reads the current Spans API span_id field, and failed enrichment still leaves the primary issue response intact.

Issue and trace detail results expose matching Markdown and structured suggested-actions follow-ups with complete transcript arguments. Catalog-only continuation uses execute_sentry_tool, direct sessions invoke the target directly, and unsupported event results retain the same callable guidance.