### PR TITLE
feat(tools): Structure create_dsn results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -154,6 +154,29 @@
       },
       "required": ["organizationSlug", "projectSlug", "name"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "dsn": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "dsn": {
+              "type": "string"
+            }
+          },
+          "required": ["id", "name", "dsn"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["dsn"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["project:write"],
     "skills": ["project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/create-dsn.test.ts
+++ b/packages/mcp-core/src/tools/catalog/create-dsn.test.ts
@@ -1,8 +1,37 @@
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
 import createDsn from "./create-dsn.js";
+import { getServerContext } from "../../test-setup.js";
 
 describe("create_dsn", () => {
-  it("serializes", async () => {
+  it("returns the created DSN as structured content", async () => {
+    mswServer.use(
+      http.post(
+        "https://sentry.io/api/0/projects/*/*/keys/",
+        async ({ request }) => {
+          expect(new URL(request.url).pathname).toBe(
+            "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/keys/",
+          );
+          await expect(request.json()).resolves.toEqual({ name: "Default" });
+
+          return HttpResponse.json({
+            id: 12345,
+            name: "Default",
+            dsn: {
+              public: "https://public@example.ingest.sentry.io/12345",
+              secret: "backend-only-secret",
+            },
+            isActive: true,
+            dateCreated: "2026-07-28T00:00:00.000Z",
+            browserSdkVersion: "9.0.0",
+            backendOnlyField: "must-not-leak",
+          });
+        },
+        { once: true },
+      ),
+    );
+
     const result = await createDsn.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -10,26 +39,20 @@ describe("create_dsn", () => {
         name: "Default",
         regionUrl: null,
       },
-      {
-        constraints: {
-          organizationSlug: null,
-          projectSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# New DSN in **sentry-mcp-evals/cloudflare-mcp**
 
-      **DSN**: https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945
-      **Name**: Default
-
-      ## Response Notes
-
-      - Please tell the user the DSN.
-      - The \`SENTRY_DSN\` value is a URL used to initialize Sentry SDKs.
-      "
+    expect(result.structuredContent).toMatchInlineSnapshot(`
+      {
+        "dsn": {
+          "dsn": "https://public@example.ingest.sentry.io/12345",
+          "id": "12345",
+          "name": "Default",
+        },
+      }
     `);
+    expect(result.structuredContent).not.toHaveProperty("isActive");
+    expect(result.structuredContent.dsn).not.toHaveProperty("secret");
+    expect(result.structuredContent).not.toHaveProperty("backendOnlyField");
   });
 });

--- a/packages/mcp-core/src/tools/catalog/create-dsn.ts
+++ b/packages/mcp-core/src/tools/catalog/create-dsn.ts
@@ -2,12 +2,21 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { ServerContext } from "../../types";
 import {
   ParamOrganizationSlug,
   ParamRegionUrl,
   ParamProjectSlug,
 } from "../../schema";
+
+export const createDsnOutputSchema = z.object({
+  dsn: z.object({
+    id: z.string(),
+    name: z.string(),
+    dsn: z.string(),
+  }),
+});
 
 export default defineTool({
   name: "create_dsn",
@@ -51,6 +60,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: createDsnOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -65,13 +75,12 @@ export default defineTool({
       projectSlug: params.projectSlug,
       name: params.name,
     });
-    let output = `# New DSN in **${organizationSlug}/${params.projectSlug}**\n\n`;
-    output += `**DSN**: ${clientKey.dsn.public}\n`;
-    output += `**Name**: ${clientKey.name}\n\n`;
-    output += "## Response Notes\n\n";
-    output += "- Please tell the user the DSN.\n";
-    output +=
-      "- The `SENTRY_DSN` value is a URL used to initialize Sentry SDKs.\n";
-    return output;
+    return structuredResult({
+      dsn: {
+        id: String(clientKey.id),
+        name: clientKey.name,
+        dsn: clientKey.dsn.public,
+      },
+    });
   },
 });


### PR DESCRIPTION
Migrate `create_dsn` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains only the created client key's stable string ID, name, and public DSN. Secret and unrelated backend fields are intentionally excluded while preserving the value users need to configure Sentry SDKs.

The focused MSW test validates the request body, ID normalization, structured snapshot, and field-leak prevention. TypeScript and lint pass.

Refs #1193