### PR TITLE
fix(alerts): Use organization metric alert endpoints

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2125,16 +2125,17 @@ export class SentryApiService {
     },
     opts?: RequestOptions,
   ): Promise<{ rules: MetricAlertRuleList; nextCursor: string | null }> {
+    const project = projectSlug
+      ? await this.getProject(
+          {
+            organizationSlug,
+            projectSlugOrId: projectSlug,
+          },
+          opts,
+        )
+      : undefined;
+
     if (query) {
-      const project = projectSlug
-        ? await this.getProject(
-            {
-              organizationSlug,
-              projectSlugOrId: projectSlug,
-            },
-            opts,
-          )
-        : undefined;
       const body = await this.listCombinedAlertRules(
         {
           organizationSlug,
@@ -2159,11 +2160,12 @@ export class SentryApiService {
     if (limit !== undefined) {
       searchQuery.set("per_page", String(limit));
     }
+    if (project) {
+      searchQuery.set("projectSlug", project.slug);
+    }
 
     const queryString = searchQuery.toString();
-    const path = projectSlug
-      ? `/projects/${organizationSlug}/${projectSlug}/alert-rules/`
-      : `/organizations/${organizationSlug}/alert-rules/`;
+    const path = `/organizations/${organizationSlug}/alert-rules/`;
     const response = await this.request(
       `${path}${queryString ? `?${queryString}` : ""}`,
       undefined,
@@ -2179,18 +2181,14 @@ export class SentryApiService {
   async getMetricAlertRule(
     {
       organizationSlug,
-      projectSlug,
       ruleId,
     }: {
       organizationSlug: string;
-      projectSlug?: string;
       ruleId: string | number;
     },
     opts?: RequestOptions,
   ): Promise<MetricAlertRule> {
-    const path = projectSlug
-      ? `/projects/${organizationSlug}/${projectSlug}/alert-rules/${encodeURIComponent(String(ruleId))}/`
-      : `/organizations/${organizationSlug}/alert-rules/${encodeURIComponent(String(ruleId))}/`;
+    const path = `/organizations/${organizationSlug}/alert-rules/${encodeURIComponent(String(ruleId))}/`;
     const body = await this.requestJSON(path, undefined, opts);
     return MetricAlertRuleSchema.parse(body);
   }

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2161,7 +2161,7 @@ export class SentryApiService {
       searchQuery.set("per_page", String(limit));
     }
     if (project) {
-      searchQuery.set("projectSlug", project.slug);
+      searchQuery.set("project", String(project.id));
     }
 
     const queryString = searchQuery.toString();

--- a/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
@@ -143,9 +143,9 @@ describe("find_alert_rules", () => {
       "cloudflare-mcp",
     );
     expect(metricRequestUrl).not.toBeNull();
-    expect(
-      new URL(metricRequestUrl ?? "").searchParams.get("projectSlug"),
-    ).toBe("cloudflare-mcp");
+    expect(new URL(metricRequestUrl ?? "").searchParams.get("project")).toBe(
+      project.id,
+    );
     expect(result).toMatchInlineSnapshot(`
       "# Alert Rules in **sentry-mcp-evals/cloudflare-mcp**
 
@@ -242,9 +242,9 @@ describe("find_alert_rules", () => {
     );
 
     expect(metricRequestUrl).not.toBeNull();
-    expect(
-      new URL(metricRequestUrl ?? "").searchParams.get("projectSlug"),
-    ).toBe("cloudflare-mcp");
+    expect(new URL(metricRequestUrl ?? "").searchParams.get("project")).toBe(
+      project.id,
+    );
   });
 
   it("returns next cursors for direct alert rule list endpoints", async () => {

--- a/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
@@ -100,10 +100,6 @@ function useAlertRuleHandlers() {
       "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/",
       () => HttpResponse.json([metricAlertRule]),
     ),
-    http.get(
-      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/",
-      () => HttpResponse.json([metricAlertRule]),
-    ),
   );
 }
 
@@ -121,7 +117,7 @@ describe("find_alert_rules", () => {
         },
       ),
       http.get(
-        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/",
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/",
         ({ request }) => {
           metricRequestUrl = request.url;
           return HttpResponse.json([metricAlertRule]);
@@ -147,6 +143,9 @@ describe("find_alert_rules", () => {
       "cloudflare-mcp",
     );
     expect(metricRequestUrl).not.toBeNull();
+    expect(
+      new URL(metricRequestUrl ?? "").searchParams.get("projectSlug"),
+    ).toBe("cloudflare-mcp");
     expect(result).toMatchInlineSnapshot(`
       "# Alert Rules in **sentry-mcp-evals/cloudflare-mcp**
 
@@ -211,6 +210,41 @@ describe("find_alert_rules", () => {
     expect(result).toContain(
       "Issue alert rules are project-scoped; pass `projectSlug` to include them.",
     );
+  });
+
+  it("resolves project redirects before listing metric alerts", async () => {
+    let metricRequestUrl: string | null = null;
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/legacy-cloudflare-mcp/",
+        () => HttpResponse.json(project),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/",
+        ({ request }) => {
+          metricRequestUrl = request.url;
+          return HttpResponse.json([metricAlertRule]);
+        },
+      ),
+    );
+
+    await findAlertRules.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        kind: "metric",
+        projectSlug: "legacy-cloudflare-mcp",
+        query: null,
+        cursor: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(metricRequestUrl).not.toBeNull();
+    expect(
+      new URL(metricRequestUrl ?? "").searchParams.get("projectSlug"),
+    ).toBe("cloudflare-mcp");
   });
 
   it("returns next cursors for direct alert rule list endpoints", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-alert-rule.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-alert-rule.test.ts
@@ -105,10 +105,6 @@ function useAlertRuleHandlers() {
       () => HttpResponse.json([issueAlertRule]),
     ),
     http.get(
-      "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/",
-      () => HttpResponse.json([metricAlertRule]),
-    ),
-    http.get(
       "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/456/",
       () => HttpResponse.json(metricAlertRule),
     ),
@@ -207,12 +203,12 @@ describe("get_alert_rule", () => {
     `);
   });
 
-  it("falls back to organization metric alert details after a project ID miss", async () => {
+  it("uses organization metric alert details for a project-scoped ID", async () => {
     useAlertRuleHandlers();
     mswServer.use(
       http.get(
         "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/456/",
-        () => HttpResponse.json({}, { status: 404 }),
+        () => HttpResponse.json({}, { status: 500 }),
       ),
     );
 
@@ -232,13 +228,9 @@ describe("get_alert_rule", () => {
     expect(result).toContain("### Triggers");
   });
 
-  it("rejects organization metric alert fallback outside the active project constraint", async () => {
+  it("rejects organization metric alert details outside the active project constraint", async () => {
     useAlertRuleHandlers();
     mswServer.use(
-      http.get(
-        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/456/",
-        () => HttpResponse.json({}, { status: 404 }),
-      ),
       http.get(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/456/",
         () =>
@@ -263,7 +255,7 @@ describe("get_alert_rule", () => {
     ).rejects.toThrow('Metric alert rule is outside project "cloudflare-mcp"');
   });
 
-  it("falls back to organization metric alert details after resolving an exact name", async () => {
+  it("uses organization metric alert details after resolving an exact name", async () => {
     useAlertRuleHandlers();
     mswServer.use(
       http.get(
@@ -284,7 +276,7 @@ describe("get_alert_rule", () => {
       ),
       http.get(
         "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/456/",
-        () => HttpResponse.json({}, { status: 404 }),
+        () => HttpResponse.json({}, { status: 500 }),
       ),
     );
 
@@ -499,7 +491,7 @@ describe("get_alert_rule", () => {
       ),
       http.get(
         "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/alert-rules/789/",
-        () => HttpResponse.json({}, { status: 404 }),
+        () => HttpResponse.json({}, { status: 500 }),
       ),
       http.get(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/789/",
@@ -521,6 +513,44 @@ describe("get_alert_rule", () => {
     expect(result).toContain("## 123");
     expect(result).toContain("**Kind**: Metric Alert");
     expect(result).toContain("**ID**: 789");
+  });
+
+  it("rejects exact-name metric matches outside the active project constraint", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+        () => HttpResponse.json(project),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/workflows/",
+        () => HttpResponse.json([]),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/combined-rules/",
+        () => HttpResponse.json([metricAlertRule]),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/alert-rules/456/",
+        () =>
+          HttpResponse.json({
+            ...metricAlertRule,
+            projects: ["frontend"],
+          }),
+      ),
+    );
+
+    await expect(
+      getAlertRule.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: null,
+          kind: "all",
+          projectSlug: null,
+          ruleIdOrName: "P95 latency",
+        },
+        projectConstrainedContext,
+      ),
+    ).rejects.toThrow('Metric alert rule is outside project "cloudflare-mcp"');
   });
 
   it("rejects ambiguous exact-name lookups", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-alert-rule.ts
+++ b/packages/mcp-core/src/tools/catalog/get-alert-rule.ts
@@ -14,7 +14,6 @@ import { assertProjectRefWithinConstraint } from "./support/project-constraints"
 import {
   formatIssueAlertRule,
   formatMetricAlertRule,
-  getMetricAlertRuleWithOrgFallback,
   resolveIssueAlertRule,
   resolveMetricAlertRule,
 } from "./support/alerts";
@@ -207,9 +206,8 @@ export default defineTool({
             }
           : {
               ...found,
-              rule: await getMetricAlertRuleWithOrgFallback(apiService, {
+              rule: await apiService.getMetricAlertRule({
                 organizationSlug,
-                projectSlug: found.projectSlug,
                 ruleId: found.rule.id,
               }),
             };

--- a/packages/mcp-core/src/tools/catalog/support/alerts.ts
+++ b/packages/mcp-core/src/tools/catalog/support/alerts.ts
@@ -408,27 +408,6 @@ async function findExactMetricAlertRuleMatches(
   );
 }
 
-export async function getMetricAlertRuleWithOrgFallback(
-  apiService: SentryApiService,
-  params: {
-    organizationSlug: string;
-    projectSlug?: string;
-    ruleId: string | number;
-  },
-): Promise<MetricAlertRule> {
-  try {
-    return await apiService.getMetricAlertRule(params);
-  } catch (error) {
-    if (!(error instanceof ApiNotFoundError) || !params.projectSlug) {
-      throw error;
-    }
-  }
-  return apiService.getMetricAlertRule({
-    organizationSlug: params.organizationSlug,
-    ruleId: params.ruleId,
-  });
-}
-
 export async function resolveIssueAlertRule(
   apiService: SentryApiService,
   params: {
@@ -484,9 +463,8 @@ export async function resolveMetricAlertRule(
 ): Promise<MetricAlertRule> {
   if (isNumericAlertRuleId(params.ruleIdOrName)) {
     try {
-      return await getMetricAlertRuleWithOrgFallback(apiService, {
+      return await apiService.getMetricAlertRule({
         organizationSlug: params.organizationSlug,
-        projectSlug: params.projectSlug,
         ruleId: params.ruleIdOrName,
       });
     } catch (error) {
@@ -503,9 +481,8 @@ export async function resolveMetricAlertRule(
   });
 
   if (matches.length === 1) {
-    return getMetricAlertRuleWithOrgFallback(apiService, {
+    return apiService.getMetricAlertRule({
       organizationSlug: params.organizationSlug,
-      projectSlug: params.projectSlug,
       ruleId: matches[0].id,
     });
   }


### PR DESCRIPTION
Metric alert reads currently use deprecated project-scoped endpoints that are entering scheduled brownouts. This moves the list and detail requests to the organization-scoped endpoints while keeping project-scoped tool behavior intact.

Project-filtered lists now resolve the project first and pass its canonical slug to the organization endpoint, preserving renamed-project redirects and missing-project errors. Detail lookups use the organization endpoint directly, retain active project-constraint checks, and remove the obsolete project-first fallback retry.

Regression coverage verifies canonical project filtering, organization detail endpoint selection, numeric and exact-name resolution, and rejection of metric rules outside the active project constraint.

Fixes #1145