### PR TITLE
fix(api): Accept nullable onboarding reference lists

### DIFF
--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -2146,7 +2146,13 @@ export const AgenticOnboardingRunSchema = z.object({
   expiresAt: z.string(),
   continueUpdates: z.boolean(),
   runStatus: AgenticOnboardingRunStatusSchema,
-  projectSlugs: z.array(z.string()),
-  issueIds: z.array(z.string()),
+  projectSlugs: z
+    .array(z.string())
+    .nullable()
+    .transform((projectSlugs) => projectSlugs ?? []),
+  issueIds: z
+    .array(z.string())
+    .nullable()
+    .transform((issueIds) => issueIds ?? []),
   stages: z.array(AgenticOnboardingStageStateSchema),
 });

--- a/packages/mcp-core/src/tools/catalog/onboarding-status-update.test.ts
+++ b/packages/mcp-core/src/tools/catalog/onboarding-status-update.test.ts
@@ -108,6 +108,43 @@ describe("onboarding_status_update", () => {
     ).resolves.toBe("Onboarding status updated. Continue updates: yes.");
   });
 
+  it("accepts nullable reference lists from the backend", async () => {
+    mswServer.use(
+      http.post(
+        "https://us.sentry.io/api/0/organizations/sentry-mcp-evals/onboarding/agent/status/",
+        () =>
+          HttpResponse.json({
+            schemaVersion: 1,
+            runId: "2d27f6654b754dcaa2d26af18274d142",
+            channelId: "6835652362204cb1b10719783c26983a",
+            clientRunId: "e806c6f4-fef8-47b4-a720-5ab582b2fcf0",
+            createdAt: "2026-08-12T12:00:00Z",
+            updatedAt: "2026-08-12T12:01:00Z",
+            sequence: 1,
+            expiresAt: "2026-08-13T12:00:00Z",
+            continueUpdates: true,
+            runStatus: "active",
+            projectSlugs: null,
+            issueIds: null,
+            stages: [],
+          }),
+      ),
+    );
+
+    await expect(
+      onboardingStatusUpdate.handler(
+        {
+          organizationSlug: "sentry-mcp-evals",
+          regionUrl: "https://us.sentry.io",
+          runToken: "a1B2c3D4e5",
+          stage: "connect_mcp",
+          status: "completed",
+        },
+        context,
+      ),
+    ).resolves.toBe("Onboarding status updated. Continue updates: yes.");
+  });
+
   it("reports when the run no longer accepts updates", async () => {
     mswServer.use(
       http.post(


### PR DESCRIPTION
The onboarding status endpoint can return `null` for `projectSlugs` and `issueIds` before resources are associated with a run. The MCP response parser currently rejects that successful response and reports a tool failure even though the UI update was accepted.

Normalize nullable reference lists to empty arrays at the API boundary and cover the production response shape with a regression test.

Fixes https://sentry.sentry.io/issues/MCP-SERVER-G77