### PR TITLE
fix(test-client): surface provider errors instead of silent empty response

### DIFF
--- a/packages/mcp-test-client/src/agent.test.ts
+++ b/packages/mcp-test-client/src/agent.test.ts
@@ -1,6 +1,23 @@
+import { APICallError, RetryError } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runAgent } from "./agent.js";
+import { describeProviderError, runAgent } from "./agent.js";
 import type { MCPConnection } from "./types.js";
+
+// Capture the status the Sentry span is given so tests can assert a provider
+// failure is reported as an error (code 2) rather than silently swallowed.
+const { spanStatuses } = vi.hoisted(() => ({
+  spanStatuses: [] as Array<{ code: number }>,
+}));
+
+vi.mock("@sentry/core", () => ({
+  startNewTrace: (cb: () => unknown) => cb(),
+  startSpan: (_opts: unknown, cb: (span: unknown) => unknown) =>
+    cb({
+      setStatus: (status: { code: number }) => {
+        spanStatuses.push(status);
+      },
+    }),
+}));
 
 function createStreamingResponse() {
   const encoder = new TextEncoder();
@@ -28,12 +45,72 @@ function createStreamingResponse() {
   );
 }
 
+// A provider error response (invalid key -> 401, rate limit -> 429, 5xx). The
+// AI SDK does not throw for these while streaming, it ends textStream empty.
+function createErrorResponse(status: number, code: string) {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: `Simulated provider error (${status})`,
+        type: "invalid_request_error",
+        code,
+      },
+    }),
+    {
+      status,
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+// A successful stream that carries no text content, the legitimate empty case.
+function createEmptyStreamingResponse() {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"openai/gpt-5.6-luna","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+const testConnection: MCPConnection = {
+  client: {
+    tools: async () => ({}),
+  },
+  tools: new Map(),
+  disconnect: async () => {},
+  sessionId: "test-session",
+  transport: "stdio",
+};
+
+function captureStdout() {
+  const chunks: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  return chunks;
+}
+
 describe("runAgent", () => {
   const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
   const originalOpenRouterModel = process.env.OPENROUTER_MODEL;
   const originalMcpModel = process.env.MCP_MODEL;
 
   beforeEach(() => {
+    spanStatuses.length = 0;
     process.env.OPENROUTER_API_KEY = "sk-or-test";
     delete process.env.OPENROUTER_MODEL;
     delete process.env.MCP_MODEL;
@@ -105,5 +182,124 @@ describe("runAgent", () => {
       model: "openai/gpt-5.6-luna",
       stream: true,
     });
+  });
+
+  it("surfaces an authentication error instead of a silent empty response", async () => {
+    const output = captureStdout();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => createErrorResponse(401, "invalid_api_key")),
+    );
+
+    await expect(
+      runAgent(testConnection, "hello", {
+        provider: "openrouter",
+        maxSteps: 1,
+      }),
+    ).rejects.toThrow(/authentication failed/i);
+
+    const printed = output.join("");
+    // The user must see a real error, not the misleading fallback.
+    expect(printed).not.toContain("No response generated");
+    expect(printed).toContain("Agent execution failed");
+    // The error must reach Sentry: the span is marked errored (code 2).
+    expect(spanStatuses).toContainEqual({ code: 2 });
+    expect(spanStatuses).not.toContainEqual({ code: 1 });
+  });
+
+  it("maps a rate limit error to a clear message", async () => {
+    captureStdout();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => createErrorResponse(429, "rate_limit_exceeded")),
+    );
+
+    await expect(
+      runAgent(testConnection, "hello", {
+        provider: "openrouter",
+        maxSteps: 1,
+      }),
+    ).rejects.toThrow(/rate limit exceeded/i);
+    expect(spanStatuses).toContainEqual({ code: 2 });
+  }, 15000);
+
+  it("still reports a legitimate empty response without throwing", async () => {
+    const output = captureStdout();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => createEmptyStreamingResponse()),
+    );
+
+    await expect(
+      runAgent(testConnection, "hello", {
+        provider: "openrouter",
+        maxSteps: 1,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(output.join("")).toContain("(No response generated)");
+    expect(spanStatuses).toContainEqual({ code: 1 });
+    expect(spanStatuses).not.toContainEqual({ code: 2 });
+  });
+});
+
+describe("describeProviderError", () => {
+  function apiError(statusCode: number, message = "provider said no") {
+    return new APICallError({
+      message,
+      url: "https://api.example.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode,
+    });
+  }
+
+  it("maps 401 and 403 to an authentication message with the provider env var", () => {
+    expect(describeProviderError(apiError(401), "openai")).toBe(
+      "OpenAI API authentication failed. Please check your OPENAI_API_KEY environment variable.",
+    );
+    expect(describeProviderError(apiError(403), "openrouter")).toBe(
+      "OpenRouter API authentication failed. Please check your OPENROUTER_API_KEY environment variable.",
+    );
+  });
+
+  it("maps 429 to a rate limit message", () => {
+    expect(describeProviderError(apiError(429), "openai")).toBe(
+      "OpenAI API rate limit exceeded. Please wait and try again.",
+    );
+  });
+
+  it("maps 5xx to a service error message", () => {
+    expect(describeProviderError(apiError(500), "openai")).toBe(
+      "OpenAI API service error. The service may be temporarily unavailable.",
+    );
+    expect(describeProviderError(apiError(503), "openrouter")).toBe(
+      "OpenRouter API service error. The service may be temporarily unavailable.",
+    );
+  });
+
+  it("unwraps a RetryError to classify the underlying provider status", () => {
+    const retry = new RetryError({
+      message: "Failed after 3 attempts",
+      reason: "maxRetriesExceeded",
+      errors: [apiError(429)],
+    });
+    expect(describeProviderError(retry, "openrouter")).toBe(
+      "OpenRouter API rate limit exceeded. Please wait and try again.",
+    );
+  });
+
+  it("falls back to the raw message for other API errors", () => {
+    expect(describeProviderError(apiError(400, "bad request"), "openai")).toBe(
+      "OpenAI API request failed (HTTP 400): bad request",
+    );
+  });
+
+  it("handles non-API errors", () => {
+    expect(describeProviderError(new Error("socket hang up"), "openai")).toBe(
+      "OpenAI API request failed: socket hang up",
+    );
   });
 });

--- a/packages/mcp-test-client/src/agent.ts
+++ b/packages/mcp-test-client/src/agent.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { streamText, stepCountIs } from "ai";
+import { streamText, stepCountIs, APICallError, RetryError } from "ai";
 import { startNewTrace, startSpan } from "@sentry/core";
 import type { MCPConnection } from "./types.js";
 import {
@@ -42,6 +42,58 @@ export interface AgentConfig {
   model?: string;
   maxSteps?: number;
   provider?: "openai" | "openrouter";
+}
+
+/**
+ * Finds the underlying provider APICallError inside whatever the AI SDK
+ * surfaces. Retryable failures (429, 5xx) are wrapped in a RetryError once
+ * retries run out, so the HTTP status lives on the wrapped `lastError`.
+ */
+function findApiCallError(error: unknown): APICallError | undefined {
+  if (APICallError.isInstance(error)) {
+    return error;
+  }
+  if (RetryError.isInstance(error) && error.lastError) {
+    return findApiCallError(error.lastError);
+  }
+  if (error && typeof error === "object" && "cause" in error && error.cause) {
+    return findApiCallError((error as { cause: unknown }).cause);
+  }
+  return undefined;
+}
+
+/**
+ * Builds a user-facing message for a provider failure raised while streaming.
+ *
+ * The Vercel AI SDK does not throw when a provider request fails mid-stream.
+ * It reports the failure through the `onError` callback and ends `textStream`
+ * with no chunks, so the error has to be surfaced explicitly (see issue #500).
+ */
+export function describeProviderError(
+  error: unknown,
+  provider: "openai" | "openrouter",
+): string {
+  const label = provider === "openrouter" ? "OpenRouter API" : "OpenAI API";
+  const envVar =
+    provider === "openrouter" ? "OPENROUTER_API_KEY" : "OPENAI_API_KEY";
+
+  const apiError = findApiCallError(error);
+  if (apiError) {
+    const status = apiError.statusCode;
+    if (status === 401 || status === 403) {
+      return `${label} authentication failed. Please check your ${envVar} environment variable.`;
+    }
+    if (status === 429) {
+      return `${label} rate limit exceeded. Please wait and try again.`;
+    }
+    if (status !== undefined && status >= 500) {
+      return `${label} service error. The service may be temporarily unavailable.`;
+    }
+    return `${label} request failed${status ? ` (HTTP ${status})` : ""}: ${apiError.message}`;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return `${label} request failed: ${message}`;
 }
 
 /**
@@ -97,6 +149,7 @@ export async function runAgent(
           const tools = await connection.client.tools();
           let toolCallCount = 0;
           let isStreaming = false;
+          let streamError: unknown;
 
           const result = await streamText({
             model: languageModel,
@@ -106,6 +159,12 @@ export async function runAgent(
             stopWhen: stepCountIs(maxSteps),
             experimental_telemetry: {
               isEnabled: true,
+            },
+            onError: ({ error }) => {
+              // Provider failures (invalid key, rate limit, 5xx) arrive here
+              // rather than as a thrown error. Capture and surface after the
+              // stream drains so the Sentry span and the user both see it.
+              streamError = error;
             },
             onStepFinish: ({ toolCalls, toolResults }) => {
               if (toolCalls && toolCalls.length > 0) {
@@ -160,6 +219,19 @@ export async function runAgent(
             chunkCount++;
             logStreamWrite(chunk);
             currentOutput += chunk;
+          }
+
+          // Surface a provider failure captured during streaming. Throwing
+          // routes it through the catch below, which marks the span errored
+          // and rethrows so Sentry records it, instead of the silent fallback.
+          if (streamError !== undefined) {
+            if (isStreaming) {
+              logStreamEnd();
+              isStreaming = false;
+            }
+            throw new Error(describeProviderError(streamError, provider), {
+              cause: streamError,
+            });
           }
 
           // Show message if no response generated and no tools were used

--- a/packages/mcp-test-client/src/agent.ts
+++ b/packages/mcp-test-client/src/agent.ts
@@ -1,7 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { streamText, stepCountIs, APICallError, RetryError } from "ai";
 import { startNewTrace, startSpan } from "@sentry/core";
-import type { MCPConnection } from "./types.js";
+import { APICallError, RetryError, stepCountIs, streamText } from "ai";
 import {
   DEFAULT_OPENAI_MODEL,
   DEFAULT_OPENROUTER_MODEL,
@@ -9,13 +8,14 @@ import {
 } from "./constants.js";
 import {
   logError,
+  logStreamEnd,
+  logStreamStart,
+  logStreamWrite,
   logTool,
   logToolResult,
-  logStreamStart,
-  logStreamEnd,
-  logStreamWrite,
 } from "./logger.js";
 import { formatToolOutputForDisplay } from "./tool-output-format.js";
+import type { MCPConnection } from "./types.js";
 import { LIB_VERSION } from "./version.js";
 
 const SYSTEM_PROMPT = `You are a helpful assistant designed EXCLUSIVELY for testing the Sentry MCP server. Your sole purpose is to test MCP functionality - nothing more, nothing less.


### PR DESCRIPTION
When the MCP test client hit a provider error (an invalid key, a rate limit or a 5xx), it printed `(No response generated)` and the real reason was lost. The Vercel AI SDK the repo pins (`ai@6`) does not throw from `streamText`: it ends `textStream` with zero chunks and reports the failure only through an `onError` callback the code never set. So the loop finished empty, `runAgent` never entered its `catch`, the Sentry span kept its OK status and nothing was captured. The failure was invisible to the user and to Sentry at once.

This sets `onError` to capture the failure, then rethrows it after the stream drains so it flows through the existing `catch`, which marks the span errored and rethrows to the CLI's `captureException`. `describeProviderError` maps 401/403 to auth, 429 to rate limit and 5xx to service, then unwraps `RetryError.lastError` for retryable failures. The legitimate empty-response path is untouched. Confirmed against the installed `ai@6.0.230`: `textStream` yields zero chunks without throwing and the error arrives via `onError` as an `APICallError`; the guess in the issue of `result.errorPromise` does not exist on this version.

Fixes #500

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally: the `@sentry/mcp-test-client` vitest suite (70 to 79 passing), the new tests failing before and passing after the fix, `tsc --noEmit`, Biome lint and format, ast-grep, plus a real Sentry send showing the error now reaches Sentry with the span marked errored.
