### PR TITLE
feat(tools): Structure update_project results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -3288,6 +3288,39 @@
       },
       "required": ["organizationSlug", "projectSlug"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "platform": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["id", "slug", "name", "platform"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["project"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["project:write"],
     "skills": ["project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/update-project.test.ts
+++ b/packages/mcp-core/src/tools/catalog/update-project.test.ts
@@ -4,6 +4,10 @@ import { afterEach, describe, it, expect } from "vitest";
 import { UserInputError } from "../../errors.js";
 import updateProject from "./update-project.js";
 import { prepareToolParams } from "../catalog-runtime/availability";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content";
 
 const context = {
   constraints: {
@@ -20,6 +24,24 @@ describe("update_project", () => {
   });
 
   it("updates name and platform", async () => {
+    mswServer.use(
+      http.put(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/",
+        async ({ request }) => {
+          expect(await request.json()).toEqual({
+            name: "New Project Name",
+            platform: "python",
+          });
+          return HttpResponse.json({
+            id: 4509109104082945,
+            slug: "cloudflare-mcp",
+            name: "New Project Name",
+            platform: "python",
+          });
+        },
+      ),
+    );
+
     const result = await updateProject.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -31,22 +53,17 @@ describe("update_project", () => {
       },
       context,
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Updated Project in **sentry-mcp-evals**
 
-      **ID**: 4509109104082945
-      **Slug**: cloudflare-mcp
-      **Name**: New Project Name
-      **Platform**: python
-
-      ## Updates Applied
-      - Updated name to "New Project Name"
-      - Updated platform to "python"
-
-      ## Response Notes
-
-      - Project slug for later requests: \`cloudflare-mcp\`
-      "
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "project": {
+          "id": "4509109104082945",
+          "name": "New Project Name",
+          "platform": "python",
+          "slug": "cloudflare-mcp",
+        },
+      }
     `);
   });
 
@@ -83,7 +100,15 @@ describe("update_project", () => {
 
     expect(paths).toEqual(["/api/0/projects/MyOrg/OldProject/"]);
     expect(updateBody).toEqual({ slug: "NewProject" });
-    expect(result).toContain("**Slug**: NewProject");
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      project: {
+        id: "4509109104082945",
+        slug: "NewProject",
+        name: "New Project",
+        platform: "node",
+      },
+    });
   });
 
   it("rejects calls without metadata fields", async () => {

--- a/packages/mcp-core/src/tools/catalog/update-project.ts
+++ b/packages/mcp-core/src/tools/catalog/update-project.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import { logIssue } from "../../telem/logging";
 import { UserInputError } from "../../errors";
 import type { ServerContext } from "../../types";
@@ -12,6 +13,15 @@ import {
   ParamProjectSlug,
   ParamPlatform,
 } from "../../schema";
+
+export const updateProjectOutputSchema = z.object({
+  project: z.object({
+    id: z.string(),
+    slug: z.string(),
+    name: z.string(),
+    platform: z.string().nullable(),
+  }),
+});
 
 export default defineTool({
   name: "update_project",
@@ -72,6 +82,7 @@ export default defineTool({
     idempotentHint: false,
     openWorldHint: true,
   },
+  outputSchema: updateProjectOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -111,28 +122,13 @@ export default defineTool({
       );
     }
 
-    let output = `# Updated Project in **${organizationSlug}**\n\n`;
-    output += `**ID**: ${project.id}\n`;
-    output += `**Slug**: ${project.slug}\n`;
-    output += `**Name**: ${project.name}\n`;
-    if (project.platform) {
-      output += `**Platform**: ${project.platform}\n`;
-    }
-
-    // Display what was updated
-    const updates: string[] = [];
-    if (params.name) updates.push(`name to "${params.name}"`);
-    if (params.slug) updates.push(`slug to "${params.slug}"`);
-    if (params.platform) updates.push(`platform to "${params.platform}"`);
-
-    if (updates.length > 0) {
-      output += `\n## Updates Applied\n`;
-      output += updates.map((update) => `- Updated ${update}`).join("\n");
-      output += `\n`;
-    }
-
-    output += "\n## Response Notes\n\n";
-    output += `- Project slug for later requests: \`${project.slug}\`\n`;
-    return output;
+    return structuredResult({
+      project: {
+        id: String(project.id),
+        slug: project.slug,
+        name: project.name,
+        platform: project.platform ?? null,
+      },
+    });
   },
 });


### PR DESCRIPTION
Migrate `update_project` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains the project state confirmed by Sentry after the update: stable string ID, slug, name, and nullable platform. Request echoes, applied-update prose, and response-note steering are removed.

The entire existing tool test file passes: 6 tests covering metadata updates, mixed-case slugs, validation, scoped-session restrictions, and annotations. TypeScript and lint pass.

Refs #1193