### PR TITLE
fix: Enable gen_ai spans with vite plugin

### DIFF
--- a/packages/mcp-cloudflare/src/server/sentry.config.ts
+++ b/packages/mcp-cloudflare/src/server/sentry.config.ts
@@ -21,7 +21,7 @@ export default function getSentryConfig(env: Env): CloudflareOptions {
     environment:
       env.SENTRY_ENVIRONMENT ??
       (process.env.NODE_ENV !== "production" ? "development" : "production"),
-    integrations: [Sentry.zodErrorsIntegration(), Sentry.vercelAIIntegration()],
+    integrations: [Sentry.zodErrorsIntegration()],
   };
 }
 

--- a/packages/mcp-cloudflare/vite.config.ts
+++ b/packages/mcp-cloudflare/vite.config.ts
@@ -2,6 +2,7 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { cloudflare } from "@cloudflare/vite-plugin";
+import { sentryCloudflareVitePlugin } from "@sentry/cloudflare/vite";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
 import { generateHomepageFallbackHtml } from "./src/homepage-content";
@@ -37,6 +38,7 @@ export default defineConfig({
     cloudflare(),
     tailwindcss(),
     homepageFallbackHtmlPlugin(),
+    sentryCloudflareVitePlugin(),
     sentryVitePlugin({
       org: "sentry",
       project: "mcp-server",


### PR DESCRIPTION
With v11 we move over to orchestrion. Since the MCP is using `ai@6` it needs build time instrumentations to actually receive spans for libraries that do not support tracing channels OOTB.

Currently the AI dashboards are not receiving data (as there is also none sent). This plugin adds these 