### PR TITLE
feat(tools): Add get_sentry_mcp_info catalog tool

### DIFF
--- a/packages/mcp-core/src/server.test.ts
+++ b/packages/mcp-core/src/server.test.ts
@@ -17,6 +17,7 @@ import {
 import { createExecuteTool } from "./tools/special/execute-tool";
 import type { ToolConfig } from "./tools/types";
 import type { ServerContext } from "./types";
+import { LIB_VERSION } from "./version";
 
 // Mock the Sentry core module
 vi.mock("@sentry/core", () => ({
@@ -1139,6 +1140,43 @@ describe("buildServer", () => {
       }>(result);
 
       expect(payload.results.map((tool) => tool.name)).toContain("whoami");
+    });
+
+    it("discovers and executes Sentry MCP server information from the catalog", async () => {
+      const searchServer = buildServer({
+        context: baseContext,
+      });
+
+      const toolNames = getRegisteredToolNames(searchServer);
+      expect(toolNames).not.toContain("get_sentry_mcp_info");
+
+      const searchResult = await callRegisteredTool(
+        searchServer,
+        "search_sentry_tools",
+        {
+          query: "server version",
+          limit: 8,
+        },
+      );
+      const searchPayload = getStructuredContent<{
+        results: Array<{ name: string }>;
+      }>(searchResult);
+      expect(searchPayload.results[0]?.name).toBe("get_sentry_mcp_info");
+
+      const executeServer = buildServer({
+        context: baseContext,
+      });
+      const executeResult = await callRegisteredTool(
+        executeServer,
+        "execute_sentry_tool",
+        {
+          name: "get_sentry_mcp_info",
+          arguments: {},
+        },
+      );
+      expect(getStructuredContent(executeResult)).toEqual({
+        version: LIB_VERSION,
+      });
     });
 
     it("search_sentry_tools omits unavailable non-inspect tools", async () => {

--- a/packages/mcp-core/src/skillDefinitions.json
+++ b/packages/mcp-core/src/skillDefinitions.json
@@ -5,7 +5,7 @@
     "description": "Read-only access to core Sentry data: issues, events, traces, replays, releases, cron monitors, uptime monitors, profiles, documentation, and project metadata",
     "defaultEnabled": true,
     "order": 1,
-    "toolCount": 37,
+    "toolCount": 38,
     "tools": [
       {
         "name": "find_alert_rules",
@@ -133,6 +133,11 @@
         "requiredScopes": ["org:read", "project:read", "event:read"]
       },
       {
+        "name": "get_sentry_mcp_info",
+        "description": "Get information about the running Sentry MCP server.\n\nUse this tool when you need to:\n- Check the Sentry MCP server version\n- Verify compatibility with a Skill or integration",
+        "requiredScopes": []
+      },
+      {
         "name": "get_sentry_resource",
         "description": "Fetch a Sentry resource by URL, or by resourceType plus resourceId.\nPass a Sentry URL directly when possible; the resource type is auto-detected.\n\nSupports issues, events, traces, spans, agent conversations, replays, monitors, preprod snapshots, and snapshot images.\nTrace lookups return a condensed overview by default.\n\nAgent Conversations: A conversation is a set of spans sharing the same gen_ai.conversation.id. Use resourceType='ai_conversation' with a conversation ID, or pass a Sentry conversation URL, to fetch the transcript/details. To discover or list conversations, use search_agent_conversations. Conversations are NOT issues — do not use search_issues for conversation queries.\n\nFor preprod snapshot URLs (matching 'sentry.io/preprod/snapshots/'):\n- Without ?selectedSnapshot=: returns the snapshot diff summary (changed, added, removed images)\n- With ?selectedSnapshot=<image_file_name>: returns the image preview and metadata. Use the Sentry tool `get_snapshot_image` for full-resolution image bytes.\n\nResource IDs:\n- monitor: <monitorSlug>\n- snapshot: <snapshotId>\n\n<examples>\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\nget_sentry_resource(resourceType='ai_conversation', organizationSlug='my-org', resourceId='conversation-123')\nget_sentry_resource(url='https://sentry.sentry.io/preprod/snapshots/123/')\nget_sentry_resource(url='https://sentry.sentry.io/preprod/snapshots/123/?selectedSnapshot=login_screen.png')\n</examples>",
         "requiredScopes": ["event:read", "project:read"]
@@ -200,7 +205,7 @@
     "description": "Sentry's AI debugger that helps you analyze, root cause, and fix issues",
     "defaultEnabled": true,
     "order": 2,
-    "toolCount": 11,
+    "toolCount": 12,
     "tools": [
       {
         "name": "analyze_issue_with_seer",
@@ -231,6 +236,11 @@
         "name": "get_issue_details",
         "description": "Get detailed information about a specific Sentry issue by ID.\n\nUSE THIS TOOL WHEN USERS:\n- Provide a specific issue ID (e.g., 'CLOUDFLARE-MCP-41', 'PROJECT-123')\n- Ask to 'explain [ISSUE-ID]', 'tell me about [ISSUE-ID]'\n- Want details/stacktrace/analysis for a known issue\n- Provide a Sentry issue URL\n\nDO NOT USE for:\n- General searching or listing issues (use search_issues)\n\nTRIGGER PATTERNS:\n- 'Explain ISSUE-123' → use get_issue_details\n- 'Tell me about PROJECT-456' → use get_issue_details\n- 'What happened in [issue URL]' → use get_issue_details\n\n<examples>\n### With Sentry URL (recommended - simplest approach)\n```\nget_issue_details(issueUrl='https://sentry.sentry.io/issues/6916805731/?project=4509062593708032&query=is%3Aunresolved')\n```\n\n### With issue ID and organization\n```\nget_issue_details(organizationSlug='my-organization', issueId='CLOUDFLARE-MCP-41')\n```\n\n### With event ID and organization\n```\nget_issue_details(organizationSlug='my-organization', eventId='c49541c747cb4d8aa3efb70ca5aba243')\n```\n</examples>\n\n<hints>\n- **IMPORTANT**: If user provides a Sentry URL, pass the ENTIRE URL to issueUrl parameter unchanged\n- When using issueUrl, all other parameters are automatically extracted - don't provide them separately\n- If using issueId (not URL), then organizationSlug is required\n</hints>",
         "requiredScopes": ["event:read"]
+      },
+      {
+        "name": "get_sentry_mcp_info",
+        "description": "Get information about the running Sentry MCP server.\n\nUse this tool when you need to:\n- Check the Sentry MCP server version\n- Verify compatibility with a Skill or integration",
+        "requiredScopes": []
       },
       {
         "name": "get_sentry_resource",
@@ -266,7 +276,7 @@
     "defaultEnabled": false,
     "deprecated": true,
     "order": 3,
-    "toolCount": 5,
+    "toolCount": 6,
     "tools": [
       {
         "name": "find_organizations",
@@ -281,6 +291,11 @@
       {
         "name": "get_doc",
         "description": "Fetch the full markdown content of a Sentry documentation page.\n\nUse this tool when you need to:\n- Read the complete documentation for a specific topic\n- Get detailed implementation examples or code snippets\n- Access the full context of a documentation page\n- Extract specific sections from documentation\n\n<examples>\n### Get the Next.js integration guide\n\n```\nget_doc(path='/platforms/javascript/guides/nextjs.md')\n```\n</examples>\n\n<hints>\n- Use the path from search_docs results for accurate fetching\n- Paths should end with .md extension\n</hints>",
+        "requiredScopes": []
+      },
+      {
+        "name": "get_sentry_mcp_info",
+        "description": "Get information about the running Sentry MCP server.\n\nUse this tool when you need to:\n- Check the Sentry MCP server version\n- Verify compatibility with a Skill or integration",
         "requiredScopes": []
       },
       {
@@ -301,7 +316,7 @@
     "description": "Resolve, assign, and update issues",
     "defaultEnabled": false,
     "order": 4,
-    "toolCount": 17,
+    "toolCount": 18,
     "tools": [
       {
         "name": "add_issue_note",
@@ -354,6 +369,11 @@
         "requiredScopes": ["event:read"]
       },
       {
+        "name": "get_sentry_mcp_info",
+        "description": "Get information about the running Sentry MCP server.\n\nUse this tool when you need to:\n- Check the Sentry MCP server version\n- Verify compatibility with a Skill or integration",
+        "requiredScopes": []
+      },
+      {
         "name": "get_sentry_resource",
         "description": "Fetch a Sentry resource by URL, or by resourceType plus resourceId.\nPass a Sentry URL directly when possible; the resource type is auto-detected.\n\nSupports issues, events, traces, spans, agent conversations, replays, preprod snapshots, and snapshot images.\nTrace lookups return a condensed overview by default.\n\nAgent Conversations: A conversation is a set of spans sharing the same gen_ai.conversation.id. Use resourceType='ai_conversation' with a conversation ID, or pass a Sentry conversation URL, to fetch the transcript/details. To discover or list conversations, use search_agent_conversations. Conversations are NOT issues — do not use search_issues for conversation queries.\n\nFor preprod snapshot URLs (matching 'sentry.io/preprod/snapshots/'):\n- Without ?selectedSnapshot=: returns the snapshot diff summary (changed, added, removed images)\n- With ?selectedSnapshot=<image_file_name>: returns the image preview and metadata. Full-resolution snapshot image bytes are not available in this session.\n\nResource IDs:\n- snapshot: <snapshotId>\n\n<examples>\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\nget_sentry_resource(resourceType='ai_conversation', organizationSlug='my-org', resourceId='conversation-123')\nget_sentry_resource(url='https://sentry.sentry.io/preprod/snapshots/123/')\nget_sentry_resource(url='https://sentry.sentry.io/preprod/snapshots/123/?selectedSnapshot=login_screen.png')\n</examples>",
         "requiredScopes": ["event:read", "project:read"]
@@ -396,7 +416,7 @@
     "description": "Create and modify projects, teams, DSNs, and uptime monitors",
     "defaultEnabled": false,
     "order": 5,
-    "toolCount": 15,
+    "toolCount": 16,
     "tools": [
       {
         "name": "add_team_to_project",
@@ -447,6 +467,11 @@
         "name": "find_teams",
         "description": "Find teams in an organization in Sentry.\n\nUse this tool when you need to:\n- View teams in a Sentry organization\n- Find a team's slug and numeric ID to aid other tool requests\n- Search for specific teams by name or slug\n\nReturns up to 25 results. When hasMore is true, use the query parameter to narrow down results.",
         "requiredScopes": ["team:read"]
+      },
+      {
+        "name": "get_sentry_mcp_info",
+        "description": "Get information about the running Sentry MCP server.\n\nUse this tool when you need to:\n- Check the Sentry MCP server version\n- Verify compatibility with a Skill or integration",
+        "requiredScopes": []
       },
       {
         "name": "remove_team_from_project",

--- a/packages/mcp-core/src/toolDefinitions.json
+++ b/packages/mcp-core/src/toolDefinitions.json
@@ -4004,6 +4004,25 @@
     "surface": "catalog"
   },
   {
+    "name": "get_sentry_mcp_info",
+    "description": "Get information about the running Sentry MCP server.\n\nUse this tool when you need to:\n- Check the Sentry MCP server version\n- Verify compatibility with a Skill or integration",
+    "inputSchema": {},
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The Sentry MCP server version."
+        }
+      },
+      "required": ["version"],
+      "additionalProperties": false
+    },
+    "requiredScopes": [],
+    "skills": ["inspect", "seer", "docs", "triage", "project-management"],
+    "surface": "catalog"
+  },
+  {
     "name": "get_sentry_resource",
     "description": "Fetch a Sentry resource by URL, or by resourceType plus resourceId.\nPass a Sentry URL directly when possible; the resource type is auto-detected.\n\nSupports issues, events, traces, spans, agent conversations, replays, monitors, preprod snapshots, and snapshot images.\nTrace lookups return a condensed overview by default.\n\nAgent Conversations: A conversation is a set of spans sharing the same gen_ai.conversation.id. Use resourceType='ai_conversation' with a conversation ID, or pass a Sentry conversation URL, to fetch the transcript/details. To discover or list conversations, use search_agent_conversations. Conversations are NOT issues — do not use search_issues for conversation queries.\n\nFor preprod snapshot URLs (matching 'sentry.io/preprod/snapshots/'):\n- Without ?selectedSnapshot=: returns the snapshot diff summary (changed, added, removed images)\n- With ?selectedSnapshot=<image_file_name>: returns the image preview and metadata. Use the Sentry tool `get_snapshot_image` for full-resolution image bytes.\n\nResource IDs:\n- monitor: <monitorSlug>\n- snapshot: <snapshotId>\n\n<examples>\nget_sentry_resource(url='https://sentry.io/issues/PROJECT-123/')\nget_sentry_resource(resourceType='issue', organizationSlug='my-org', resourceId='PROJECT-123')\nget_sentry_resource(resourceType='ai_conversation', organizationSlug='my-org', resourceId='conversation-123')\nget_sentry_resource(url='https://sentry.sentry.io/preprod/snapshots/123/')\nget_sentry_resource(url='https://sentry.sentry.io/preprod/snapshots/123/?selectedSnapshot=login_screen.png')\n</examples>",
     "inputSchema": {

--- a/packages/mcp-core/src/tools/catalog/get-sentry-mcp-info.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-sentry-mcp-info.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createTestContext } from "../../test-utils/context.js";
+import {
+  assertStructuredOnlyResult,
+  getStructuredContent,
+} from "../../test-utils/structured-content.js";
+import { LIB_VERSION } from "../../version.js";
+import getSentryMcpInfo, {
+  getSentryMcpInfoOutputSchema,
+} from "./get-sentry-mcp-info.js";
+
+describe("get_sentry_mcp_info", () => {
+  it("returns the Sentry MCP server information", async () => {
+    const result = await getSentryMcpInfo.handler({}, createTestContext());
+
+    assertStructuredOnlyResult(result);
+    const content = getStructuredContent<{ version: string }>(result);
+
+    expect(getSentryMcpInfo.outputSchema).toBe(getSentryMcpInfoOutputSchema);
+    expect(getSentryMcpInfoOutputSchema.safeParse(content).success).toBe(true);
+    expect(content).toEqual({ version: LIB_VERSION });
+    expect({ ...content, version: "<version>" }).toMatchInlineSnapshot(`
+      {
+        "version": "<version>",
+      }
+    `);
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/get-sentry-mcp-info.ts
+++ b/packages/mcp-core/src/tools/catalog/get-sentry-mcp-info.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { defineTool } from "../../internal/tool-helpers/define";
+import { structuredResult } from "../../internal/tool-helpers/results";
+import { ALL_SKILLS } from "../../skills";
+import { LIB_VERSION } from "../../version";
+
+export const getSentryMcpInfoOutputSchema = z.object({
+  version: z.string().describe("The Sentry MCP server version."),
+});
+
+export default defineTool({
+  name: "get_sentry_mcp_info",
+  description: [
+    "Get information about the running Sentry MCP server.",
+    "",
+    "Use this tool when you need to:",
+    "- Check the Sentry MCP server version",
+    "- Verify compatibility with a Skill or integration",
+  ].join("\n"),
+  inputSchema: {},
+  outputSchema: getSentryMcpInfoOutputSchema,
+  skills: ALL_SKILLS,
+  requiredScopes: [],
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+  },
+  async handler() {
+    return structuredResult({
+      version: LIB_VERSION,
+    });
+  },
+});

--- a/packages/mcp-core/src/tools/catalog/index.ts
+++ b/packages/mcp-core/src/tools/catalog/index.ts
@@ -1,4 +1,5 @@
 import whoami from "./whoami";
+import getSentryMcpInfo from "./get-sentry-mcp-info";
 import findOrganizations from "./find-organizations";
 import findTeams from "./find-teams";
 import findProjects from "./find-projects";
@@ -128,6 +129,7 @@ const catalogTools = {
   search_issue_events: searchIssueEvents,
   get_profile: getProfile,
   get_profile_details: getProfileDetails,
+  get_sentry_mcp_info: getSentryMcpInfo,
   get_sentry_resource: getSentryResource,
   get_snapshot: getSnapshot,
   get_snapshot_image: getSnapshotImage,


### PR DESCRIPTION
## Summary

- Add a catalog-only `get_sentry_mcp_info` tool
- Return the running Sentry MCP server version using the existing `LIB_VERSION`
- Make the tool available to all Skills without requiring Sentry API scopes
- Regenerate tool and Skill definitions
- Add unit and server-level coverage for catalog discovery and execution

This allows Skills and integrations to check the running Sentry MCP version and verify compatibility.
Fixes #1148

## Test plan

- `pnpm run tsc`
- `pnpm run lint`
- `pnpm run test`
- Verified that `search_sentry_tools` finds `get_sentry_mcp_info` for `server version`
- Verified that `execute_sentry_tool` returns:

```json
{
  "version": "0.39.0"
}
