### PR TITLE
feat(tools): Structure find_projects results

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -1653,16 +1653,17 @@ export class SentryApiService {
    * @param organizationSlug Organization identifier
    * @param params Query parameters
    * @param params.query Search query to filter projects by name/slug
+   * @param params.limit Maximum number of projects to return
    * @param opts Request options
-   * @returns Array of projects in the organization (limited to 25 results)
+   * @returns Array of projects in the organization
    */
   async listProjects(
     organizationSlug: string,
-    params?: { query?: string },
+    params?: { query?: string; limit?: number },
     opts?: RequestOptions,
   ): Promise<ProjectList> {
     const queryParams = new URLSearchParams();
-    queryParams.set("per_page", "25");
+    queryParams.set("per_page", String(params?.limit ?? 25));
     if (params?.query) {
       queryParams.set("query", params.query);
     }

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -29,7 +29,7 @@
       },
       {
         "name": "find_projects",
-        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["project:read"]
       },
       {
@@ -204,7 +204,7 @@
       },
       {
         "name": "find_projects",
-        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["project:read"]
       },
       {
@@ -265,7 +265,7 @@
       },
       {
         "name": "find_projects",
-        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["project:read"]
       },
       {
@@ -305,7 +305,7 @@
       },
       {
         "name": "find_projects",
-        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["project:read"]
       },
       {
@@ -420,7 +420,7 @@
       },
       {
         "name": "find_projects",
-        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["project:read"]
       },
       {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -578,7 +578,7 @@
   },
   {
     "name": "find_projects",
-    "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+    "description": "Find projects in Sentry.\n\nUse this tool when you need to:\n- View projects in a Sentry organization\n- Find a project's slug to aid other tool requests\n- Search for specific projects by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -612,6 +612,29 @@
         }
       },
       "required": ["organizationSlug"]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "projects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": {
+                "type": "string"
+              }
+            },
+            "required": ["slug"],
+            "additionalProperties": false
+          }
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "required": ["projects", "hasMore"],
+      "additionalProperties": false
     },
     "requiredScopes": ["project:read"],
     "skills": ["inspect", "seer", "docs", "triage", "project-management"],

--- a/packages/mcp-core/src/tools/catalog/find-projects.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-projects.test.ts
@@ -1,12 +1,32 @@
 import { mswServer } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
-import findProjects from "./find-projects.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
+import findProjects, { findProjectsOutputSchema } from "./find-projects.js";
 import { prepareToolParams } from "../catalog-runtime/availability";
 import { getServerContext } from "../../test-setup.js";
 
 describe("find_projects", () => {
   it("serializes", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/projects/",
+        ({ request }) => {
+          expect(new URL(request.url).searchParams.get("per_page")).toBe("26");
+          return HttpResponse.json([
+            {
+              id: "1",
+              slug: "cloudflare-mcp",
+              name: "Cloudflare MCP",
+            },
+          ]);
+        },
+      ),
+    );
+
     const result = await findProjects.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -15,12 +35,57 @@ describe("find_projects", () => {
       },
       getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Projects in **sentry-mcp-evals**
 
-      - **cloudflare-mcp**
-      "
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(findProjectsOutputSchema.parse(structuredContent)).toEqual(
+      structuredContent,
+    );
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "hasMore": false,
+        "projects": [
+          {
+            "slug": "cloudflare-mcp",
+          },
+        ],
+      }
     `);
+  });
+
+  it("reports more results and returns only the first 25 projects", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/projects/",
+        ({ request }) => {
+          expect(new URL(request.url).searchParams.get("per_page")).toBe("26");
+          return HttpResponse.json(
+            Array.from({ length: 26 }, (_, index) => ({
+              id: String(index + 1),
+              slug: `project-${String(index + 1).padStart(2, "0")}`,
+              name: `Project ${index + 1}`,
+            })),
+          );
+        },
+      ),
+    );
+
+    const result = await findProjects.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        query: null,
+      },
+      getServerContext(),
+    );
+
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      projects: Array.from({ length: 25 }, (_, index) => ({
+        slug: `project-${String(index + 1).padStart(2, "0")}`,
+      })),
+      hasMore: true,
+    });
   });
 
   it("preserves mixed-case organization slug in the API path", async () => {
@@ -56,7 +121,10 @@ describe("find_projects", () => {
 
     const result = await findProjects.handler(params, context);
 
-    expect(result).toContain("# Projects in **MyOrg**");
-    expect(result).toContain("- **MyProject**");
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      projects: [{ slug: "MyProject" }],
+      hasMore: false,
+    });
   });
 });

--- a/packages/mcp-core/src/tools/catalog/find-projects.ts
+++ b/packages/mcp-core/src/tools/catalog/find-projects.ts
@@ -1,6 +1,8 @@
 import { setTag } from "@sentry/core";
+import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import { UserInputError } from "../../errors";
 import type { ServerContext } from "../../types";
 import {
@@ -11,6 +13,15 @@ import {
 import { ALL_SKILLS } from "../../skills";
 
 const RESULT_LIMIT = 25;
+
+export const findProjectsOutputSchema = z.object({
+  projects: z.array(
+    z.object({
+      slug: z.string(),
+    }),
+  ),
+  hasMore: z.boolean(),
+});
 
 export default defineTool({
   name: "find_projects",
@@ -24,7 +35,7 @@ export default defineTool({
     "- Find a project's slug to aid other tool requests",
     "- Search for specific projects by name or slug",
     "",
-    `Returns up to ${RESULT_LIMIT} results. If you hit this limit, use the query parameter to narrow down results.`,
+    `Returns up to ${RESULT_LIMIT} results. When hasMore is true, use the query parameter to narrow down results.`,
   ].join("\n"),
   inputSchema: {
     organizationSlug: ParamOrganizationSlug,
@@ -36,6 +47,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findProjectsOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -52,27 +64,14 @@ export default defineTool({
 
     const projects = await apiService.listProjects(organizationSlug, {
       query: params.query ?? undefined,
+      limit: RESULT_LIMIT + 1,
     });
 
-    let output = `# Projects in **${organizationSlug}**\n\n`;
-
-    if (params.query) {
-      output += `**Search query:** "${params.query}"\n\n`;
-    }
-
-    if (projects.length === 0) {
-      output += params.query
-        ? `No projects found matching "${params.query}".\n`
-        : "No projects found.\n";
-      return output;
-    }
-
-    output += projects.map((project) => `- **${project.slug}**\n`).join("");
-
-    if (projects.length === RESULT_LIMIT) {
-      output += `\n---\n\n**Note:** Showing ${RESULT_LIMIT} results (maximum). There may be more projects available. Use the \`query\` parameter to search for specific projects.`;
-    }
-
-    return output;
+    return structuredResult({
+      projects: projects
+        .slice(0, RESULT_LIMIT)
+        .map((project) => ({ slug: project.slug })),
+      hasMore: projects.length > RESULT_LIMIT,
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_projects` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains only project slugs and an accurate `hasMore` flag. The tool requests 26 projects, returns at most 25, and sets `hasMore` when the extra result proves the response was truncated. 

The API client now accepts a project list limit while preserving its existing default. Tests validate the structured schema, `per_page=26`, result slicing, and generated definitions.

Refs #1193