### PR TITLE
feat(tools): Structure remove_team_from_project results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -2269,6 +2269,35 @@
       },
       "required": ["organizationSlug", "projectSlug", "teamSlug"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "changed": {
+          "type": "boolean"
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["id", "slug", "name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["changed", "teams"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["project:write", "team:read", "org:read"],
     "skills": ["project-management"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/remove-team-from-project.test.ts
+++ b/packages/mcp-core/src/tools/catalog/remove-team-from-project.test.ts
@@ -2,6 +2,10 @@ import { mswServer, teamFixture } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import { UserInputError } from "../../errors";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content";
 import { prepareToolParams } from "../catalog-runtime/availability";
 import { TOP_LEVEL_TOOL_NAMES } from "../surfaces";
 import catalogTools from "./index";
@@ -16,7 +20,7 @@ const context = {
   userId: "1",
 };
 
-function team(overrides: { id: string; slug: string; name: string }) {
+function team(overrides: { id: string | number; slug: string; name: string }) {
   return {
     ...teamFixture,
     ...overrides,
@@ -67,22 +71,18 @@ describe("remove_team_from_project", () => {
 
     expect(listCalls).toBe(2);
     expect(deleteCalls).toBe(1);
-    expect(result).toMatchInlineSnapshot(`
-      "# Team Access Revoked in **sentry-mcp-evals**
-
-      **Project**: cloudflare-mcp
-      **Removed Team**: the-goats
-      **Result**: Team access was revoked.
-
-      ## Current Project Teams
-
-      - **backend** (ID: 4509109078196224) - Backend
-
-      ## Response Notes
-
-      - Project slug for later requests: \`cloudflare-mcp\`
-      - Current team slugs: \`backend\`
-      "
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "changed": true,
+        "teams": [
+          {
+            "id": "4509109078196224",
+            "name": "Backend",
+            "slug": "backend",
+          },
+        ],
+      }
     `);
   });
 
@@ -172,7 +172,7 @@ describe("remove_team_from_project", () => {
             listCalls === 1
               ? [
                   team({
-                    id: "99",
+                    id: 99,
                     slug: "TeamABC",
                     name: "Team ABC",
                   }),
@@ -224,7 +224,17 @@ describe("remove_team_from_project", () => {
       "/api/0/projects/MyOrg/MyProject/teams/TeamABC/",
       "/api/0/projects/MyOrg/MyProject/teams/",
     ]);
-    expect(result).toContain("**Removed Team**: TeamABC");
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      changed: true,
+      teams: [
+        {
+          id: "100",
+          slug: "OtherTeam",
+          name: "Other Team",
+        },
+      ],
+    });
   });
 
   it("is registered as catalog-only", () => {

--- a/packages/mcp-core/src/tools/catalog/remove-team-from-project.ts
+++ b/packages/mcp-core/src/tools/catalog/remove-team-from-project.ts
@@ -1,6 +1,8 @@
 import { setTag } from "@sentry/core";
+import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import { UserInputError } from "../../errors";
 import type { Team } from "../../api-client/index";
 import type { ServerContext } from "../../types";
@@ -11,45 +13,23 @@ import {
   ParamTeamSlug,
 } from "../../schema";
 
-function formatProjectTeams(teams: Team[]): string {
-  if (teams.length === 0) {
-    return "No teams are currently assigned to this project.\n";
-  }
+const assignedTeamSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+});
 
-  return teams
-    .map((team) => `- **${team.slug}** (ID: ${team.id}) - ${team.name}`)
-    .join("\n");
-}
+export const removeTeamFromProjectOutputSchema = z.object({
+  changed: z.boolean(),
+  teams: z.array(assignedTeamSchema),
+});
 
-function formatTeamSlugs(teams: Team[]): string {
-  if (teams.length === 0) {
-    return "none";
-  }
-
-  return teams.map((team) => `\`${team.slug}\``).join(", ");
-}
-
-function formatResponse({
-  organizationSlug,
-  projectSlug,
-  teamSlug,
-  teams,
-}: {
-  organizationSlug: string;
-  projectSlug: string;
-  teamSlug: string;
-  teams: Team[];
-}): string {
-  let output = `# Team Access Revoked in **${organizationSlug}**\n\n`;
-  output += `**Project**: ${projectSlug}\n`;
-  output += `**Removed Team**: ${teamSlug}\n`;
-  output += "**Result**: Team access was revoked.\n\n";
-  output += "## Current Project Teams\n\n";
-  output += formatProjectTeams(teams);
-  output += "\n\n## Response Notes\n\n";
-  output += `- Project slug for later requests: \`${projectSlug}\`\n`;
-  output += `- Current team slugs: ${formatTeamSlugs(teams)}\n`;
-  return output;
+function mapTeam(team: Team) {
+  return {
+    id: String(team.id),
+    slug: team.slug,
+    name: team.name,
+  };
 }
 
 export default defineTool({
@@ -86,6 +66,7 @@ export default defineTool({
     destructiveHint: true,
     openWorldHint: true,
   },
+  outputSchema: removeTeamFromProjectOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -127,11 +108,9 @@ export default defineTool({
       projectSlug: params.projectSlug,
     });
 
-    return formatResponse({
-      organizationSlug,
-      projectSlug: params.projectSlug,
-      teamSlug: params.teamSlug,
-      teams: updatedTeams,
+    return structuredResult({
+      changed: true,
+      teams: updatedTeams.map(mapTeam),
     });
   },
 });


### PR DESCRIPTION
Migrate `remove_team_from_project` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result matches `add_team_to_project`: `changed` reports the successful mutation and `teams` contains the confirmed current project team list with normalized string IDs, slugs, and names. Existing validation errors remain unchanged.

The entire existing tool test file passes: 5 tests covering successful removal, unassigned and last-team validation, request counts, mixed-case constraints, and catalog registration. TypeScript and lint pass.

Refs #1193