### PR TITLE
test(attachments): Cover binary MCP attachment responses

### DIFF
--- a/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
+++ b/packages/mcp-cloudflare/src/server/lib/mcp-handler.test.ts
@@ -406,6 +406,51 @@ describe("MCP Handler", () => {
       });
     });
 
+    it("returns binary attachment bytes in the HTTP MCP response", async () => {
+      const request = createMcpRequest("tools/call", {
+        name: "execute_sentry_tool",
+        arguments: {
+          name: "get_event_attachment",
+          arguments: {
+            organizationSlug: "sentry-mcp-evals",
+            projectSlug: "cloudflare-mcp",
+            eventId: "d49541c747cb4d8aa3efb70ca5aba244",
+            attachmentId: "456",
+          },
+        },
+      });
+      const ctx = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext;
+
+      const response = await handleSentryBearerMcpRequest(
+        request,
+        createTestEnv(),
+        ctx,
+        "sntryu_test-token",
+      );
+
+      expect(response.status).toBe(200);
+      const body = await parseSSEResponse<{
+        result: {
+          content: Array<{
+            type: string;
+            resource?: { blob?: string; mimeType?: string; uri?: string };
+          }>;
+        };
+      }>(response);
+
+      expect(body.result.content).toContainEqual({
+        type: "resource",
+        resource: {
+          uri: "file://attachment.bin",
+          mimeType: "application/octet-stream",
+          blob: "YmluYXJ5IGF0dGFjaG1lbnQ=",
+        },
+      });
+    });
+
     it("applies the Sentry-Bearer MCP rate limit per token", async () => {
       const mockTokenRateLimiter = {
         limit: vi.fn().mockResolvedValue({ success: true }),

--- a/packages/mcp-cloudflare/src/test-utils/fetch-mock-setup.ts
+++ b/packages/mcp-cloudflare/src/test-utils/fetch-mock-setup.ts
@@ -356,6 +356,36 @@ export function registerFetchMockInterceptors(fetchMock: FetchMockLike) {
       .reply(200, eventFixture, { headers: JSON_HEADERS })
       .persist();
 
+    // ===== Event Attachments =====
+    pool
+      .intercept({
+        path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/d49541c747cb4d8aa3efb70ca5aba244/attachments/",
+      })
+      .reply(
+        200,
+        [
+          {
+            id: "456",
+            name: "attachment.bin",
+            type: "event.attachment",
+            size: 17,
+            mimetype: "application/octet-stream",
+            dateCreated: "2025-04-08T21:15:04.000Z",
+          },
+        ],
+        { headers: JSON_HEADERS },
+      )
+      .persist();
+
+    pool
+      .intercept({
+        path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/d49541c747cb4d8aa3efb70ca5aba244/attachments/456/?download=1",
+      })
+      .reply(200, "binary attachment", {
+        headers: { "Content-Type": "application/octet-stream" },
+      })
+      .persist();
+
     // ===== Traces =====
     pool
       .intercept({

--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { McpServer as LegacyMcpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpServer as ModernMcpServer } from "@modelcontextprotocol/server";
 import { type Span, setUser, startSpan } from "@sentry/core";
 import { mswServer } from "@sentry/mcp-server-mocks";
@@ -81,7 +82,7 @@ async function listRegisteredTools(server: ReturnType<typeof buildServer>) {
 }
 
 async function callRegisteredTool(
-  server: ReturnType<typeof buildServer>,
+  server: LegacyMcpServer | ModernMcpServer,
   name: string,
   args: Record<string, unknown>,
 ) {
@@ -187,6 +188,48 @@ describe("buildServer", () => {
     ).resolves.toMatchObject({
       content: [{ type: "text", text: "v2:ok" }],
     });
+  });
+
+  it("returns attachment bytes through the SDK v2 catalog execution path", async () => {
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/d49541c747cb4d8aa3efb70ca5aba244/attachments/456/",
+        () =>
+          new HttpResponse(new Blob(["binary attachment"]), {
+            headers: { "content-type": "application/octet-stream" },
+          }),
+        { once: true },
+      ),
+    );
+
+    const server = buildServer({
+      context: baseContext,
+      sdkVersion: "v2",
+    });
+
+    const result = await callRegisteredTool(server, "execute_sentry_tool", {
+      name: "get_event_attachment",
+      arguments: {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        eventId: "d49541c747cb4d8aa3efb70ca5aba244",
+        attachmentId: "456",
+      },
+    });
+
+    expect(result).not.toMatchObject({ isError: true });
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        {
+          type: "resource",
+          resource: {
+            uri: "file://screenshot.png",
+            mimeType: "application/octet-stream",
+            blob: "YmluYXJ5IGF0dGFjaG1lbnQ=",
+          },
+        },
+      ]),
+    );
   });
 
   describe("telemetry context", () => {


### PR DESCRIPTION
Binary event attachments are now covered through both the SDK v2 catalog and Cloudflare Worker SSE paths, ensuring the returned MCP resource retains its MIME type and base64 body.

This is regression coverage only: the current source already preserves attachment bytes, while the reported live response requires deployment- and fixture-specific follow-up. Refs #1267.
