### PR TITLE
feat(tools): Structure find_organizations results

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -1503,8 +1503,9 @@ export class SentryApiService {
    *
    * @param params Query parameters
    * @param params.query Search query to filter organizations by name/slug
+   * @param params.limit Maximum number of organizations to return (defaults to 25)
    * @param opts Request options
-   * @returns Array of organizations across all accessible regions (limited to 25 results)
+   * @returns Array of organizations across all accessible regions
    *
    * @example
    * ```typescript
@@ -1516,12 +1517,14 @@ export class SentryApiService {
    * ```
    */
   async listOrganizations(
-    params?: { query?: string },
+    params?: { query?: string; limit?: number },
     opts?: RequestOptions,
   ): Promise<OrganizationList> {
+    const limit = params?.limit ?? 25;
+
     // Build query parameters
     const queryParams = new URLSearchParams();
-    queryParams.set("per_page", "25");
+    queryParams.set("per_page", String(limit));
     if (params?.query) {
       queryParams.set("query", params.query);
     }
@@ -1559,7 +1562,7 @@ export class SentryApiService {
         .reduce((acc, curr) => acc.concat(curr), []);
 
       // Apply the limit after combining results from all regions
-      return allOrganizations.slice(0, 25);
+      return allOrganizations.slice(0, limit);
     } catch (error) {
       // If regions endpoint fails (e.g., older self-hosted versions identifying as sentry.io),
       // fall back to direct organizations endpoint

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -306,7 +306,6 @@ describe("buildServer", () => {
       expect(toolNames).toContain("experimental_tool");
     });
 
-
     it("does not filter tools with experimental: false", () => {
       const server = buildServer({
         context: baseContext,
@@ -901,7 +900,6 @@ describe("buildServer", () => {
       );
     });
 
-
     it("keeps snapshot tools catalog-only while enforcing the inspect skill gate", async () => {
       const withoutInspect = buildServer({
         context: {
@@ -953,7 +951,6 @@ describe("buildServer", () => {
       expect(catalogToolNames).toContain("get_snapshot_image");
       expect(catalogToolNames).toContain("get_latest_base_snapshot");
     });
-
 
     it("exposes catalog tools with conservative safety annotations", async () => {
       const server = buildServer({
@@ -1260,7 +1257,19 @@ describe("buildServer", () => {
         arguments: {},
       });
 
-      expect(getTextContent(result)).toContain("# Organizations");
+      expect(getStructuredContent(result)).toEqual({
+        organizations: [
+          {
+            slug: "sentry-mcp-evals",
+            webUrl: "https://sentry.io/sentry-mcp-evals",
+            regionUrl: "https://us.sentry.io",
+          },
+        ],
+        hasMore: false,
+      });
+      expect(getTextContent(result)).toBe(
+        getGeneratedTextFromStructuredContent(result),
+      );
     });
 
     it("execute_sentry_tool dispatches to a catalog-only tool", async () => {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -572,6 +572,51 @@
         }
       }
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "organizations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": {
+                "type": "string"
+              },
+              "webUrl": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "regionUrl": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": ["slug", "webUrl", "regionUrl"],
+            "additionalProperties": false
+          }
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "required": ["organizations", "hasMore"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["org:read"],
     "skills": ["inspect", "seer", "docs", "triage", "project-management"],
     "surface": "direct"

--- a/packages/mcp-core/src/tools/catalog/find-organizations.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-organizations.test.ts
@@ -1,59 +1,137 @@
-import { describe, it, expect } from "vitest";
+import { mswServer } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SentryApiService } from "../../api-client/index.js";
+import { getServerContext } from "../../test-setup.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
 import findOrganizations from "./find-organizations.js";
 
+function mockOrganizations(organizations: unknown[]) {
+  mswServer.use(
+    http.get("https://sentry.io/api/0/users/me/regions/", () =>
+      HttpResponse.json({
+        regions: [{ name: "us", url: "https://us.sentry.io" }],
+      }),
+    ),
+    http.get("https://us.sentry.io/api/0/organizations/", ({ request }) => {
+      expect(new URL(request.url).searchParams.get("per_page")).toBe("26");
+      return HttpResponse.json(organizations);
+    }),
+  );
+}
+
 describe("find_organizations", () => {
-  it("serializes", async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns only the structured organization payload", async () => {
+    mockOrganizations([
+      {
+        id: "1",
+        slug: "cloud-org",
+        name: "Cloud Org",
+        links: {
+          organizationUrl: "https://sentry.io/cloud-org",
+          regionUrl: "https://us.sentry.io",
+        },
+      },
+      {
+        id: "2",
+        slug: "self-hosted-org",
+        name: "Self-hosted Org",
+      },
+    ]);
+
     const result = await findOrganizations.handler(
       { query: null },
-      {
-        constraints: {
-          organizationSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Organizations
 
-      ## **sentry-mcp-evals**
-
-      **Web URL:** https://sentry.io/sentry-mcp-evals
-      **Region URL:** https://us.sentry.io
-
-      ## Response Notes
-
-      - The organization slug is used as \`organizationSlug\` in other tools.
-      - The Region URL shown above is the \`regionUrl\` value for later tools that accept it. This keeps Sentry Cloud requests on the correct region.
-      "
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "hasMore": false,
+        "organizations": [
+          {
+            "regionUrl": "https://us.sentry.io",
+            "slug": "cloud-org",
+            "webUrl": "https://sentry.io/cloud-org",
+          },
+          {
+            "regionUrl": null,
+            "slug": "self-hosted-org",
+            "webUrl": null,
+          },
+        ],
+      }
     `);
+    assertStructuredOnlyResult(result);
   });
 
-  it("handles empty regionUrl parameter", async () => {
+  it("maps a whitespace-only region URL to null", async () => {
+    vi.spyOn(
+      SentryApiService.prototype,
+      "listOrganizations",
+    ).mockResolvedValueOnce([
+      {
+        id: "1",
+        slug: "whitespace-region-org",
+        name: "Whitespace Region Org",
+        links: {
+          organizationUrl: "https://sentry.io/whitespace-region-org",
+          regionUrl: " \t\n ",
+        },
+      },
+    ]);
+
     const result = await findOrganizations.handler(
       { query: null },
-      {
-        constraints: {
-          organizationSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toContain("Organizations");
+
+    expect(getStructuredContent(result)).toEqual({
+      organizations: [
+        {
+          slug: "whitespace-region-org",
+          webUrl: "https://sentry.io/whitespace-region-org",
+          regionUrl: null,
+        },
+      ],
+      hasMore: false,
+    });
+    assertStructuredOnlyResult(result);
   });
 
-  it("handles undefined regionUrl parameter", async () => {
+  it("requests 26 organizations and returns 25 with hasMore", async () => {
+    mockOrganizations(
+      Array.from({ length: 26 }, (_, index) => ({
+        id: String(index + 1),
+        slug: `organization-${index + 1}`,
+        name: `Organization ${index + 1}`,
+        links: {
+          organizationUrl: `https://sentry.io/organization-${index + 1}`,
+          regionUrl: "https://us.sentry.io",
+        },
+      })),
+    );
+
     const result = await findOrganizations.handler(
       { query: null },
-      {
-        constraints: {
-          organizationSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toContain("Organizations");
+    const structuredContent = getStructuredContent<{
+      organizations: Array<{ slug: string }>;
+      hasMore: boolean;
+    }>(result);
+
+    expect(structuredContent.organizations).toHaveLength(25);
+    expect(structuredContent.organizations.at(-1)?.slug).toBe(
+      "organization-25",
+    );
+    expect(structuredContent.hasMore).toBe(true);
+    assertStructuredOnlyResult(result);
   });
 });

--- a/packages/mcp-core/src/tools/catalog/find-organizations.ts
+++ b/packages/mcp-core/src/tools/catalog/find-organizations.ts
@@ -1,10 +1,27 @@
+import { z } from "zod";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { ServerContext } from "../../types";
 import { ParamSearchQuery } from "../../schema";
 import { ALL_SKILLS } from "../../skills";
 
 const RESULT_LIMIT = 25;
+
+export const findOrganizationsOutputSchema = z.object({
+  organizations: z.array(
+    z.object({
+      slug: z.string(),
+      webUrl: z.string().url().nullable(),
+      regionUrl: z.string().url().nullable(),
+    }),
+  ),
+  hasMore: z.boolean(),
+});
+
+function normalizeUrl(url: string | undefined): string | null {
+  return url?.trim() ? url : null;
+}
 
 export default defineTool({
   name: "find_organizations",
@@ -28,55 +45,25 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findOrganizationsOutputSchema,
   async handler(params, context: ServerContext) {
     // User data endpoints (like /users/me/regions/) should never use regionUrl
     // as they must always query the main API server, not region-specific servers
     const apiService = apiServiceFromContext(context);
     const organizations = await apiService.listOrganizations({
       query: params.query ?? undefined,
+      limit: RESULT_LIMIT + 1,
     });
 
-    let output = "# Organizations\n\n";
-
-    if (params.query) {
-      output += `**Search query:** "${params.query}"\n\n`;
-    }
-
-    if (organizations.length === 0) {
-      output += params.query
-        ? `No organizations found matching "${params.query}".\n`
-        : "You don't appear to be a member of any organizations.\n";
-      return output;
-    }
-
-    output += organizations
-      .map((org) =>
-        [
-          `## **${org.slug}**`,
-          "",
-          `**Web URL:** ${org.links?.organizationUrl || "Not available"}`,
-          `**Region URL:** ${org.links?.regionUrl || ""}`,
-        ].join("\n"),
-      )
-      .join("\n\n");
-
-    if (organizations.length === RESULT_LIMIT) {
-      output += `\n\n---\n\n**Note:** Showing ${RESULT_LIMIT} results (maximum). There may be more organizations available. Use the \`query\` parameter to search for specific organizations.`;
-    }
-
-    output += "\n\n## Response Notes\n\n";
-    output += `- The organization slug is used as \`organizationSlug\` in other tools.\n`;
-
-    const hasValidRegionUrls = organizations.some((org) =>
-      org.links?.regionUrl?.trim(),
-    );
-
-    if (hasValidRegionUrls) {
-      output += `- The Region URL shown above is the \`regionUrl\` value for later tools that accept it. This keeps Sentry Cloud requests on the correct region.\n`;
-    } else {
-      output += `- This appears to be a self-hosted Sentry installation. The \`regionUrl\` parameter can be omitted in other tools.\n`;
-    }
-
-    return output;
+    return structuredResult({
+      organizations: organizations
+        .slice(0, RESULT_LIMIT)
+        .map((organization) => ({
+          slug: organization.slug,
+          webUrl: normalizeUrl(organization.links?.organizationUrl),
+          regionUrl: normalizeUrl(organization.links?.regionUrl),
+        })),
+      hasMore: organizations.length > RESULT_LIMIT,
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_organizations` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains organization slugs, nullable web and region URLs, and an accurate `hasMore` flag. The tool requests 26 organizations, returns at most 25 across combined SaaS regions, and normalizes missing or blank URLs to `null` without broadening the upstream API schema.

The entire tool test file passes: 3 tests covering URL nullability, whitespace handling, `per_page=26`, and truncation. TypeScript and lint pass.

Refs #1193