### PR TITLE
fix(api): Support stage-specific onboarding metadata

### DIFF
--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -2098,11 +2098,43 @@ export const AgenticOnboardingStageStatusUpdateSchema = z.enum([
   "failed",
 ]);
 
-export const AgenticOnboardingStageStateSchema = z.object({
-  stage: AgenticOnboardingStageSchema,
+const AgenticOnboardingCreateProjectExtraSchema = z
+  .object({
+    projectSlugs: z.array(z.string().trim().min(1)),
+  })
+  .strict();
+
+const AgenticOnboardingVerificationErrorExtraSchema = z
+  .object({
+    issueIds: z.array(z.string().trim().min(1)),
+  })
+  .strict();
+
+const AgenticOnboardingStageWithoutExtraSchema =
+  AgenticOnboardingStageSchema.exclude([
+    "create_project",
+    "receive_verification_error",
+  ]);
+
+const AgenticOnboardingStageStateBaseSchema = z.object({
   status: AgenticOnboardingStageStatusSchema.nullable(),
   eventNote: z.string().nullable(),
 });
+
+export const AgenticOnboardingStageStateSchema = z.discriminatedUnion("stage", [
+  AgenticOnboardingStageStateBaseSchema.extend({
+    stage: z.literal("create_project"),
+    extra: AgenticOnboardingCreateProjectExtraSchema.nullable(),
+  }),
+  AgenticOnboardingStageStateBaseSchema.extend({
+    stage: z.literal("receive_verification_error"),
+    extra: AgenticOnboardingVerificationErrorExtraSchema.nullable(),
+  }),
+  AgenticOnboardingStageStateBaseSchema.extend({
+    stage: AgenticOnboardingStageWithoutExtraSchema,
+    extra: z.null(),
+  }),
+]);
 
 export const AgenticOnboardingRunStatusSchema = z.enum([
   "active",
@@ -2116,16 +2148,35 @@ export const AgenticOnboardingRunStatusUpdateSchema = z.enum([
   "failed",
 ]);
 
-export const AgenticOnboardingStatusUpdateSchema = z.object({
+export const AgenticOnboardingRunTokenSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9]{10}$/);
+
+const AgenticOnboardingStatusUpdateBaseSchema = z.object({
   schemaVersion: z.literal(1),
-  runToken: z.string().regex(/^[A-Za-z0-9]{10}$/),
-  stage: AgenticOnboardingStageSchema,
+  runToken: AgenticOnboardingRunTokenSchema,
   status: AgenticOnboardingStageStatusUpdateSchema,
   runStatus: AgenticOnboardingRunStatusUpdateSchema.optional(),
   eventNote: z.string().trim().min(1).max(256).optional(),
-  projectSlugs: z.array(z.string().trim().min(1)).min(1).max(100).optional(),
-  issueIds: z.array(z.string().trim().min(1)).min(1).max(100).optional(),
 });
+
+export const AgenticOnboardingStatusUpdateSchema = z.discriminatedUnion(
+  "stage",
+  [
+    AgenticOnboardingStatusUpdateBaseSchema.extend({
+      stage: z.literal("create_project"),
+      extra: AgenticOnboardingCreateProjectExtraSchema.optional(),
+    }),
+    AgenticOnboardingStatusUpdateBaseSchema.extend({
+      stage: z.literal("receive_verification_error"),
+      extra: AgenticOnboardingVerificationErrorExtraSchema.optional(),
+    }),
+    AgenticOnboardingStatusUpdateBaseSchema.extend({
+      stage: AgenticOnboardingStageWithoutExtraSchema,
+      extra: z.never().optional(),
+    }),
+  ],
+);
 
 export const AgenticOnboardingRunSchema = z.object({
   schemaVersion: z.literal(1),
@@ -2138,13 +2189,5 @@ export const AgenticOnboardingRunSchema = z.object({
   expiresAt: z.string(),
   continueUpdates: z.boolean(),
   runStatus: AgenticOnboardingRunStatusSchema,
-  projectSlugs: z
-    .array(z.string())
-    .nullable()
-    .transform((projectSlugs) => projectSlugs ?? []),
-  issueIds: z
-    .array(z.string())
-    .nullable()
-    .transform((issueIds) => issueIds ?? []),
   stages: z.array(AgenticOnboardingStageStateSchema),
 });

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -3806,59 +3806,159 @@
           "pattern": "^[A-Za-z0-9]{10}$",
           "description": "The 10-character onboarding run token supplied by Sentry."
         },
-        "stage": {
-          "type": "string",
-          "enum": [
-            "connect_mcp",
-            "analyze_project",
-            "create_project",
-            "instrument_app",
-            "plan_test_error",
-            "send_verification_error",
-            "receive_verification_error",
-            "prepare_production",
-            "check_stack_trace_quality"
+        "update": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "waiting",
+                    "completed",
+                    "skipped",
+                    "failed"
+                  ],
+                  "description": "The stage's current status."
+                },
+                "runStatus": {
+                  "description": "Set only when the entire onboarding run has completed or failed.",
+                  "type": "string",
+                  "enum": ["completed", "failed"]
+                },
+                "eventNote": {
+                  "description": "Short context to display with this progress event. Required when status is failed.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
+                "stage": {
+                  "type": "string",
+                  "const": "create_project",
+                  "description": "Report progress while creating or selecting Sentry projects."
+                },
+                "extra": {
+                  "description": "Project metadata accepted only by the create_project stage.",
+                  "type": "object",
+                  "properties": {
+                    "projectSlugs": {
+                      "minItems": 1,
+                      "maxItems": 100,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": "Sentry project slugs created or selected during onboarding. Values accumulate across updates; include each project as it becomes usable while active, then all known projects when completed."
+                    }
+                  },
+                  "required": ["projectSlugs"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["status", "stage"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "waiting",
+                    "completed",
+                    "skipped",
+                    "failed"
+                  ],
+                  "description": "The stage's current status."
+                },
+                "runStatus": {
+                  "description": "Set only when the entire onboarding run has completed or failed.",
+                  "type": "string",
+                  "enum": ["completed", "failed"]
+                },
+                "eventNote": {
+                  "description": "Short context to display with this progress event. Required when status is failed.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
+                "stage": {
+                  "type": "string",
+                  "const": "receive_verification_error",
+                  "description": "Report progress while receiving the verification error in Sentry."
+                },
+                "extra": {
+                  "description": "Issue metadata accepted only by the receive_verification_error stage.",
+                  "type": "object",
+                  "properties": {
+                    "issueIds": {
+                      "minItems": 1,
+                      "maxItems": 100,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": "Sentry issue IDs observed after sending the verification error. Values accumulate across updates; include each matching issue as it is confirmed, then all known issues when completed."
+                    }
+                  },
+                  "required": ["issueIds"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["status", "stage"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "waiting",
+                    "completed",
+                    "skipped",
+                    "failed"
+                  ],
+                  "description": "The stage's current status."
+                },
+                "runStatus": {
+                  "description": "Set only when the entire onboarding run has completed or failed.",
+                  "type": "string",
+                  "enum": ["completed", "failed"]
+                },
+                "eventNote": {
+                  "description": "Short context to display with this progress event. Required when status is failed.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
+                "stage": {
+                  "type": "string",
+                  "enum": [
+                    "connect_mcp",
+                    "analyze_project",
+                    "instrument_app",
+                    "plan_test_error",
+                    "send_verification_error",
+                    "prepare_production",
+                    "check_stack_trace_quality"
+                  ],
+                  "description": "Report progress for a stage that does not accept extra metadata."
+                }
+              },
+              "required": ["status", "stage"],
+              "additionalProperties": false
+            }
           ],
-          "description": "The onboarding stage being updated."
-        },
-        "status": {
-          "type": "string",
-          "enum": ["active", "waiting", "completed", "skipped", "failed"],
-          "description": "The stage's current status."
-        },
-        "runStatus": {
-          "description": "Set only when the entire onboarding run has completed or failed.",
-          "type": "string",
-          "enum": ["completed", "failed"]
-        },
-        "eventNote": {
-          "description": "Short context to display with this progress event. Required when status is failed.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 256
-        },
-        "projectSlugs": {
-          "description": "Validated Sentry project slugs. Send only for create_project. Values accumulate across updates; include each project as it becomes usable while active, then all known projects when completed.",
-          "minItems": 1,
-          "maxItems": 100,
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "issueIds": {
-          "description": "Validated Sentry issue IDs returned by MCP. Send only for receive_verification_error. Values accumulate across updates; include each matching issue as it is confirmed, then all known issues when completed.",
-          "minItems": 1,
-          "maxItems": 100,
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
+          "description": "The stage-specific onboarding progress update."
         }
       },
-      "required": ["organizationSlug", "runToken", "stage", "status"]
+      "required": ["organizationSlug", "runToken", "update"]
     },
     "requiredScopes": ["org:read"],
     "skills": ["inspect", "seer", "docs", "triage", "project-management"],

--- a/packages/mcp-core/src/tools/catalog/onboarding-status-update.test.ts
+++ b/packages/mcp-core/src/tools/catalog/onboarding-status-update.test.ts
@@ -36,13 +36,12 @@ describe("onboarding_status_update", () => {
             expiresAt: "2026-08-13T12:00:00Z",
             continueUpdates: true,
             runStatus: "active",
-            projectSlugs: ["private-project", "worker-project"],
-            issueIds: [],
             stages: [
               {
                 stage: "analyze_project",
                 status: "bypassed",
                 eventNote: null,
+                extra: null,
               },
             ],
           });
@@ -55,10 +54,12 @@ describe("onboarding_status_update", () => {
         organizationSlug: "sentry-mcp-evals",
         regionUrl: "https://us.sentry.io",
         runToken: "a1B2c3D4e5",
-        stage: "create_project",
-        status: "completed",
-        eventNote: "Project already existed.",
-        projectSlugs: ["private-project", "worker-project"],
+        update: {
+          stage: "create_project",
+          status: "completed",
+          eventNote: "Project already existed.",
+          extra: { projectSlugs: ["private-project", "worker-project"] },
+        },
       },
       context,
     );
@@ -69,7 +70,7 @@ describe("onboarding_status_update", () => {
       stage: "create_project",
       status: "completed",
       eventNote: "Project already existed.",
-      projectSlugs: ["private-project", "worker-project"],
+      extra: { projectSlugs: ["private-project", "worker-project"] },
     });
     expect(result).toMatchInlineSnapshot(
       `"Onboarding status updated. Continue updates: yes."`,
@@ -80,16 +81,44 @@ describe("onboarding_status_update", () => {
 
   it("does not accept the backend-derived bypassed status as input", () => {
     expect(
-      onboardingStatusUpdate.inputSchema.status.safeParse("bypassed").success,
+      onboardingStatusUpdate.inputSchema.update.safeParse({
+        stage: "connect_mcp",
+        status: "bypassed",
+      }).success,
     ).toBe(false);
     expect(onboardingStatusUpdate.inputSchema).not.toHaveProperty(
       "failureReason",
     );
     expect(
-      onboardingStatusUpdate.inputSchema.projectSlugs.safeParse([]).success,
+      onboardingStatusUpdate.inputSchema.update.safeParse({
+        stage: "create_project",
+        status: "completed",
+        extra: { projectSlugs: [] },
+      }).success,
     ).toBe(false);
     expect(
-      onboardingStatusUpdate.inputSchema.issueIds.safeParse([]).success,
+      onboardingStatusUpdate.inputSchema.update.safeParse({
+        stage: "receive_verification_error",
+        status: "completed",
+        extra: { issueIds: [] },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects metadata that does not belong to the stage", () => {
+    expect(
+      onboardingStatusUpdate.inputSchema.update.safeParse({
+        stage: "receive_verification_error",
+        status: "completed",
+        extra: { projectSlugs: ["private-project"] },
+      }).success,
+    ).toBe(false);
+    expect(
+      onboardingStatusUpdate.inputSchema.update.safeParse({
+        stage: "connect_mcp",
+        status: "completed",
+        extra: { issueIds: ["123"] },
+      }).success,
     ).toBe(false);
   });
 
@@ -100,15 +129,14 @@ describe("onboarding_status_update", () => {
           organizationSlug: "sentry-mcp-evals",
           regionUrl: null,
           runToken: "a1B2c3D4e5",
-          stage: "connect_mcp",
-          status: "completed",
+          update: { stage: "connect_mcp", status: "completed" },
         },
         context,
       ),
     ).resolves.toBe("Onboarding status updated. Continue updates: yes.");
   });
 
-  it("accepts nullable reference lists from the backend", async () => {
+  it("accepts nullable stage extras from the backend", async () => {
     mswServer.use(
       http.post(
         "https://us.sentry.io/api/0/organizations/sentry-mcp-evals/onboarding/agent/status/",
@@ -124,8 +152,6 @@ describe("onboarding_status_update", () => {
             expiresAt: "2026-08-13T12:00:00Z",
             continueUpdates: true,
             runStatus: "active",
-            projectSlugs: null,
-            issueIds: null,
             stages: [],
           }),
       ),
@@ -137,8 +163,7 @@ describe("onboarding_status_update", () => {
           organizationSlug: "sentry-mcp-evals",
           regionUrl: "https://us.sentry.io",
           runToken: "a1B2c3D4e5",
-          stage: "connect_mcp",
-          status: "completed",
+          update: { stage: "connect_mcp", status: "completed" },
         },
         context,
       ),
@@ -161,8 +186,6 @@ describe("onboarding_status_update", () => {
             expiresAt: "2026-08-13T12:00:00Z",
             continueUpdates: false,
             runStatus: "completed",
-            projectSlugs: [],
-            issueIds: [],
             stages: [],
           }),
       ),
@@ -174,9 +197,11 @@ describe("onboarding_status_update", () => {
           organizationSlug: "sentry-mcp-evals",
           regionUrl: "https://us.sentry.io",
           runToken: "a1B2c3D4e5",
-          stage: "check_stack_trace_quality",
-          status: "completed",
-          runStatus: "completed",
+          update: {
+            stage: "check_stack_trace_quality",
+            status: "completed",
+            runStatus: "completed",
+          },
         },
         context,
       ),

--- a/packages/mcp-core/src/tools/catalog/onboarding-status-update.ts
+++ b/packages/mcp-core/src/tools/catalog/onboarding-status-update.ts
@@ -1,6 +1,7 @@
 import { setTag } from "@sentry/core";
 import { z } from "zod";
 import {
+  AgenticOnboardingRunTokenSchema,
   AgenticOnboardingRunStatusUpdateSchema,
   AgenticOnboardingStageSchema,
   AgenticOnboardingStageStatusUpdateSchema,
@@ -11,6 +12,85 @@ import { defineTool } from "../../internal/tool-helpers/define";
 import { ParamOrganizationSlug, ParamRegionUrl } from "../../schema";
 import { ALL_SKILLS } from "../../skills";
 import type { ServerContext } from "../../types";
+
+const updateBaseSchema = z
+  .object({
+    status: AgenticOnboardingStageStatusUpdateSchema.describe(
+      "The stage's current status.",
+    ),
+    runStatus: AgenticOnboardingRunStatusUpdateSchema.optional().describe(
+      "Set only when the entire onboarding run has completed or failed.",
+    ),
+    eventNote: z
+      .string()
+      .trim()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        "Short context to display with this progress event. Required when status is failed.",
+      ),
+  })
+  .strict();
+
+const createProjectUpdateSchema = updateBaseSchema.extend({
+  stage: z
+    .literal("create_project")
+    .describe("Report progress while creating or selecting Sentry projects."),
+  extra: z
+    .object({
+      projectSlugs: z
+        .array(z.string().trim().min(1))
+        .min(1)
+        .max(100)
+        .describe(
+          "Sentry project slugs created or selected during onboarding. Values accumulate across updates; include each project as it becomes usable while active, then all known projects when completed.",
+        ),
+    })
+    .strict()
+    .optional()
+    .describe("Project metadata accepted only by the create_project stage."),
+});
+
+const receiveVerificationErrorUpdateSchema = updateBaseSchema.extend({
+  stage: z
+    .literal("receive_verification_error")
+    .describe(
+      "Report progress while receiving the verification error in Sentry.",
+    ),
+  extra: z
+    .object({
+      issueIds: z
+        .array(z.string().trim().min(1))
+        .min(1)
+        .max(100)
+        .describe(
+          "Sentry issue IDs observed after sending the verification error. Values accumulate across updates; include each matching issue as it is confirmed, then all known issues when completed.",
+        ),
+    })
+    .strict()
+    .optional()
+    .describe(
+      "Issue metadata accepted only by the receive_verification_error stage.",
+    ),
+});
+
+const updateWithoutExtraSchema = updateBaseSchema.extend({
+  stage: AgenticOnboardingStageSchema.exclude([
+    "create_project",
+    "receive_verification_error",
+  ]).describe(
+    "Report progress for a stage that does not accept extra metadata.",
+  ),
+});
+
+const onboardingUpdateSchema = z
+  .discriminatedUnion("stage", [
+    createProjectUpdateSchema,
+    receiveVerificationErrorUpdateSchema,
+    updateWithoutExtraSchema,
+  ])
+  .describe("The stage-specific onboarding progress update.");
 
 export default defineTool({
   name: "onboarding_status_update",
@@ -34,34 +114,10 @@ export default defineTool({
   inputSchema: {
     organizationSlug: ParamOrganizationSlug,
     regionUrl: ParamRegionUrl.nullable().default(null),
-    runToken: AgenticOnboardingStatusUpdateSchema.shape.runToken.describe(
+    runToken: AgenticOnboardingRunTokenSchema.describe(
       "The 10-character onboarding run token supplied by Sentry.",
     ),
-    stage: AgenticOnboardingStageSchema.describe(
-      "The onboarding stage being updated.",
-    ),
-    status: AgenticOnboardingStageStatusUpdateSchema.describe(
-      "The stage's current status.",
-    ),
-    runStatus: AgenticOnboardingRunStatusUpdateSchema.optional().describe(
-      "Set only when the entire onboarding run has completed or failed.",
-    ),
-    eventNote: z
-      .string()
-      .trim()
-      .min(1)
-      .max(256)
-      .optional()
-      .describe(
-        "Short context to display with this progress event. Required when status is failed.",
-      ),
-    projectSlugs:
-      AgenticOnboardingStatusUpdateSchema.shape.projectSlugs.describe(
-        "Validated Sentry project slugs. Send only for create_project. Values accumulate across updates; include each project as it becomes usable while active, then all known projects when completed.",
-      ),
-    issueIds: AgenticOnboardingStatusUpdateSchema.shape.issueIds.describe(
-      "Validated Sentry issue IDs returned by MCP. Send only for receive_verification_error. Values accumulate across updates; include each matching issue as it is confirmed, then all known issues when completed.",
-    ),
+    update: onboardingUpdateSchema,
   },
   annotations: {
     readOnlyHint: false,
@@ -76,18 +132,15 @@ export default defineTool({
 
     setTag("organization.slug", params.organizationSlug);
 
+    const update = AgenticOnboardingStatusUpdateSchema.parse({
+      schemaVersion: 1,
+      runToken: params.runToken,
+      ...params.update,
+    });
+
     const run = await apiService.updateAgenticOnboardingStatus({
       organizationSlug: params.organizationSlug,
-      update: {
-        schemaVersion: 1,
-        runToken: params.runToken,
-        stage: params.stage,
-        status: params.status,
-        ...(params.runStatus ? { runStatus: params.runStatus } : {}),
-        ...(params.eventNote ? { eventNote: params.eventNote } : {}),
-        ...(params.projectSlugs ? { projectSlugs: params.projectSlugs } : {}),
-        ...(params.issueIds ? { issueIds: params.issueIds } : {}),
-      },
+      update,
     });
 
     return `Onboarding status updated. Continue updates: ${run.continueUpdates ? "yes" : "no"}.`;

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -416,13 +416,12 @@ export const restHandlers = buildHandlers([
         expiresAt: "2026-08-13T12:00:00Z",
         continueUpdates: true,
         runStatus: "active",
-        projectSlugs: [],
-        issueIds: [],
         stages: [
           {
             stage: "connect_mcp",
             status: "completed",
             eventNote: null,
+            extra: null,
           },
         ],
       });


### PR DESCRIPTION
Sentry onboarding runs now store project slugs and verification issue IDs in stage-specific `extra` objects. This updates the API schemas, outgoing status payloads, response parsing, and mocks to follow the contract introduced by getsentry/sentry#122076.

The `onboarding_status_update` tool now accepts a nested `update` object whose schema discriminates on `stage`. Callers must move `stage`, `status`, `runStatus`, and `eventNote` under `update`, and send `projectSlugs` or `issueIds` through that stage's `extra` object.
