### PR TITLE
feat(ai-conversations): Prefer details envelope and return title

### DIFF
--- a/docs/specs/ai-conversations.md
+++ b/docs/specs/ai-conversations.md
@@ -238,6 +238,7 @@ raw span dump and not a lossy grouping invented by MCP.
 Current expected behavior:
 
 - Input is organization slug plus conversation ID.
+- Output includes `title` when Sentry has conversation metadata (`null` otherwise).
 - Output includes a chronological transcript timeline.
 - Timeline events are sorted by event timestamp and include a `type`
   discriminator.

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -79,7 +79,7 @@ import {
   ReplayRecordingSegmentsSchema,
   StacktraceLinkSchema,
   AIConversationSummaryListSchema,
-  AIConversationSpanListSchema,
+  AIConversationDetailsResponseSchema,
   UserReportListSchema,
 } from "./schema";
 import { ConfigurationError } from "../errors";
@@ -132,6 +132,7 @@ import type {
   ReplayRecordingSegments,
   StacktraceLink,
   AIConversationSummary,
+  AIConversationDetails,
   AIConversationSpanList,
   UserReportList,
 } from "./types";
@@ -4169,13 +4170,16 @@ export class SentryApiService {
       maxPages?: number;
     },
     opts?: RequestOptions,
-  ): Promise<AIConversationSpanList> {
+  ): Promise<AIConversationDetails> {
     const spans: AIConversationSpanList = [];
+    let title: string | null = null;
     let cursor: string | null = null;
 
     for (let page = 0; page < maxPages; page++) {
       const queryParams = new URLSearchParams();
       queryParams.set("per_page", String(perPage));
+      // Temporary: drop when Sentry defaults conversation details to the v2 envelope.
+      queryParams.set("apiVersion", "2");
       this.applyTimeParams(
         queryParams,
         start || end ? undefined : statsPeriod,
@@ -4196,7 +4200,10 @@ export class SentryApiService {
         opts,
       );
       const body = await this.parseJsonResponse(response);
-      spans.push(...AIConversationSpanListSchema.parse(body));
+      const details = AIConversationDetailsResponseSchema.parse(body);
+      // Pages repeat the same conversation-scoped title.
+      title = details.title;
+      spans.push(...details.spans);
 
       cursor = getNextCursor(response.headers.get("link"));
       if (!cursor) {
@@ -4204,7 +4211,11 @@ export class SentryApiService {
       }
     }
 
-    return spans;
+    return {
+      conversationId,
+      title,
+      spans,
+    };
   }
 
   /**

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1551,6 +1551,15 @@ export const AIConversationSpanSchema = z
 
 export const AIConversationSpanListSchema = z.array(AIConversationSpanSchema);
 
+/** Conversation details response envelope (`conversationId`, `title`, `spans`). */
+export const AIConversationDetailsResponseSchema = z
+  .object({
+    conversationId: z.string(),
+    title: z.string().nullable(),
+    spans: AIConversationSpanListSchema,
+  })
+  .passthrough();
+
 /**
  * Schemas validated against getsentry/sentry:
  * - `src/sentry/api/endpoints/organization_ai_conversations.py`

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -43,6 +43,7 @@ import type {
   AssignedToSchema,
   AIConversationSummaryListSchema,
   AIConversationSummarySchema,
+  AIConversationDetailsResponseSchema,
   AIConversationSpanListSchema,
   AIConversationSpanSchema,
   AIConversationUserSchema,
@@ -203,6 +204,9 @@ export type Trace = z.infer<typeof TraceSchema>;
 export type AIConversationSpan = z.infer<typeof AIConversationSpanSchema>;
 export type AIConversationSpanList = z.infer<
   typeof AIConversationSpanListSchema
+>;
+export type AIConversationDetails = z.infer<
+  typeof AIConversationDetailsResponseSchema
 >;
 export type AIConversationUser = z.infer<typeof AIConversationUserSchema>;
 export type AIConversationSummary = z.infer<typeof AIConversationSummarySchema>;

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -750,6 +750,16 @@
         "conversationId": {
           "type": "string"
         },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "organizationSlug": {
           "type": "string"
         },
@@ -1165,6 +1175,7 @@
       },
       "required": [
         "conversationId",
+        "title",
         "organizationSlug",
         "url",
         "lookupWindow",

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
@@ -111,6 +111,7 @@ function mockConversationEndpoint(
   org = "test-org",
   conversationId = "conv-123",
   spans = conversationSpans,
+  title: string | null = null,
 ) {
   mswServer.use(
     http.get(
@@ -120,7 +121,8 @@ function mockConversationEndpoint(
         expect(url.searchParams.get("statsPeriod")).toBe("30d");
         expect(url.searchParams.get("per_page")).toBe("1000");
         expect(url.searchParams.get("project")).toBe("-1");
-        return HttpResponse.json(spans);
+        expect(url.searchParams.get("apiVersion")).toBe("2");
+        return HttpResponse.json({ conversationId, title, spans });
       },
     ),
   );
@@ -128,7 +130,12 @@ function mockConversationEndpoint(
 
 describe("get_ai_conversation_details", () => {
   it("returns structured conversation details", async () => {
-    mockConversationEndpoint();
+    mockConversationEndpoint(
+      "test-org",
+      "conv-123",
+      conversationSpans,
+      "Checkout worker timeouts",
+    );
 
     const result = await getAIConversationDetails.handler(
       {
@@ -145,6 +152,7 @@ describe("get_ai_conversation_details", () => {
     expect(structuredContent).not.toHaveProperty("focusedSpanPresent");
     expect(structuredContent).not.toHaveProperty("messages");
     expect(structuredContent).not.toHaveProperty("spanIds");
+    expect(structuredContent.title).toBe("Checkout worker timeouts");
     expect(structuredContent.timeline[0].genAi).toMatchObject({
       operationType: "ai_client",
       requestModel: "gpt-5-mini",
@@ -356,6 +364,7 @@ describe("get_ai_conversation_details", () => {
             "type": "message",
           },
         ],
+        "title": "Checkout worker timeouts",
         "toolCallCount": 1,
         "totalTokens": 100,
         "traceIds": [
@@ -539,7 +548,12 @@ describe("get_ai_conversation_details", () => {
           );
           expect(url.searchParams.get("end")).toBe("2026-05-23T02:34:56.137Z");
           expect(url.searchParams.get("project")).toBe("4510944073809921");
-          return HttpResponse.json(conversationSpans);
+          expect(url.searchParams.get("apiVersion")).toBe("2");
+          return HttpResponse.json({
+            conversationId: "conv-123",
+            title: null,
+            spans: conversationSpans,
+          });
         },
       ),
     );
@@ -570,7 +584,12 @@ describe("get_ai_conversation_details", () => {
             "2026-05-23T00:23:27.667Z",
           );
           expect(url.searchParams.get("end")).toBe("2026-05-23T02:34:56.137Z");
-          return HttpResponse.json([]);
+          expect(url.searchParams.get("apiVersion")).toBe("2");
+          return HttpResponse.json({
+            conversationId: "conv-empty",
+            title: null,
+            spans: [],
+          });
         },
       ),
     );
@@ -588,6 +607,7 @@ describe("get_ai_conversation_details", () => {
     assertStructuredOnlyResult(result);
     expect(getStructuredContent(result)).toMatchObject({
       conversationId: "conv-empty",
+      title: null,
       lookupWindow: {
         start: "2026-05-23T00:23:27.667Z",
         end: "2026-05-23T02:34:56.137Z",

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.ts
@@ -184,6 +184,7 @@ const spanSummarySchema = z.object({
 
 export const aiConversationDetailsOutputSchema = z.object({
   conversationId: z.string(),
+  title: z.string().nullable(),
   organizationSlug: z.string(),
   url: z.string().url(),
   lookupWindow: lookupWindowSchema,
@@ -609,6 +610,7 @@ function buildConversationArtifact(
   apiService: SentryApiService,
   organizationSlug: string,
   conversationId: string,
+  title: string | null,
   spans: AIConversationSpan[],
   lookupWindow: LookupWindow,
 ): AIConversationDetailsOutput {
@@ -633,6 +635,7 @@ function buildConversationArtifact(
 
   return withoutUndefined({
     conversationId,
+    title,
     organizationSlug,
     url: apiService.getAIConversationUrl(organizationSlug, conversationId),
     lookupWindow,
@@ -718,7 +721,7 @@ export default defineTool({
       projectId = params.project;
     }
 
-    const spans = await apiService.getAIConversation(
+    const conversation = await apiService.getAIConversation(
       {
         organizationSlug: params.organizationSlug,
         conversationId: params.conversationId,
@@ -733,7 +736,8 @@ export default defineTool({
       apiService,
       params.organizationSlug,
       params.conversationId,
-      spans,
+      conversation.title,
+      conversation.spans,
       params.start && params.end
         ? { start: params.start, end: params.end }
         : { statsPeriod: "30d" },


### PR DESCRIPTION
Conversation details now use Sentry’s envelope response so agents get the conversation title alongside the transcript.

Until that shape is the server default, requests opt into it with `apiVersion=2`. Clients that only read the projected tool output still see the same timeline and span summaries; `title` is new (`null` when Sentry has no metadata).

For MCP response this is just an additive change, no breaking changes, we just added a new field (`title`) to a response from MCP, but from Sentry we have completely changed the shape of the response so that it's easier to extend it in the future 