### PR TITLE
ref(ai-conversations): Stop sending apiVersion=2

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -4216,8 +4216,6 @@ export class SentryApiService {
     for (let page = 0; page < maxPages; page++) {
       const queryParams = new URLSearchParams();
       queryParams.set("per_page", String(perPage));
-      // Temporary: drop when Sentry defaults conversation details to the v2 envelope.
-      queryParams.set("apiVersion", "2");
       this.applyTimeParams(
         queryParams,
         start || end ? undefined : statsPeriod,

--- a/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-ai-conversation-details.test.ts
@@ -121,7 +121,6 @@ function mockConversationEndpoint(
         expect(url.searchParams.get("statsPeriod")).toBe("30d");
         expect(url.searchParams.get("per_page")).toBe("1000");
         expect(url.searchParams.get("project")).toBe("-1");
-        expect(url.searchParams.get("apiVersion")).toBe("2");
         return HttpResponse.json({ conversationId, title, spans });
       },
     ),
@@ -548,7 +547,6 @@ describe("get_ai_conversation_details", () => {
           );
           expect(url.searchParams.get("end")).toBe("2026-05-23T02:34:56.137Z");
           expect(url.searchParams.get("project")).toBe("4510944073809921");
-          expect(url.searchParams.get("apiVersion")).toBe("2");
           return HttpResponse.json({
             conversationId: "conv-123",
             title: null,
@@ -584,7 +582,6 @@ describe("get_ai_conversation_details", () => {
             "2026-05-23T00:23:27.667Z",
           );
           expect(url.searchParams.get("end")).toBe("2026-05-23T02:34:56.137Z");
-          expect(url.searchParams.get("apiVersion")).toBe("2");
           return HttpResponse.json({
             conversationId: "conv-empty",
             title: null,


### PR DESCRIPTION
Conversation detail requests no longer pass `apiVersion=2`. Sentry now returns the v2 envelope by default, so the temporary query override can go.