### PR TITLE
fix(api): build valid Logs Explorer links

### DIFF
--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -327,6 +327,86 @@ describe("getEventsExplorerUrl", () => {
       expect(result).toContain("mode=aggregate");
     });
   });
+
+  describe("logs dataset", () => {
+    it("should build a sample Logs Explorer URL scoped to all projects", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "severity:error",
+        undefined,
+        "logs",
+        ["timestamp", "message", "severity"],
+        "-timestamp",
+        undefined,
+        undefined,
+        "7d",
+      );
+      const url = new URL(result);
+
+      expect(url.pathname).toBe("/explore/logs/");
+      expect(url.searchParams.get("logsQuery")).toBe("severity:error");
+      expect(url.searchParams.getAll("logsFields")).toEqual([
+        "timestamp",
+        "message",
+        "severity",
+      ]);
+      expect(url.searchParams.get("logsSortBys")).toBe("-timestamp");
+      expect(url.searchParams.get("mode")).toBe("samples");
+      expect(url.searchParams.get("project")).toBe("-1");
+      expect(url.searchParams.get("statsPeriod")).toBe("7d");
+      expect(url.searchParams.has("query")).toBe(false);
+      expect(url.searchParams.has("field")).toBe(false);
+      expect(url.searchParams.has("sort")).toBe(false);
+    });
+
+    it("should preserve explicit project and absolute time scope", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "service:api",
+        "123456",
+        "logs",
+        ["timestamp", "message"],
+        "-timestamp",
+        undefined,
+        undefined,
+        "7d",
+        "2025-07-29T07:00:00",
+        "2025-07-31T06:59:59",
+      );
+      const url = new URL(result);
+
+      expect(url.searchParams.get("project")).toBe("123456");
+      expect(url.searchParams.get("start")).toBe("2025-07-29T07:00:00");
+      expect(url.searchParams.get("end")).toBe("2025-07-31T06:59:59");
+      expect(url.searchParams.has("statsPeriod")).toBe(false);
+    });
+
+    it("should build an aggregate Logs Explorer URL", () => {
+      const apiService = new SentryApiService({ host: "sentry.io" });
+      const result = apiService.getEventsExplorerUrl(
+        "sentry-mcp",
+        "severity:error",
+        undefined,
+        "logs",
+        ["service", "count()"],
+        "-count()",
+        ["count()"],
+        ["service"],
+      );
+      const url = new URL(result);
+
+      expect(url.searchParams.get("mode")).toBe("aggregate");
+      expect(url.searchParams.getAll("aggregateField")).toEqual([
+        JSON.stringify({ groupBy: "service" }),
+        JSON.stringify({ yAxes: ["count()"] }),
+      ]);
+      expect(url.searchParams.get("logsAggregateSortBys")).toBe("-count()");
+      expect(url.searchParams.has("logsFields")).toBe(false);
+      expect(url.searchParams.has("logsSortBys")).toBe(false);
+    });
+  });
 });
 
 describe("monitor time parameters", () => {
@@ -1602,21 +1682,19 @@ describe("API query builders", () => {
       });
     });
 
-    describe("buildEapUrl", () => {
+    describe("spans explorer URLs", () => {
       it("should build correct URL for spans dataset with aggregate fields", () => {
         const apiService = new SentryApiService({ host: "sentry.io" });
-
-        // @ts-expect-error - accessing private method for testing
-        const url = apiService.buildEapUrl({
-          organizationSlug: "my-org",
-          query: "is_transaction:True",
-          dataset: "spans",
-          projectId: "123456",
-          fields: ["span.description", "count()"],
-          sort: "-count()",
-          aggregateFunctions: ["count()"],
-          groupByFields: ["span.description"],
-        });
+        const url = apiService.getEventsExplorerUrl(
+          "my-org",
+          "is_transaction:True",
+          "123456",
+          "spans",
+          ["span.description", "count()"],
+          "-count()",
+          ["count()"],
+          ["span.description"],
+        );
 
         expect(url).toContain("https://my-org.sentry.io/explore/traces/");
         expect(url).toContain("mode=aggregate");
@@ -1633,17 +1711,16 @@ describe("API query builders", () => {
 
       it("should not include empty groupBy in aggregateField", () => {
         const apiService = new SentryApiService({ host: "sentry.io" });
-
-        // @ts-expect-error - accessing private method for testing
-        const url = apiService.buildEapUrl({
-          organizationSlug: "my-org",
-          query: "span.op:db",
-          dataset: "spans",
-          fields: ["count()"],
-          sort: "-count()",
-          aggregateFunctions: ["count()"],
-          groupByFields: [],
-        });
+        const url = apiService.getEventsExplorerUrl(
+          "my-org",
+          "span.op:db",
+          undefined,
+          "spans",
+          ["count()"],
+          "-count()",
+          ["count()"],
+          [],
+        );
 
         expect(url).toContain("mode=aggregate");
         expect(url).toContain(
@@ -1654,17 +1731,16 @@ describe("API query builders", () => {
 
       it("should handle multiple groupBy fields", () => {
         const apiService = new SentryApiService({ host: "sentry.io" });
-
-        // @ts-expect-error - accessing private method for testing
-        const url = apiService.buildEapUrl({
-          organizationSlug: "my-org",
-          query: "",
-          dataset: "spans",
-          fields: ["span.op", "span.description", "count()"],
-          sort: "-count()",
-          aggregateFunctions: ["count()"],
-          groupByFields: ["span.op", "span.description"],
-        });
+        const url = apiService.getEventsExplorerUrl(
+          "my-org",
+          "",
+          undefined,
+          "spans",
+          ["span.op", "span.description", "count()"],
+          "-count()",
+          ["count()"],
+          ["span.op", "span.description"],
+        );
 
         expect(url).toContain(
           `aggregateField=%7B%22groupBy%22%3A%22span.op%22%7D`,
@@ -1679,15 +1755,14 @@ describe("API query builders", () => {
 
       it("should handle non-aggregate queries", () => {
         const apiService = new SentryApiService({ host: "sentry.io" });
-
-        // @ts-expect-error - accessing private method for testing
-        const url = apiService.buildEapUrl({
-          organizationSlug: "my-org",
-          query: "span.op:http",
-          dataset: "spans",
-          fields: ["span.op", "span.description", "span.duration"],
-          sort: "-span.duration",
-        });
+        const url = apiService.getEventsExplorerUrl(
+          "my-org",
+          "span.op:http",
+          undefined,
+          "spans",
+          ["span.op", "span.description", "span.duration"],
+          "-span.duration",
+        );
 
         expect(url).not.toContain("mode=aggregate");
         expect(url).not.toContain("aggregateField");
@@ -1697,31 +1772,15 @@ describe("API query builders", () => {
         expect(url).toContain("sort=-span.duration");
       });
 
-      it("should use correct path for logs dataset", () => {
-        const apiService = new SentryApiService({ host: "sentry.io" });
-
-        // @ts-expect-error - accessing private method for testing
-        const url = apiService.buildEapUrl({
-          organizationSlug: "my-org",
-          query: "severity:error",
-          dataset: "logs",
-          fields: ["timestamp", "message"],
-        });
-
-        expect(url).toContain("/explore/logs/");
-        expect(url).not.toContain("/explore/traces/");
-      });
-
       it("should handle self-hosted URLs correctly", () => {
         const apiService = new SentryApiService({ host: "sentry.example.com" });
-
-        // @ts-expect-error - accessing private method for testing
-        const url = apiService.buildEapUrl({
-          organizationSlug: "my-org",
-          query: "",
-          dataset: "spans",
-          fields: ["span.op"],
-        });
+        const url = apiService.getEventsExplorerUrl(
+          "my-org",
+          "",
+          undefined,
+          "spans",
+          ["span.op"],
+        );
 
         expect(url).toMatchInlineSnapshot(
           `"https://sentry.example.com/organizations/my-org/explore/traces/?query=&field=span.op&statsPeriod=24h&table=span"`,

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -141,6 +141,22 @@ import type {
 
 const SENTRY_MCP_SEARCH_EVENTS_REFERRER = "api.mcp.search-events";
 
+type ExplorerAggregateParams = {
+  fields?: string[];
+  aggregateFunctions?: string[];
+  groupByFields?: string[];
+};
+
+type ExplorerUrlParams = ExplorerAggregateParams & {
+  organizationSlug: string;
+  query: string;
+  projectId?: string;
+  sort?: string;
+  statsPeriod?: string;
+  start?: string;
+  end?: string;
+};
+
 /**
  * Mapping of common network error codes to user-friendly messages.
  * These help users understand and resolve connection issues.
@@ -1172,42 +1188,91 @@ export class SentryApiService {
     return `${path}?${urlParams.toString()}`;
   }
 
+  private isAggregateExplorerQuery(params: ExplorerAggregateParams): boolean {
+    return Boolean(
+      params.aggregateFunctions?.length ||
+        params.fields?.some(
+          (field) => field.includes("(") && field.includes(")"),
+        ),
+    );
+  }
+
   /**
-   * Builds a URL for the modern EAP (Event Analytics Platform) API used by spans/logs.
-   *
-   * The EAP API uses structured aggregate queries with separate aggregateField
-   * parameters containing JSON objects for groupBy and yAxes.
+   * Adds the structured aggregate fields shared by the Spans and Logs Explorer
+   * URL formats. Each group-by and collection of y-axes is encoded as a
+   * separate JSON-valued `aggregateField` parameter.
    *
    * @example
-   * // URL format: /explore/traces/?aggregateField={"groupBy":"span.op"}&aggregateField={"yAxes":["count()"]}
-   * buildEapUrl("my-org", "span.op:db", "123", ["span.op", "count()"], "-count()", ["count()"], ["span.op"])
+   * aggregateField={"groupBy":"span.op"}&aggregateField={"yAxes":["count()"]}
    */
-  private buildEapUrl(params: {
-    organizationSlug: string;
-    query: string;
-    dataset: "spans" | "logs";
-    projectId?: string;
-    fields?: string[];
-    sort?: string;
-    statsPeriod?: string;
-    start?: string;
-    end?: string;
-    aggregateFunctions?: string[];
-    groupByFields?: string[];
-  }): string {
-    const {
-      organizationSlug,
-      query,
-      dataset,
-      projectId,
-      fields,
-      sort,
-      statsPeriod,
-      start,
-      end,
-      aggregateFunctions,
-      groupByFields,
-    } = params;
+  private appendAggregateFields(
+    urlParams: URLSearchParams,
+    params: ExplorerAggregateParams,
+  ): void {
+    const { fields, aggregateFunctions, groupByFields } = params;
+
+    if (aggregateFunctions?.length || groupByFields?.length) {
+      // Prefer the structured aggregate metadata returned by search_events.
+      for (const field of groupByFields ?? []) {
+        urlParams.append("aggregateField", JSON.stringify({ groupBy: field }));
+      }
+
+      if (aggregateFunctions?.length) {
+        urlParams.append(
+          "aggregateField",
+          JSON.stringify({ yAxes: aggregateFunctions }),
+        );
+      }
+      return;
+    }
+
+    // Fall back to deriving aggregate metadata from the selected fields.
+    const parsedGroupByFields =
+      fields?.filter((field) => !field.includes("(") && !field.includes(")")) ??
+      [];
+    const parsedAggregateFunctions =
+      fields?.filter((field) => field.includes("(") && field.includes(")")) ??
+      [];
+
+    for (const field of parsedGroupByFields) {
+      urlParams.append("aggregateField", JSON.stringify({ groupBy: field }));
+    }
+
+    if (parsedAggregateFunctions.length > 0) {
+      urlParams.append(
+        "aggregateField",
+        JSON.stringify({ yAxes: parsedAggregateFunctions }),
+      );
+    }
+  }
+
+  private appendExplorerTimeParams(
+    urlParams: URLSearchParams,
+    params: { statsPeriod?: string; start?: string; end?: string },
+  ): void {
+    if (params.start && params.end) {
+      urlParams.set("start", params.start);
+      urlParams.set("end", params.end);
+    } else {
+      urlParams.set("statsPeriod", params.statsPeriod || "24h");
+    }
+  }
+
+  private buildExplorePath(
+    organizationSlug: string,
+    page: "logs" | "traces",
+  ): string {
+    // For SaaS instances, always use sentry.io for web UI URLs regardless of region.
+    // Regional subdomains (e.g., us.sentry.io) are only for API endpoints.
+    if (this.isSaas()) {
+      return `${this.protocol}://${organizationSlug}.sentry.io/explore/${page}/`;
+    }
+    return `${this.protocol}://${this.host}/organizations/${organizationSlug}/explore/${page}/`;
+  }
+
+  /** Builds a Spans Explorer URL using its `query`, `field`, and `sort` contract. */
+  private buildSpansExplorerUrl(params: ExplorerUrlParams): string {
+    const { organizationSlug, query, projectId, fields, sort } = params;
 
     const urlParams = new URLSearchParams();
     urlParams.set("query", query);
@@ -1216,68 +1281,14 @@ export class SentryApiService {
       urlParams.set("project", projectId);
     }
 
-    // Determine if this is an aggregate query
-    const isAggregateQuery =
-      (aggregateFunctions?.length ?? 0) > 0 ||
-      fields?.some((field) => field.includes("(") && field.includes(")")) ||
-      false;
+    const isAggregateQuery = this.isAggregateExplorerQuery(params);
 
     if (isAggregateQuery) {
-      // EAP API uses structured aggregate parameters
-      if (
-        (aggregateFunctions?.length ?? 0) > 0 ||
-        (groupByFields?.length ?? 0) > 0
-      ) {
-        // Add each groupBy field as a separate aggregateField parameter
-        if (groupByFields && groupByFields.length > 0) {
-          for (const field of groupByFields) {
-            urlParams.append(
-              "aggregateField",
-              JSON.stringify({ groupBy: field }),
-            );
-          }
-        }
-
-        // Add aggregate functions (yAxes)
-        if (aggregateFunctions && aggregateFunctions.length > 0) {
-          urlParams.append(
-            "aggregateField",
-            JSON.stringify({ yAxes: aggregateFunctions }),
-          );
-        }
-      } else {
-        // Fallback: parse fields to extract aggregate info
-        const parsedGroupByFields =
-          fields?.filter(
-            (field) => !field.includes("(") && !field.includes(")"),
-          ) || [];
-        const parsedAggregateFunctions =
-          fields?.filter(
-            (field) => field.includes("(") && field.includes(")"),
-          ) || [];
-
-        for (const field of parsedGroupByFields) {
-          urlParams.append(
-            "aggregateField",
-            JSON.stringify({ groupBy: field }),
-          );
-        }
-
-        if (parsedAggregateFunctions.length > 0) {
-          urlParams.append(
-            "aggregateField",
-            JSON.stringify({ yAxes: parsedAggregateFunctions }),
-          );
-        }
-      }
-
+      this.appendAggregateFields(urlParams, params);
       urlParams.set("mode", "aggregate");
     } else {
-      // Non-aggregate query, add individual fields
-      if (fields && fields.length > 0) {
-        for (const field of fields) {
-          urlParams.append("field", field);
-        }
+      for (const field of fields ?? []) {
+        urlParams.append("field", field);
       }
     }
 
@@ -1286,28 +1297,43 @@ export class SentryApiService {
       urlParams.set("sort", sort);
     }
 
-    // Add time parameters - either statsPeriod or start/end
-    if (start && end) {
-      urlParams.set("start", start);
-      urlParams.set("end", end);
+    this.appendExplorerTimeParams(urlParams, params);
+    urlParams.set("table", "span");
+
+    return `${this.buildExplorePath(organizationSlug, "traces")}?${urlParams.toString()}`;
+  }
+
+  /**
+   * Builds a Logs Explorer URL using its logs-specific page parameters.
+   * Sample and aggregate views use distinct field and sort parameters, and an
+   * omitted project is represented by `project=-1` to preserve all-project scope.
+   */
+  private buildLogsExplorerUrl(params: ExplorerUrlParams): string {
+    const { organizationSlug, query, projectId, fields, sort } = params;
+    const urlParams = new URLSearchParams();
+
+    urlParams.set("logsQuery", query);
+    urlParams.set("project", projectId ?? "-1");
+
+    const isAggregateQuery = this.isAggregateExplorerQuery(params);
+    if (isAggregateQuery) {
+      this.appendAggregateFields(urlParams, params);
     } else {
-      urlParams.set("statsPeriod", statsPeriod || "24h");
+      for (const field of fields ?? []) {
+        urlParams.append("logsFields", field);
+      }
     }
 
-    // Add table parameter for spans dataset (required for UI)
-    if (dataset === "spans") {
-      urlParams.set("table", "span");
+    urlParams.set("mode", isAggregateQuery ? "aggregate" : "samples");
+    if (sort) {
+      urlParams.set(
+        isAggregateQuery ? "logsAggregateSortBys" : "logsSortBys",
+        sort,
+      );
     }
 
-    const basePath = dataset === "logs" ? "logs" : "traces";
-    // For SaaS instances, always use sentry.io for web UI URLs regardless of region
-    // Regional subdomains (e.g., us.sentry.io) are only for API endpoints
-    const webHost = this.isSaas() ? "sentry.io" : this.host;
-    const path = this.isSaas()
-      ? `${this.protocol}://${organizationSlug}.${webHost}/explore/${basePath}/`
-      : `${this.protocol}://${this.host}/organizations/${organizationSlug}/explore/${basePath}/`;
-
-    return `${path}?${urlParams.toString()}`;
+    this.appendExplorerTimeParams(urlParams, params);
+    return `${this.buildExplorePath(organizationSlug, "logs")}?${urlParams.toString()}`;
   }
 
   private extractTraceMetricsFromResults(
@@ -1426,11 +1452,9 @@ export class SentryApiService {
       );
     }
 
-    // Route to modern EAP API (spans and logs)
-    return this.buildEapUrl({
+    const explorerParams = {
       organizationSlug,
       query,
-      dataset,
       projectId,
       fields,
       sort,
@@ -1439,7 +1463,11 @@ export class SentryApiService {
       end,
       aggregateFunctions,
       groupByFields,
-    });
+    };
+
+    return dataset === "logs"
+      ? this.buildLogsExplorerUrl(explorerParams)
+      : this.buildSpansExplorerUrl(explorerParams);
   }
 
   /**


### PR DESCRIPTION
This attempts to fix the MCP interaction that produces log urls to open in a browser that are either incorrect or misleading. I kept using the MCP to query sentry logs and would get back sensical data from the text description but the URL didn't match up. Clanker-assisted diagnosis suggests this is due to the MCP producing incorrect parameters for `/explore/logs` pages like `/explore/logs/?query=severity:error&field=timestamp&field=message&sort=-timestamp` . When opened, Sentry for some reason appends its own `logsFields`/`logsSortBys` params, which effectively broke the actual filter logic. This change attempts to fix that behavior. Clanker description below:

---

## Summary
Fixes search_events deep links for the logs dataset so they open Logs Explorer with the same query, columns, sorting, time range, and project scope used by MCP.

### Key Changes
- Emit Logs Explorer-specific query, field, sort, and mode parameters
- Explicitly select all projects when the MCP search was unscoped
- Separate span and log page URL builders while sharing neutral serialization helpers
- Add regression coverage for sample and aggregate log links

### Breaking Changes
- None