### PR TITLE
feat(tools): Structure get_issue_tag_values results

### DIFF
--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -1678,6 +1678,72 @@
       },
       "required": ["tagKey"]
     },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "totalValues": {
+              "type": "number"
+            },
+            "topValues": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "count": {
+                    "type": "number"
+                  },
+                  "firstSeen": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "lastSeen": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": ["value", "count", "firstSeen", "lastSeen"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": ["key", "name", "totalValues", "topValues"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["tag"],
+      "additionalProperties": false
+    },
     "requiredScopes": ["event:read"],
     "skills": ["inspect"],
     "surface": "catalog"

--- a/packages/mcp-core/src/tools/catalog/get-issue-tag-values.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-tag-values.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { mswServer } from "@sentry/mcp-server-mocks";
-import getIssueTagValues from "./get-issue-tag-values.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
+import getIssueTagValues, {
+  getIssueTagValuesOutputSchema,
+} from "./get-issue-tag-values.js";
 import { getServerContext } from "../../test-setup.js";
 import { UserInputError } from "../../errors.js";
 
@@ -17,30 +23,52 @@ describe("get_issue_tag_values", () => {
       },
       getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Tag Distribution: Url
-
-      **Issue**: CLOUDFLARE-MCP-41
-      **Tag Key**: \`url\`
-      **Total Unique Values**: 156
-
-      ## Top Values
-
-      | Value | Count | First Seen | Last Seen |
-      |-------|-------|------------|----------|
-      | \`/upload/github/org/repo/commit/abc123\` | 45 | 2024-01-10 | 2024-01-15 |
-      | \`/api/v1/users/profile\` | 32 | 2024-01-11 | 2024-01-15 |
-      | \`/dashboard/overview\` | 28 | 2024-01-12 | 2024-01-15 |
-      | \`/settings/notifications\` | 21 | 2024-01-13 | 2024-01-14 |
-      | \`/checkout/payment\` | 15 | 2024-01-14 | 2024-01-14 |
-
-      *Showing top 5 of 156 unique values*
-
-      ## Response Notes
-
-      - Full issue details: \`get_sentry_resource(resourceType='issue', organizationSlug='sentry-mcp-evals', resourceId='CLOUDFLARE-MCP-41')\`
-      - Other common tag keys: url, browser, environment, release, os, device, user
-      "
+    assertStructuredOnlyResult(result);
+    expect(getIssueTagValues.outputSchema).toBe(getIssueTagValuesOutputSchema);
+    const structuredContent = getStructuredContent(result);
+    expect(getIssueTagValuesOutputSchema.parse(structuredContent)).toEqual(
+      structuredContent,
+    );
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "tag": {
+          "key": "url",
+          "name": "Url",
+          "topValues": [
+            {
+              "count": 45,
+              "firstSeen": "2024-01-10T08:00:00.000Z",
+              "lastSeen": "2024-01-15T10:30:00.000Z",
+              "value": "/upload/github/org/repo/commit/abc123",
+            },
+            {
+              "count": 32,
+              "firstSeen": "2024-01-11T14:20:00.000Z",
+              "lastSeen": "2024-01-15T09:45:00.000Z",
+              "value": "/api/v1/users/profile",
+            },
+            {
+              "count": 28,
+              "firstSeen": "2024-01-12T11:30:00.000Z",
+              "lastSeen": "2024-01-15T08:15:00.000Z",
+              "value": "/dashboard/overview",
+            },
+            {
+              "count": 21,
+              "firstSeen": "2024-01-13T16:45:00.000Z",
+              "lastSeen": "2024-01-14T22:00:00.000Z",
+              "value": "/settings/notifications",
+            },
+            {
+              "count": 15,
+              "firstSeen": "2024-01-14T10:00:00.000Z",
+              "lastSeen": "2024-01-14T18:30:00.000Z",
+              "value": "/checkout/payment",
+            },
+          ],
+          "totalValues": 156,
+        },
+      }
     `);
   });
 
@@ -56,8 +84,14 @@ describe("get_issue_tag_values", () => {
       },
       getServerContext(),
     );
-    expect(result).toContain("# Tag Distribution: Browser");
-    expect(result).toContain("**Tag Key**: `browser`");
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchObject({
+      tag: {
+        key: "browser",
+        name: "Browser",
+        totalValues: 156,
+      },
+    });
   });
 
   it("rejects issues outside the active project constraint", async () => {
@@ -180,8 +214,8 @@ describe("get_issue_tag_values", () => {
                 name: null,
                 value: null,
                 count: 5,
-                lastSeen: "2024-01-14T09:00:00.000Z",
-                firstSeen: "2024-01-12T14:00:00.000Z",
+                lastSeen: null,
+                firstSeen: null,
               },
             ],
           });
@@ -200,10 +234,27 @@ describe("get_issue_tag_values", () => {
       getServerContext(),
     );
 
-    // Verify the output handles null values by displaying "(null)"
-    expect(result).toContain("# Tag Distribution: Custom Tag");
-    expect(result).toContain("`valid_value`");
-    expect(result).toContain("`(null)`");
-    expect(result).toContain("| 5 |"); // The null value entry should have count 5
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      tag: {
+        key: "custom_tag",
+        name: "Custom Tag",
+        totalValues: 2,
+        topValues: [
+          {
+            value: "valid_value",
+            count: 10,
+            firstSeen: "2024-01-10T08:00:00.000Z",
+            lastSeen: "2024-01-15T10:30:00.000Z",
+          },
+          {
+            value: null,
+            count: 5,
+            firstSeen: null,
+            lastSeen: null,
+          },
+        ],
+      },
+    });
   });
 });

--- a/packages/mcp-core/src/tools/catalog/get-issue-tag-values.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-tag-values.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import {
   ensureIssueWithinProjectConstraint,
   parseIssueParams,
@@ -16,6 +17,22 @@ import {
   ParamIssueShortId,
   ParamIssueUrl,
 } from "../../schema";
+
+export const getIssueTagValuesOutputSchema = z.object({
+  tag: z.object({
+    key: z.string(),
+    name: z.string(),
+    totalValues: z.number(),
+    topValues: z.array(
+      z.object({
+        value: z.string().nullable(),
+        count: z.number(),
+        firstSeen: z.string().nullable(),
+        lastSeen: z.string().nullable(),
+      }),
+    ),
+  }),
+});
 
 export default defineTool({
   name: "get_issue_tag_values",
@@ -84,6 +101,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: getIssueTagValuesOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -143,52 +161,18 @@ export default defineTool({
       throw error;
     }
 
-    // Format the output
-    let output = `# Tag Distribution: ${tagValues.name}\n\n`;
-    output += `**Issue**: ${parsedIssueId}\n`;
-    output += `**Tag Key**: \`${tagValues.key}\`\n`;
-    output += `**Total Unique Values**: ${tagValues.totalValues}\n\n`;
-
-    if (tagValues.topValues.length === 0) {
-      output += "No values found for this tag.\n";
-      return output;
-    }
-
-    output += "## Top Values\n\n";
-    output += "| Value | Count | First Seen | Last Seen |\n";
-    output += "|-------|-------|------------|----------|\n";
-
-    for (const value of tagValues.topValues) {
-      const firstSeen = value.firstSeen
-        ? new Date(value.firstSeen).toISOString().split("T")[0]
-        : "-";
-      const lastSeen = value.lastSeen
-        ? new Date(value.lastSeen).toISOString().split("T")[0]
-        : "-";
-      // Handle null values (can occur with certain tag types)
-      const rawValue = value.value ?? "(null)";
-      // Truncate long values for readability
-      let displayValue =
-        rawValue.length > 60 ? `${rawValue.substring(0, 57)}...` : rawValue;
-      // Escape markdown table special characters (backslashes first)
-      displayValue = displayValue
-        .replace(/\\/g, "\\\\")
-        .replace(/\|/g, "\\|")
-        .replace(/`/g, "\\`")
-        .replace(/\n/g, " ");
-      output += `| \`${displayValue}\` | ${value.count} | ${firstSeen} | ${lastSeen} |\n`;
-    }
-
-    if (tagValues.topValues.length > 0 && tagValues.totalValues > 0) {
-      const shownCount = tagValues.topValues.length;
-      output += `\n*Showing top ${shownCount} of ${tagValues.totalValues} unique values*\n`;
-    }
-
-    // Add lightweight follow-up hints
-    output += "\n## Response Notes\n\n";
-    output += `- Full issue details: \`get_sentry_resource(resourceType='issue', organizationSlug='${orgSlug}', resourceId='${parsedIssueId}')\`\n`;
-    output += `- Other common tag keys: url, browser, environment, release, os, device, user\n`;
-
-    return output;
+    return structuredResult({
+      tag: {
+        key: tagValues.key,
+        name: tagValues.name,
+        totalValues: tagValues.totalValues,
+        topValues: tagValues.topValues.map((tagValue) => ({
+          value: tagValue.value,
+          count: tagValue.count,
+          firstSeen: tagValue.firstSeen ?? null,
+          lastSeen: tagValue.lastSeen ?? null,
+        })),
+      },
+    });
   },
 });


### PR DESCRIPTION
Migrate `get_issue_tag_values` from handwritten markdown to a minimal structured result with a declared `outputSchema`.

The result contains the tag key, display name, total unique value count, and top values with counts and full nullable first/last-seen timestamps. Issue scope, markdown display truncation, and response-note steering are not duplicated.

A verification subagent ran the entire tool test file: 9 tests passed. TypeScript and lint pass, and generated definitions were refreshed after rebasing onto current `main`.

Refs #1193