### PR TITLE
feat(tools): Structure whoami results

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -361,12 +361,36 @@ describe("MCP Handler", () => {
       );
 
       expect(response.status).toBe(200);
+      const structuredContent = {
+        user: {
+          id: "123456",
+          name: "Test User",
+          email: "test@example.com",
+        },
+        sessionConstraints: null,
+      };
       const body = await parseSSEResponse<{
-        result?: { content?: Array<{ text?: string }> };
+        jsonrpc: "2.0";
+        id: number;
+        result: {
+          content: Array<{ type: "text"; text: string }>;
+          structuredContent: typeof structuredContent;
+        };
       }>(response);
-      const text = body.result?.content?.map((item) => item.text).join("\n");
 
-      expect(text).toContain("You are authenticated as");
+      expect(body).toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(structuredContent, null, 2),
+            },
+          ],
+          structuredContent,
+        },
+      });
     });
 
     it("applies the Sentry-Bearer MCP rate limit per token", async () => {

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -306,7 +306,6 @@ describe("buildServer", () => {
       expect(toolNames).toContain("experimental_tool");
     });
 
-
     it("does not filter tools with experimental: false", () => {
       const server = buildServer({
         context: baseContext,
@@ -901,7 +900,6 @@ describe("buildServer", () => {
       );
     });
 
-
     it("keeps snapshot tools catalog-only while enforcing the inspect skill gate", async () => {
       const withoutInspect = buildServer({
         context: {
@@ -953,7 +951,6 @@ describe("buildServer", () => {
       expect(catalogToolNames).toContain("get_snapshot_image");
       expect(catalogToolNames).toContain("get_latest_base_snapshot");
     });
-
 
     it("exposes catalog tools with conservative safety annotations", async () => {
       const server = buildServer({
@@ -1367,7 +1364,28 @@ describe("buildServer", () => {
         arguments: {},
       });
 
-      expect(getTextContent(result)).toContain("You are authenticated as");
+      const payload = getStructuredContent<{
+        user: {
+          id: string;
+          name: string | null;
+          email: string;
+        };
+        sessionConstraints: null;
+      }>(result);
+
+      expect(payload).toMatchInlineSnapshot(`
+        {
+          "sessionConstraints": null,
+          "user": {
+            "email": "test@example.com",
+            "id": "123456",
+            "name": "Test User",
+          },
+        }
+      `);
+      expect(getTextContent(result)).toBe(
+        getGeneratedTextFromStructuredContent(result),
+      );
     });
 
     it("execute_sentry_tool dispatches structured catalog results", async () => {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -3296,6 +3296,58 @@
     "name": "whoami",
     "description": "Identify the authenticated user in Sentry.\n\nUse this tool when you need to:\n- Get the user's name and email address.",
     "inputSchema": {},
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "email": {
+              "type": "string"
+            }
+          },
+          "required": ["id", "name", "email"],
+          "additionalProperties": false
+        },
+        "sessionConstraints": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "organizationSlug": {
+                  "type": "string"
+                },
+                "projectSlug": {
+                  "type": "string"
+                },
+                "regionUrl": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["user", "sessionConstraints"],
+      "additionalProperties": false
+    },
     "requiredScopes": [],
     "skills": ["inspect", "seer", "docs", "triage", "project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/whoami.test.ts
+++ b/packages/mcp-core/src/tools/catalog/whoami.test.ts
@@ -1,12 +1,29 @@
+import { http, HttpResponse } from "msw";
+import { mswServer } from "@sentry/mcp-server-mocks";
 import { describe, it, expect } from "vitest";
-import whoami from "./whoami.js";
+import whoami, { whoamiOutputSchema } from "./whoami.js";
 import {
   createTestContext,
   createTestContextWithConstraints,
 } from "../../test-utils/context.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
 
 describe("whoami", () => {
   it("serializes without constraints", async () => {
+    mswServer.use(
+      http.get("https://sentry.io/api/0/auth/", () =>
+        HttpResponse.json({
+          id: 123456,
+          name: "Test User",
+          email: "test@example.com",
+          backendOnlyField: "do-not-leak",
+        }),
+      ),
+    );
+
     const result = await whoami.handler(
       {},
       createTestContext({
@@ -15,13 +32,20 @@ describe("whoami", () => {
         userId: "123456",
       }),
     );
-    expect(result).toMatchInlineSnapshot(
-      `
-      "You are authenticated as Test User (test@example.com).
-
-      Your Sentry User ID is 123456."
-    `,
-    );
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(whoami.outputSchema).toBe(whoamiOutputSchema);
+    expect(whoamiOutputSchema.safeParse(structuredContent).success).toBe(true);
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "sessionConstraints": null,
+        "user": {
+          "email": "test@example.com",
+          "id": "123456",
+          "name": "Test User",
+        },
+      }
+    `);
   });
 
   it("serializes with constraints", async () => {
@@ -39,21 +63,23 @@ describe("whoami", () => {
         },
       ),
     );
-    expect(result).toMatchInlineSnapshot(
-      `
-      "You are authenticated as Test User (test@example.com).
-
-      Your Sentry User ID is 123456.
-
-      ## Session Constraints
-
-      - **Organization**: sentry
-      - **Project**: mcp-server
-      - **Region URL**: https://us.sentry.io
-
-      These constraints limit the scope of this MCP session."
-    `,
-    );
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(whoamiOutputSchema.safeParse(structuredContent).success).toBe(true);
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "sessionConstraints": {
+          "organizationSlug": "sentry",
+          "projectSlug": "mcp-server",
+          "regionUrl": "https://us.sentry.io",
+        },
+        "user": {
+          "email": "test@example.com",
+          "id": "123456",
+          "name": "Test User",
+        },
+      }
+    `);
   });
 
   it("serializes with partial constraints", async () => {
@@ -69,18 +95,20 @@ describe("whoami", () => {
         },
       ),
     );
-    expect(result).toMatchInlineSnapshot(
-      `
-      "You are authenticated as Test User (test@example.com).
-
-      Your Sentry User ID is 123456.
-
-      ## Session Constraints
-
-      - **Organization**: sentry
-
-      These constraints limit the scope of this MCP session."
-    `,
-    );
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(whoamiOutputSchema.safeParse(structuredContent).success).toBe(true);
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "sessionConstraints": {
+          "organizationSlug": "sentry",
+        },
+        "user": {
+          "email": "test@example.com",
+          "id": "123456",
+          "name": "Test User",
+        },
+      }
+    `);
   });
 });

--- a/packages/mcp-core/src/tools/catalog/whoami.ts
+++ b/packages/mcp-core/src/tools/catalog/whoami.ts
@@ -1,7 +1,24 @@
+import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { ServerContext } from "../../types";
 import { ALL_SKILLS } from "../../skills";
+
+export const whoamiOutputSchema = z.object({
+  user: z.object({
+    id: z.string(),
+    name: z.string().nullable(),
+    email: z.string(),
+  }),
+  sessionConstraints: z
+    .object({
+      organizationSlug: z.string().optional(),
+      projectSlug: z.string().optional(),
+      regionUrl: z.string().optional(),
+    })
+    .nullable(),
+});
 
 export default defineTool({
   name: "whoami",
@@ -12,6 +29,7 @@ export default defineTool({
     "- Get the user's name and email address.",
   ].join("\n"),
   inputSchema: {},
+  outputSchema: whoamiOutputSchema,
   skills: ALL_SKILLS, // Foundational tool - available to all skills
   requiredScopes: [], // No specific scopes required - uses authentication token
   annotations: {
@@ -26,30 +44,31 @@ export default defineTool({
     // API client will throw ApiClientError/ApiServerError which the MCP server wrapper handles
     const user = await apiService.getAuthenticatedUser();
 
-    let output = `You are authenticated as ${user.name} (${user.email}).\n\nYour Sentry User ID is ${user.id}.`;
-
-    // Add constraints information
     const constraints = context.constraints;
-    if (
+    const sessionConstraints =
       constraints.organizationSlug ||
       constraints.projectSlug ||
       constraints.regionUrl
-    ) {
-      output += "\n\n## Session Constraints\n\n";
+        ? {
+            ...(constraints.organizationSlug
+              ? { organizationSlug: constraints.organizationSlug }
+              : {}),
+            ...(constraints.projectSlug
+              ? { projectSlug: constraints.projectSlug }
+              : {}),
+            ...(constraints.regionUrl
+              ? { regionUrl: constraints.regionUrl }
+              : {}),
+          }
+        : null;
 
-      if (constraints.organizationSlug) {
-        output += `- **Organization**: ${constraints.organizationSlug}\n`;
-      }
-      if (constraints.projectSlug) {
-        output += `- **Project**: ${constraints.projectSlug}\n`;
-      }
-      if (constraints.regionUrl) {
-        output += `- **Region URL**: ${constraints.regionUrl}\n`;
-      }
-
-      output += "\nThese constraints limit the scope of this MCP session.";
-    }
-
-    return output;
+    return structuredResult({
+      user: {
+        id: String(user.id),
+        name: user.name ?? null,
+        email: user.email,
+      },
+      sessionConstraints,
+    });
   },
 });


### PR DESCRIPTION
Migrate `whoami` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result exposes the authenticated user's stable string ID, nullable name, and email. Session constraints are included only because they change what the current MCP session can access; absent constraints are represented as `null`, and partial constraints omit unrelated fields.

Tests validate all existing constraint cases, schema conformance, structured-only output, ID normalization, and that passthrough backend fields do not leak.

Refs #1193