### PR TITLE
feat(tools): Structure find_dsns results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -464,6 +464,32 @@
       },
       "required": ["organizationSlug", "projectSlug"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "dsns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "dsn": {
+                "type": "string"
+              }
+            },
+            "required": ["id", "name", "dsn"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["dsns"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["project:read"],
     "skills": ["project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/find-dsns.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-dsns.test.ts
@@ -1,35 +1,91 @@
-import { describe, it, expect } from "vitest";
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { getServerContext } from "../../test-setup";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content";
 import findDsns from "./find-dsns.js";
 
 describe("find_dsns", () => {
-  it("serializes", async () => {
+  it("returns all project DSNs as structured content", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/test-org/test-project/keys/",
+        () =>
+          HttpResponse.json([
+            {
+              id: 123,
+              name: "Production",
+              dsn: {
+                public: "https://public@example.ingest.sentry.io/1",
+                secret: "do-not-leak",
+              },
+              isActive: true,
+              dateCreated: "2026-07-28T12:00:00.000Z",
+              secretKey: "do-not-leak",
+              backendOnlyField: "do-not-leak",
+            },
+            {
+              id: "456",
+              name: "Development",
+              dsn: {
+                public: "https://development@example.ingest.sentry.io/2",
+              },
+              isActive: false,
+              dateCreated: "2026-07-28T12:00:00.000Z",
+            },
+          ]),
+      ),
+    );
+
     const result = await findDsns.handler(
       {
-        organizationSlug: "sentry-mcp-evals",
-        projectSlug: "cloudflare-mcp",
+        organizationSlug: "test-org",
+        projectSlug: "test-project",
         regionUrl: null,
       },
-      {
-        constraints: {
-          organizationSlug: null,
-          projectSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# DSNs in **sentry-mcp-evals/cloudflare-mcp**
 
-      ## Default
-      **ID**: d20df0a1ab5031c7f3c7edca9c02814d
-      **DSN**: https://d20df0a1ab5031c7f3c7edca9c02814d@o4509106732793856.ingest.us.sentry.io/4509109104082945
-
-      ## Response Notes
-
-      - Please tell the user the DSN.
-      - The \`SENTRY_DSN\` value is a URL used to initialize Sentry SDKs.
-      "
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "dsns": [
+          {
+            "dsn": "https://public@example.ingest.sentry.io/1",
+            "id": "123",
+            "name": "Production",
+          },
+          {
+            "dsn": "https://development@example.ingest.sentry.io/2",
+            "id": "456",
+            "name": "Development",
+          },
+        ],
+      }
     `);
+  });
+
+  it("returns an empty DSN array", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/test-org/empty-project/keys/",
+        () => HttpResponse.json([]),
+      ),
+    );
+
+    const result = await findDsns.handler(
+      {
+        organizationSlug: "test-org",
+        projectSlug: "empty-project",
+        regionUrl: null,
+      },
+      getServerContext(),
+    );
+
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({ dsns: [] });
   });
 });

--- a/packages/mcp-core/src/tools/catalog/find-dsns.ts
+++ b/packages/mcp-core/src/tools/catalog/find-dsns.ts
@@ -1,13 +1,24 @@
 import { setTag } from "@sentry/core";
+import { z } from "zod";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
 import { defineTool } from "../../internal/tool-helpers/define";
-import { formatToolCallInstruction } from "../../internal/tool-helpers/tool-call-formatting";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import {
   ParamOrganizationSlug,
   ParamProjectSlug,
   ParamRegionUrl,
 } from "../../schema";
 import type { ServerContext } from "../../types";
+
+export const findDsnsOutputSchema = z.object({
+  dsns: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      dsn: z.string(),
+    }),
+  ),
+});
 
 export default defineTool({
   name: "find_dsns",
@@ -34,6 +45,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findDsnsOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -47,32 +59,13 @@ export default defineTool({
       organizationSlug,
       projectSlug: params.projectSlug,
     });
-    let output = `# DSNs in **${organizationSlug}/${params.projectSlug}**\n\n`;
-    if (clientKeys.length === 0) {
-      output += `No DSNs were found.\n\nYou can create a new one. ${formatToolCallInstruction(
-        {
-          toolName: "create_dsn",
-          arguments: {
-            organizationSlug,
-            projectSlug: params.projectSlug,
-            name: "Production",
-          },
-          experimentalMode: context.experimentalMode ?? false,
-          availableToolNames: context.availableToolNames,
-          directToolNames: context.directToolNames,
-        },
-      )}.`;
-      return output;
-    }
-    for (const clientKey of clientKeys) {
-      output += `## ${clientKey.name}\n`;
-      output += `**ID**: ${clientKey.id}\n`;
-      output += `**DSN**: ${clientKey.dsn.public}\n\n`;
-    }
-    output += "## Response Notes\n\n";
-    output += "- Please tell the user the DSN.\n";
-    output +=
-      "- The `SENTRY_DSN` value is a URL used to initialize Sentry SDKs.\n";
-    return output;
+
+    return structuredResult({
+      dsns: clientKeys.map((clientKey) => ({
+        id: String(clientKey.id),
+        name: clientKey.name,
+        dsn: clientKey.dsn.public,
+      })),
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_dsns` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains the complete project DSN collection with stable string IDs, names, and public DSN values. The endpoint returns all client keys, so no pagination metadata is added. Secret and unrelated backend fields are intentionally excluded.

Focused MSW tests cover multiple keys, mixed upstream ID types, empty results, and field-leak prevention. TypeScript and lint pass.

Refs #1193