### PR TITLE
fix(attachments): prevent worker OOM on large event attachments

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -256,6 +256,14 @@ type RequestOptions = {
   allowStatuses?: number[];
 };
 
+/**
+ * Default cap for returning attachment bytes inline over the MCP transport.
+ * A 30 MB attachment takes ~80 MB in memory once base64-encoded and serialized,
+ * which fits the Cloudflare Worker's 128 MB isolate with room for the rest of the
+ * request; above it, getEventAttachment returns a reference instead of the bytes.
+ */
+export const DEFAULT_MAX_INLINE_ATTACHMENT_BYTES = 30 * 1024 * 1024;
+
 export type TraceItemType = "spans" | "logs" | "tracemetrics";
 
 type ClientKeyRateLimit = {
@@ -3839,16 +3847,16 @@ export class SentryApiService {
       projectSlug,
       eventId,
       attachmentId,
-      maxInlineBytes,
+      maxInlineBytes = DEFAULT_MAX_INLINE_ATTACHMENT_BYTES,
     }: {
       organizationSlug: string;
       projectSlug: string;
       eventId: string;
       attachmentId: string;
       /**
-       * When set, attachments larger than this (by metadata `size`) are not
-       * downloaded; the method returns `bytes: null` so the caller can hand back
-       * a download reference instead.
+       * Attachments larger than this (by metadata `size`) skip download —
+       * `getEventAttachment` returns `bytes: null`. Defaults to
+       * {@link DEFAULT_MAX_INLINE_ATTACHMENT_BYTES}.
        */
       maxInlineBytes?: number;
     },
@@ -3890,7 +3898,7 @@ export class SentryApiService {
     // Skip the download for oversized attachments — buffering and base64
     // encoding them can exhaust the worker's memory. Decide from the metadata
     // size so we never issue the request.
-    if (maxInlineBytes !== undefined && attachment.size > maxInlineBytes) {
+    if (attachment.size > maxInlineBytes) {
       const directDownloadUrl = await this.resolveDirectDownloadUrl(
         downloadPath,
         opts,

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -3839,18 +3839,32 @@ export class SentryApiService {
       projectSlug,
       eventId,
       attachmentId,
+      maxInlineBytes,
     }: {
       organizationSlug: string;
       projectSlug: string;
       eventId: string;
       attachmentId: string;
+      /**
+       * When set, attachments larger than this (by metadata `size`) are not
+       * downloaded; the method returns `bytes: null` so the caller can hand back
+       * a download reference instead.
+       */
+      maxInlineBytes?: number;
     },
     opts?: RequestOptions,
   ): Promise<{
     attachment: EventAttachment;
+    /** Authenticated API download URL (requires credentials). */
     downloadUrl: string;
+    /**
+     * Presigned URL that downloads the file directly without credentials, or
+     * `null` when unavailable. Only set on the skipped-download path.
+     */
+    directDownloadUrl: string | null;
     filename: string;
-    blob: Blob;
+    /** Raw file bytes, or `null` when the download was skipped. */
+    bytes: Uint8Array | null;
     contentType: string;
   }> {
     // Get the attachment metadata first
@@ -3869,12 +3883,31 @@ export class SentryApiService {
       );
     }
 
-    // Download the actual file content
-    const downloadUrl =
+    const downloadPath =
       apiPath`/projects/${organizationSlug}/${projectSlug}/events/${eventId}/attachments/${attachmentId}/` +
       `?download=1`;
+
+    // Skip the download for oversized attachments — buffering and base64
+    // encoding them can exhaust the worker's memory. Decide from the metadata
+    // size so we never issue the request.
+    if (maxInlineBytes !== undefined && attachment.size > maxInlineBytes) {
+      const directDownloadUrl = await this.resolveDirectDownloadUrl(
+        downloadPath,
+        opts,
+      );
+      return {
+        attachment,
+        downloadUrl: `${this.apiPrefix}${downloadPath}`,
+        directDownloadUrl,
+        filename: attachment.name,
+        bytes: null,
+        contentType: attachment.mimetype || "application/octet-stream",
+      };
+    }
+
+    // Download the actual file content
     const downloadResponse = await this.request(
-      downloadUrl,
+      downloadPath,
       { method: "GET" },
       opts,
     );
@@ -3887,13 +3920,45 @@ export class SentryApiService {
       attachment.mimetype ||
       "application/octet-stream";
 
+    // Read the body once as bytes; arrayBuffer() avoids the extra copy that
+    // blob() + blob.arrayBuffer() would hold at the same time.
+    const bytes = new Uint8Array(await downloadResponse.arrayBuffer());
+
     return {
       attachment,
       downloadUrl: downloadResponse.url,
+      directDownloadUrl: null,
       filename: attachment.name,
-      blob: await downloadResponse.blob(),
+      bytes,
       contentType,
     };
+  }
+
+  /**
+   * Probe the download endpoint for a presigned URL without buffering the file.
+   *
+   * Objectstore attachments redirect to a presigned URL (returned here); legacy
+   * ones stream a 200 with no redirect, so there is no direct URL. The body is
+   * discarded either way — we only need the URL.
+   */
+  private async resolveDirectDownloadUrl(
+    downloadPath: string,
+    opts?: RequestOptions,
+  ): Promise<string | null> {
+    try {
+      const response = await this.request(
+        downloadPath,
+        { method: "GET" },
+        opts,
+      );
+      const directUrl = response.redirected ? response.url : null;
+      // Don't await cancel(): we already have the URL, and awaiting it can
+      // stall on some runtimes.
+      void response.body?.cancel().catch(() => {});
+      return directUrl;
+    } catch {
+      return null;
+    }
   }
 
   async getReplayDetails(

--- a/packages/mcp-core/src/internal/blob-utils.ts
+++ b/packages/mcp-core/src/internal/blob-utils.ts
@@ -6,6 +6,18 @@ export async function blobToBase64(blob: Blob): Promise<string> {
   return Buffer.from(await blob.arrayBuffer()).toString("base64");
 }
 
+/**
+ * Base64-encode raw bytes without an intermediate copy.
+ *
+ * `Buffer.from(bytes.buffer, …)` views the existing memory instead of copying
+ * it. Prefer this over a `Blob` round-trip when you already hold a `Uint8Array`.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString(
+    "base64",
+  );
+}
+
 export interface ImagePreviewOptions {
   maxDimension?: number;
   jpegQuality?: number;

--- a/packages/mcp-core/src/tools/catalog/get-event-attachment.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-attachment.test.ts
@@ -132,6 +132,125 @@ describe("get_event_attachment", () => {
     });
   });
 
+  it("decodes and inlines a text/plain (.log) attachment", async () => {
+    const result = await getEventAttachment.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        eventId: "e49541c747cb4d8aa3efb70ca5aba245",
+        attachmentId: "789",
+        regionUrl: null,
+      },
+      {
+        constraints: { organizationSlug: null, projectSlug: null },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    // Text files are inlined as a single text block — no image/resource part.
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "text" });
+    const text = (result[0] as { text: string }).text;
+    expect(text).toContain("**MIME Type:** text/plain");
+    expect(text).toContain("## File Content");
+    expect(text).toContain("INFO app started");
+    expect(text).toContain("ERROR db connection failed");
+  });
+
+  it("returns a presigned direct-download URL for an oversized objectstore attachment", async () => {
+    const result = await getEventAttachment.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        eventId: "f49541c747cb4d8aa3efb70ca5aba246",
+        attachmentId: "999",
+        regionUrl: null,
+      },
+      {
+        constraints: { organizationSlug: null, projectSlug: null },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    // Oversized objectstore: no bytes downloaded; a guidance string leading with
+    // the presigned direct link (no auth) is returned.
+    expect(typeof result).toBe("string");
+    const text = result as string;
+    expect(text).toContain("Too Large to Return Inline");
+    expect(text).toContain("50.0 MB");
+    expect(text).toContain("30.0 MB");
+    expect(text).toContain("Direct download");
+    expect(text).toContain("no authentication needed");
+    expect(text).toContain(
+      "https://objectstore.example.test/attachments/999/blob?sig=test-signature",
+    );
+    // The authenticated API endpoint is still offered as a fallback.
+    expect(text).toContain(
+      "sentry api projects/sentry-mcp-evals/cloudflare-mcp/events/f49541c747cb4d8aa3efb70ca5aba246/attachments/999/?download=1",
+    );
+  });
+
+  it("falls back to authenticated-download instructions for an oversized legacy attachment", async () => {
+    const result = await getEventAttachment.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        eventId: "h49541c747cb4d8aa3efb70ca5aba248",
+        attachmentId: "222",
+        regionUrl: null,
+      },
+      {
+        constraints: { organizationSlug: null, projectSlug: null },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    // Oversized legacy (no presigned URL): auth-required guidance only.
+    expect(typeof result).toBe("string");
+    const text = result as string;
+    expect(text).toContain("Too Large to Return Inline");
+    expect(text).toContain("40.0 MB");
+    expect(text).toContain("requires your Sentry credentials");
+    expect(text).not.toContain("objectstore.example.test");
+
+    // The uploader-controlled filename must not be interpolated into the shell
+    // command — the redirect target uses the validated attachment ID instead.
+    expect(text).toContain(
+      "sentry api projects/sentry-mcp-evals/cloudflare-mcp/events/h49541c747cb4d8aa3efb70ca5aba248/attachments/222/?download=1 > attachment-222",
+    );
+    expect(text).not.toContain("?download=1 > pwn");
+  });
+
+  it("flags an empty download body when metadata reports a non-empty file", async () => {
+    const result = await getEventAttachment.handler(
+      {
+        organizationSlug: "sentry-mcp-evals",
+        projectSlug: "cloudflare-mcp",
+        eventId: "g49541c747cb4d8aa3efb70ca5aba247",
+        attachmentId: "111",
+        regionUrl: null,
+      },
+      {
+        constraints: { organizationSlug: null, projectSlug: null },
+        accessToken: "access-token",
+        userId: "1",
+      },
+    );
+
+    // Zero-byte body: no binary/image part is emitted; the text flags the gap.
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "text" });
+    const text = (result[0] as { text: string }).text;
+    expect(text).toContain("## Empty Content");
+    expect(text).toContain("returned no data");
+    expect(text).toContain("1024 bytes");
+  });
+
   it("throws error for malformed regionUrl", async () => {
     await expect(
       getEventAttachment.handler(

--- a/packages/mcp-core/src/tools/catalog/get-event-attachment.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-attachment.ts
@@ -4,7 +4,7 @@ import type {
   TextContent,
 } from "@modelcontextprotocol/sdk/types.js";
 import { setTag } from "@sentry/core";
-import { blobToBase64 } from "../../internal/blob-utils";
+import { bytesToBase64 } from "../../internal/blob-utils";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
 import { defineTool } from "../../internal/tool-helpers/define";
 import { formatToolCallInstruction } from "../../internal/tool-helpers/tool-call-formatting";
@@ -16,6 +16,76 @@ import {
   ParamRegionUrl,
 } from "../../schema";
 import type { ServerContext } from "../../types";
+
+/**
+ * Max attachment size returned inline over the MCP transport. Larger payloads
+ * can exhaust the worker's memory while base64-encoding, so above this we return
+ * download instructions instead of the bytes.
+ */
+const MAX_INLINE_ATTACHMENT_BYTES = 30 * 1024 * 1024;
+
+function formatMegabytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Render the response for an attachment too large to inline: a presigned direct
+ * link when available, otherwise authenticated-download instructions.
+ */
+function formatOversizedAttachment(
+  params: {
+    organizationSlug: string;
+    projectSlug: string;
+    eventId: string;
+    attachmentId: string;
+  },
+  attachment: {
+    downloadUrl: string;
+    directDownloadUrl: string | null;
+    filename: string;
+    contentType: string;
+    attachment: { type: string; size: number; dateCreated: string };
+  },
+): string {
+  const sizeBytes = attachment.attachment.size;
+  const downloadApiPath = `projects/${params.organizationSlug}/${params.projectSlug}/events/${params.eventId}/attachments/${params.attachmentId}/?download=1`;
+  // Use the validated attachment ID (not the uploader-controlled filename) as the
+  // output name so the command examples can't carry shell metacharacters.
+  const outputName = `attachment-${params.attachmentId}`;
+
+  let output = "# Event Attachment — Too Large to Return Inline\n\n";
+  output += `**Event ID:** ${params.eventId}\n`;
+  output += `**Attachment ID:** ${params.attachmentId}\n`;
+  output += `**Filename:** ${attachment.filename}\n`;
+  output += `**Type:** ${attachment.attachment.type}\n`;
+  output += `**Size:** ${sizeBytes} bytes (${formatMegabytes(sizeBytes)})\n`;
+  output += `**MIME Type:** ${attachment.contentType}\n`;
+  output += `**Created:** ${attachment.attachment.dateCreated}\n\n`;
+  output += `This attachment (${formatMegabytes(sizeBytes)}) exceeds the ${formatMegabytes(
+    MAX_INLINE_ATTACHMENT_BYTES,
+  )} inline limit for MCP responses, so its contents were not downloaded.\n\n`;
+  output += "## How to download it\n\n";
+
+  if (attachment.directDownloadUrl) {
+    output +=
+      "**Direct download** (a presigned link — no authentication needed; it expires shortly, so fetch it promptly):\n\n";
+    output += `${attachment.directDownloadUrl}\n\n`;
+    output +=
+      "If the link has expired, re-run this tool to get a fresh one, or use the authenticated API endpoint below.\n\n";
+    output +=
+      "**Authenticated Sentry API endpoint** (requires Sentry credentials):\n";
+    output += `- Sentry CLI: \`sentry api ${downloadApiPath} > ${outputName}\`\n`;
+    output += `- Or an \`Authorization: Bearer <token>\` request to: ${attachment.downloadUrl}\n`;
+  } else {
+    output +=
+      "The download URL is an authenticated Sentry API endpoint — it is not a public link and requires your Sentry credentials (a bare fetch returns HTTP 401).\n\n";
+    output += "- **Sentry CLI** (handles auth automatically):\n";
+    output += `  \`sentry api ${downloadApiPath} > ${outputName}\`\n`;
+    output += `- **Any HTTP client** with an \`Authorization: Bearer <token>\` header against: ${attachment.downloadUrl}\n`;
+    output += "- **Sentry UI:** open the event and use the Attachments tab.\n";
+  }
+  return output;
+}
 
 export default defineTool({
   name: "get_event_attachment",
@@ -76,7 +146,21 @@ export default defineTool({
         projectSlug: params.projectSlug,
         eventId: params.eventId,
         attachmentId: params.attachmentId,
+        maxInlineBytes: MAX_INLINE_ATTACHMENT_BYTES,
       });
+
+      // Too large to inline — return download instructions instead of the bytes.
+      if (attachment.bytes === null) {
+        return formatOversizedAttachment(
+          {
+            organizationSlug: params.organizationSlug,
+            projectSlug: params.projectSlug,
+            eventId: params.eventId,
+            attachmentId: params.attachmentId,
+          },
+          attachment,
+        );
+      }
 
       const contentParts: (TextContent | ImageContent | EmbeddedResource)[] =
         [];
@@ -86,10 +170,12 @@ export default defineTool({
       // even when the file is an image — and Step 2 is the authoritative signal.
       const effectiveMimeType = attachment.contentType;
       const isBinary = !effectiveMimeType.startsWith("text/");
+      // A zero-byte body for a non-empty file means a failed/truncated download.
+      const isEmpty = attachment.bytes.length === 0;
 
-      if (isBinary) {
+      if (isBinary && !isEmpty) {
         const isImage = effectiveMimeType.startsWith("image/");
-        const base64 = await blobToBase64(attachment.blob);
+        const base64 = bytesToBase64(attachment.bytes);
         if (isImage) {
           const image: ImageContent = {
             type: "image",
@@ -120,13 +206,19 @@ export default defineTool({
       output += `**Created:** ${attachment.attachment.dateCreated}\n\n`;
       output += `**Download URL:** ${attachment.downloadUrl}\n\n`;
 
-      if (isBinary) {
+      if (isEmpty) {
+        output += `## Empty Content\n\n`;
+        if (attachment.attachment.size > 0) {
+          output += `The download returned no data even though the attachment metadata reports ${attachment.attachment.size} bytes. This usually indicates a failed or truncated download; try again, or download it directly from the URL above (requires Sentry authentication).\n`;
+        } else {
+          output += `This attachment is empty (0 bytes).\n`;
+        }
+      } else if (isBinary) {
         output += `## Binary Content\n\n`;
         output += `The attachment is included as a resource and accessible through your client.\n`;
       } else {
-        // If it's a text file and we have blob content, decode and display it instead
-        // of embedding it as an image or resource
-        const textContent = await attachment.blob.text();
+        // Text file: inline the decoded content.
+        const textContent = new TextDecoder().decode(attachment.bytes);
         output += `## File Content\n\n`;
         output += `\`\`\`\n${textContent}\n\`\`\`\n\n`;
       }

--- a/packages/mcp-core/src/tools/catalog/get-event-attachment.ts
+++ b/packages/mcp-core/src/tools/catalog/get-event-attachment.ts
@@ -4,6 +4,7 @@ import type {
   TextContent,
 } from "@modelcontextprotocol/sdk/types.js";
 import { setTag } from "@sentry/core";
+import { DEFAULT_MAX_INLINE_ATTACHMENT_BYTES } from "../../api-client";
 import { bytesToBase64 } from "../../internal/blob-utils";
 import { apiServiceFromContext } from "../../internal/tool-helpers/api";
 import { defineTool } from "../../internal/tool-helpers/define";
@@ -16,13 +17,6 @@ import {
   ParamRegionUrl,
 } from "../../schema";
 import type { ServerContext } from "../../types";
-
-/**
- * Max attachment size returned inline over the MCP transport. Larger payloads
- * can exhaust the worker's memory while base64-encoding, so above this we return
- * download instructions instead of the bytes.
- */
-const MAX_INLINE_ATTACHMENT_BYTES = 30 * 1024 * 1024;
 
 function formatMegabytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -62,7 +56,7 @@ function formatOversizedAttachment(
   output += `**MIME Type:** ${attachment.contentType}\n`;
   output += `**Created:** ${attachment.attachment.dateCreated}\n\n`;
   output += `This attachment (${formatMegabytes(sizeBytes)}) exceeds the ${formatMegabytes(
-    MAX_INLINE_ATTACHMENT_BYTES,
+    DEFAULT_MAX_INLINE_ATTACHMENT_BYTES,
   )} inline limit for MCP responses, so its contents were not downloaded.\n\n`;
   output += "## How to download it\n\n";
 
@@ -146,7 +140,6 @@ export default defineTool({
         projectSlug: params.projectSlug,
         eventId: params.eventId,
         attachmentId: params.attachmentId,
-        maxInlineBytes: MAX_INLINE_ATTACHMENT_BYTES,
       });
 
       // Too large to inline — return download instructions instead of the bytes.

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -1622,6 +1622,116 @@ export const restHandlers = buildHandlers([
       });
     },
   },
+  // A text/plain (.log) attachment (the shape reported in #1267).
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/e49541c747cb4d8aa3efb70ca5aba245/attachments/",
+    fetch: () =>
+      HttpResponse.json([
+        {
+          id: "789",
+          name: "application.log",
+          type: "event.attachment",
+          size: 44,
+          mimetype: "text/plain",
+          dateCreated: "2025-04-08T21:15:04.000Z",
+          headers: { "Content-Type": "text/plain" },
+        },
+      ]),
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/e49541c747cb4d8aa3efb70ca5aba245/attachments/789/",
+    fetch: () =>
+      new HttpResponse(
+        new Blob(["INFO app started\nERROR db connection failed\n"], {
+          type: "text/plain",
+        }),
+        { headers: { "Content-Type": "text/plain" } },
+      ),
+  },
+  // Oversized objectstore attachment: the download 302-redirects to a presigned
+  // URL (mocked below).
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/f49541c747cb4d8aa3efb70ca5aba246/attachments/",
+    fetch: () =>
+      HttpResponse.json([
+        {
+          id: "999",
+          name: "core.dmp",
+          type: "event.attachment",
+          size: 50 * 1024 * 1024,
+          mimetype: "application/octet-stream",
+          dateCreated: "2025-04-08T21:15:04.000Z",
+          headers: { "Content-Type": "application/octet-stream" },
+        },
+      ]),
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/f49541c747cb4d8aa3efb70ca5aba246/attachments/999/",
+    fetch: () =>
+      HttpResponse.redirect(
+        "https://objectstore.example.test/attachments/999/blob?sig=test-signature",
+        302,
+      ),
+  },
+  // Oversized legacy attachment: the download streams a 200 with no redirect, so
+  // there is no presigned URL.
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/h49541c747cb4d8aa3efb70ca5aba248/attachments/",
+    fetch: () =>
+      HttpResponse.json([
+        {
+          id: "222",
+          // Hostile, uploader-controlled name: must never reach a shell command.
+          name: "pwn; rm -rf ~ #.dmp",
+          type: "event.attachment",
+          size: 40 * 1024 * 1024,
+          mimetype: "application/octet-stream",
+          dateCreated: "2025-04-08T21:15:04.000Z",
+          headers: { "Content-Type": "application/octet-stream" },
+        },
+      ]),
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/h49541c747cb4d8aa3efb70ca5aba248/attachments/222/",
+    fetch: () =>
+      new HttpResponse(
+        new Blob(["legacy bytes"], { type: "application/octet-stream" }),
+        {
+          headers: { "Content-Type": "application/octet-stream" },
+        },
+      ),
+  },
+  // Metadata reports a non-empty file but the download returns zero bytes.
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/g49541c747cb4d8aa3efb70ca5aba247/attachments/",
+    fetch: () =>
+      HttpResponse.json([
+        {
+          id: "111",
+          name: "screenshot.png",
+          type: "event.attachment",
+          size: 1024,
+          mimetype: "image/png",
+          dateCreated: "2025-04-08T21:15:04.000Z",
+          headers: { "Content-Type": "image/png" },
+        },
+      ]),
+  },
+  {
+    method: "get",
+    path: "/api/0/projects/sentry-mcp-evals/cloudflare-mcp/events/g49541c747cb4d8aa3efb70ca5aba247/attachments/111/",
+    fetch: () =>
+      new HttpResponse(new Blob([], { type: "image/png" }), {
+        headers: { "Content-Type": "image/png" },
+      }),
+  },
   {
     method: "get",
     path: "/api/0/organizations/:organizationSlug/repos/",
@@ -1663,6 +1773,10 @@ export const restHandlers = buildHandlers([
 
 // Add handlers for mcp.sentry.dev and localhost
 export const searchHandlers = [
+  // Presigned target for the oversized-attachment redirect (999).
+  http.get("https://objectstore.example.test/attachments/999/blob", () =>
+    HttpResponse.text("presigned blob bytes"),
+  ),
   http.post("https://mcp.sentry.dev/api/search", async ({ request }) => {
     const body = (await request.json()) as any;
 


### PR DESCRIPTION
## Summary

`get_event_attachment` crashes the Cloudflare Worker with `TypeError: Memory limit exceeded before EOF` when downloading large attachments. This is live and ongoing — Sentry issue [MCP-SERVER-F5W](https://sentry.sentry.io/issues/7284551639/): **161 events, 10 users**, first seen 2026-02-22, still firing (last 2026-09-01) across orgs and clients (`codex`, `cursor`).

Root cause: the download buffered the file **~4–5× in memory at once** — `downloadResponse.blob()` → `blob.arrayBuffer()` (a copy) → base64 (`+33%`) → JSON-serialization of the base64 — blowing the 128 MB isolate on the tens-of-MB tail. Real download sizes (90d span telemetry): p50 ≈ 90 KB, p99 ≈ 16 MB, **max ≈ 38 MB**.

Refs #1267.

## Changes

- **Halve peak memory:** read the body once via `arrayBuffer()` and base64-encode from a `Buffer` view (`bytesToBase64`, no intermediate `Blob`/copy). Peak drops from ~4–5× to ~2× the payload.
- **Inline size cap (30 MB):** gated on the already-fetched metadata `size`, so an oversized attachment never issues the doomed download. 30 MB → ~80 MB peak, safely under the isolate; covers p99 and all observed traffic inline.
- **Usable oversized fallback:** the download URL is an authenticated API endpoint (bare fetch → 401), so a plain link is a dead end for agents. For **objectstore** attachments (the modern default) we resolve the **presigned URL** from the download endpoint's `302 Location` — a self-authenticating, time-limited link that downloads with **no credentials**. Legacy filestore attachments (no redirect) fall back to authenticated-download instructions (`sentry api …`).
- **Empty/truncated guard:** a zero-byte body when metadata reports a non-empty file is now surfaced instead of emitting empty content.

## Verification

Confirmed end-to-end against a real attachment (created in a test org):
1. Authenticated download → `302` to an objectstore presigned URL.
2. That presigned URL fetched with **no auth header** → `200` + the correct bytes.

Also confirmed the download endpoint is auth-gated (401/403 unauthenticated) and validated the redirect vs. streaming behavior against `getsentry/sentry` source.

## Testing

`pnpm tsc`, `biome lint`/`format`, `ast-grep`, and the full `mcp-core` suite pass. New coverage: text (`.log`) attachments, oversized objectstore (→ presigned URL), oversized legacy (→ auth instructions), and empty body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)