### PR TITLE
ref(core): Replace ad hoc record guards with schemas

### DIFF
--- a/packages/mcp-cloudflare/src/server/routes/chat-oauth.ts
+++ b/packages/mcp-cloudflare/src/server/routes/chat-oauth.ts
@@ -242,9 +242,11 @@ export default new Hono<{
     if (!state || !storedState || state !== storedState) {
       deleteCookie(c, "chat_oauth_state", getSecureCookieOptions(c.req.url));
       logIssue("Invalid state parameter received", {
-        oauth: {
-          state,
-          expectedState: storedState,
+        contexts: {
+          oauth: {
+            hasState: Boolean(state),
+            hasExpectedState: Boolean(storedState),
+          },
         },
       });
       return c.html(

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1370,13 +1370,14 @@ describe("API query builders", () => {
                 key: "tags[count,number]",
                 name: "count",
                 attributeType: "number",
+                attributeSource: { source_type: "user" },
               },
               {
-                key: "tags[fallback]",
-                name: 42,
-                attributeType: "invalid",
-                attributeSource: { source_type: "invalid" },
-                secondaryAliases: ["fallback.alias", 42],
+                key: "tags[secondary]",
+                name: "secondary",
+                attributeType: "string",
+                attributeSource: { source_type: "user" },
+                secondaryAliases: ["secondary.alias"],
               },
             ]),
         });
@@ -1409,10 +1410,11 @@ describe("API query builders", () => {
           attributeSource: { source_type: "user" },
         },
         {
-          key: "tags[fallback]",
-          name: "tags[fallback]",
+          key: "tags[secondary]",
+          name: "secondary",
           type: "string",
-          secondaryAliases: ["fallback.alias"],
+          attributeSource: { source_type: "user" },
+          secondaryAliases: ["secondary.alias"],
         },
       ]);
       expect(urls).toHaveLength(1);
@@ -1448,9 +1450,14 @@ describe("API query builders", () => {
             json: () =>
               Promise.resolve({
                 valid: false,
-                projects: { malformed: true },
-                dataset: [],
-                environment: [],
+                projects: [{ valid: true, error: null }],
+                dataset: [{ name: "spans", valid: true, error: null }],
+                environment: [
+                  {
+                    valid: false,
+                    error: "Unknown environments selected",
+                  },
+                ],
                 field: [
                   {
                     name: "tags[type]",
@@ -1502,9 +1509,9 @@ describe("API query builders", () => {
 
       expect(result).toEqual({
         valid: false,
-        projects: [],
-        dataset: [],
-        environment: [],
+        projects: [{ valid: true }],
+        dataset: [{ name: "spans", valid: true }],
+        environment: [{ valid: false, error: "Unknown environments selected" }],
         field: [
           { name: "tags[type]", valid: true, type: "string" },
           {

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -1371,6 +1371,13 @@ describe("API query builders", () => {
                 name: "count",
                 attributeType: "number",
               },
+              {
+                key: "tags[fallback]",
+                name: 42,
+                attributeType: "invalid",
+                attributeSource: { source_type: "invalid" },
+                secondaryAliases: ["fallback.alias", 42],
+              },
             ]),
         });
       });
@@ -1400,6 +1407,12 @@ describe("API query builders", () => {
           name: "enabled",
           type: "boolean",
           attributeSource: { source_type: "user" },
+        },
+        {
+          key: "tags[fallback]",
+          name: "tags[fallback]",
+          type: "string",
+          secondaryAliases: ["fallback.alias"],
         },
       ]);
       expect(urls).toHaveLength(1);
@@ -1435,7 +1448,7 @@ describe("API query builders", () => {
             json: () =>
               Promise.resolve({
                 valid: false,
-                projects: [],
+                projects: { malformed: true },
                 dataset: [],
                 environment: [],
                 field: [

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -315,198 +315,150 @@ export type EventsValidationResult = {
   orderby: EventsAttributeValidationResult[];
 };
 
-function parseEventsValidationIssue(
-  value: unknown,
-): EventsValidationIssue | null {
-  if (!isRecord(value) || typeof value.valid !== "boolean") {
-    return null;
-  }
-  const issue: EventsValidationIssue = { valid: value.valid };
-  if (typeof value.error === "string" && value.error.length > 0) {
-    issue.error = value.error;
-  }
-  return issue;
+const TraceItemAttributeTypeSchema = z.enum(["string", "number", "boolean"]);
+const TraceItemAttributeSourceSchema = z.object({
+  source_type: z.enum(["sentry", "user"]),
+  is_transformed_alias: z.boolean().optional(),
+});
+
+const optionalErrorSchema = z
+  .string()
+  .nullable()
+  .optional()
+  .transform((error) => (error ? error : undefined));
+
+const EventsValidationIssueSchema = z
+  .object({
+    valid: z.boolean(),
+    error: optionalErrorSchema,
+  })
+  .transform(
+    ({ valid, error }): EventsValidationIssue => ({
+      valid,
+      ...(error ? { error } : {}),
+    }),
+  );
+
+const EventsNamedValidationIssueSchema = z
+  .object({
+    name: z.string(),
+    valid: z.boolean(),
+    error: optionalErrorSchema,
+  })
+  .transform(
+    ({ name, valid, error }): EventsNamedValidationIssue => ({
+      name,
+      valid,
+      ...(error ? { error } : {}),
+    }),
+  );
+
+const EventsAttributeValidationSchema = z
+  .object({
+    name: z.string(),
+    valid: z.boolean(),
+    attrType: TraceItemAttributeTypeSchema.nullable().optional(),
+    error: optionalErrorSchema,
+  })
+  .transform(
+    ({ name, valid, attrType, error }): EventsAttributeValidationResult => ({
+      name,
+      valid,
+      ...(attrType ? { type: attrType } : {}),
+      ...(error ? { error } : {}),
+    }),
+  );
+
+function parsedArraySchema<Schema extends z.ZodTypeAny>(itemSchema: Schema) {
+  return z
+    .array(z.unknown())
+    .default([])
+    .transform((values): z.output<Schema>[] =>
+      values.flatMap<z.output<Schema>>((value) => {
+        const result = itemSchema.safeParse(value);
+        return result.success ? [result.data] : [];
+      }),
+    )
+    .catch([]);
 }
 
-function parseEventsAttributeValidation(
-  value: unknown,
-): EventsAttributeValidationResult | null {
-  if (
-    !isRecord(value) ||
-    typeof value.name !== "string" ||
-    typeof value.valid !== "boolean"
-  ) {
-    return null;
-  }
-  const result: EventsAttributeValidationResult = {
-    name: value.name,
-    valid: value.valid,
-  };
-  if (isTraceItemAttributeType(value.attrType)) {
-    result.type = value.attrType;
-  }
-  if (typeof value.error === "string" && value.error.length > 0) {
-    result.error = value.error;
-  }
-  return result;
-}
+const EventsValidationIssueListSchema = parsedArraySchema(
+  EventsValidationIssueSchema,
+);
+const EventsNamedValidationIssueListSchema = parsedArraySchema(
+  EventsNamedValidationIssueSchema,
+);
+const EventsAttributeValidationListSchema = parsedArraySchema(
+  EventsAttributeValidationSchema,
+);
+const EventsQueryValidationSchema = z
+  .object({
+    valid: z.boolean(),
+    error: optionalErrorSchema,
+    fields: EventsAttributeValidationListSchema,
+  })
+  .transform(
+    ({ valid, error, fields }): EventsQueryValidation => ({
+      valid,
+      fields,
+      ...(error ? { error } : {}),
+    }),
+  )
+  .catch({ valid: false, fields: [] });
 
-function parseEventsValidationIssues(value: unknown): EventsValidationIssue[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .map(parseEventsValidationIssue)
-    .filter((issue): issue is EventsValidationIssue => issue !== null);
-}
+const INVALID_EVENTS_VALIDATION_RESULT: EventsValidationResult = {
+  valid: false,
+  projects: [],
+  dataset: [],
+  environment: [],
+  field: [],
+  query: { valid: false, fields: [] },
+  orderby: [],
+};
 
-function parseEventsAttributeValidations(
-  value: unknown,
-): EventsAttributeValidationResult[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .map(parseEventsAttributeValidation)
-    .filter((item): item is EventsAttributeValidationResult => item !== null);
-}
-
-function parseEventsNamedValidationIssue(
-  value: unknown,
-): EventsNamedValidationIssue | null {
-  if (
-    !isRecord(value) ||
-    typeof value.name !== "string" ||
-    typeof value.valid !== "boolean"
-  ) {
-    return null;
-  }
-  const issue: EventsNamedValidationIssue = {
-    name: value.name,
-    valid: value.valid,
-  };
-  if (typeof value.error === "string" && value.error.length > 0) {
-    issue.error = value.error;
-  }
-  return issue;
-}
-
-function parseEventsNamedValidationIssues(
-  value: unknown,
-): EventsNamedValidationIssue[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .map(parseEventsNamedValidationIssue)
-    .filter((issue): issue is EventsNamedValidationIssue => issue !== null);
-}
-
-function parseEventsQueryValidation(value: unknown): EventsQueryValidation {
-  if (!isRecord(value) || typeof value.valid !== "boolean") {
-    return { valid: false, fields: [] };
-  }
-  const query: EventsQueryValidation = {
-    valid: value.valid,
-    fields: parseEventsAttributeValidations(value.fields),
-  };
-  if (typeof value.error === "string" && value.error.length > 0) {
-    query.error = value.error;
-  }
-  return query;
-}
-
-function parseEventsValidationResponse(body: unknown): EventsValidationResult {
-  if (!isRecord(body)) {
-    return {
-      valid: false,
-      projects: [],
-      dataset: [],
-      environment: [],
-      field: [],
-      query: { valid: false, fields: [] },
-      orderby: [],
-    };
-  }
-
-  return {
-    valid: typeof body.valid === "boolean" ? body.valid : false,
-    projects: parseEventsValidationIssues(body.projects),
-    dataset: parseEventsNamedValidationIssues(body.dataset),
-    environment: parseEventsValidationIssues(body.environment),
-    field: parseEventsAttributeValidations(body.field),
-    query: parseEventsQueryValidation(body.query),
-    orderby: parseEventsAttributeValidations(body.orderby),
-  };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isTraceItemAttributeType(
-  value: unknown,
-): value is TraceItemAttributeType {
-  return value === "string" || value === "number" || value === "boolean";
-}
-
-function isTraceItemAttributeSourceType(
-  value: unknown,
-): value is TraceItemAttributeSourceType {
-  return value === "sentry" || value === "user";
-}
-
-function parseTraceItemAttributeSource(
-  value: unknown,
-): TraceItemAttributeSource | undefined {
-  if (!isRecord(value) || !isTraceItemAttributeSourceType(value.source_type)) {
-    return undefined;
-  }
-
-  const source: TraceItemAttributeSource = { source_type: value.source_type };
-  if (typeof value.is_transformed_alias === "boolean") {
-    source.is_transformed_alias = value.is_transformed_alias;
-  }
-  return source;
-}
+const EventsValidationResponseSchema = z
+  .object({
+    valid: z.boolean().catch(false),
+    projects: EventsValidationIssueListSchema,
+    dataset: EventsNamedValidationIssueListSchema,
+    environment: EventsValidationIssueListSchema,
+    field: EventsAttributeValidationListSchema,
+    query: EventsQueryValidationSchema,
+    orderby: EventsAttributeValidationListSchema,
+  })
+  .transform((result): EventsValidationResult => result)
+  .catch(INVALID_EVENTS_VALIDATION_RESULT);
 
 function parseTraceItemAttributes(
   body: unknown,
   fallbackType: TraceItemAttributeType,
 ): TraceItemAttribute[] {
-  if (!Array.isArray(body)) {
-    return [];
-  }
-
-  const attributes: TraceItemAttribute[] = [];
-  for (const value of body) {
-    if (!isRecord(value) || typeof value.key !== "string") {
-      continue;
-    }
-
-    const attribute: TraceItemAttribute = {
-      key: value.key,
-      name: typeof value.name === "string" ? value.name : value.key,
-      type: isTraceItemAttributeType(value.attributeType)
-        ? value.attributeType
-        : fallbackType,
-    };
-
-    const attributeSource = parseTraceItemAttributeSource(
-      value.attributeSource,
+  const attributeSchema = z
+    .object({
+      key: z.string(),
+      name: z.string().optional().catch(undefined),
+      attributeType: TraceItemAttributeTypeSchema.optional().catch(undefined),
+      attributeSource:
+        TraceItemAttributeSourceSchema.optional().catch(undefined),
+      secondaryAliases: z
+        .array(z.unknown())
+        .transform((aliases) =>
+          aliases.filter((alias): alias is string => typeof alias === "string"),
+        )
+        .optional()
+        .catch(undefined),
+    })
+    .transform(
+      ({ key, name, attributeType, attributeSource, secondaryAliases }) => ({
+        key,
+        name: name ?? key,
+        type: attributeType ?? fallbackType,
+        ...(attributeSource ? { attributeSource } : {}),
+        ...(secondaryAliases ? { secondaryAliases } : {}),
+      }),
     );
-    if (attributeSource) {
-      attribute.attributeSource = attributeSource;
-    }
-    if (Array.isArray(value.secondaryAliases)) {
-      attribute.secondaryAliases = value.secondaryAliases.filter(
-        (alias): alias is string => typeof alias === "string",
-      );
-    }
-    attributes.push(attribute);
-  }
 
-  return attributes;
+  return parsedArraySchema(attributeSchema).parse(body);
 }
 
 /**
@@ -3056,7 +3008,7 @@ export class SentryApiService {
       { ...opts, allowStatuses: [400] },
     );
     const body = await this.parseJsonResponse(response);
-    return parseEventsValidationResponse(body);
+    return EventsValidationResponseSchema.parse(body);
   }
 
   private async fetchTraceItemAttributes(

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -271,7 +271,7 @@ export type TraceItemAttribute = {
   key: string;
   name: string;
   type: TraceItemAttributeType;
-  attributeSource?: TraceItemAttributeSource;
+  attributeSource: TraceItemAttributeSource;
   secondaryAliases?: string[];
 };
 
@@ -321,16 +321,12 @@ const TraceItemAttributeSourceSchema = z.object({
   is_transformed_alias: z.boolean().optional(),
 });
 
-const optionalErrorSchema = z
-  .string()
-  .nullable()
-  .optional()
-  .transform((error) => (error ? error : undefined));
+const ValidationErrorSchema = z.string().nullable();
 
 const EventsValidationIssueSchema = z
   .object({
     valid: z.boolean(),
-    error: optionalErrorSchema,
+    error: ValidationErrorSchema,
   })
   .transform(
     ({ valid, error }): EventsValidationIssue => ({
@@ -343,7 +339,7 @@ const EventsNamedValidationIssueSchema = z
   .object({
     name: z.string(),
     valid: z.boolean(),
-    error: optionalErrorSchema,
+    error: ValidationErrorSchema,
   })
   .transform(
     ({ name, valid, error }): EventsNamedValidationIssue => ({
@@ -357,8 +353,8 @@ const EventsAttributeValidationSchema = z
   .object({
     name: z.string(),
     valid: z.boolean(),
-    attrType: TraceItemAttributeTypeSchema.nullable().optional(),
-    error: optionalErrorSchema,
+    attrType: TraceItemAttributeTypeSchema.nullable(),
+    error: ValidationErrorSchema,
   })
   .transform(
     ({ name, valid, attrType, error }): EventsAttributeValidationResult => ({
@@ -369,32 +365,17 @@ const EventsAttributeValidationSchema = z
     }),
   );
 
-function parsedArraySchema<Schema extends z.ZodTypeAny>(itemSchema: Schema) {
-  return z
-    .array(z.unknown())
-    .default([])
-    .transform((values): z.output<Schema>[] =>
-      values.flatMap<z.output<Schema>>((value) => {
-        const result = itemSchema.safeParse(value);
-        return result.success ? [result.data] : [];
-      }),
-    )
-    .catch([]);
-}
-
-const EventsValidationIssueListSchema = parsedArraySchema(
-  EventsValidationIssueSchema,
-);
-const EventsNamedValidationIssueListSchema = parsedArraySchema(
+const EventsValidationIssueListSchema = z.array(EventsValidationIssueSchema);
+const EventsNamedValidationIssueListSchema = z.array(
   EventsNamedValidationIssueSchema,
 );
-const EventsAttributeValidationListSchema = parsedArraySchema(
+const EventsAttributeValidationListSchema = z.array(
   EventsAttributeValidationSchema,
 );
 const EventsQueryValidationSchema = z
   .object({
     valid: z.boolean(),
-    error: optionalErrorSchema,
+    error: ValidationErrorSchema,
     fields: EventsAttributeValidationListSchema,
   })
   .transform(
@@ -403,22 +384,11 @@ const EventsQueryValidationSchema = z
       fields,
       ...(error ? { error } : {}),
     }),
-  )
-  .catch({ valid: false, fields: [] });
-
-const INVALID_EVENTS_VALIDATION_RESULT: EventsValidationResult = {
-  valid: false,
-  projects: [],
-  dataset: [],
-  environment: [],
-  field: [],
-  query: { valid: false, fields: [] },
-  orderby: [],
-};
+  );
 
 const EventsValidationResponseSchema = z
   .object({
-    valid: z.boolean().catch(false),
+    valid: z.boolean(),
     projects: EventsValidationIssueListSchema,
     dataset: EventsNamedValidationIssueListSchema,
     environment: EventsValidationIssueListSchema,
@@ -426,40 +396,27 @@ const EventsValidationResponseSchema = z
     query: EventsQueryValidationSchema,
     orderby: EventsAttributeValidationListSchema,
   })
-  .transform((result): EventsValidationResult => result)
-  .catch(INVALID_EVENTS_VALIDATION_RESULT);
+  .transform((result): EventsValidationResult => result);
 
-function parseTraceItemAttributes(
-  body: unknown,
-  fallbackType: TraceItemAttributeType,
-): TraceItemAttribute[] {
-  const attributeSchema = z
-    .object({
-      key: z.string(),
-      name: z.string().optional().catch(undefined),
-      attributeType: TraceItemAttributeTypeSchema.optional().catch(undefined),
-      attributeSource:
-        TraceItemAttributeSourceSchema.optional().catch(undefined),
-      secondaryAliases: z
-        .array(z.unknown())
-        .transform((aliases) =>
-          aliases.filter((alias): alias is string => typeof alias === "string"),
-        )
-        .optional()
-        .catch(undefined),
-    })
-    .transform(
-      ({ key, name, attributeType, attributeSource, secondaryAliases }) => ({
-        key,
-        name: name ?? key,
-        type: attributeType ?? fallbackType,
-        ...(attributeSource ? { attributeSource } : {}),
-        ...(secondaryAliases ? { secondaryAliases } : {}),
-      }),
-    );
+const TraceItemAttributeSchema = z
+  .object({
+    key: z.string(),
+    name: z.string(),
+    attributeType: TraceItemAttributeTypeSchema,
+    attributeSource: TraceItemAttributeSourceSchema,
+    secondaryAliases: z.array(z.string()).optional(),
+  })
+  .transform(
+    ({ key, name, attributeType, attributeSource, secondaryAliases }) => ({
+      key,
+      name,
+      type: attributeType,
+      attributeSource,
+      ...(secondaryAliases ? { secondaryAliases } : {}),
+    }),
+  );
 
-  return parsedArraySchema(attributeSchema).parse(body);
-}
+const TraceItemAttributeListSchema = z.array(TraceItemAttributeSchema);
 
 /**
  * Sentry API client service for interacting with Sentry's REST API.
@@ -3038,7 +2995,7 @@ export class SentryApiService {
     const url = `/organizations/${organizationSlug}/trace-items/attributes/?${queryParams.toString()}`;
 
     const body = await this.requestJSON(url, undefined, opts);
-    return parseTraceItemAttributes(body, "string");
+    return TraceItemAttributeListSchema.parse(body);
   }
 
   /**

--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -21,6 +21,7 @@ import {
   ProfileFrameSchema,
   ReleaseSchema,
   ReplayDetailsSchema,
+  ReplayRecordingSegmentsSchema,
   TagSchema,
   TraceMetaSchema,
   TransactionProfileSampleSchema,
@@ -537,6 +538,44 @@ describe("ReplayDetailsSchema", () => {
       region: null,
       subdivision: null,
     });
+  });
+});
+
+describe("ReplayRecordingSegmentsSchema", () => {
+  it("keeps usable event fields when sibling fields are malformed", () => {
+    expect(
+      ReplayRecordingSegmentsSchema.parse([
+        [
+          {
+            timestamp: "invalid",
+            type: 5,
+            data: {
+              tag: "ui.click",
+              href: 123,
+              payload: {
+                message: "Clicked checkout",
+                data: { duration: "invalid" },
+              },
+            },
+          },
+        ],
+      ]),
+    ).toEqual([
+      [
+        {
+          timestamp: undefined,
+          type: 5,
+          data: {
+            tag: "ui.click",
+            href: undefined,
+            payload: {
+              message: "Clicked checkout",
+              data: { duration: undefined },
+            },
+          },
+        },
+      ],
+    ]);
   });
 });
 

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -412,7 +412,47 @@ export const ReplayDetailsSchema = z
   })
   .passthrough();
 
-export const ReplayRecordingSegmentsSchema = z.array(z.array(z.unknown()));
+const ReplayRecordingPayloadSchema = z
+  .object({
+    op: z.string().optional().catch(undefined),
+    description: z.string().optional().catch(undefined),
+    message: z.string().optional().catch(undefined),
+    category: z.string().optional().catch(undefined),
+    type: z.string().optional().catch(undefined),
+    data: z
+      .object({
+        duration: z.number().optional().catch(undefined),
+      })
+      .passthrough()
+      .optional()
+      .catch(undefined),
+  })
+  .passthrough();
+
+export const ReplayRecordingEventSchema = z
+  .object({
+    timestamp: z.number().optional().catch(undefined),
+    type: z.number().optional().catch(undefined),
+    data: z
+      .object({
+        tag: z.string().optional().catch(undefined),
+        href: z.string().optional().catch(undefined),
+        payload: ReplayRecordingPayloadSchema.optional().catch(undefined),
+      })
+      .passthrough()
+      .optional()
+      .catch(undefined),
+  })
+  .passthrough();
+
+export const ReplayRecordingSegmentsSchema = z.array(
+  z.array(z.unknown()).transform((events) =>
+    events.flatMap((event) => {
+      const result = ReplayRecordingEventSchema.safeParse(event);
+      return result.success ? [result.data] : [];
+    }),
+  ),
+);
 
 export const ReplayListResponseSchema = z.object({
   data: z.array(ReplayDetailsSchema),

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -101,6 +101,7 @@ import type {
   ReleaseSchema,
   ReplayDetailsSchema,
   ReplayListResponseSchema,
+  ReplayRecordingEventSchema,
   ReplayRecordingSegmentsSchema,
   TagListSchema,
   TagSchema,
@@ -162,6 +163,7 @@ export type AutofixRunState = z.infer<typeof AutofixRunStateSchema>;
 export type AssignedTo = z.infer<typeof AssignedToSchema>;
 export type ReplayDetails = z.infer<typeof ReplayDetailsSchema>;
 export type ReplayList = z.infer<typeof ReplayListResponseSchema>["data"];
+export type ReplayRecordingEvent = z.infer<typeof ReplayRecordingEventSchema>;
 export type ReplayRecordingSegments = z.infer<
   typeof ReplayRecordingSegmentsSchema
 >;

--- a/packages/mcp-core/src/internal/formatting.ts
+++ b/packages/mcp-core/src/internal/formatting.ts
@@ -36,6 +36,7 @@ import {
 } from "./tool-helpers/seer";
 import { formatToolCallInstruction } from "./tool-helpers/tool-call-formatting";
 import { formatUserGeoSummary } from "./user-formatting";
+import { isPlainObject } from "./type-guards";
 
 /**
  * Convert Seer fixability score to actionability label.
@@ -1658,10 +1659,6 @@ function formatPerformanceIssueOutput(
   return parts.length > 0 ? `${parts.join("\n")}\n` : "";
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isPrimitive(value: unknown): value is string | number | boolean {
   return (
     typeof value === "string" ||
@@ -1686,15 +1683,15 @@ function getMetricAlertSnubaQuery(
   }
 
   for (const dataSource of dataSources) {
-    if (!isRecord(dataSource)) {
+    if (!isPlainObject(dataSource)) {
       continue;
     }
     const queryObj = dataSource.query_obj;
-    if (!isRecord(queryObj)) {
+    if (!isPlainObject(queryObj)) {
       continue;
     }
     const snubaQuery = queryObj.snuba_query;
-    if (isRecord(snubaQuery)) {
+    if (isPlainObject(snubaQuery)) {
       return snubaQuery;
     }
   }
@@ -1738,7 +1735,7 @@ function formatMetricAlertValue(value: unknown): string | undefined {
     return formattedValue;
   }
 
-  if (isRecord(value)) {
+  if (isPlainObject(value)) {
     return formatPrimitive(value.value);
   }
 
@@ -1778,7 +1775,7 @@ function formatMetricAlertDetails(
   const conditions = evidenceData.conditions;
   if (Array.isArray(conditions)) {
     const formattedConditions = conditions
-      .filter(isRecord)
+      .filter(isPlainObject)
       .map(formatMetricAlertCondition)
       .filter((condition): condition is string => condition != null);
     if (formattedConditions.length > 0) {

--- a/packages/mcp-core/src/internal/type-guards.ts
+++ b/packages/mcp-core/src/internal/type-guards.ts
@@ -1,0 +1,5 @@
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/mcp-core/src/internal/user-formatting.ts
+++ b/packages/mcp-core/src/internal/user-formatting.ts
@@ -1,8 +1,6 @@
-export function isPlainObject(
-  value: unknown,
-): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import { isPlainObject } from "./type-guards";
+
+export { isPlainObject } from "./type-guards";
 
 export function formatUserGeoSummary(value: unknown): string | null {
   if (!isPlainObject(value)) {

--- a/packages/mcp-core/src/telem/logging.test.ts
+++ b/packages/mcp-core/src/telem/logging.test.ts
@@ -36,4 +36,35 @@ describe("logging", () => {
       },
     });
   });
+
+  it("preserves issue contexts, attachments, and logger scope", async () => {
+    vi.resetModules();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { logIssue } = await import("./logging");
+
+    logIssue(new Error("issue failed"), {
+      contexts: {
+        request: { requestId: "request-123" },
+      },
+      attachments: {
+        "details.txt": "details",
+      },
+      loggerScope: ["tests", "issues"],
+    });
+
+    expect(error).toHaveBeenCalledTimes(1);
+    const [payload] = error.mock.calls[0];
+    expect(JSON.parse(payload as string)).toMatchObject({
+      level: "ERROR",
+      message: "issue failed",
+      logger: "sentry.mcp.tests.issues",
+      properties: {
+        attachments: ["details.txt"],
+        sentryContexts: {
+          request: { requestId: "request-123" },
+        },
+      },
+    });
+  });
 });

--- a/packages/mcp-core/src/telem/logging.ts
+++ b/packages/mcp-core/src/telem/logging.ts
@@ -195,98 +195,11 @@ export function getLogger(
 
 const ISSUE_LOGGER_SCOPE = ["runtime", "issues"] as const;
 
-interface ParsedBaseOptions {
-  contexts?: SentryLogContexts;
-  extra?: LogContext;
-  loggerScope?: string | readonly string[];
-}
-
-interface ParsedLogIssueOptions extends ParsedBaseOptions {
-  attachments?: LogAttachments;
-}
-
 interface SerializedError {
   message: string;
   name?: string;
   stack?: string;
   cause?: SerializedError;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isSentryContexts(value: unknown): value is SentryLogContexts {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  return Object.values(value).every((entry) => isRecord(entry));
-}
-
-function isBaseLogOptionsCandidate(value: unknown): value is BaseLogOptions {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  if ("extra" in value || "loggerScope" in value) {
-    return true;
-  }
-
-  if ("contexts" in value) {
-    const contexts = (value as { contexts?: unknown }).contexts;
-    return contexts === undefined || isSentryContexts(contexts);
-  }
-
-  return false;
-}
-
-function isLogIssueOptionsCandidate(value: unknown): value is LogIssueOptions {
-  return (
-    isBaseLogOptionsCandidate(value) ||
-    (isRecord(value) && "attachments" in value)
-  );
-}
-
-function parseBaseOptions(
-  contextsOrOptions?: SentryLogContexts | BaseLogOptions,
-): ParsedBaseOptions {
-  if (isBaseLogOptionsCandidate(contextsOrOptions)) {
-    const { contexts, extra, loggerScope } = contextsOrOptions;
-    return {
-      contexts,
-      extra,
-      loggerScope,
-    };
-  }
-
-  if (isSentryContexts(contextsOrOptions)) {
-    return { contexts: contextsOrOptions };
-  }
-
-  return {};
-}
-
-function parseLogIssueOptions(
-  contextsOrOptions?: SentryLogContexts | LogIssueOptions,
-  attachmentsArg?: LogAttachments,
-): ParsedLogIssueOptions {
-  const base = parseBaseOptions(contextsOrOptions);
-
-  const attachments = isLogIssueOptionsCandidate(contextsOrOptions)
-    ? contextsOrOptions.attachments
-    : undefined;
-
-  return {
-    ...base,
-    attachments: attachments ?? attachmentsArg,
-  };
-}
-
-function parseLogOptions(
-  contextsOrOptions?: SentryLogContexts | LogOptions,
-): LogOptions {
-  return parseBaseOptions(contextsOrOptions);
 }
 
 function safeJsonStringify(value: unknown): string | undefined {
@@ -365,7 +278,7 @@ const DEFAULT_LOGGER_SCOPE: readonly string[] = [];
 
 function buildLogProperties(
   level: LogLevel,
-  options: ParsedBaseOptions,
+  options: BaseLogOptions,
   serializedError?: SerializedError,
 ): LogContext {
   const properties: LogContext = {
@@ -400,11 +313,10 @@ function buildLogProperties(
 function logWithLevel(
   level: LogLevel,
   value: unknown,
-  contextsOrOptions?: SentryLogContexts | LogOptions,
+  options: LogOptions = {},
 ): void {
   ensureLoggingConfigured();
 
-  const options = parseLogOptions(contextsOrOptions);
   const serializedError =
     value instanceof Error ? serializeError(value) : undefined;
   const message = serializedError
@@ -439,60 +351,28 @@ function logWithLevel(
   }
 }
 
-export function logDebug(
-  value: unknown,
-  contextsOrOptions?: SentryLogContexts | LogOptions,
-): void {
-  logWithLevel("debug", value, contextsOrOptions);
+export function logDebug(value: unknown, options?: LogOptions): void {
+  logWithLevel("debug", value, options);
 }
 
-export function logInfo(
-  value: unknown,
-  contextsOrOptions?: SentryLogContexts | LogOptions,
-): void {
-  logWithLevel("info", value, contextsOrOptions);
+export function logInfo(value: unknown, options?: LogOptions): void {
+  logWithLevel("info", value, options);
 }
 
-export function logWarn(
-  value: unknown,
-  contextsOrOptions?: SentryLogContexts | LogOptions,
-): void {
-  logWithLevel("warning", value, contextsOrOptions);
+export function logWarn(value: unknown, options?: LogOptions): void {
+  logWithLevel("warning", value, options);
 }
 
-export function logError(
-  value: unknown,
-  contextsOrOptions?: SentryLogContexts | LogOptions,
-): void {
-  logWithLevel("error", value, contextsOrOptions);
+export function logError(value: unknown, options?: LogOptions): void {
+  logWithLevel("error", value, options);
 }
 
-export function logIssue(
-  error: Error | unknown,
-  contexts?: SentryLogContexts,
-  attachments?: LogAttachments,
-): string | undefined;
-export function logIssue(
-  error: Error | unknown,
-  options: LogIssueOptions,
-): string | undefined;
-export function logIssue(
-  message: string,
-  contexts?: SentryLogContexts,
-  attachments?: LogAttachments,
-): string | undefined;
-export function logIssue(
-  message: string,
-  options: LogIssueOptions,
-): string | undefined;
 export function logIssue(
   error: unknown,
-  contextsOrOptions?: SentryLogContexts | LogIssueOptions,
-  attachmentsArg?: LogAttachments,
+  options: LogIssueOptions = {},
 ): string | undefined {
   ensureLoggingConfigured();
 
-  const options = parseLogIssueOptions(contextsOrOptions, attachmentsArg);
   const eventId = withScope((scopeInstance) => {
     if (options.contexts) {
       for (const [key, context] of Object.entries(options.contexts)) {

--- a/packages/mcp-core/src/tools/catalog/get-issue-activity.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-activity.ts
@@ -7,6 +7,7 @@ import {
   parseIssueParams,
 } from "../../internal/tool-helpers/issue";
 import type { IssueActivity, IssueComment } from "../../api-client/types";
+import { isPlainObject } from "../../internal/type-guards";
 import { formatAvailableToolCallInstruction } from "../../internal/tool-helpers/tool-call-formatting";
 import type { ServerContext } from "../../types";
 import {
@@ -20,7 +21,6 @@ import {
   formatDate,
   formatId,
   formatUnknown,
-  isRecord,
   readString,
 } from "./support/api-formatting";
 
@@ -45,7 +45,9 @@ function formatActivity(activity: IssueActivity | IssueComment): string {
   const date = formatDate(activity.dateCreated) ?? "unknown time";
   const text = getActivityText(activity);
   const details =
-    !text && isRecord(activity.data) && Object.keys(activity.data).length > 0
+    !text &&
+    isPlainObject(activity.data) &&
+    Object.keys(activity.data).length > 0
       ? `\n  - Data: ${formatUnknown(activity.data)}`
       : "";
   return `- ${date}: ${activity.type ?? "activity"} by ${actor} (${formatId(activity.id)})${text ? `\n  - ${text}` : ""}${details}`;

--- a/packages/mcp-core/src/tools/catalog/get-replay-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-replay-details.ts
@@ -2,6 +2,7 @@ import { setTag } from "@sentry/core";
 import type {
   Issue,
   ReplayDetails,
+  ReplayRecordingEvent,
   ReplayRecordingSegments,
   SentryApiService,
   TraceMeta,
@@ -30,6 +31,10 @@ interface ReplayActivityEvent {
   label: string;
   details: string[];
 }
+
+type ReplayRecordingPayload = NonNullable<
+  NonNullable<ReplayRecordingEvent["data"]>["payload"]
+>;
 
 interface RelatedReplayIssue {
   eventId: string;
@@ -468,15 +473,13 @@ function extractReplayActivityEvents(
   return events;
 }
 
-function summarizeReplayEvent(event: unknown): ReplayActivityEvent | null {
-  if (!isRecord(event)) {
-    return null;
-  }
-
+function summarizeReplayEvent(
+  event: ReplayRecordingEvent,
+): ReplayActivityEvent | null {
   const timestampMs = getEventTimestampMillis(event.timestamp);
-  const data = isRecord(event.data) ? event.data : null;
-  const tag = typeof data?.tag === "string" ? data.tag : "";
-  const payload = isRecord(data?.payload) ? data.payload : null;
+  const data = event.data;
+  const tag = data?.tag ?? "";
+  const payload = data?.payload ?? null;
 
   if (tag) {
     const replayEvent = summarizeTaggedReplayEvent(tag, payload);
@@ -485,8 +488,8 @@ function summarizeReplayEvent(event: unknown): ReplayActivityEvent | null {
     }
   }
 
-  if (typeof event.type === "number" && data) {
-    const href = typeof data.href === "string" ? data.href : null;
+  if (event.type !== undefined && data) {
+    const href = data.href ?? null;
     if (href) {
       return {
         timestampMs,
@@ -501,15 +504,12 @@ function summarizeReplayEvent(event: unknown): ReplayActivityEvent | null {
 
 function summarizeTaggedReplayEvent(
   tag: string,
-  payload: Record<string, unknown> | null,
+  payload: ReplayRecordingPayload | null,
 ): Omit<ReplayActivityEvent, "timestampMs"> | null {
   if (tag === "performanceSpan") {
     const op = firstString(payload?.op);
     const description = firstString(payload?.description);
-    const durationMs =
-      isRecord(payload?.data) && typeof payload.data.duration === "number"
-        ? payload.data.duration
-        : null;
+    const durationMs = payload?.data?.duration ?? null;
 
     if (description || op) {
       return {
@@ -567,10 +567,10 @@ function formatRelativeTime(offsetMs: number): string {
 }
 
 function summarizeObject(
-  value: unknown,
+  value: Record<string, unknown> | null,
   excludedKeys: ReadonlySet<string> = new Set(),
 ): string | null {
-  if (!isRecord(value)) {
+  if (!value) {
     return null;
   }
 
@@ -595,10 +595,6 @@ function firstString(...values: unknown[]): string | null {
     }
   }
   return null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function quoteDetail(value: string): string {

--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -2484,6 +2484,7 @@ describe("search_events", () => {
                 {
                   name: "spon.duration",
                   valid: false,
+                  attrType: null,
                   error: "Unknown attribute",
                 },
               ],
@@ -2494,6 +2495,7 @@ describe("search_events", () => {
                   {
                     name: "spon.duration",
                     valid: false,
+                    attrType: null,
                     error: "Unknown attribute",
                   },
                 ],
@@ -2502,6 +2504,7 @@ describe("search_events", () => {
                 {
                   name: "-spon.duration",
                   valid: false,
+                  attrType: null,
                   error: "Orderby must also be a selected field",
                 },
               ],
@@ -2676,6 +2679,7 @@ describe("search_events", () => {
                 {
                   name: "spon.duration",
                   valid: false,
+                  attrType: null,
                   error: "Unknown attribute",
                 },
               ],
@@ -2902,6 +2906,7 @@ describe("search_events", () => {
               {
                 name: "spon.duration",
                 valid: false,
+                attrType: null,
                 error: "Unknown attribute",
               },
             ],
@@ -2912,6 +2917,7 @@ describe("search_events", () => {
                 {
                   name: "spon.duration",
                   valid: false,
+                  attrType: null,
                   error: "Unknown attribute",
                 },
               ],

--- a/packages/mcp-core/src/tools/catalog/support/alerts.ts
+++ b/packages/mcp-core/src/tools/catalog/support/alerts.ts
@@ -5,13 +5,13 @@ import type {
 import type { SentryApiService } from "../../../api-client";
 import { ApiNotFoundError } from "../../../api-client";
 import { UserInputError } from "../../../errors";
+import { isPlainObject } from "../../../internal/type-guards";
 import {
   compactLines,
   formatActor,
   formatDate,
   formatId,
   formatUnknown,
-  isRecord,
 } from "./api-formatting";
 
 const NUMERIC_ID_PATTERN = /^\d+$/;
@@ -83,7 +83,7 @@ function formatDetailValue(value: unknown): string | null {
       .filter((item): item is string => item !== null);
     return items.length > 0 ? items.join(", ") : null;
   }
-  if (isRecord(value)) {
+  if (isPlainObject(value)) {
     const details = Object.entries(value)
       .filter(([key]) => key !== "id")
       .map(([key, item]) => {
@@ -116,7 +116,7 @@ function getComponentDetailEntries(
       value !== null &&
       !shouldSkipDetail(key, value)
     ) {
-      if (key === "config" && isRecord(value)) {
+      if (key === "config" && isPlainObject(value)) {
         detailEntries.push(
           ...Object.entries(value).filter(
             ([configKey, configValue]) =>
@@ -231,7 +231,7 @@ function readComponentList(value: unknown): AlertComponent[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
-  return value.filter(isRecord);
+  return value.filter(isPlainObject);
 }
 
 function formatComponentSummary(

--- a/packages/mcp-core/src/tools/catalog/support/api-formatting.ts
+++ b/packages/mcp-core/src/tools/catalog/support/api-formatting.ts
@@ -1,6 +1,4 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import { isPlainObject } from "../../../internal/type-guards";
 
 export function formatId(value: string | number | undefined | null): string {
   return value === undefined || value === null ? "unknown" : String(value);
@@ -24,7 +22,7 @@ export function formatActor(value: unknown): string {
     return value;
   }
 
-  if (!isRecord(value)) {
+  if (!isPlainObject(value)) {
     return "unknown";
   }
 

--- a/packages/mcp-core/src/tools/support/search-events/utils.test.ts
+++ b/packages/mcp-core/src/tools/support/search-events/utils.test.ts
@@ -383,16 +383,23 @@ describe("fetchCustomAttributes", () => {
             }
 
             return HttpResponse.json([
-              { key: "span.op", name: "Operation", attributeType: "string" },
+              {
+                key: "span.op",
+                name: "Operation",
+                attributeType: "string",
+                attributeSource: { source_type: "sentry" },
+              },
               {
                 key: "sentry:internal",
                 name: "Internal",
                 attributeType: "string",
+                attributeSource: { source_type: "sentry" },
               },
               {
                 key: "span.duration",
                 name: "Duration",
                 attributeType: "number",
+                attributeSource: { source_type: "sentry" },
               },
             ]);
           },
@@ -458,13 +465,20 @@ describe("fetchCustomAttributes", () => {
                 key: "metric.name",
                 name: "Metric Name",
                 attributeType: "string",
+                attributeSource: { source_type: "sentry" },
               },
               {
                 key: "metric.type",
                 name: "Metric Type",
                 attributeType: "string",
+                attributeSource: { source_type: "sentry" },
               },
-              { key: "value", name: "Metric Value", attributeType: "number" },
+              {
+                key: "value",
+                name: "Metric Value",
+                attributeType: "number",
+                attributeSource: { source_type: "sentry" },
+              },
             ]);
           },
         ),
@@ -505,16 +519,19 @@ describe("fetchCustomAttributes", () => {
                 key: "tags[type]",
                 name: "type",
                 attributeType: "string",
+                attributeSource: { source_type: "sentry" },
               },
               {
                 key: "tags[sequence,number]",
                 name: "sequence",
                 attributeType: "number",
+                attributeSource: { source_type: "user" },
               },
               {
                 key: "tags[enabled,boolean]",
                 name: "enabled",
                 attributeType: "boolean",
+                attributeSource: { source_type: "user" },
               },
             ]);
           },

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -140,9 +140,6 @@ import traceItemsAttributesTraceMetricsNumberFixture from "./fixtures/trace-item
 import traceItemsAttributesTraceMetricsStringFixture from "./fixtures/trace-items-attributes-tracemetrics-string.json" with {
   type: "json",
 };
-import traceItemsAttributesFixture from "./fixtures/trace-items-attributes.json" with {
-  type: "json",
-};
 import traceMetaWithNullsFixture from "./fixtures/trace-meta-with-nulls.json" with {
   type: "json",
 };
@@ -210,6 +207,17 @@ function buildHandlers(
   }
 
   return result;
+}
+
+function withTraceItemAttributeMetadata(
+  attributes: readonly { key: string; name: string }[],
+  attributeType: "string" | "number" | "boolean",
+) {
+  return attributes.map((attribute) => ({
+    ...attribute,
+    attributeType,
+    attributeSource: { source_type: "sentry" as const },
+  }));
 }
 
 type IssueUpdateBody = {
@@ -1106,37 +1114,37 @@ export const restHandlers = buildHandlers([
       if (!attributeType) {
         if (normalizedItemType === "span") {
           return HttpResponse.json([
-            ...traceItemsAttributesSpansStringFixture.map((attribute) => ({
-              ...attribute,
-              attributeType: "string",
-            })),
-            ...traceItemsAttributesSpansNumberFixture.map((attribute) => ({
-              ...attribute,
-              attributeType: "number",
-            })),
+            ...withTraceItemAttributeMetadata(
+              traceItemsAttributesSpansStringFixture,
+              "string",
+            ),
+            ...withTraceItemAttributeMetadata(
+              traceItemsAttributesSpansNumberFixture,
+              "number",
+            ),
           ]);
         }
         if (normalizedItemType === "logs") {
           return HttpResponse.json([
-            ...traceItemsAttributesLogsStringFixture.map((attribute) => ({
-              ...attribute,
-              attributeType: "string",
-            })),
-            ...traceItemsAttributesLogsNumberFixture.map((attribute) => ({
-              ...attribute,
-              attributeType: "number",
-            })),
+            ...withTraceItemAttributeMetadata(
+              traceItemsAttributesLogsStringFixture,
+              "string",
+            ),
+            ...withTraceItemAttributeMetadata(
+              traceItemsAttributesLogsNumberFixture,
+              "number",
+            ),
           ]);
         }
         return HttpResponse.json([
-          ...traceItemsAttributesTraceMetricsStringFixture.map((attribute) => ({
-            ...attribute,
-            attributeType: "string",
-          })),
-          ...traceItemsAttributesTraceMetricsNumberFixture.map((attribute) => ({
-            ...attribute,
-            attributeType: "number",
-          })),
+          ...withTraceItemAttributeMetadata(
+            traceItemsAttributesTraceMetricsStringFixture,
+            "string",
+          ),
+          ...withTraceItemAttributeMetadata(
+            traceItemsAttributesTraceMetricsNumberFixture,
+            "number",
+          ),
         ]);
       }
 
@@ -1153,27 +1161,57 @@ export const restHandlers = buildHandlers([
       // Return appropriate fixture based on parameters
       if (normalizedItemType === "span") {
         if (attributeType === "string") {
-          return HttpResponse.json(traceItemsAttributesSpansStringFixture);
+          return HttpResponse.json(
+            withTraceItemAttributeMetadata(
+              traceItemsAttributesSpansStringFixture,
+              "string",
+            ),
+          );
         }
-        return HttpResponse.json(traceItemsAttributesSpansNumberFixture);
+        return HttpResponse.json(
+          withTraceItemAttributeMetadata(
+            traceItemsAttributesSpansNumberFixture,
+            "number",
+          ),
+        );
       }
       if (normalizedItemType === "logs") {
         if (attributeType === "string") {
-          return HttpResponse.json(traceItemsAttributesLogsStringFixture);
+          return HttpResponse.json(
+            withTraceItemAttributeMetadata(
+              traceItemsAttributesLogsStringFixture,
+              "string",
+            ),
+          );
         }
-        return HttpResponse.json(traceItemsAttributesLogsNumberFixture);
+        return HttpResponse.json(
+          withTraceItemAttributeMetadata(
+            traceItemsAttributesLogsNumberFixture,
+            "number",
+          ),
+        );
       }
       if (normalizedItemType === "tracemetrics") {
         if (attributeType === "string") {
           return HttpResponse.json(
-            traceItemsAttributesTraceMetricsStringFixture,
+            withTraceItemAttributeMetadata(
+              traceItemsAttributesTraceMetricsStringFixture,
+              "string",
+            ),
           );
         }
-        return HttpResponse.json(traceItemsAttributesTraceMetricsNumberFixture);
+        return HttpResponse.json(
+          withTraceItemAttributeMetadata(
+            traceItemsAttributesTraceMetricsNumberFixture,
+            "number",
+          ),
+        );
       }
 
-      // Fallback (should not reach here with valid inputs)
-      return HttpResponse.json(traceItemsAttributesFixture);
+      return HttpResponse.json(
+        { detail: "Unsupported trace item attribute request" },
+        { status: 400 },
+      );
     },
   },
   {

--- a/packages/mcp-test-client/package.json
+++ b/packages/mcp-test-client/package.json
@@ -27,7 +27,8 @@
     "chalk": "catalog:",
     "commander": "catalog:",
     "dotenv": "catalog:",
-    "open": "catalog:"
+    "open": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "tsdown": "catalog:",

--- a/packages/mcp-test-client/src/tool-output-format.test.ts
+++ b/packages/mcp-test-client/src/tool-output-format.test.ts
@@ -24,6 +24,15 @@ describe("formatToolOutputForDisplay", () => {
     ).toBe('{"status":"ok","count":2}');
   });
 
+  it("uses structured content when the content container is malformed", () => {
+    expect(
+      formatToolOutputForDisplay({
+        content: "invalid",
+        structuredContent: { status: "ok" },
+      }),
+    ).toBe('{"status":"ok"}');
+  });
+
   it("renders non-text content with placeholders", () => {
     expect(
       formatToolOutputForDisplay({
@@ -33,6 +42,18 @@ describe("formatToolOutputForDisplay", () => {
         ],
       }),
     ).toBe("<image message><resource message>");
+  });
+
+  it("preserves valid content when a sibling item is malformed", () => {
+    expect(
+      formatToolOutputForDisplay({
+        content: [
+          { type: "text", text: "valid text" },
+          null,
+          { type: "text", text: 42 },
+        ],
+      }),
+    ).toBe("valid text<unknown message><text message>");
   });
 
   it("supports legacy toolResult payloads", () => {

--- a/packages/mcp-test-client/src/tool-output-format.ts
+++ b/packages/mcp-test-client/src/tool-output-format.ts
@@ -1,47 +1,19 @@
-interface ToolOutputRecord {
-  [key: string]: unknown;
-}
+import { z } from "zod";
 
-interface ToolContentPart {
-  type: string;
-}
+const ToolContentPartSchema = z
+  .object({
+    type: z.string(),
+    text: z.unknown().optional(),
+  })
+  .passthrough();
 
-interface TextToolContentPart extends ToolContentPart {
-  type: "text";
-  text: string;
-}
-
-function isRecord(value: unknown): value is ToolOutputRecord {
-  return typeof value === "object" && value !== null;
-}
-
-function hasContentArray(
-  value: unknown,
-): value is ToolOutputRecord & { content: unknown[] } {
-  return isRecord(value) && Array.isArray(value.content);
-}
-
-function hasStructuredContent(
-  value: unknown,
-): value is ToolOutputRecord & { structuredContent: unknown } {
-  return isRecord(value) && "structuredContent" in value;
-}
-
-function hasLegacyToolResult(
-  value: unknown,
-): value is ToolOutputRecord & { toolResult: unknown } {
-  return isRecord(value) && "toolResult" in value;
-}
-
-function isToolContentPart(value: unknown): value is ToolContentPart {
-  return isRecord(value) && typeof value.type === "string";
-}
-
-function isTextToolContentPart(value: unknown): value is TextToolContentPart {
-  return (
-    isRecord(value) && value.type === "text" && typeof value.text === "string"
-  );
-}
+const ToolOutputSchema = z
+  .object({
+    content: z.array(z.unknown()).optional().catch(undefined),
+    structuredContent: z.unknown().optional(),
+    toolResult: z.unknown().optional(),
+  })
+  .passthrough();
 
 function stringifyUnknown(value: unknown): string {
   if (typeof value === "string") {
@@ -60,18 +32,28 @@ export function formatToolOutputForDisplay(output: unknown): string {
     return output;
   }
 
-  if (hasContentArray(output)) {
-    const renderedContent = output.content
+  const parsedOutput = ToolOutputSchema.safeParse(output);
+  if (!parsedOutput.success) {
+    return stringifyUnknown(output);
+  }
+
+  const { content, structuredContent, toolResult } = parsedOutput.data;
+  if (content) {
+    const renderedContent = content
       .map((item) => {
-        if (isTextToolContentPart(item)) {
-          return item.text;
+        const parsedItem = ToolContentPartSchema.safeParse(item);
+        if (!parsedItem.success) {
+          return "<unknown message>";
         }
 
-        if (isToolContentPart(item)) {
-          return `<${item.type} message>`;
+        if (
+          parsedItem.data.type === "text" &&
+          typeof parsedItem.data.text === "string"
+        ) {
+          return parsedItem.data.text;
         }
 
-        return "<unknown message>";
+        return `<${parsedItem.data.type} message>`;
       })
       .join("");
 
@@ -80,12 +62,12 @@ export function formatToolOutputForDisplay(output: unknown): string {
     }
   }
 
-  if (hasStructuredContent(output) && output.structuredContent !== undefined) {
-    return stringifyUnknown(output.structuredContent);
+  if (structuredContent !== undefined) {
+    return stringifyUnknown(structuredContent);
   }
 
-  if (hasLegacyToolResult(output)) {
-    return stringifyUnknown(output.toolResult);
+  if (toolResult !== undefined) {
+    return stringifyUnknown(toolResult);
   }
 
   return stringifyUnknown(output);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       open:
         specifier: 'catalog:'
         version: 10.1.2
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       tsdown:
         specifier: 'catalog:'


### PR DESCRIPTION
Unknown API, replay, and tool-result payloads now cross explicit Zod schemas, while generic object inspection is limited to formatting code that genuinely accepts arbitrary records.

Events validation and trace-item attribute schemas match the required fields emitted by the current Sentry source instead of fabricating defaults for impossible response shapes. Replay recordings remain selectively parsed because the upstream endpoint intentionally exposes arbitrary RRWeb dictionaries. The related mocks and regression fixtures now use those source-backed contracts.

Logging also accepts one typed options object, and the OAuth callback records only state-presence booleans rather than raw CSRF state values.