### PR TITLE
fix(tools): skip autofix fetch when seer skill is disabled

### DIFF
--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@sentry/mcp-server-mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
+import type { Skill } from "../../skills";
 import {
   getStructuredContent,
   getTextContent,
@@ -1338,6 +1339,65 @@ describe("get_issue_details", () => {
     );
     // When Seer data is available, these would pass:
     // expect(result).toContain("## Seer AI Analysis");
+  });
+
+  it("skips the autofix request when the seer skill is not granted", async () => {
+    let autofixRequested = false;
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/autofix/",
+        () => {
+          autofixRequested = true;
+          return HttpResponse.json({ autofix: null });
+        },
+      ),
+    );
+
+    const result = await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      {
+        ...baseContext,
+        grantedSkills: new Set<Skill>(["inspect"]),
+      },
+    );
+
+    expect(autofixRequested).toBe(false);
+    expect(result).toContain("# Issue CLOUDFLARE-MCP-41");
+  });
+
+  it("requests autofix state when the seer skill is granted", async () => {
+    let autofixRequested = false;
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/autofix/",
+        () => {
+          autofixRequested = true;
+          return HttpResponse.json({ autofix: null });
+        },
+      ),
+    );
+
+    await getIssueDetails.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        issueId: "CLOUDFLARE-MCP-41",
+        eventId: undefined,
+        issueUrl: undefined,
+        regionUrl: null,
+      },
+      {
+        ...baseContext,
+        grantedSkills: new Set<Skill>(["inspect", "seer"]),
+      },
+    );
+
+    expect(autofixRequested).toBe(true);
   });
 
   it.skip("includes Seer analysis when in progress - processing state", async () => {

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -167,6 +167,7 @@ export default defineTool({
           apiService,
           organizationSlug: orgSlug,
           issue,
+          seerEnabled: isSeerGranted(context),
         }),
       ]);
 
@@ -259,6 +260,7 @@ export default defineTool({
         apiService,
         organizationSlug: orgSlug,
         issue,
+        seerEnabled: isSeerGranted(context),
       }),
     ]);
 
@@ -326,17 +328,20 @@ async function fetchEventEnrichment({
 
 /**
  * Fetches supplementary data for an issue in parallel: Seer analysis and external links.
- * Both calls are non-blocking -- failures are silently caught so they never
- * prevent the primary issue details from being returned.
+ * All calls are non-blocking -- failures are silently caught so they never
+ * prevent the primary issue details from being returned. Seer analysis is
+ * skipped entirely when the `seer` skill is not granted.
  */
 async function fetchIssueEnrichmentData({
   apiService,
   organizationSlug,
   issue,
+  seerEnabled,
 }: {
   apiService: SentryApiService;
   organizationSlug: string;
   issue: Issue;
+  seerEnabled: boolean;
 }): Promise<{
   autofixState: AutofixRunState | undefined;
   externalIssues: ExternalIssueList | undefined;
@@ -344,9 +349,12 @@ async function fetchIssueEnrichmentData({
 }> {
   const issueId = String(issue.id);
   const [autofixState, externalIssues, relatedReplayIds] = await Promise.all([
-    apiService
-      .getAutofixState({ organizationSlug, issueId: issue.shortId })
-      .catch(() => undefined),
+    maybeFetchAutofixState({
+      apiService,
+      organizationSlug,
+      issue,
+      seerEnabled,
+    }),
     apiService
       .getIssueExternalLinks({ organizationSlug, issueId: issue.shortId })
       .catch(() => undefined),
@@ -360,6 +368,39 @@ async function fetchIssueEnrichmentData({
   ]);
 
   return { autofixState, externalIssues, relatedReplayIds };
+}
+
+/**
+ * Whether Seer output can be used at all in this session.
+ *
+ * A session started with `--disable-skills=seer` (or `--skills` that omits it)
+ * drops Seer output on the floor, so requesting it is pure overhead -- and on
+ * deployments without Seer the autofix endpoint answers 500, making it a
+ * guaranteed-failing request on every issue lookup. An unknown granted set
+ * keeps the previous behaviour and fetches.
+ */
+function isSeerGranted(context: ServerContext): boolean {
+  return context.grantedSkills ? context.grantedSkills.has("seer") : true;
+}
+
+async function maybeFetchAutofixState({
+  apiService,
+  organizationSlug,
+  issue,
+  seerEnabled,
+}: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  issue: Issue;
+  seerEnabled: boolean;
+}): Promise<AutofixRunState | undefined> {
+  if (!seerEnabled) {
+    return undefined;
+  }
+
+  return apiService
+    .getAutofixState({ organizationSlug, issueId: issue.shortId })
+    .catch(() => undefined);
 }
 
 async function maybeFetchPerformanceTrace({


### PR DESCRIPTION
`--disable-skills=seer` (#794) removes `analyze_issue_with_seer` from the active tool set, but it does not stop `get_issue_details` from requesting Seer autofix state. The call lives in `fetchIssueEnrichmentData` and is never gated on the granted skills:

```ts
const [autofixState, externalIssues, relatedReplayIds] = await Promise.all([
  apiService
    .getAutofixState({ organizationSlug, issueId: issue.shortId })
    .catch(() => undefined),
  ...
```

`get_issue_details` belongs to `["inspect", "triage", "seer"]`, so disabling `seer` leaves the tool available through the other two skills — and every lookup still hits `/api/0/organizations/{org}/issues/{issue}/autofix/`.

### Why it matters

On a deployment without Seer that endpoint is a guaranteed 500: `GroupAutofixEndpoint.get` calls through to Seer with no transport-error handling, so an unreachable Seer surfaces as an unhandled `ConnectionError`.

The failure is invisible from the client side — `.catch(() => undefined)` swallows it and the tool output is unaffected — so the flag looks like it works. But the request still goes out, and the target instance logs a 5xx for every issue lookup.

Observed on a self-hosted instance: 105 × HTTP 500 in 30 minutes from a single agent session, all from `get_issue_details`, at ~30/min. Ingress error-rate alerting is usually a *ratio*, so on a low-traffic instance this reads as a ~20% error rate and pages.

### Change

Gate the autofix fetch on the `seer` skill, so the flag that already exists suppresses the request as well as the tool:

```ts
function isSeerGranted(context: ServerContext): boolean {
  return context.grantedSkills ? context.grantedSkills.has("seer") : true;
}
```

An unknown granted set keeps the previous behaviour and fetches, so nothing changes for callers that don't configure skills.

`ServerContext.grantedSkills` is populated by both transports (stdio via `--skills` / `--disable-skills`, remote via `?skills=` / `?disable-skills=`), so this works for hosted sessions too.

### Notes

- Two tests added: autofix is not requested when `seer` is absent from the granted set, and still requested when present.
- `packages/mcp-core` tsc and `biome check` are clean for the touched files. The pre-existing `msw` import-sort finding in `get-issue-details.test.ts` is left alone — it reproduces on `main`.
- This is deliberately scoped to honouring the existing flag. It does not help a caller who leaves all skills enabled; the general fix for that belongs upstream in `sentry`, where the endpoint should degrade instead of raising when Seer is unreachable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
