### PR TITLE
feat(api-client): retry transient upstream 5xx on idempotent GETs

### DIFF
--- a/docs/contributing/api-patterns.md
+++ b/docs/contributing/api-patterns.md
@@ -223,6 +223,21 @@ try {
 
 See error patterns in [common-patterns.md](common-patterns.md#error-handling).
 
+### Automatic Retries
+
+`SentryApiService.request()` transparently retries transient upstream gateway
+failures (`502`/`503`/`504`) using exponential backoff. Retries are:
+
+- **GET-only** — non-idempotent methods (`POST`/`PUT`/`DELETE`) are never
+  retried, so an automatic retry can never replay a mutation.
+- **Gateway-only** — gated on `ApiServerError.isGatewayError()`. Persistent
+  `500`s, `4xx` client errors, and network/configuration errors fail fast.
+- **Bypassed by `allowStatuses`** — a status the caller opts into is returned
+  as-is from `requestOnce`, never retried.
+
+Callers and tools need no changes: a retried request either resolves normally or
+throws the same `ApiServerError` it would have thrown without retries.
+
 ## Best Practices
 
 1. **Always use context helper** when in tools/prompts

--- a/packages/mcp-core/src/api-client/client.test.ts
+++ b/packages/mcp-core/src/api-client/client.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigurationError } from "../errors";
 import { SentryApiService } from "./client";
+import { ApiServerError } from "./errors";
 
 describe("getIssueUrl", () => {
   it("should work with sentry.io", () => {
@@ -729,6 +730,144 @@ describe("network error handling", () => {
     await expect(apiService.getAuthenticatedUser()).rejects.toThrow(
       ConfigurationError,
     );
+  });
+});
+
+describe("transient 5xx retry", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  // A transient gateway failure like the ones Sentry's edge returns
+  // ("upstream connect error ... reset before headers"), reported as 503.
+  const serviceUnavailable = () =>
+    new Response(
+      "upstream connect error or disconnect/reset before headers. reset reason: connection termination",
+      { status: 503, statusText: "Service Unavailable" },
+    );
+
+  const internalError = () =>
+    new Response(JSON.stringify({ detail: "Internal Error" }), {
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const authOk = () =>
+    new Response(
+      JSON.stringify({ id: "1", name: "Test User", email: "test@example.com" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("retries a transient gateway error on a GET and succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(serviceUnavailable())
+      .mockResolvedValueOnce(serviceUnavailable())
+      .mockResolvedValueOnce(authOk());
+    globalThis.fetch = fetchMock;
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+    });
+
+    const promise = apiService.getAuthenticatedUser();
+    await vi.runAllTimersAsync();
+    const user = await promise;
+
+    expect(user.id).toBe("1");
+    // Initial attempt + 2 retries, succeeding on the last one.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after exhausting the retry budget on a persistent gateway error", async () => {
+    // A fresh Response per attempt — a Response body can only be read once.
+    const fetchMock = vi.fn().mockImplementation(() => serviceUnavailable());
+    globalThis.fetch = fetchMock;
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+    });
+
+    const promise = apiService.getAuthenticatedUser();
+    // Attach a catch synchronously so the rejection is never unhandled while
+    // fake timers advance through the backoff waits.
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+
+    await expect(promise).rejects.toBeInstanceOf(ApiServerError);
+    // Initial attempt + 2 retries, all failing.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a non-gateway 500", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(internalError());
+    globalThis.fetch = fetchMock;
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+    });
+
+    await expect(apiService.getAuthenticatedUser()).rejects.toBeInstanceOf(
+      ApiServerError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a non-idempotent (POST) request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(serviceUnavailable());
+    globalThis.fetch = fetchMock;
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+    });
+
+    const promise = apiService.createTeam({
+      organizationSlug: "my-org",
+      name: "My Team",
+    });
+    promise.catch(() => {});
+    await vi.runAllTimersAsync();
+
+    await expect(promise).rejects.toBeInstanceOf(ApiServerError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 5xx that the caller opted into via allowStatuses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(serviceUnavailable());
+    globalThis.fetch = fetchMock;
+
+    const apiService = new SentryApiService({
+      host: "sentry.io",
+      accessToken: "test-token",
+    });
+
+    // getEventAttachment passes allowStatuses so the caller can inspect the raw
+    // response; such requests must be returned as-is, never retried.
+    const response = await (
+      apiService as unknown as {
+        request: (
+          path: string,
+          options?: RequestInit,
+          requestOptions?: { host?: string; allowStatuses?: number[] },
+        ) => Promise<Response>;
+      }
+    ).request("/auth/", undefined, { allowStatuses: [503] });
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -30,9 +30,15 @@ import {
   isSentryHost,
   type TraceMetricIdentifier,
 } from "../utils/url-utils";
+import { retryWithBackoff } from "../internal/fetch-utils";
 import { USER_AGENT } from "../version";
 import { apiPath } from "./api-path";
-import { ApiNotFoundError, ApiValidationError, createApiError } from "./errors";
+import {
+  ApiNotFoundError,
+  ApiServerError,
+  ApiValidationError,
+  createApiError,
+} from "./errors";
 import {
   AgenticOnboardingRunSchema,
   AIConversationDetailsResponseSchema,
@@ -255,6 +261,18 @@ type RequestOptions = {
   host?: string;
   allowStatuses?: number[];
 };
+
+/**
+ * Automatic retry policy for transient upstream gateway failures (502/503/504).
+ *
+ * Sentry's edge intermittently returns short-lived gateway errors (e.g.
+ * "upstream connect error or disconnect/reset before headers") that clear on a
+ * retry. We retry only idempotent GET requests so an automatic retry can never
+ * replay a mutation, and keep the budget small so a still-failing tool call
+ * resolves quickly under the Cloudflare Workers request lifetime.
+ */
+const RETRYABLE_REQUEST_MAX_RETRIES = 2;
+const RETRYABLE_REQUEST_INITIAL_DELAY_MS = 250;
 
 /**
  * Default cap for returning attachment bytes inline over the MCP transport.
@@ -680,6 +698,42 @@ export class SentryApiService {
   }
 
   /**
+   * Makes an authenticated request to the Sentry API, transparently retrying
+   * transient upstream gateway failures (502/503/504).
+   *
+   * Retries are limited to idempotent GET requests so an automatic retry can
+   * never replay a mutation, and are gated on `ApiServerError.isGatewayError()`
+   * so persistent 500s, 4xx client errors, and network/configuration errors
+   * fail fast without waiting. Callers that opt a 5xx into `allowStatuses`
+   * receive the raw response from `requestOnce` and are never retried.
+   *
+   * @param path API endpoint path (without /api/0 prefix)
+   * @param options Fetch options
+   * @param requestOptions Additional request configuration
+   * @returns Promise resolving to Response object
+   * @throws {ApiError} Enhanced API errors with user-friendly messages
+   * @throws {Error} Network or parsing errors
+   */
+  private async request(
+    path: string,
+    options: RequestInit = {},
+    requestOptions: { host?: string; allowStatuses?: number[] } = {},
+  ): Promise<Response> {
+    const method = (options.method ?? "GET").toUpperCase();
+    const isIdempotent = method === "GET";
+
+    return retryWithBackoff(
+      () => this.requestOnce(path, options, requestOptions),
+      {
+        maxRetries: isIdempotent ? RETRYABLE_REQUEST_MAX_RETRIES : 0,
+        initialDelay: RETRYABLE_REQUEST_INITIAL_DELAY_MS,
+        shouldRetry: (error) =>
+          error instanceof ApiServerError && error.isGatewayError(),
+      },
+    );
+  }
+
+  /**
    * Internal method for making authenticated requests to Sentry API.
    *
    * Handles:
@@ -695,7 +749,7 @@ export class SentryApiService {
    * @throws {ApiError} Enhanced API errors with user-friendly messages
    * @throws {Error} Network or parsing errors
    */
-  private async request(
+  private async requestOnce(
     path: string,
     options: RequestInit = {},
     { host, allowStatuses }: { host?: string; allowStatuses?: number[] } = {},


### PR DESCRIPTION
## Summary

The `ApiServerError` / `createApiError` cluster in the **MCP-SERVER** project (e.g. [MCP-SERVER-FV3](https://sentry.sentry.io/issues/MCP-SERVER-FV3), FQ1, F4X, F7R, and dozens more — tens of thousands of events combined) is **not a code bug**. Every event is an upstream Sentry gateway error (`502`/`503`/`504`) that we reflect verbatim — most are transient (`"upstream connect error or disconnect/reset before headers. reset reason: connection termination"`), and Seer marks them `super_low` actionability.

Crucially, the failing upstream calls are **idempotent GETs** (the `Method: POST` in these events is the MCP transport call, not the upstream request — e.g. FV3 fails inside `getProject` → `GET /projects/{org}/{project}/`). A retry clears the vast majority of them.

## Changes

`SentryApiService.request()` now wraps the existing `retryWithBackoff` helper to retry transient upstream gateway failures:

- **GET-only** — non-idempotent methods (`POST`/`PUT`/`DELETE`) are never retried, so an automatic retry can never replay a mutation.
- **Gateway-only** — gated on `ApiServerError.isGatewayError()` (`502`/`503`/`504`). Persistent `500`s, `4xx` client errors, and network/configuration errors still fail fast.
- **Respects `allowStatuses`** — a status the caller opts into (e.g. `getEventAttachment`) is returned as-is from `requestOnce`, never retried.
- Small budget (**2 retries, 250 ms initial delay**, exponential backoff) to stay well within the Cloudflare Workers request lifetime. The happy path is untouched — retries only fire on a gateway error.

The change is transparent to callers/tools: a request either resolves normally or throws the same `ApiServerError` it would have thrown before. `retryWithBackoff` is reused as-is; no other files change.

## Testing

- `pnpm run tsc && pnpm run lint` ✅
- `pnpm --filter @sentry/mcp-core test` ✅
- New `client.test.ts` cases: retries a transient gateway error on a GET and succeeds; gives up after exhausting the budget; does not retry a non-gateway `500`; does not retry a `POST`; does not retry a status opted into via `allowStatuses`.

## Related

Addresses the `ApiServerError` (`createApiError`) cluster in MCP-SERVER (FV3, FY4, F4X, F7R, FQ1, …). Deliberately not using `Fixes` since one retry policy spans dozens of issues and won't eliminate sustained outages — leaving the close/resolve decision to maintainers after measuring the drop.

## Not included (open questions)

- **Downgrading pure-outage passthrough from error→warning** (`logIssue` → `logWarn` in `error-handling.ts`) was discussed as a follow-up. Recommend measuring the post-retry volume first: what survives retries is a *sustained* outage or a real `500`, which is exactly the signal worth keeping as an issue. `500`s should never be downgraded.
- **Retrying network-level errors** (connection resets where `fetch` throws) is intentionally out of scope here to keep the change tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)