### PR TITLE
feat(tools): Structure create_team results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -260,6 +260,29 @@
       },
       "required": ["organizationSlug", "name"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["id", "slug", "name"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["team"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["team:write"],
     "skills": ["project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/create-team.test.ts
+++ b/packages/mcp-core/src/tools/catalog/create-team.test.ts
@@ -1,12 +1,38 @@
-import { describe, it, expect } from "vitest";
+import { mswServer, teamFixture } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, it, expect } from "vitest";
 import createTeam from "./create-team.js";
 
 describe("create_team", () => {
-  it("serializes", async () => {
+  afterEach(() => {
+    mswServer.resetHandlers();
+  });
+
+  it("returns structured team details", async () => {
+    mswServer.use(
+      http.post(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/teams/",
+        async ({ request }) => {
+          expect(await request.json()).toEqual({
+            name: "Platform Engineering",
+          });
+          return HttpResponse.json(
+            {
+              ...teamFixture,
+              id: 4509109078196224,
+              slug: "platform-engineering",
+              name: "Platform Engineering",
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
     const result = await createTeam.handler(
       {
         organizationSlug: "sentry-mcp-evals",
-        name: "the-goats",
+        name: "Platform Engineering",
         regionUrl: null,
       },
       {
@@ -18,16 +44,15 @@ describe("create_team", () => {
       },
     );
     expect(result).toMatchInlineSnapshot(`
-      "# New Team in **sentry-mcp-evals**
-
-      **ID**: 4509109078196224
-      **Slug**: the-goats
-      **Name**: the-goats
-
-      ## Response Notes
-
-      - Please tell the user the team slug.
-      "
+      {
+        "structuredContent": {
+          "team": {
+            "id": "4509109078196224",
+            "name": "Platform Engineering",
+            "slug": "platform-engineering",
+          },
+        },
+      }
     `);
   });
 });

--- a/packages/mcp-core/src/tools/catalog/create-team.ts
+++ b/packages/mcp-core/src/tools/catalog/create-team.ts
@@ -2,8 +2,17 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { ServerContext } from "../../types";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../../schema";
+
+export const createTeamOutputSchema = z.object({
+  team: z.object({
+    id: z.string(),
+    slug: z.string(),
+    name: z.string(),
+  }),
+});
 
 export default defineTool({
   name: "create_team",
@@ -40,6 +49,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: createTeamOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -52,12 +62,12 @@ export default defineTool({
       organizationSlug,
       name: params.name,
     });
-    let output = `# New Team in **${organizationSlug}**\n\n`;
-    output += `**ID**: ${team.id}\n`;
-    output += `**Slug**: ${team.slug}\n`;
-    output += `**Name**: ${team.name}\n`;
-    output += "\n## Response Notes\n\n";
-    output += `- Please tell the user the team slug.\n`;
-    return output;
+    return structuredResult({
+      team: {
+        id: String(team.id),
+        slug: team.slug,
+        name: team.name,
+      },
+    });
   },
 });


### PR DESCRIPTION
Migrate `create_team` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains only the created team's stable string ID, slug, and name. This removes response-note steering while preserving every value needed for follow-up project and team operations.

The focused MSW test validates the request body, ID normalization, and structured snapshot. TypeScript and lint pass.

Refs #1193