### PR TITLE
feat(tools): Structure find_releases results

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -2448,16 +2448,21 @@ export class SentryApiService {
       organizationSlug,
       projectSlug,
       query,
+      limit,
     }: {
       organizationSlug: string;
       projectSlug?: string;
       query?: string;
+      limit?: number;
     },
     opts?: RequestOptions,
   ): Promise<ReleaseList> {
     const searchQuery = new URLSearchParams();
     if (query) {
       searchQuery.set("query", query);
+    }
+    if (limit !== undefined) {
+      searchQuery.set("per_page", String(limit));
     }
 
     const path = projectSlug

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -34,7 +34,7 @@
       },
       {
         "name": "find_releases",
-        "description": "Find releases in Sentry.\n\nUse this tool when you need to:\n- Find recent releases in a Sentry organization\n- Find the most recent version released of a specific project\n- Determine when a release was deployed to an environment\n\n<examples>\n### Find the most recent releases in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization')\n```\n\n### Find releases matching '2ce6a27' in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization', query='2ce6a27')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n</hints>",
+        "description": "Find releases in Sentry.\n\nUse this tool when you need to:\n- Find recent releases in a Sentry organization\n- Find the most recent version released of a specific project\n- Determine when a release was deployed to an environment\n\nReturns up to 25 results. When hasMore is true, use the projectSlug or query parameter to narrow down results.\n\n<examples>\n### Find the most recent releases in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization')\n```\n\n### Find releases matching '2ce6a27' in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization', query='2ce6a27')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n</hints>",
         "requiredScopes": ["project:read"]
       },
       {

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -1206,7 +1206,7 @@
   },
   {
     "name": "find_releases",
-    "description": "Find releases in Sentry.\n\nUse this tool when you need to:\n- Find recent releases in a Sentry organization\n- Find the most recent version released of a specific project\n- Determine when a release was deployed to an environment\n\n<examples>\n### Find the most recent releases in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization')\n```\n\n### Find releases matching '2ce6a27' in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization', query='2ce6a27')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n</hints>",
+    "description": "Find releases in Sentry.\n\nUse this tool when you need to:\n- Find recent releases in a Sentry organization\n- Find the most recent version released of a specific project\n- Determine when a release was deployed to an environment\n\nReturns up to 25 results. When hasMore is true, use the projectSlug or query parameter to narrow down results.\n\n<examples>\n### Find the most recent releases in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization')\n```\n\n### Find releases matching '2ce6a27' in the 'my-organization' organization\n\n```\nfind_releases(organizationSlug='my-organization', query='2ce6a27')\n```\n</examples>\n\n<hints>\n- If the user passes a parameter in the form of name/otherName, its likely in the format of <organizationSlug>/<projectSlug>.\n</hints>",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1252,6 +1252,187 @@
         }
       },
       "required": ["organizationSlug"]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "releases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "string"
+              },
+              "dateCreated": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+              },
+              "dateReleased": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "firstEvent": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "lastEvent": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "newIssues": {
+                "type": "number"
+              },
+              "projects": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "lastCommit": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "author": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "dateCreated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                      }
+                    },
+                    "required": ["id", "message", "author", "dateCreated"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "lastDeploy": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "environment": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "dateStarted": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "dateFinished": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "environment",
+                      "dateStarted",
+                      "dateFinished"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "version",
+              "dateCreated",
+              "dateReleased",
+              "firstEvent",
+              "lastEvent",
+              "newIssues",
+              "projects",
+              "lastCommit",
+              "lastDeploy"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "required": ["releases", "hasMore"],
+      "additionalProperties": false
     },
     "requiredScopes": ["project:read"],
     "skills": ["inspect"],

--- a/packages/mcp-core/src/tools/catalog/find-releases.test.ts
+++ b/packages/mcp-core/src/tools/catalog/find-releases.test.ts
@@ -1,8 +1,37 @@
+import { mswServer, releaseFixture } from "@sentry/mcp-server-mocks";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect } from "vitest";
-import findReleases from "./find-releases.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
+import { getServerContext } from "../../test-setup.js";
+import findReleases, { findReleasesOutputSchema } from "./find-releases.js";
 
 describe("find_releases", () => {
   it("works without project", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/",
+        ({ request }) => {
+          const searchParams = new URL(request.url).searchParams;
+          expect(searchParams.get("per_page")).toBe("26");
+          expect(searchParams.has("query")).toBe(false);
+          return HttpResponse.json([
+            {
+              ...releaseFixture,
+              projects: releaseFixture.projects.map(
+                (project: (typeof releaseFixture.projects)[number]) => ({
+                  ...project,
+                  name: "Cloudflare MCP",
+                }),
+              ),
+            },
+          ]);
+        },
+      ),
+    );
+
     const result = await findReleases.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -10,34 +39,49 @@ describe("find_releases", () => {
         regionUrl: null,
         query: null,
       },
-      {
-        constraints: {
-          organizationSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Releases in **sentry-mcp-evals**
 
-      ## 8ce89484-0fec-4913-a2cd-e8e2d41dee36
-
-      **Created**: 2025-04-13T19:54:21.764Z
-      **First Event**: 2025-04-13T19:54:21.000Z
-      **Last Event**: 2025-04-13T20:28:23.000Z
-      **New Issues**: 0
-      **Projects**: cloudflare-mcp
-
-      ## Response Notes
-
-      - Release versions can be referenced in commit messages or documentation.
-      - Release filter syntax for issue searches: \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
-      "
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent(result);
+    expect(findReleasesOutputSchema.parse(structuredContent)).toEqual(
+      structuredContent,
+    );
+    expect(structuredContent).toMatchInlineSnapshot(`
+      {
+        "hasMore": false,
+        "releases": [
+          {
+            "dateCreated": "2025-04-13T19:54:21.764Z",
+            "dateReleased": null,
+            "firstEvent": "2025-04-13T19:54:21.000Z",
+            "lastCommit": null,
+            "lastDeploy": null,
+            "lastEvent": "2025-04-13T20:28:23.000Z",
+            "newIssues": 0,
+            "projects": [
+              "cloudflare-mcp",
+            ],
+            "version": "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
+          },
+        ],
+      }
     `);
   });
 
   it("works with project", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/releases/",
+        ({ request }) => {
+          const searchParams = new URL(request.url).searchParams;
+          expect(searchParams.get("per_page")).toBe("26");
+          expect(searchParams.has("query")).toBe(false);
+          return HttpResponse.json([releaseFixture]);
+        },
+      ),
+    );
+
     const result = await findReleases.handler(
       {
         organizationSlug: "sentry-mcp-evals",
@@ -45,30 +89,137 @@ describe("find_releases", () => {
         regionUrl: null,
         query: null,
       },
-      {
-        constraints: {
-          organizationSlug: null,
-        },
-        accessToken: "access-token",
-        userId: "1",
-      },
+      getServerContext(),
     );
-    expect(result).toMatchInlineSnapshot(`
-      "# Releases in **sentry-mcp-evals/cloudflare-mcp**
 
-      ## 8ce89484-0fec-4913-a2cd-e8e2d41dee36
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      releases: [
+        {
+          version: "8ce89484-0fec-4913-a2cd-e8e2d41dee36",
+          dateCreated: "2025-04-13T19:54:21.764Z",
+          dateReleased: null,
+          firstEvent: "2025-04-13T19:54:21.000Z",
+          lastEvent: "2025-04-13T20:28:23.000Z",
+          newIssues: 0,
+          projects: ["cloudflare-mcp"],
+          lastCommit: null,
+          lastDeploy: null,
+        },
+      ],
+      hasMore: false,
+    });
+  });
 
-      **Created**: 2025-04-13T19:54:21.764Z
-      **First Event**: 2025-04-13T19:54:21.000Z
-      **Last Event**: 2025-04-13T20:28:23.000Z
-      **New Issues**: 0
-      **Projects**: cloudflare-mcp
+  it("maps commit and deploy summaries without leaking upstream fields", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/",
+        () =>
+          HttpResponse.json([
+            {
+              ...releaseFixture,
+              version: "backend@1.2.3+build.4",
+              shortVersion: "backend@1.2.3",
+              dateReleased: "2025-04-14T08:00:00Z",
+              lastCommit: {
+                id: 12345,
+                message: "Ship release",
+                dateCreated: "2025-04-14T07:30:00Z",
+                author: {
+                  name: null,
+                  email: "developer@example.com",
+                  avatarUrl: "https://example.com/avatar.png",
+                },
+                repository: { name: "backend" },
+              },
+              lastDeploy: {
+                id: 67890,
+                environment: "production",
+                dateStarted: "2025-04-14T07:45:00Z",
+                dateFinished: "2025-04-14T08:00:00Z",
+                url: "https://example.com/deploy/67890",
+              },
+              secretBackendField: "must-not-leak",
+            },
+          ]),
+      ),
+    );
 
-      ## Response Notes
+    const result = await findReleases.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: null,
+        regionUrl: null,
+        query: "backend@1.2",
+      },
+      getServerContext(),
+    );
 
-      - Release versions can be referenced in commit messages or documentation.
-      - Release filter syntax for issue searches: \`release:8ce89484-0fec-4913-a2cd-e8e2d41dee36\`.
-      "
-    `);
+    assertStructuredOnlyResult(result);
+    expect(getStructuredContent(result)).toEqual({
+      releases: [
+        {
+          version: "backend@1.2.3",
+          dateCreated: "2025-04-13T19:54:21.764Z",
+          dateReleased: "2025-04-14T08:00:00.000Z",
+          firstEvent: "2025-04-13T19:54:21.000Z",
+          lastEvent: "2025-04-13T20:28:23.000Z",
+          newIssues: 0,
+          projects: ["cloudflare-mcp"],
+          lastCommit: {
+            id: "12345",
+            message: "Ship release",
+            author: "developer@example.com",
+            dateCreated: "2025-04-14T07:30:00.000Z",
+          },
+          lastDeploy: {
+            id: "67890",
+            environment: "production",
+            dateStarted: "2025-04-14T07:45:00.000Z",
+            dateFinished: "2025-04-14T08:00:00.000Z",
+          },
+        },
+      ],
+      hasMore: false,
+    });
+  });
+
+  it("reports more results and returns only the first 25 releases", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/releases/",
+        ({ request }) => {
+          expect(new URL(request.url).searchParams.get("per_page")).toBe("26");
+          return HttpResponse.json(
+            Array.from({ length: 26 }, (_, index) => ({
+              ...releaseFixture,
+              id: index + 1,
+              version: `release-${String(index + 1).padStart(2, "0")}`,
+              shortVersion: `release-${String(index + 1).padStart(2, "0")}`,
+            })),
+          );
+        },
+      ),
+    );
+
+    const result = await findReleases.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: null,
+        regionUrl: null,
+        query: null,
+      },
+      getServerContext(),
+    );
+
+    assertStructuredOnlyResult(result);
+    const structuredContent = getStructuredContent<{
+      releases: Array<{ version: string }>;
+      hasMore: boolean;
+    }>(result);
+    expect(structuredContent.releases).toHaveLength(25);
+    expect(structuredContent.releases.at(-1)?.version).toBe("release-25");
+    expect(structuredContent.hasMore).toBe(true);
   });
 });

--- a/packages/mcp-core/src/tools/catalog/find-releases.ts
+++ b/packages/mcp-core/src/tools/catalog/find-releases.ts
@@ -2,12 +2,46 @@ import { z } from "zod";
 import { setTag } from "@sentry/core";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
+import { structuredResult } from "../../internal/tool-helpers/results";
 import type { ServerContext } from "../../types";
 import {
   ParamOrganizationSlug,
   ParamRegionUrl,
   ParamProjectSlugOrAll,
 } from "../../schema";
+
+const RESULT_LIMIT = 25;
+
+export const findReleasesOutputSchema = z.object({
+  releases: z.array(
+    z.object({
+      version: z.string(),
+      dateCreated: z.string().datetime(),
+      dateReleased: z.string().datetime().nullable(),
+      firstEvent: z.string().datetime().nullable(),
+      lastEvent: z.string().datetime().nullable(),
+      newIssues: z.number(),
+      projects: z.array(z.string()),
+      lastCommit: z
+        .object({
+          id: z.string(),
+          message: z.string().nullable(),
+          author: z.string().nullable(),
+          dateCreated: z.string().datetime(),
+        })
+        .nullable(),
+      lastDeploy: z
+        .object({
+          id: z.string(),
+          environment: z.string().nullable(),
+          dateStarted: z.string().datetime().nullable(),
+          dateFinished: z.string().datetime().nullable(),
+        })
+        .nullable(),
+    }),
+  ),
+  hasMore: z.boolean(),
+});
 
 export default defineTool({
   name: "find_releases",
@@ -20,6 +54,8 @@ export default defineTool({
     "- Find recent releases in a Sentry organization",
     "- Find the most recent version released of a specific project",
     "- Determine when a release was deployed to an environment",
+    "",
+    `Returns up to ${RESULT_LIMIT} results. When hasMore is true, use the projectSlug or query parameter to narrow down results.`,
     "",
     "<examples>",
     "### Find the most recent releases in the 'my-organization' organization",
@@ -55,6 +91,7 @@ export default defineTool({
     destructiveHint: false,
     openWorldHint: true,
   },
+  outputSchema: findReleasesOutputSchema,
   async handler(params, context: ServerContext) {
     const apiService = apiServiceFromContext(context, {
       regionUrl: params.regionUrl ?? undefined,
@@ -67,82 +104,53 @@ export default defineTool({
       organizationSlug,
       projectSlug: params.projectSlug ?? undefined,
       query: params.query ?? undefined,
+      limit: RESULT_LIMIT + 1,
     });
-    let output = `# Releases in **${organizationSlug}${params.projectSlug ? `/${params.projectSlug}` : ""}**\n\n`;
-    if (releases.length === 0) {
-      output += "No releases found.\n";
-      return output;
-    }
-    output += releases
-      .map((release) => {
-        const releaseInfo = [
-          `## ${release.shortVersion}`,
-          "",
-          `**Created**: ${new Date(release.dateCreated).toISOString()}`,
-        ];
-        if (release.dateReleased) {
-          releaseInfo.push(
-            `**Released**: ${new Date(release.dateReleased).toISOString()}`,
-          );
-        }
-        if (release.firstEvent) {
-          releaseInfo.push(
-            `**First Event**: ${new Date(release.firstEvent).toISOString()}`,
-          );
-        }
-        if (release.lastEvent) {
-          releaseInfo.push(
-            `**Last Event**: ${new Date(release.lastEvent).toISOString()}`,
-          );
-        }
-        if (release.newGroups !== undefined) {
-          releaseInfo.push(`**New Issues**: ${release.newGroups}`);
-        }
-        if (release.projects && release.projects.length > 0) {
-          releaseInfo.push(
-            `**Projects**: ${release.projects.map((p) => p.name).join(", ")}`,
-          );
-        }
-        if (release.lastCommit) {
-          const commitAuthor =
-            release.lastCommit.author?.name ??
-            release.lastCommit.author?.email ??
-            "Unknown";
-          releaseInfo.push("", `### Last Commit`, "");
-          releaseInfo.push(`**Commit ID**: ${release.lastCommit.id}`);
-          releaseInfo.push(
-            `**Commit Message**: ${release.lastCommit.message ?? "Unknown"}`,
-          );
-          releaseInfo.push(`**Commit Author**: ${commitAuthor}`);
-          releaseInfo.push(
-            `**Commit Date**: ${new Date(release.lastCommit.dateCreated).toISOString()}`,
-          );
-        }
-        if (release.lastDeploy) {
-          releaseInfo.push("", `### Last Deploy`, "");
-          releaseInfo.push(`**Deploy ID**: ${release.lastDeploy.id}`);
-          releaseInfo.push(
-            `**Environment**: ${release.lastDeploy.environment ?? "Unknown"}`,
-          );
-          if (release.lastDeploy.dateStarted) {
-            releaseInfo.push(
-              `**Deploy Started**: ${new Date(release.lastDeploy.dateStarted).toISOString()}`,
-            );
-          }
-          if (release.lastDeploy.dateFinished) {
-            releaseInfo.push(
-              `**Deploy Finished**: ${new Date(release.lastDeploy.dateFinished).toISOString()}`,
-            );
-          }
-        }
-        return releaseInfo.join("\n");
-      })
-      .join("\n\n");
-    output += "\n\n";
-    output += "## Response Notes\n\n";
-    output +=
-      "- Release versions can be referenced in commit messages or documentation.\n";
-    output += `- Release filter syntax for issue searches: \`release:${releases.length ? releases[0]!.shortVersion : "VERSION"}\`.\n`;
-    return output;
+
+    return structuredResult({
+      releases: releases.slice(0, RESULT_LIMIT).map((release) => ({
+        version: release.shortVersion,
+        dateCreated: new Date(release.dateCreated).toISOString(),
+        dateReleased: release.dateReleased
+          ? new Date(release.dateReleased).toISOString()
+          : null,
+        firstEvent: release.firstEvent
+          ? new Date(release.firstEvent).toISOString()
+          : null,
+        lastEvent: release.lastEvent
+          ? new Date(release.lastEvent).toISOString()
+          : null,
+        newIssues: release.newGroups,
+        projects: release.projects
+          .map((project) => project.slug)
+          .filter((slug): slug is string => slug !== null),
+        lastCommit: release.lastCommit
+          ? {
+              id: String(release.lastCommit.id),
+              message: release.lastCommit.message,
+              author:
+                release.lastCommit.author?.name ??
+                release.lastCommit.author?.email ??
+                null,
+              dateCreated: new Date(
+                release.lastCommit.dateCreated,
+              ).toISOString(),
+            }
+          : null,
+        lastDeploy: release.lastDeploy
+          ? {
+              id: String(release.lastDeploy.id),
+              environment: release.lastDeploy.environment,
+              dateStarted: release.lastDeploy.dateStarted
+                ? new Date(release.lastDeploy.dateStarted).toISOString()
+                : null,
+              dateFinished: release.lastDeploy.dateFinished
+                ? new Date(release.lastDeploy.dateFinished).toISOString()
+                : null,
+            }
+          : null,
+      })),
+      hasMore: releases.length > RESULT_LIMIT,
+    });
   },
 });


### PR DESCRIPTION
Migrate `find_releases` from handwritten markdown to a structured result with a declared `outputSchema`.

The result contains stable release version/date/project data, nullable last-commit and last-deploy summaries, and an accurate `hasMore` flag. The Sentry organization and project release endpoints both support the 26-item over-fetch used to detect truncation. Raw upstream fields and response-note prose are excluded.

The implementation subagent ran the entire tool file: 4 tests passed. The branch was rebased onto current `main`, and the full repository TypeScript, lint, and test gate passes.

Refs #1193