### PR TITLE
feat(tools): Structure add_team_to_project results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -76,6 +76,35 @@
       },
       "required": ["organizationSlug", "projectSlug", "teamSlug"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "changed": {
+          "type": "boolean"
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["id", "slug", "name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["changed", "teams"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["project:write", "team:read", "org:read"],
     "skills": ["project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/add-team-to-project.test.ts
+++ b/packages/mcp-core/src/tools/catalog/add-team-to-project.test.ts
@@ -1,6 +1,10 @@
 import { mswServer, teamFixture } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content";
 import { prepareToolParams } from "../catalog-runtime/availability";
 import { TOP_LEVEL_TOOL_NAMES } from "../surfaces";
 import addTeamToProject from "./add-team-to-project";
@@ -15,7 +19,7 @@ const context = {
   userId: "1",
 };
 
-function team(overrides: { id: string; slug: string; name: string }) {
+function team(overrides: { id: string | number; slug: string; name: string }) {
   return {
     ...teamFixture,
     ...overrides,
@@ -66,23 +70,23 @@ describe("add_team_to_project", () => {
 
     expect(listCalls).toBe(2);
     expect(postCalls).toBe(1);
-    expect(result).toMatchInlineSnapshot(`
-      "# Team Access Granted in **sentry-mcp-evals**
-
-      **Project**: cloudflare-mcp
-      **Team**: backend
-      **Result**: Team access was granted.
-
-      ## Current Project Teams
-
-      - **the-goats** (ID: 4509106740854784) - the-goats
-      - **backend** (ID: 4509109078196224) - Backend
-
-      ## Response Notes
-
-      - Project slug for later requests: \`cloudflare-mcp\`
-      - Current team slugs: \`the-goats\`, \`backend\`
-      "
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "changed": true,
+        "teams": [
+          {
+            "id": "4509106740854784",
+            "name": "the-goats",
+            "slug": "the-goats",
+          },
+          {
+            "id": "4509109078196224",
+            "name": "Backend",
+            "slug": "backend",
+          },
+        ],
+      }
     `);
   });
 
@@ -92,11 +96,15 @@ describe("add_team_to_project", () => {
       slug: "backend",
       name: "Backend",
     });
+    let listCalls = 0;
     let postCalls = 0;
     mswServer.use(
       http.get(
         "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/teams/",
-        () => HttpResponse.json([teamFixture, backendTeam]),
+        () => {
+          listCalls += 1;
+          return HttpResponse.json([teamFixture, backendTeam]);
+        },
       ),
       http.post(
         "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/teams/backend/",
@@ -120,12 +128,26 @@ describe("add_team_to_project", () => {
       context,
     );
 
+    expect(listCalls).toBe(1);
     expect(postCalls).toBe(0);
-    expect(result).toContain("# Team Already Assigned");
-    expect(result).toContain(
-      "No change was made because the team already had project access.",
-    );
-    expect(result).toContain("- **backend** (ID: 4509109078196224) - Backend");
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "changed": false,
+        "teams": [
+          {
+            "id": "4509106740854784",
+            "name": "the-goats",
+            "slug": "the-goats",
+          },
+          {
+            "id": "4509109078196224",
+            "name": "Backend",
+            "slug": "backend",
+          },
+        ],
+      }
+    `);
   });
 
   it("preserves mixed-case slugs and injects active constraints", async () => {
@@ -142,7 +164,7 @@ describe("add_team_to_project", () => {
               ? []
               : [
                   team({
-                    id: "99",
+                    id: 99,
                     slug: "TeamABC",
                     name: "Team ABC",
                   }),
@@ -189,7 +211,17 @@ describe("add_team_to_project", () => {
       "/api/0/projects/MyOrg/MyProject/teams/TeamABC/",
       "/api/0/projects/MyOrg/MyProject/teams/",
     ]);
-    expect(result).toContain("**Team**: TeamABC");
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      changed: true,
+      teams: [
+        {
+          id: "99",
+          slug: "TeamABC",
+          name: "Team ABC",
+        },
+      ],
+    });
   });
 
   it("is registered as catalog-only", () => {

--- a/packages/mcp-core/src/tools/catalog/add-team-to-project.ts
+++ b/packages/mcp-core/src/tools/catalog/add-team-to-project.ts
@@ -1,6 +1,8 @@
 import { setTag } from "@sentry/core";
+import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { Team } from "../../api-client/index";
 import type { ServerContext } from "../../types";
 import {
@@ -10,53 +12,23 @@ import {
   ParamTeamSlug,
 } from "../../schema";
 
-function formatProjectTeams(teams: Team[]): string {
-  if (teams.length === 0) {
-    return "No teams are currently assigned to this project.\n";
-  }
+const assignedTeamSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+});
 
-  return teams
-    .map((team) => `- **${team.slug}** (ID: ${team.id}) - ${team.name}`)
-    .join("\n");
-}
+export const addTeamToProjectOutputSchema = z.object({
+  changed: z.boolean(),
+  teams: z.array(assignedTeamSchema),
+});
 
-function formatTeamSlugs(teams: Team[]): string {
-  if (teams.length === 0) {
-    return "none";
-  }
-
-  return teams.map((team) => `\`${team.slug}\``).join(", ");
-}
-
-function formatResponse({
-  organizationSlug,
-  projectSlug,
-  teamSlug,
-  teams,
-  alreadyAssigned,
-}: {
-  organizationSlug: string;
-  projectSlug: string;
-  teamSlug: string;
-  teams: Team[];
-  alreadyAssigned: boolean;
-}): string {
-  let output = alreadyAssigned
-    ? `# Team Already Assigned in **${organizationSlug}**\n\n`
-    : `# Team Access Granted in **${organizationSlug}**\n\n`;
-  output += `**Project**: ${projectSlug}\n`;
-  output += `**Team**: ${teamSlug}\n`;
-  output += `**Result**: ${
-    alreadyAssigned
-      ? "No change was made because the team already had project access."
-      : "Team access was granted."
-  }\n\n`;
-  output += "## Current Project Teams\n\n";
-  output += formatProjectTeams(teams);
-  output += "\n\n## Response Notes\n\n";
-  output += `- Project slug for later requests: \`${projectSlug}\`\n`;
-  output += `- Current team slugs: ${formatTeamSlugs(teams)}\n`;
-  return output;
+function mapTeam(team: Team) {
+  return {
+    id: String(team.id),
+    slug: team.slug,
+    name: team.name,
+  };
 }
 
 export default defineTool({
@@ -92,6 +64,7 @@ export default defineTool({
     idempotentHint: true,
     openWorldHint: true,
   },
+  outputSchema: addTeamToProjectOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -111,12 +84,9 @@ export default defineTool({
     );
 
     if (alreadyAssigned) {
-      return formatResponse({
-        organizationSlug,
-        projectSlug: params.projectSlug,
-        teamSlug: params.teamSlug,
-        teams: currentTeams,
-        alreadyAssigned: true,
+      return structuredResult({
+        changed: false,
+        teams: currentTeams.map(mapTeam),
       });
     }
 
@@ -131,12 +101,9 @@ export default defineTool({
       projectSlug: params.projectSlug,
     });
 
-    return formatResponse({
-      organizationSlug,
-      projectSlug: params.projectSlug,
-      teamSlug: params.teamSlug,
-      teams: updatedTeams,
-      alreadyAssigned: false,
+    return structuredResult({
+      changed: true,
+      teams: updatedTeams.map(mapTeam),
     });
   },
 });


### PR DESCRIPTION
Migrate `add_team_to_project` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result uses the shared assignment contract: `changed` indicates whether a POST was required, and `teams` contains the confirmed current project team list with normalized string IDs, slugs, and names. Request scope and response-note steering are not duplicated.

The entire existing tool test file passes: 4 tests covering assignment, already-assigned behavior, mixed-case constraints, request counts, and catalog registration. TypeScript and lint pass.

Refs #1193