### PR TITLE
feat(tools): Structure find_alert_rules results

### DIFF
--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -9,7 +9,7 @@
     "tools": [
       {
         "name": "find_alert_rules",
-        "description": "Find Sentry alert rules.\n\nUse this tool when you need to:\n- List issue alert rules for a project\n- List metric alert rules for an organization or project\n- Find an alert rule ID by name before inspecting it\n- Check alert conditions, queries, triggers, actions, owner, or environment\n\n<examples>\nfind_alert_rules(organizationSlug='my-org')\nfind_alert_rules(organizationSlug='my-org', projectSlug='backend')\nfind_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')\n</examples>\n\n<hints>\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n- Metric alert rules can be listed organization-wide or project-scoped.\n</hints>",
+        "description": "Find Sentry alert rules.\n\nUse this tool when you need to:\n- List issue alert rules for a project\n- List metric alert rules for an organization or project\n- Find an alert rule ID by name before inspecting it\n- Check alert conditions, queries, triggers, actions, owner, or environment\n\n<examples>\nfind_alert_rules(organizationSlug='my-org')\nfind_alert_rules(organizationSlug='my-org', projectSlug='backend')\nfind_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')\n</examples>\n\n<hints>\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n- Metric alert rules can be listed organization-wide or project-scoped.\n- Issue and metric alert rules have independent pagination state. Reuse a nextCursor only with its matching kind.\n</hints>",
         "requiredScopes": ["org:read", "project:read"]
       },
       {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -368,7 +368,7 @@
   },
   {
     "name": "find_alert_rules",
-    "description": "Find Sentry alert rules.\n\nUse this tool when you need to:\n- List issue alert rules for a project\n- List metric alert rules for an organization or project\n- Find an alert rule ID by name before inspecting it\n- Check alert conditions, queries, triggers, actions, owner, or environment\n\n<examples>\nfind_alert_rules(organizationSlug='my-org')\nfind_alert_rules(organizationSlug='my-org', projectSlug='backend')\nfind_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')\n</examples>\n\n<hints>\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n- Metric alert rules can be listed organization-wide or project-scoped.\n</hints>",
+    "description": "Find Sentry alert rules.\n\nUse this tool when you need to:\n- List issue alert rules for a project\n- List metric alert rules for an organization or project\n- Find an alert rule ID by name before inspecting it\n- Check alert conditions, queries, triggers, actions, owner, or environment\n\n<examples>\nfind_alert_rules(organizationSlug='my-org')\nfind_alert_rules(organizationSlug='my-org', projectSlug='backend')\nfind_alert_rules(organizationSlug='my-org', kind='issue', projectSlug='backend', query='critical')\n</examples>\n\n<hints>\n- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.\n- Metric alert rules can be listed organization-wide or project-scoped.\n- Issue and metric alert rules have independent pagination state. Reuse a nextCursor only with its matching kind.\n</hints>",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -439,6 +439,315 @@
         }
       },
       "required": ["organizationSlug"]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "issueRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "actionMatch": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "filterMatch": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "frequencyMinutes": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "environment": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "owner": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "dateCreated": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "dateUpdated": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "lastTriggered": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "webUrl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "status",
+              "actionMatch",
+              "filterMatch",
+              "frequencyMinutes",
+              "environment",
+              "owner",
+              "dateCreated",
+              "dateUpdated",
+              "lastTriggered",
+              "webUrl"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "metricRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "dataset": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "aggregate": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "query": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "timeWindowMinutes": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "projects": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "environment": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "owner": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "dateCreated": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "webUrl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "status",
+              "dataset",
+              "aggregate",
+              "query",
+              "timeWindowMinutes",
+              "projects",
+              "environment",
+              "owner",
+              "dateCreated",
+              "webUrl"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "issue": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "nextCursor": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["nextCursor"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "metric": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "nextCursor": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["nextCursor"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": ["issue", "metric"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["issueRules", "metricRules", "pagination"],
+      "additionalProperties": false
     },
     "requiredScopes": ["org:read", "project:read"],
     "skills": ["inspect"],

--- a/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-alert-rules.test.ts
@@ -1,7 +1,13 @@
 import { mswServer } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
-import findAlertRules from "./find-alert-rules.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content";
+import findAlertRules, {
+  findAlertRulesOutputSchema,
+} from "./find-alert-rules.js";
 
 const context = {
   constraints: {
@@ -146,46 +152,56 @@ describe("find_alert_rules", () => {
     expect(new URL(metricRequestUrl ?? "").searchParams.get("project")).toBe(
       project.id,
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Alert Rules in **sentry-mcp-evals/cloudflare-mcp**
-
-      ## Issue Alert Rules
-
-      ### Notify backend team
-
-      **Kind**: Issue Alert
-      **ID**: 123
-      **Project**: cloudflare-mcp
-      **Status**: enabled
-      **Frequency**: 30 minutes
-      **Environment**: production
-      **Owner**: team:backend
-      **Created**: 2026-01-02T03:04:05.000Z
-      **Updated**: 2026-01-02T04:04:05.000Z
-      **URL**: https://sentry-mcp-evals.sentry.io/monitors/alerts/123/
-
-      ## Metric Alert Rules
-
-      ### P95 latency
-
-      **Kind**: Metric Alert
-      **ID**: 456
-      **Status**: 0
-      **Dataset**: transactions
-      **Aggregate**: p95(transaction.duration)
-      **Query**: environment:production
-      **Time Window**: 5 minutes
-      **Projects**: cloudflare-mcp
-      **Environment**: production
-      **Owner**: team:backend
-      **Created**: 2026-01-03T03:04:05.000Z
-      **URL**: https://sentry-mcp-evals.sentry.io/issues/alerts/rules/details/456/
-
-      ## Response Notes
-
-      - Use \`get_alert_rule\` with \`kind\` and the numeric rule ID for full details.
-      - Use full details to inspect alert conditions, filters, and notification actions before changing a rule in Sentry.
-      "
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(findAlertRulesOutputSchema.parse(structuredContent)).toEqual(
+      structuredContent,
+    );
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "issueRules": [
+          {
+            "actionMatch": null,
+            "dateCreated": "2026-01-02T03:04:05.000Z",
+            "dateUpdated": "2026-01-02T04:04:05.000Z",
+            "environment": "production",
+            "filterMatch": null,
+            "frequencyMinutes": 30,
+            "id": "123",
+            "lastTriggered": null,
+            "name": "Notify backend team",
+            "owner": "team:backend",
+            "status": "enabled",
+            "webUrl": "https://sentry-mcp-evals.sentry.io/monitors/alerts/123/",
+          },
+        ],
+        "metricRules": [
+          {
+            "aggregate": "p95(transaction.duration)",
+            "dataset": "transactions",
+            "dateCreated": "2026-01-03T03:04:05.000Z",
+            "environment": "production",
+            "id": "456",
+            "name": "P95 latency",
+            "owner": "team:backend",
+            "projects": [
+              "cloudflare-mcp",
+            ],
+            "query": "environment:production",
+            "status": 0,
+            "timeWindowMinutes": 5,
+            "webUrl": "https://sentry-mcp-evals.sentry.io/issues/alerts/rules/details/456/",
+          },
+        ],
+        "pagination": {
+          "issue": {
+            "nextCursor": null,
+          },
+          "metric": {
+            "nextCursor": null,
+          },
+        },
+      }
     `);
   });
 
@@ -205,11 +221,14 @@ describe("find_alert_rules", () => {
       context,
     );
 
-    expect(result).toContain("## Metric Alert Rules");
-    expect(result).not.toContain("## Issue Alert Rules");
-    expect(result).toContain(
-      "Issue alert rules are project-scoped; pass `projectSlug` to include them.",
-    );
+    expect(getStructuredContent(result)).toMatchObject({
+      issueRules: [],
+      metricRules: [{ id: "456", name: "P95 latency" }],
+      pagination: {
+        issue: null,
+        metric: { nextCursor: null },
+      },
+    });
   });
 
   it("resolves project redirects before listing metric alerts", async () => {
@@ -274,9 +293,10 @@ describe("find_alert_rules", () => {
       context,
     );
 
-    expect(result).toContain(
-      'More issue alert rules are available. Pass `kind: "issue"` and `cursor: "issue-page-2"`',
-    );
+    expect(getStructuredContent(result).pagination).toEqual({
+      issue: { nextCursor: "issue-page-2" },
+      metric: null,
+    });
   });
 
   it("uses workflows for issue query searches and combined-rules for metric query searches", async () => {
@@ -313,8 +333,13 @@ describe("find_alert_rules", () => {
       context,
     );
 
-    expect(result).toContain("Notify backend team");
-    expect(result).toContain("P95 latency");
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent.issueRules).toMatchObject([
+      { id: "123", name: "Notify backend team" },
+    ]);
+    expect(structuredContent.metricRules).toMatchObject([
+      { id: "456", name: "P95 latency" },
+    ]);
     expect(issueRequestUrl).not.toBeNull();
     const issueParams = new URL(issueRequestUrl ?? "").searchParams;
     expect(issueParams.get("query")).toBe('name:"*backend*"');
@@ -358,8 +383,9 @@ describe("find_alert_rules", () => {
       context,
     );
 
-    expect(result).toContain("Notify backend team");
-    expect(result).not.toContain("Organization workflow");
+    expect(getStructuredContent(result).issueRules).toMatchObject([
+      { id: "123", name: "Notify backend team" },
+    ]);
   });
 
   it("follows workflow pages until enough attached issue rules are found", async () => {
@@ -409,8 +435,9 @@ describe("find_alert_rules", () => {
     expect(new URL(requestUrls[1]).searchParams.get("cursor")).toBe(
       "workflow-page-2",
     );
-    expect(result).toContain("Notify backend team");
-    expect(result).not.toContain("Organization workflow");
+    expect(getStructuredContent(result).issueRules).toMatchObject([
+      { id: "123", name: "Notify backend team" },
+    ]);
   });
 
   it("does not expose a workflow cursor when an overfull page is capped", async () => {
@@ -449,29 +476,33 @@ describe("find_alert_rules", () => {
       context,
     );
 
-    expect(result).toMatchInlineSnapshot(`
-      "# Alert Rules in **sentry-mcp-evals/cloudflare-mcp**
-
-      ## Issue Alert Rules
-
-      ### Notify backend team
-
-      **Kind**: Issue Alert
-      **ID**: 123
-      **Project**: cloudflare-mcp
-      **Status**: enabled
-      **Frequency**: 30 minutes
-      **Environment**: production
-      **Owner**: team:backend
-      **Created**: 2026-01-02T03:04:05.000Z
-      **Updated**: 2026-01-02T04:04:05.000Z
-      **URL**: https://sentry-mcp-evals.sentry.io/monitors/alerts/123/
-
-      ## Response Notes
-
-      - Use \`get_alert_rule\` with \`kind\` and the numeric rule ID for full details.
-      - Use full details to inspect alert conditions, filters, and notification actions before changing a rule in Sentry.
-      "
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchInlineSnapshot(`
+      {
+        "issueRules": [
+          {
+            "actionMatch": null,
+            "dateCreated": "2026-01-02T03:04:05.000Z",
+            "dateUpdated": "2026-01-02T04:04:05.000Z",
+            "environment": "production",
+            "filterMatch": null,
+            "frequencyMinutes": 30,
+            "id": "123",
+            "lastTriggered": null,
+            "name": "Notify backend team",
+            "owner": "team:backend",
+            "status": "enabled",
+            "webUrl": "https://sentry-mcp-evals.sentry.io/monitors/alerts/123/",
+          },
+        ],
+        "metricRules": [],
+        "pagination": {
+          "issue": {
+            "nextCursor": null,
+          },
+          "metric": null,
+        },
+      }
     `);
   });
 
@@ -507,10 +538,13 @@ describe("find_alert_rules", () => {
       context,
     );
 
-    expect(result).toContain("P95 latency");
-    expect(result).toContain(
-      'More metric alert rules are available. Pass `kind: "metric"` and `cursor: "metric-query-page-2"`',
-    );
+    expect(getStructuredContent(result)).toMatchObject({
+      metricRules: [{ id: "456", name: "P95 latency" }],
+      pagination: {
+        issue: null,
+        metric: { nextCursor: "metric-query-page-2" },
+      },
+    });
   });
 
   it("rejects issue alert search without a project", async () => {

--- a/packages/mcp-core/src/tools/catalog/find-alert-rules.ts
+++ b/packages/mcp-core/src/tools/catalog/find-alert-rules.ts
@@ -2,21 +2,88 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import { UserInputError } from "../../errors";
 import type { ServerContext } from "../../types";
+import type { IssueAlertRule, MetricAlertRule } from "../../api-client/types";
 import {
   ParamOrganizationSlug,
   ParamProjectSlugOrAll,
   ParamRegionUrl,
 } from "../../schema";
 import { assertProjectRefWithinConstraint } from "./support/project-constraints";
-import { formatIssueAlertRule, formatMetricAlertRule } from "./support/alerts";
+import { formatActor, formatDate } from "./support/api-formatting";
 
 const AlertRuleKind = z
   .enum(["all", "issue", "metric"])
   .describe(
     "Which alert rule family to search. Use `all` to include metric alerts, plus issue alerts when a project is available.",
   );
+
+const issueAlertRuleSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string().nullable(),
+  actionMatch: z.string().nullable(),
+  filterMatch: z.string().nullable(),
+  frequencyMinutes: z.number().nullable(),
+  environment: z.string().nullable(),
+  owner: z.string().nullable(),
+  dateCreated: z.string().nullable(),
+  dateUpdated: z.string().nullable(),
+  lastTriggered: z.string().nullable(),
+  webUrl: z.string(),
+});
+
+const metricAlertRuleSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.union([z.string(), z.number()]).nullable(),
+  dataset: z.string().nullable(),
+  aggregate: z.string().nullable(),
+  query: z.string().nullable(),
+  timeWindowMinutes: z.number().nullable(),
+  projects: z.array(z.string()),
+  environment: z.string().nullable(),
+  owner: z.string().nullable(),
+  dateCreated: z.string().nullable(),
+  webUrl: z.string(),
+});
+
+const paginationStateSchema = z.object({
+  nextCursor: z.string().nullable(),
+});
+
+export const findAlertRulesOutputSchema = z.object({
+  issueRules: z.array(issueAlertRuleSummarySchema),
+  metricRules: z.array(metricAlertRuleSummarySchema),
+  pagination: z.object({
+    issue: paginationStateSchema.nullable(),
+    metric: paginationStateSchema.nullable(),
+  }),
+});
+
+function getIssueAlertRuleFrequency(rule: IssueAlertRule): number | null {
+  if (typeof rule.frequency === "number") {
+    return rule.frequency;
+  }
+  const frequency = rule.config.frequency;
+  return typeof frequency === "number" ? frequency : null;
+}
+
+function getIssueAlertRuleStatus(rule: IssueAlertRule): string | null {
+  if (rule.status) {
+    return rule.status;
+  }
+  if (rule.enabled === undefined) {
+    return null;
+  }
+  return rule.enabled ? "enabled" : "disabled";
+}
+
+function getOwner(owner: unknown): string | null {
+  return owner ? formatActor(owner) : null;
+}
 
 export default defineTool({
   name: "find_alert_rules",
@@ -40,6 +107,7 @@ export default defineTool({
     "<hints>",
     "- Issue alert rules are project-scoped, so `projectSlug` is required when `kind` is `issue`.",
     "- Metric alert rules can be listed organization-wide or project-scoped.",
+    "- Issue and metric alert rules have independent pagination state. Reuse a nextCursor only with its matching kind.",
     "</hints>",
   ].join("\n"),
   inputSchema: {
@@ -74,6 +142,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findAlertRulesOutputSchema,
   async handler(params, context: ServerContext) {
     const requestedProjectSlug =
       params.projectSlug && params.projectSlug !== "all"
@@ -129,67 +198,39 @@ export default defineTool({
           limit: params.limit,
         })
       : { rules: [], nextCursor: null };
-    const issueRules = issuePage.rules;
-    const metricRules = metricPage.rules;
-
-    const scopeLabel = projectSlug
-      ? `${organizationSlug}/${projectSlug}`
-      : organizationSlug;
-    let output = `# Alert Rules in **${scopeLabel}**\n\n`;
-    if (issueRules.length === 0 && metricRules.length === 0) {
-      output += "No alert rules found.\n";
-      if (params.kind === "all" && !projectSlug) {
-        output +=
-          "\nIssue alert rules are project-scoped; pass `projectSlug` to include them.\n";
-      }
-      return output;
-    }
-
-    if (issueRules.length > 0) {
-      output += "## Issue Alert Rules\n\n";
-      output += issueRules
-        .slice(0, params.limit)
-        .map((rule) =>
-          formatIssueAlertRule(rule, projectSlug ?? "", {
-            headingLevel: 3,
-            includeComponents: false,
-            url: apiService.getIssueAlertRuleUrl(organizationSlug, rule.id),
-          }),
-        )
-        .join("\n\n");
-      output += "\n\n";
-    }
-
-    if (metricRules.length > 0) {
-      output += "## Metric Alert Rules\n\n";
-      output += metricRules
-        .slice(0, params.limit)
-        .map((rule) =>
-          formatMetricAlertRule(rule, {
-            headingLevel: 3,
-            includeComponents: false,
-            url: apiService.getMetricAlertRuleUrl(organizationSlug, rule.id),
-          }),
-        )
-        .join("\n\n");
-      output += "\n\n";
-    }
-
-    output += "## Response Notes\n\n";
-    output +=
-      "- Use `get_alert_rule` with `kind` and the numeric rule ID for full details.\n";
-    output +=
-      "- Use full details to inspect alert conditions, filters, and notification actions before changing a rule in Sentry.\n";
-    if (issuePage.nextCursor) {
-      output += `- More issue alert rules are available. Pass \`kind: "issue"\` and \`cursor: "${issuePage.nextCursor}"\` with the same search scope to fetch the next page.\n`;
-    }
-    if (metricPage.nextCursor) {
-      output += `- More metric alert rules are available. Pass \`kind: "metric"\` and \`cursor: "${metricPage.nextCursor}"\` with the same search scope to fetch the next page.\n`;
-    }
-    if (params.kind === "all" && !projectSlug) {
-      output +=
-        "- Issue alert rules are project-scoped; pass `projectSlug` to include them.\n";
-    }
-    return output;
+    return structuredResult({
+      issueRules: issuePage.rules.map((rule: IssueAlertRule) => ({
+        id: String(rule.id),
+        name: rule.name,
+        status: getIssueAlertRuleStatus(rule),
+        actionMatch: rule.actionMatch ?? null,
+        filterMatch: rule.filterMatch ?? null,
+        frequencyMinutes: getIssueAlertRuleFrequency(rule),
+        environment: rule.environment ?? null,
+        owner: getOwner(rule.owner),
+        dateCreated: formatDate(rule.dateCreated),
+        dateUpdated: formatDate(rule.dateUpdated),
+        lastTriggered: formatDate(rule.lastTriggered),
+        webUrl: apiService.getIssueAlertRuleUrl(organizationSlug, rule.id),
+      })),
+      metricRules: metricPage.rules.map((rule: MetricAlertRule) => ({
+        id: String(rule.id),
+        name: rule.name,
+        status: rule.status ?? null,
+        dataset: rule.dataset ?? null,
+        aggregate: rule.aggregate ?? null,
+        query: rule.query ?? null,
+        timeWindowMinutes: rule.timeWindow ?? null,
+        projects: rule.projects,
+        environment: rule.environment ?? null,
+        owner: getOwner(rule.owner),
+        dateCreated: formatDate(rule.dateCreated),
+        webUrl: apiService.getMetricAlertRuleUrl(organizationSlug, rule.id),
+      })),
+      pagination: {
+        issue: includeIssue ? { nextCursor: issuePage.nextCursor } : null,
+        metric: includeMetric ? { nextCursor: metricPage.nextCursor } : null,
+      },
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_alert_rules` from handwritten markdown to a structured result with a declared `outputSchema`.

The result contains stable issue and metric alert summaries with independent pagination state for each kind. This keeps the different rule models explicit while removing scope echoes and handwritten cursor instructions.

The implementation subagent ran the entire test file: 11 tests passed and two inline snapshots were updated. The branch was reviewed, formatted, committed, and rebased onto current `main`.

Refs #1193