### PR TITLE
fix(schema): accept null dateReceived and nullish generic occurrence

### DIFF
--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -317,7 +317,7 @@ describe("EventSchema", () => {
 
     const result = EventSchema.parse(genericEvent);
     expect(result.dateReceived).toBeNull();
-    expect(result.occurrence).toBeNull();
+    expect(result).toHaveProperty("occurrence", null);
   });
 
   it("should allow partially populated user geo payloads", () => {

--- a/packages/mcp-core/src/api-client/schema.test.ts
+++ b/packages/mcp-core/src/api-client/schema.test.ts
@@ -302,6 +302,24 @@ describe("EventSchema", () => {
     expect(result.type).toBe("error");
   });
 
+  it("should parse null dateReceived and null generic occurrence", () => {
+    const genericEvent = {
+      id: "2d9a3f30ee5a4a95b712e78b87631f9a",
+      title: "Metric regression",
+      message: null,
+      platform: null,
+      type: "generic",
+      entries: [],
+      dateCreated: "2025-01-01T00:00:00Z",
+      dateReceived: null,
+      occurrence: null,
+    };
+
+    const result = EventSchema.parse(genericEvent);
+    expect(result.dateReceived).toBeNull();
+    expect(result.occurrence).toBeNull();
+  });
+
   it("should allow partially populated user geo payloads", () => {
     const errorEvent = {
       id: "geo123",

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1103,7 +1103,7 @@ const BaseEventSchema = z.object({
   // It's safer to type as unknown since its structure varies
   _meta: z.unknown().optional(),
   // dateReceived is when the server received the event (may not be present in all contexts)
-  dateReceived: z.string().datetime().optional(),
+  dateReceived: z.string().datetime().nullish(),
 });
 
 export const ErrorEventSchema = BaseEventSchema.omit({
@@ -1195,7 +1195,7 @@ export const GenericEventSchema = BaseEventSchema.omit({
   type: z.literal("generic"),
   culprit: z.string().nullable().optional(),
   dateCreated: z.string().datetime(),
-  occurrence: OccurrenceSchema.optional(),
+  occurrence: OccurrenceSchema.nullish(),
 });
 
 export const UnknownEventSchema = BaseEventSchema.omit({


### PR DESCRIPTION
## Summary

Accept nullable date fields in `EventSchema` responses that are valid according to the Sentry API contract.

## Problem

On a self-hosted Sentry instance, the event API returned this payload:

```json
{"id":"2d9a3f30ee5a4a95b712e78b87631f9a","eventID":"2d9a3f30ee5a4a95b712e78b87631f9a","type":"default","dateReceived":null,"occurrence":null}
```

`EventSchema.parse` then raised an `invalid_union` Zod error. In particular, the `dateReceived` branch expected a string but received `null`. This prevents `get_sentry_resource` from returning issue and breadcrumbs resources for affected events.

## API contract evidence

This is a valid server response, not a server bug. The Sentry event serializer declares `dateReceived` as `datetime | None`; when `received` is absent or invalid, the serializer can return `null`:

- [`getsentry/sentry` event serializer, lines 155-176](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/event.py#L155-L176)
- [`getsentry/sentry` event serializer, lines 328-368](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/event.py#L328-L368)

## Related precedent

- #910 made nullable `firstSeen` and `lastSeen` API dates accept `null` with `z.string().datetime().nullable()`.
- #520 fixed `occurrence: null` for transaction events after an `EventSchema` Zod error.
- #894 aligned event user and geo fields that can be `null`.
- #1236 proposes `nullish()` for API fields where `optional()` rejects explicit `null`.

## Change

- Change `dateReceived` to `z.string().datetime().nullish()`. This follows the nullable-date intent of #910 while also retaining support for omitted fields.
- Change generic `occurrence` to `OccurrenceSchema.nullish()`, consistent with the `nullish()` approach proposed in #1236 and the transaction-event handling in #520.
- Add a focused `EventSchema` regression test for `dateReceived: null` and generic `occurrence: null`.

## Testing and regression coverage

The focused Vitest regression test was added but could not be run locally: Corepack was unable to download the repository-pinned `pnpm@11.8.0` after 120-second and 300-second attempts, so dependencies could not be installed. `git diff --check` passes.

CI should run the new test with:

```sh
pnpm --filter @sentry/mcp-core exec vitest run src/api-client/schema.test.ts
```
