### PR TITLE
feat(tools): Structure find_teams results

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -1596,16 +1596,17 @@ export class SentryApiService {
    * @param organizationSlug Organization identifier
    * @param params Query parameters
    * @param params.query Search query to filter teams by name/slug
+   * @param params.limit Maximum number of teams to return
    * @param opts Request options including host override
-   * @returns Array of teams in the organization (limited to 25 results)
+   * @returns Array of teams in the organization
    */
   async listTeams(
     organizationSlug: string,
-    params?: { query?: string },
+    params?: { query?: string; limit?: number },
     opts?: RequestOptions,
   ): Promise<TeamList> {
     const queryParams = new URLSearchParams();
-    queryParams.set("per_page", "25");
+    queryParams.set("per_page", String(params?.limit ?? 25));
     if (params?.query) {
       queryParams.set("query", params.query);
     }

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -39,7 +39,7 @@
       },
       {
         "name": "find_teams",
-        "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["team:read"]
       },
       {
@@ -310,7 +310,7 @@
       },
       {
         "name": "find_teams",
-        "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["team:read"]
       },
       {
@@ -425,7 +425,7 @@
       },
       {
         "name": "find_teams",
-        "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+        "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["team:read"]
       },
       {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -672,7 +672,7 @@
   },
   {
     "name": "find_teams",
-    "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. If you hit this limit, use the query parameter to narrow down results.",
+    "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -706,6 +706,32 @@
         }
       },
       "required": ["organizationSlug"]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": ["slug", "id"],
+            "additionalProperties": false
+          }
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "required": ["teams", "hasMore"],
+      "additionalProperties": false
     },
     "requiredScopes": ["team:read"],
     "skills": ["inspect", "triage", "project-management"],

--- a/packages/mcp-core/src/tools/catalog/find-teams.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-teams.test.ts
@@ -1,27 +1,90 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
-import findTeams from "./find-teams.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
+import findTeams, { findTeamsOutputSchema } from "./find-teams.js";
+import { getServerContext } from "../../test-setup.js";
 
 describe("find_teams", () => {
   it("serializes", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/teams/",
+        ({ request }) => {
+          expect(new URL(request.url).searchParams.get("per_page")).toBe("26");
+          return HttpResponse.json([
+            {
+              id: 4509106740854784,
+              slug: "the-goats",
+              name: "The Goats",
+            },
+          ]);
+        },
+      ),
+    );
+
     const result = await findTeams.handler(
       {
         organizationSlug: "sentry-mcp-evals",
         query: null,
         regionUrl: null,
       },
-      {
-        constraints: {
-          organizationSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Teams in **sentry-mcp-evals**
-
-      - the-goats (ID: 4509106740854784)
-      "
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(findTeamsOutputSchema.parse(structuredContent)).toEqual(
+      structuredContent,
+    );
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "hasMore": false,
+        "teams": [
+          {
+            "id": "4509106740854784",
+            "slug": "the-goats",
+          },
+        ],
+      }
     `);
+  });
+
+  it("reports more results and returns only the first 25 teams", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/teams/",
+        ({ request }) => {
+          expect(new URL(request.url).searchParams.get("per_page")).toBe("26");
+          return HttpResponse.json(
+            Array.from({ length: 26 }, (_, index) => ({
+              id: index + 1,
+              slug: `team-${String(index + 1).padStart(2, "0")}`,
+              name: `Team ${index + 1}`,
+            })),
+          );
+        },
+      ),
+    );
+
+    const result = await findTeams.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        query: null,
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      teams: Array.from({ length: 25 }, (_, index) => ({
+        slug: `team-${String(index + 1).padStart(2, "0")}`,
+        id: String(index + 1),
+      })),
+      hasMore: true,
+    });
   });
 });

--- a/packages/mcp-core/src/tools/catalog/find-teams.ts
+++ b/packages/mcp-core/src/tools/catalog/find-teams.ts
@@ -1,6 +1,8 @@
 import { setTag } from "@sentry/core";
+import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import { UserInputError } from "../../errors";
 import type { ServerContext } from "../../types";
 import {
@@ -10,6 +12,16 @@ import {
 } from "../../schema";
 
 const RESULT_LIMIT = 25;
+
+export const findTeamsOutputSchema = z.object({
+  teams: z.array(
+    z.object({
+      slug: z.string(),
+      id: z.string(),
+    }),
+  ),
+  hasMore: z.boolean(),
+});
 
 export default defineTool({
   name: "find_teams",
@@ -23,7 +35,7 @@ export default defineTool({
     "- Find a team's slug and numeric ID to aid other tool requests",
     "- Search for specific teams by name or slug",
     "",
-    `Returns up to ${RESULT_LIMIT} results. If you hit this limit, use the query parameter to narrow down results.`,
+    `Returns up to ${RESULT_LIMIT} results. When hasMore is true, use the query parameter to narrow down results.`,
   ].join("\n"),
   inputSchema: {
     organizationSlug: ParamOrganizationSlug,
@@ -35,6 +47,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findTeamsOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -51,27 +64,14 @@ export default defineTool({
 
     const teams = await apiService.listTeams(organizationSlug, {
       query: params.query ?? undefined,
+      limit: RESULT_LIMIT + 1,
     });
 
-    let output = `# Teams in **${organizationSlug}**\n\n`;
-
-    if (params.query) {
-      output += `**Search query:** "${params.query}"\n\n`;
-    }
-
-    if (teams.length === 0) {
-      output += params.query
-        ? `No teams found matching "${params.query}".\n`
-        : "No teams found.\n";
-      return output;
-    }
-
-    output += teams.map((team) => `- ${team.slug} (ID: ${team.id})\n`).join("");
-
-    if (teams.length === RESULT_LIMIT) {
-      output += `\n---\n\n**Note:** Showing ${RESULT_LIMIT} results (maximum). There may be more teams available. Use the \`query\` parameter to search for specific teams.`;
-    }
-
-    return output;
+    return structuredResult({
+      teams: teams
+        .slice(0, RESULT_LIMIT)
+        .map((team) => ({ slug: team.slug, id: String(team.id) })),
+      hasMore: teams.length > RESULT_LIMIT,
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_teams` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains only team slugs, normalized string IDs, and an accurate `hasMore` flag. The tool requests 26 teams, returns at most 25, and sets `hasMore` when the extra result proves the response was truncated. Organization and query inputs are not echoed into the payload.

The API client now accepts a team list limit while preserving its existing default. Tests validate the structured schema, `per_page=26`, result slicing, ID normalization, and generated definitions.

Refs #1193