### PR TITLE
Fix: Honour RFC 8252 loopback ports in redirect URI checks

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/redirect-uri.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/redirect-uri.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { isRegisteredRedirectUri } from "./redirect-uri";
+
+describe("isRegisteredRedirectUri", () => {
+  describe("loopback URIs (RFC 8252 Section 7.3)", () => {
+    it("accepts an ephemeral port against a portless localhost registration", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/callback", [
+          "http://localhost/callback",
+        ]),
+      ).toBe(true);
+    });
+
+    it("accepts an ephemeral port against a portless 127.0.0.1 registration", () => {
+      expect(
+        isRegisteredRedirectUri("http://127.0.0.1:62210/callback", [
+          "http://127.0.0.1/callback",
+        ]),
+      ).toBe(true);
+    });
+
+    it("accepts an ephemeral port against an IPv6 loopback registration", () => {
+      expect(
+        isRegisteredRedirectUri("http://[::1]:8080/callback", [
+          "http://[::1]/callback",
+        ]),
+      ).toBe(true);
+    });
+
+    it("accepts a differing port when the registration also has one", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/callback", [
+          "http://localhost:1455/callback",
+        ]),
+      ).toBe(true);
+    });
+
+    it("matches against a later entry in the registered list", () => {
+      expect(
+        isRegisteredRedirectUri("http://127.0.0.1:3118/callback", [
+          "http://localhost/callback",
+          "http://127.0.0.1/callback",
+        ]),
+      ).toBe(true);
+    });
+
+    it("rejects a differing path", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/evil", [
+          "http://localhost/callback",
+        ]),
+      ).toBe(false);
+    });
+
+    it("rejects a differing query string", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/callback?next=evil", [
+          "http://localhost/callback",
+        ]),
+      ).toBe(false);
+    });
+
+    it("rejects a differing scheme", () => {
+      expect(
+        isRegisteredRedirectUri("https://localhost:3118/callback", [
+          "http://localhost/callback",
+        ]),
+      ).toBe(false);
+    });
+
+    it("rejects a non-loopback host that merely embeds a loopback name", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost.evil.com:3118/callback", [
+          "http://localhost/callback",
+        ]),
+      ).toBe(false);
+    });
+
+    it("rejects a non-loopback request against a loopback registration", () => {
+      expect(
+        isRegisteredRedirectUri("http://evil.com:3118/callback", [
+          "http://localhost/callback",
+        ]),
+      ).toBe(false);
+    });
+  });
+
+  describe("non-loopback URIs", () => {
+    it("accepts an exact match", () => {
+      expect(
+        isRegisteredRedirectUri("https://example.com/callback", [
+          "https://example.com/callback",
+        ]),
+      ).toBe(true);
+    });
+
+    it("rejects a differing port", () => {
+      expect(
+        isRegisteredRedirectUri("https://example.com:8443/callback", [
+          "https://example.com/callback",
+        ]),
+      ).toBe(false);
+    });
+
+    it("rejects a differing path", () => {
+      expect(
+        isRegisteredRedirectUri("https://example.com/evil", [
+          "https://example.com/callback",
+        ]),
+      ).toBe(false);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("rejects when the registered list is undefined", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/callback", undefined),
+      ).toBe(false);
+    });
+
+    it("rejects when the registered list is empty", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/callback", []),
+      ).toBe(false);
+    });
+
+    it("rejects an unparseable request URI", () => {
+      expect(
+        isRegisteredRedirectUri("not-a-uri", ["http://localhost/callback"]),
+      ).toBe(false);
+    });
+
+    it("rejects an unparseable registered URI", () => {
+      expect(
+        isRegisteredRedirectUri("http://localhost:3118/callback", [
+          "not-a-uri",
+        ]),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/mcp-cloudflare/src/server/lib/redirect-uri.ts
+++ b/packages/mcp-cloudflare/src/server/lib/redirect-uri.ts
@@ -1,0 +1,61 @@
+/**
+ * Redirect URI matching shared by the authorize and callback OAuth routes.
+ *
+ * Mirrors the semantics of `isValidRedirectUri` in `@cloudflare/workers-oauth-provider`,
+ * which validates the same URI during `parseAuthRequest` and `completeAuthorization`.
+ * Keeping the two in agreement stops a request the provider accepts from being
+ * rejected by our own route handlers.
+ */
+
+/**
+ * Checks whether a URI targets the loopback interface (127.0.0.0/8, ::1, or localhost).
+ */
+export function isLoopbackUri(uri: string): boolean {
+  try {
+    const { hostname } = new URL(uri);
+    return (
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.toLowerCase() === "localhost"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks a requested redirect URI against a client's registered URIs.
+ *
+ * Loopback URIs ignore the port, per RFC 8252 Section 7.3: native apps take an
+ * ephemeral port from the OS at request time, so a CIMD metadata document cannot
+ * declare it ahead of publication. Scheme, host, path, and query must still match.
+ * Every other URI requires exact equality.
+ */
+export function isRegisteredRedirectUri(
+  requestUri: string,
+  registeredUris: string[] | undefined,
+): boolean {
+  if (!Array.isArray(registeredUris)) {
+    return false;
+  }
+
+  return registeredUris.some((registered) => {
+    if (!isLoopbackUri(requestUri) || !isLoopbackUri(registered)) {
+      return requestUri === registered;
+    }
+
+    try {
+      const request = new URL(requestUri);
+      const allowed = new URL(registered);
+      return (
+        request.protocol === allowed.protocol &&
+        request.hostname === allowed.hostname &&
+        request.pathname === allowed.pathname &&
+        request.search === allowed.search
+      );
+    } catch {
+      return false;
+    }
+  });
+}

--- a/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/authorize.test.ts
@@ -333,6 +333,42 @@ describe("oauth authorize routes", () => {
       expect(await response.text()).toBe("Invalid redirect URI");
     });
 
+    it("accepts an ephemeral loopback port against a portless CIMD registration", async () => {
+      mockOAuthProvider.lookupClient.mockResolvedValue({
+        clientId: "https://claude.ai/oauth/claude-code-client-metadata",
+        clientName: "Claude Code",
+        redirectUris: [
+          "http://localhost/callback",
+          "http://127.0.0.1/callback",
+        ],
+        tokenEndpointAuthMethod: "none",
+      });
+      const oauthReqInfo = {
+        clientId: "https://claude.ai/oauth/claude-code-client-metadata",
+        redirectUri: "http://localhost:3118/callback",
+        scope: ["org:read"],
+        state: "original-state",
+      };
+      const formData = new FormData();
+      const signedState = await signState(
+        {
+          req: { oauthReqInfo },
+          iat: Date.now(),
+          exp: Date.now() + 10 * 60 * 1000,
+        },
+        testEnv.COOKIE_SECRET!,
+      );
+      formData.append("state", signedState);
+      formData.append("skill", "triage");
+      const request = new Request("http://localhost/oauth/authorize", {
+        method: "POST",
+        body: formData,
+      });
+      const response = await app.fetch(request, testEnv as Env);
+
+      expect(response.status).toBe(302);
+    });
+
     it("should encode skills in the redirect state", async () => {
       const oauthReqInfo = {
         clientId: "test-client",

--- a/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/callback.test.ts
@@ -258,6 +258,70 @@ describe("oauth callback routes", () => {
       expect(await response.text()).toBe("Invalid state");
     });
 
+    it("accepts an ephemeral loopback port against a portless CIMD registration", async () => {
+      const loopbackRedirectUri = "http://localhost:3118/callback";
+      const testEnv = createTestEnv();
+      const oauthApp = createTestApp();
+      const client = await testEnv.OAUTH_PROVIDER.createClient({
+        clientName: "Claude Code",
+        redirectUris: [
+          "http://localhost/callback",
+          "http://127.0.0.1/callback",
+        ],
+        tokenEndpointAuthMethod: "none",
+      });
+
+      const approvalState = await signState(
+        {
+          req: {
+            oauthReqInfo: {
+              clientId: client.clientId,
+              redirectUri: loopbackRedirectUri,
+              scope: ["org:read"],
+            },
+          },
+          iat: Date.now(),
+          exp: Date.now() + 10 * 60 * 1000,
+        },
+        COOKIE_SECRET,
+      );
+      const formData = new FormData();
+      formData.append("state", approvalState);
+      formData.append("skill", "inspect");
+      const approval = await oauthApp.fetch(
+        new Request("http://localhost/oauth/authorize", {
+          method: "POST",
+          body: formData,
+        }),
+        testEnv,
+      );
+      expect(approval.status).toBe(302);
+      const cookie = approval.headers.get("Set-Cookie")?.split(";")[0];
+
+      const now = Date.now();
+      const state = await signState(
+        {
+          req: {
+            clientId: client.clientId,
+            redirectUri: loopbackRedirectUri,
+            scope: ["org:read"],
+            skills: ["inspect"],
+          },
+          iat: now,
+          exp: now + 10 * 60 * 1000,
+        } as unknown as OAuthState,
+        COOKIE_SECRET,
+      );
+
+      const response = await callCallback(oauthApp, testEnv, {
+        state,
+        cookie,
+        code: "test-code",
+      });
+
+      expect(response.status).toBe(302);
+    });
+
     it("renders a safe upstream oauth error page and skips token exchange", async () => {
       const testEnv = createTestEnv();
       const oauthApp = createTestApp();

--- a/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/authorize.ts
@@ -7,6 +7,7 @@ import {
   parseRedirectApproval,
 } from "../../lib/approval-dialog";
 import { redirectUriHasUserInfo } from "../../lib/html-utils";
+import { isRegisteredRedirectUri } from "../../lib/redirect-uri";
 import { resolveClientFamilyFromName } from "../../lib/client-family";
 import type { Env } from "../../types";
 import { SENTRY_AUTH_URL } from "../constants";
@@ -251,9 +252,10 @@ export default new Hono<{ Bindings: Env }>()
       client = await c.env.OAUTH_PROVIDER.lookupClient(
         oauthReqWithSkills.clientId,
       );
-      const uriIsAllowed =
-        Array.isArray(client?.redirectUris) &&
-        client.redirectUris.includes(oauthReqWithSkills.redirectUri);
+      const uriIsAllowed = isRegisteredRedirectUri(
+        oauthReqWithSkills.redirectUri,
+        client?.redirectUris,
+      );
       if (!uriIsAllowed) {
         logWarn("Redirect URI not registered for client", {
           loggerScope: ["cloudflare", "oauth", "authorize"],

--- a/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
+++ b/packages/mcp-cloudflare/src/server/oauth/routes/callback.ts
@@ -5,6 +5,7 @@ import { logIssue, logWarn } from "@sentry/mcp-core/telem/logging";
 import { Hono } from "hono";
 import { clientIdAlreadyApproved } from "../../lib/approval-dialog";
 import { resolveClientFamilyFromName } from "../../lib/client-family";
+import { isRegisteredRedirectUri } from "../../lib/redirect-uri";
 import type { Env, WorkerProps } from "../../types";
 import { setSentryUserFromRequest } from "../../utils/sentry-user";
 import { SENTRY_TOKEN_URL } from "../constants";
@@ -180,9 +181,10 @@ export default new Hono<{ Bindings: Env }>().get("/", async (c) => {
       oauthReqInfo.clientId,
     );
     registeredClientName = client?.clientName;
-    const uriIsAllowed =
-      Array.isArray(client?.redirectUris) &&
-      client.redirectUris.includes(oauthReqInfo.redirectUri);
+    const uriIsAllowed = isRegisteredRedirectUri(
+      oauthReqInfo.redirectUri,
+      client?.redirectUris,
+    );
     if (!uriIsAllowed) {
       logWarn("Redirect URI not registered for client on callback", {
         loggerScope: ["cloudflare", "oauth", "callback"],


### PR DESCRIPTION
The authorize POST and callback handlers validated redirect_uri with exact array membership, which rejects native clients that take an ephemeral loopback port from the OS at request time.

CIMD metadata documents cannot declare that port ahead of publication, so enabling CIMD in 29d00ac made these checks unreachable-by-design for such clients: the provider's parseAuthRequest accepts the request and renders the dialog, then our own check returns 400.

Add a shared isRegisteredRedirectUri() mirroring the semantics of isValidRedirectUri() in workers-oauth-provider, so both layers agree. Loopback URIs ignore only the port; scheme, host, path and query must still match, and non-loopback URIs still require exact equality.

Fixes #1190
Fixes #1189