### PR TITLE
feat(tools): Structure find_monitors results

### DIFF
--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -19,7 +19,7 @@
       },
       {
         "name": "find_monitors",
-        "description": "Find Sentry cron monitors.\n\nUse this tool when you need to:\n- List cron monitors in an organization\n- Find a monitor by name or slug before getting details\n- Check monitor status, owner, project, schedule, or recent environment state\n\n<examples>\nfind_monitors(organizationSlug='my-organization')\nfind_monitors(organizationSlug='my-organization', projectSlug='backend', query='billing')\n</examples>",
+        "description": "Find Sentry cron monitors.\n\nUse this tool when you need to:\n- List cron monitors in an organization\n- Find a monitor by name or slug before getting details\n- Check monitor status, owner, project, schedule, or recent environment state\n- When `hasMore` is true, narrow the results with project, environment, owner, or query filters\n\n<examples>\nfind_monitors(organizationSlug='my-organization')\nfind_monitors(organizationSlug='my-organization', projectSlug='backend', query='billing')\n</examples>",
         "requiredScopes": ["org:read"]
       },
       {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -989,7 +989,7 @@
   },
   {
     "name": "find_monitors",
-    "description": "Find Sentry cron monitors.\n\nUse this tool when you need to:\n- List cron monitors in an organization\n- Find a monitor by name or slug before getting details\n- Check monitor status, owner, project, schedule, or recent environment state\n\n<examples>\nfind_monitors(organizationSlug='my-organization')\nfind_monitors(organizationSlug='my-organization', projectSlug='backend', query='billing')\n</examples>",
+    "description": "Find Sentry cron monitors.\n\nUse this tool when you need to:\n- List cron monitors in an organization\n- Find a monitor by name or slug before getting details\n- Check monitor status, owner, project, schedule, or recent environment state\n- When `hasMore` is true, narrow the results with project, environment, owner, or query filters\n\n<examples>\nfind_monitors(organizationSlug='my-organization')\nfind_monitors(organizationSlug='my-organization', projectSlug='backend', query='billing')\n</examples>",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1061,11 +1061,222 @@
           "default": 10,
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 100,
+          "maximum": 99,
           "description": "Maximum number of monitors to return."
         }
       },
       "required": ["organizationSlug"]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "monitors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "slug": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "projectSlug": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "owner": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "lastCheckIn": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "nextCheckIn": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "webUrl": {
+                "type": "string",
+                "format": "uri"
+              },
+              "schedule": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "checkInMargin": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "maxRuntime": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "value",
+                      "checkInMargin",
+                      "maxRuntime"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "environments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "status": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "lastCheckIn": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["name", "status", "lastCheckIn"],
+                  "additionalProperties": false
+                }
+              },
+              "hasMoreEnvironments": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "slug",
+              "name",
+              "projectSlug",
+              "status",
+              "owner",
+              "lastCheckIn",
+              "nextCheckIn",
+              "webUrl",
+              "schedule",
+              "environments",
+              "hasMoreEnvironments"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "required": ["monitors", "hasMore"],
+      "additionalProperties": false
     },
     "requiredScopes": ["org:read"],
     "skills": ["inspect"],

--- a/packages/mcp-core/src/tools/catalog/find-monitors.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-monitors.test.ts
@@ -1,7 +1,11 @@
 import { mswServer } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
-import findMonitors from "./find-monitors.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
+import findMonitors, { findMonitorsOutputSchema } from "./find-monitors.js";
 
 const context = {
   constraints: {
@@ -26,37 +30,47 @@ describe("find_monitors", () => {
       context,
     );
 
-    expect(result).toMatchInlineSnapshot(`
-      "# Cron Monitors in **sentry-mcp-evals**
-
-      ## Nightly Import
-
-      **Slug**: nightly-import
-      **ID**: 4509100000000001
-      **Project**: cloudflare-mcp
-      **Status**: ok
-      **Owner**: the-goats
-      **Last Check-In**: 2025-04-14T02:00:13.000Z
-      **Next Check-In**: 2025-04-15T02:00:00.000Z
-      **URL**: [Open Monitor](https://sentry-mcp-evals.sentry.io/crons/cloudflare-mcp/nightly-import/)
-
-      ### Schedule
-
-      **schedule**: ["crontab","0 2 * * *"]
-      **schedule_type**: crontab
-      **checkin_margin**: 5
-      **max_runtime**: 30
-
-      ### Environments
-
-      - production - ok (last check-in 2025-04-14T02:00:13.000Z)
-      - staging - missed_checkin (last check-in 2025-04-13T02:00:18.000Z)
-
-      ## Response Notes
-
-      - Use \`get_monitor_details\` with a monitor slug for check-ins and stats.
-      - Monitor issue searches commonly use \`monitor.slug:<slug>\`.
-      "
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(findMonitorsOutputSchema.parse(structuredContent)).toEqual(
+      structuredContent,
+    );
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "hasMore": false,
+        "monitors": [
+          {
+            "environments": [
+              {
+                "lastCheckIn": "2025-04-14T02:00:13.000Z",
+                "name": "production",
+                "status": "ok",
+              },
+              {
+                "lastCheckIn": "2025-04-13T02:00:18.000Z",
+                "name": "staging",
+                "status": "missed_checkin",
+              },
+            ],
+            "hasMoreEnvironments": false,
+            "id": "4509100000000001",
+            "lastCheckIn": "2025-04-14T02:00:13.000Z",
+            "name": "Nightly Import",
+            "nextCheckIn": "2025-04-15T02:00:00.000Z",
+            "owner": "the-goats",
+            "projectSlug": "cloudflare-mcp",
+            "schedule": {
+              "checkInMargin": 5,
+              "maxRuntime": 30,
+              "type": "crontab",
+              "value": "0 2 * * *",
+            },
+            "slug": "nightly-import",
+            "status": "ok",
+            "webUrl": "https://sentry-mcp-evals.sentry.io/crons/cloudflare-mcp/nightly-import/",
+          },
+        ],
+      }
     `);
   });
 
@@ -122,7 +136,7 @@ describe("find_monitors", () => {
     expect(params.get("environment")).toBe("production");
     expect(params.get("owner")).toBe("team:123");
     expect(params.get("query")).toBe("billing");
-    expect(params.get("per_page")).toBe("25");
+    expect(params.get("per_page")).toBe("26");
   });
 
   it("uses the active project constraint as the monitor list project", async () => {
@@ -199,7 +213,6 @@ describe("find_monitors", () => {
               status: "ok",
               project: {
                 id: "4509109104082945",
-                slug: "cloudflare-mcp",
                 name: "cloudflare-mcp",
               },
               config: {
@@ -225,8 +238,113 @@ describe("find_monitors", () => {
       context,
     );
 
-    expect(result).toContain(
-      "[Open Monitor](https://sentry-mcp-evals.sentry.io/crons/cloudflare-mcp/nightly%2Fimport%201/)",
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toMatchObject({
+      monitors: [
+        {
+          projectSlug: "cloudflare-mcp",
+          webUrl:
+            "https://sentry-mcp-evals.sentry.io/crons/cloudflare-mcp/nightly%2Fimport%201/",
+        },
+      ],
+    });
+  });
+
+  it("preserves object and legacy interval schedules without inventing ids", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/monitors/",
+        () =>
+          HttpResponse.json([
+            {
+              slug: "object-interval",
+              name: "Object Interval",
+              config: {
+                schedule: { type: "interval", value: 5, unit: "day" },
+              },
+              environments: [],
+            },
+            {
+              id: "2",
+              slug: "legacy-interval",
+              name: "Legacy Interval",
+              config: {
+                schedule: ["interval", 3, "hour"],
+              },
+              environments: [],
+            },
+          ]),
+      ),
     );
+
+    const result = await findMonitors.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        projectSlug: null,
+        environment: null,
+        owner: null,
+        query: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    expect(getStructuredContent(result)).toMatchObject({
+      monitors: [
+        {
+          id: null,
+          schedule: { type: "interval", value: "5 day" },
+        },
+        {
+          id: "2",
+          schedule: { type: "interval", value: "3 hour" },
+        },
+      ],
+    });
+  });
+
+  it("reports more results and returns only the requested monitor limit", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/monitors/",
+        ({ request }) => {
+          expect(new URL(request.url).searchParams.get("per_page")).toBe("11");
+          return HttpResponse.json(
+            Array.from({ length: 11 }, (_, index) => ({
+              id: String(index + 1),
+              slug: `monitor-${index + 1}`,
+              name: `Monitor ${index + 1}`,
+              status: "ok",
+              project: {
+                id: "1",
+                slug: "cloudflare-mcp",
+                name: "cloudflare-mcp",
+              },
+              config: null,
+              environments: [],
+            })),
+          );
+        },
+      ),
+    );
+
+    const result = await findMonitors.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        regionUrl: null,
+        projectSlug: null,
+        environment: null,
+        owner: null,
+        query: null,
+        limit: 10,
+      },
+      context,
+    );
+
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent.hasMore).toBe(true);
+    expect(structuredContent.monitors).toHaveLength(10);
   });
 });

--- a/packages/mcp-core/src/tools/catalog/find-monitors.ts
+++ b/packages/mcp-core/src/tools/catalog/find-monitors.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { Monitor } from "../../api-client/types";
 import type { ServerContext } from "../../types";
 import {
@@ -9,78 +10,129 @@ import {
   ParamProjectSlugOrAll,
   ParamRegionUrl,
 } from "../../schema";
-import {
-  compactLines,
-  formatActor,
-  formatDate,
-  formatId,
-  formatUnknown,
-} from "./support/api-formatting";
 import { assertProjectRefWithinConstraint } from "./support/project-constraints";
 
-function formatProject(monitor: Monitor): string | null {
-  if (!monitor.project) {
+const ENVIRONMENT_LIMIT = 5;
+
+const monitorScheduleOutputSchema = z.object({
+  type: z.string().nullable(),
+  value: z.string().nullable(),
+  checkInMargin: z.number().nullable(),
+  maxRuntime: z.number().nullable(),
+});
+
+const monitorEnvironmentOutputSchema = z.object({
+  name: z.string().nullable(),
+  status: z.string().nullable(),
+  lastCheckIn: z.string().datetime().nullable(),
+});
+
+const monitorSummaryOutputSchema = z.object({
+  id: z.string().nullable(),
+  slug: z.string(),
+  name: z.string(),
+  projectSlug: z.string().nullable(),
+  status: z.string().nullable(),
+  owner: z.string().nullable(),
+  lastCheckIn: z.string().datetime().nullable(),
+  nextCheckIn: z.string().datetime().nullable(),
+  webUrl: z.string().url(),
+  schedule: monitorScheduleOutputSchema.nullable(),
+  environments: z.array(monitorEnvironmentOutputSchema),
+  hasMoreEnvironments: z.boolean(),
+});
+
+export const findMonitorsOutputSchema = z.object({
+  monitors: z.array(monitorSummaryOutputSchema),
+  hasMore: z.boolean(),
+});
+
+function getOwnerName(monitor: Monitor): string | null {
+  const owner = monitor.owner;
+  if (!owner) {
     return null;
   }
-
-  return monitor.project.slug ?? monitor.project.name ?? null;
+  if (typeof owner === "string") {
+    return owner.trim() || null;
+  }
+  return (
+    owner.name?.trim() ||
+    owner.email?.trim() ||
+    owner.username?.trim() ||
+    (owner.id === undefined ? null : String(owner.id))
+  );
 }
 
-function formatMonitorConfig(monitor: Monitor): string[] {
+function parseSchedule(value: unknown): {
+  type: string | null;
+  value: string | null;
+} {
+  if (typeof value === "string") {
+    return { type: null, value: value.trim() || null };
+  }
+  if (Array.isArray(value)) {
+    const [first, second, third] = value;
+    if (first === "crontab" && typeof second === "string") {
+      return { type: "crontab", value: second };
+    }
+    if (
+      first === "interval" &&
+      (typeof second === "number" || typeof second === "string") &&
+      typeof third === "string"
+    ) {
+      return { type: "interval", value: `${second} ${third}` };
+    }
+    if (
+      (typeof first === "number" || typeof first === "string") &&
+      typeof second === "string"
+    ) {
+      return { type: "interval", value: `${first} ${second}` };
+    }
+    return { type: null, value: null };
+  }
+  if (!value || typeof value !== "object") {
+    return { type: null, value: null };
+  }
+  const schedule = value as Record<string, unknown>;
+  const type = typeof schedule.type === "string" ? schedule.type : null;
+  if (type === "crontab" && typeof schedule.value === "string") {
+    return { type, value: schedule.value };
+  }
+  if (
+    type === "interval" &&
+    (typeof schedule.value === "number" ||
+      typeof schedule.value === "string") &&
+    typeof schedule.unit === "string"
+  ) {
+    return { type, value: `${schedule.value} ${schedule.unit}` };
+  }
+  return { type, value: null };
+}
+
+function getSchedule(monitor: Monitor) {
   const config = monitor.config;
   if (!config) {
-    return [];
+    return null;
   }
-
-  return ["schedule", "schedule_type", "checkin_margin", "max_runtime"]
-    .filter((key) => config[key] !== undefined)
-    .map((key) => `**${key}**: ${formatUnknown(config[key])}`);
-}
-
-function formatMonitor(monitor: Monitor, monitorUrl: string): string {
-  const project = formatProject(monitor);
-  const owner = monitor.owner ? formatActor(monitor.owner) : null;
-  const environments = monitor.environments ?? [];
-
-  const lines = compactLines([
-    `## ${monitor.name ?? monitor.slug}`,
-    "",
-    `**Slug**: ${monitor.slug}`,
-    `**ID**: ${formatId(monitor.id)}`,
-    project ? `**Project**: ${project}` : null,
-    monitor.status ? `**Status**: ${monitor.status}` : null,
-    monitor.type ? `**Type**: ${monitor.type}` : null,
-    owner ? `**Owner**: ${owner}` : null,
-    formatDate(monitor.lastCheckIn)
-      ? `**Last Check-In**: ${formatDate(monitor.lastCheckIn)}`
-      : null,
-    formatDate(monitor.nextCheckIn)
-      ? `**Next Check-In**: ${formatDate(monitor.nextCheckIn)}`
-      : null,
-    `**URL**: [Open Monitor](${monitorUrl})`,
-  ]);
-
-  const configLines = formatMonitorConfig(monitor);
-  if (configLines.length > 0) {
-    lines.push("", "### Schedule", "", ...configLines);
+  const parsedSchedule = parseSchedule(config.schedule);
+  const type =
+    typeof config.schedule_type === "string"
+      ? config.schedule_type
+      : parsedSchedule.type;
+  const value = parsedSchedule.value;
+  const checkInMargin =
+    typeof config.checkin_margin === "number" ? config.checkin_margin : null;
+  const maxRuntime =
+    typeof config.max_runtime === "number" ? config.max_runtime : null;
+  if (
+    type === null &&
+    value === null &&
+    checkInMargin === null &&
+    maxRuntime === null
+  ) {
+    return null;
   }
-
-  if (environments.length > 0) {
-    lines.push("", "### Environments", "");
-    for (const environment of environments.slice(0, 5)) {
-      const label = environment.name ?? "unknown";
-      const status = environment.status ? ` - ${environment.status}` : "";
-      const lastCheckIn = formatDate(environment.lastCheckIn);
-      lines.push(
-        `- ${label}${status}${lastCheckIn ? ` (last check-in ${lastCheckIn})` : ""}`,
-      );
-    }
-    if (environments.length > 5) {
-      lines.push(`- ...and ${environments.length - 5} more`);
-    }
-  }
-
-  return lines.join("\n");
+  return { type, value, checkInMargin, maxRuntime };
 }
 
 export default defineTool({
@@ -94,6 +146,7 @@ export default defineTool({
     "- List cron monitors in an organization",
     "- Find a monitor by name or slug before getting details",
     "- Check monitor status, owner, project, schedule, or recent environment state",
+    "- When `hasMore` is true, narrow the results with project, environment, owner, or query filters",
     "",
     "<examples>",
     "find_monitors(organizationSlug='my-organization')",
@@ -128,7 +181,7 @@ export default defineTool({
       .number()
       .int()
       .positive()
-      .max(100)
+      .max(99)
       .describe("Maximum number of monitors to return.")
       .default(10),
   },
@@ -137,6 +190,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findMonitorsOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -165,33 +219,40 @@ export default defineTool({
       environment: params.environment ?? undefined,
       owner: params.owner ?? undefined,
       query: params.query ?? undefined,
-      limit: params.limit,
+      limit: params.limit + 1,
     });
 
-    let output = `# Cron Monitors in **${organizationSlug}**\n\n`;
-    if (monitors.length === 0) {
-      output += "No monitors found.\n";
-      return output;
-    }
-
-    output += monitors
-      .slice(0, params.limit)
-      .map((monitor) => {
-        const project = formatProject(monitor);
-        return formatMonitor(
-          monitor,
-          apiService.getMonitorUrl(
+    return structuredResult({
+      monitors: monitors.slice(0, params.limit).map((monitor) => {
+        const projectSlug =
+          monitor.project?.slug ?? monitor.project?.name ?? null;
+        const environments = monitor.environments ?? [];
+        return {
+          id: monitor.id === undefined ? null : String(monitor.id),
+          slug: monitor.slug,
+          name: monitor.name ?? monitor.slug,
+          projectSlug,
+          status: monitor.status ?? null,
+          owner: getOwnerName(monitor),
+          lastCheckIn: monitor.lastCheckIn ?? null,
+          nextCheckIn: monitor.nextCheckIn ?? null,
+          webUrl: apiService.getMonitorUrl(
             organizationSlug,
             monitor.slug,
-            project ?? undefined,
+            projectSlug ?? undefined,
           ),
-        );
-      })
-      .join("\n\n");
-    output += "\n\n## Response Notes\n\n";
-    output +=
-      "- Use `get_monitor_details` with a monitor slug for check-ins and stats.\n";
-    output += "- Monitor issue searches commonly use `monitor.slug:<slug>`.\n";
-    return output;
+          schedule: getSchedule(monitor),
+          environments: environments
+            .slice(0, ENVIRONMENT_LIMIT)
+            .map((environment) => ({
+              name: environment.name ?? null,
+              status: environment.status ?? null,
+              lastCheckIn: environment.lastCheckIn ?? null,
+            })),
+          hasMoreEnvironments: environments.length > ENVIRONMENT_LIMIT,
+        };
+      }),
+      hasMore: monitors.length > params.limit,
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_monitors` from handwritten markdown to a structured result with a declared `outputSchema`.

The result contains stable monitor identity, project/status/owner data, schedule configuration, recent environment state, monitor URLs, and accurate `hasMore` flags for both the monitor list and capped environment summaries. Scope echoes and response-note prose are removed.

The implementation subagent ran the entire tool file: 7 tests passed. The branch was rebased onto current `main`, and the full repository TypeScript, lint, and test gate passes.

Refs #1193