### PR TITLE
fix(issue details): cap related replays in the structured payload

### DIFF
--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -2623,8 +2623,7 @@ describe("structuredContent", () => {
   });
 
   it("caps related replays and reports the full count", async () => {
-    // a real issue came back with 51 of these. the markdown output shows a count plus the
-    // first few, so the payload should not be the one place every id lands
+    // a real issue came back with 51 of these
     const many = Array.from({ length: 51 }, (_, i) =>
       `${i}`.padStart(32, "abcdef0123456789"),
     );

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -2623,8 +2623,7 @@ describe("structuredContent", () => {
   });
 
   it("caps related replays and reports the full count", async () => {
-    // a real issue came back with 51 of these. the markdown output shows a count plus the
-    // first few, so the payload should not be the one place every id lands
+    // a real issue came back with 51 of these
     const many = Array.from({ length: 51 }, (_, i) =>
       i.toString(16).padStart(32, "0"),
     );
@@ -2637,10 +2636,8 @@ describe("structuredContent", () => {
             formatted: { format: "json", content: FORMATTER_JSON },
           }),
       ),
-      // related ids come from replay-count, keyed by the issue's numeric id. The default
-      // handler returns {}, which is what made an earlier version of this test vacuous.
-      // Echo back whichever id was asked for, so this does not depend on which issue fixture
-      // a preceding test left registered.
+      // related ids come from replay-count, keyed by numeric issue id. Echo back whichever
+      // id was asked for: a preceding test can leave a different issue fixture registered.
       http.get(
         "https://sentry.io/api/0/organizations/sentry-mcp-evals/replay-count/",
         ({ request }) => {
@@ -2655,7 +2652,6 @@ describe("structuredContent", () => {
     const payload = (result as { structuredContent: Record<string, any> })
       .structuredContent;
 
-    // unconditional: a guarded assertion here is how the cap went unchecked before
     expect(payload.replays).not.toBeNull();
     expect(payload.replays.relatedCount).toBe(51);
     expect(payload.replays.related).toHaveLength(5);

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -2621,4 +2621,37 @@ describe("structuredContent", () => {
     expect(payload.issue.queryPattern).toBe("SELECT * FROM users WHERE id = ?");
     expect(payload.issue.location).toBe("/api/checkout");
   });
+
+  it("caps related replays and reports the full count", async () => {
+    // a real issue came back with 51 of these. the markdown output shows a count plus the
+    // first few, so the payload should not be the one place every id lands
+    const many = Array.from({ length: 51 }, (_, i) =>
+      `${i}`.padStart(32, "abcdef0123456789"),
+    );
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/events/latest/",
+        () =>
+          HttpResponse.json({
+            ...createDefaultEvent(),
+            formatted: { format: "json", content: FORMATTER_JSON },
+          }),
+      ),
+      http.get(
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/replays/",
+        () => HttpResponse.json(many.map((id) => ({ id }))),
+      ),
+    );
+
+    const result = await getIssueDetails.handler(params, baseContext);
+    const payload = (result as { structuredContent: Record<string, any> })
+      .structuredContent;
+
+    if (payload.replays) {
+      expect(payload.replays.related.length).toBeLessThanOrEqual(5);
+      expect(payload.replays.relatedCount).toBeGreaterThanOrEqual(
+        payload.replays.related.length,
+      );
+    }
+  });
 });

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -2625,7 +2625,7 @@ describe("structuredContent", () => {
   it("caps related replays and reports the full count", async () => {
     // a real issue came back with 51 of these
     const many = Array.from({ length: 51 }, (_, i) =>
-      `${i}`.padStart(32, "abcdef0123456789"),
+      i.toString(16).padStart(32, "0"),
     );
     mswServer.use(
       http.get(
@@ -2636,9 +2636,17 @@ describe("structuredContent", () => {
             formatted: { format: "json", content: FORMATTER_JSON },
           }),
       ),
+      // related ids come from replay-count, keyed by the issue's numeric id. The default
+      // handler returns {}, which is what made an earlier version of this test vacuous.
+      // Echo back whichever id was asked for, so this does not depend on which issue fixture
+      // a preceding test left registered.
       http.get(
-        "https://sentry.io/api/0/organizations/sentry-mcp-evals/issues/CLOUDFLARE-MCP-41/replays/",
-        () => HttpResponse.json(many.map((id) => ({ id }))),
+        "https://sentry.io/api/0/organizations/sentry-mcp-evals/replay-count/",
+        ({ request }) => {
+          const query = new URL(request.url).searchParams.get("query") ?? "";
+          const issueId = query.match(/issue\.id:\[(\d+)\]/)?.[1];
+          return HttpResponse.json(issueId ? { [issueId]: many } : {});
+        },
       ),
     );
 
@@ -2646,11 +2654,9 @@ describe("structuredContent", () => {
     const payload = (result as { structuredContent: Record<string, any> })
       .structuredContent;
 
-    if (payload.replays) {
-      expect(payload.replays.related.length).toBeLessThanOrEqual(5);
-      expect(payload.replays.relatedCount).toBeGreaterThanOrEqual(
-        payload.replays.related.length,
-      );
-    }
+    // unconditional: a guarded assertion here is how the cap went unchecked before
+    expect(payload.replays).not.toBeNull();
+    expect(payload.replays.relatedCount).toBe(51);
+    expect(payload.replays.related).toHaveLength(5);
   });
 });

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.test.ts
@@ -2623,7 +2623,8 @@ describe("structuredContent", () => {
   });
 
   it("caps related replays and reports the full count", async () => {
-    // a real issue came back with 51 of these
+    // a real issue came back with 51 of these. the markdown output shows a count plus the
+    // first few, so the payload should not be the one place every id lands
     const many = Array.from({ length: 51 }, (_, i) =>
       i.toString(16).padStart(32, "0"),
     );

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -193,8 +193,7 @@ function buildReplays(
   if (!attached && related.length === 0) {
     return null;
   }
-  // an issue can carry dozens of these; the markdown output shows a count plus the first few
-  // rather than every id, and the payload should not be the one place they all land
+  // markdown shows a count plus the first few, not every id
   return {
     attached,
     related: related.slice(0, MAX_RELATED_REPLAYS),

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -53,11 +53,15 @@ const AI_CONVERSATION_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const TRACE_ID_PATTERN = /^[0-9a-fA-F]{32}$/;
 
 /**
- * The issue payload as `structuredContent`. Fields are mapped explicitly, never spread from an
- * api response, so a passthrough upstream schema cannot leak backend-only fields.
+ * The issue payload as `structuredContent`.
  *
- * `event.body` is the one open record: Sentry's shared formatter decides its sections, so
- * enumerating them here would be a second declaration of that contract.
+ * Every field is mapped explicitly rather than spread from an api response, so a passthrough
+ * upstream schema cannot leak backend-only fields into the public interface.
+ *
+ * `event.body` is the one open record: it is whatever Sentry's shared formatter emits
+ * for `?llmFormat=json`, and its sections are decided there. Enumerating them here would make
+ * this schema a second declaration of that contract, needing a bump every time a section is
+ * added on the Sentry side.
  */
 export const getIssueDetailsOutputSchema = z.object({
   issue: z.object({
@@ -106,7 +110,7 @@ export const getIssueDetailsOutputSchema = z.object({
     .object({
       attached: z.string().nullish(),
       related: z.array(z.string()),
-      // `related` is capped, so carry the total
+      // the full count, since `related` is capped
       relatedCount: z.number(),
     })
     .nullish(),
@@ -136,12 +140,13 @@ export type GetIssueDetailsPayload = z.infer<
 >;
 
 /**
- * The shared formatter's json body, or undefined when the org is not on the rollout yet, which
- * is the signal to keep returning markdown.
+ * Parses the shared formatter's json body. Returns undefined when the caller's org is not on
+ * the rollout yet, which is the signal to keep returning markdown: a structured result has to
+ * carry the whole answer, and without the body it would not.
  */
 function parseFormattedBody(event: Event): Record<string, unknown> | undefined {
-  // same gate the markdown path applies: a transaction needs the local rendering, which
-  // carries the performance trace the shared body does not
+  // the same event-type gate the markdown path applies: a transaction still needs the local
+  // rendering, which carries the fetched performance trace that the shared body does not
   if (!usesSharedFormatterBody(event)) {
     return undefined;
   }
@@ -188,7 +193,8 @@ function buildReplays(
   if (!attached && related.length === 0) {
     return null;
   }
-  // markdown shows a count plus the first few, not every id
+  // an issue can carry dozens of these; the markdown output shows a count plus the first few
+  // rather than every id, and the payload should not be the one place they all land
   return {
     attached,
     related: related.slice(0, MAX_RELATED_REPLAYS),
@@ -220,14 +226,15 @@ function buildIssueDetailsPayload({
   codeLocation?: CodeLocation;
 }): GetIssueDetailsPayload {
   const autofix = autofixState?.autofix;
-  // artifacts only: a whole AutofixRunState would dwarf the rest of the payload
+  // the run's own artifacts, not the whole state: an AutofixRunState carries every step and
+  // would dwarf the rest of the payload
   const summaries = autofix ? getAutofixArtifactSummaries(autofix) : undefined;
   const isPerf = isPerformanceIssueType(issue) && !!issue.metadata;
 
   return {
     issue: {
       shortId: issue.shortId,
-      // markdown prefers the metadata title for a performance issue
+      // a performance issue's metadata carries the better title, as the markdown path prefers
       title: (isPerf ? issue.metadata?.title : null) || issue.title,
       culprit: issue.culprit,
       firstSeen: issue.firstSeen,
@@ -249,8 +256,8 @@ function buildIssueDetailsPayload({
       platform: issue.platform,
       project: issue.project?.name,
       url: apiService.getIssueUrl(organizationSlug, issue.shortId),
-      // metadata.value is a query pattern for a performance issue, the exception message for
-      // an error, so reading it unconditionally misnames the error text
+      // metadata.value is a query pattern only for a performance issue; on an error it is the
+      // exception message, so reading it unconditionally would misname the error text
       location: isPerf ? issue.metadata?.location : null,
       queryPattern: isPerf ? issue.metadata?.value : null,
     },
@@ -276,7 +283,8 @@ function buildIssueDetailsPayload({
         }
       : null,
     replays: buildReplays(event, relatedReplayIds),
-    // field by field, not handed through: several upstream schemas are passthrough
+    // mapped field by field, not handed through: several upstream schemas are passthrough, and
+    // structuredContent is a product contract rather than a view of the api response
     externalIssues: externalIssues?.length
       ? externalIssues.map((issue) => ({
           id: String(issue.id),
@@ -346,8 +354,10 @@ export default defineTool({
     eventId: ParamEventId.optional(),
     issueUrl: ParamIssueUrl.optional(),
   },
-  // no outputSchema yet: tools/list would export it immediately, while an org off the rollout
-  // still gets markdown with no structuredContent. Declare it once every event carries json.
+  // outputSchema is deliberately not declared yet. tools/list would export it immediately,
+  // while an org that is not on sentry's formatter rollout still gets a markdown result with
+  // no structuredContent -- advertising a schema that some success paths cannot satisfy. Wire
+  // it up once the rollout guarantees a json body on every event.
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -53,15 +53,11 @@ const AI_CONVERSATION_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const TRACE_ID_PATTERN = /^[0-9a-fA-F]{32}$/;
 
 /**
- * The issue payload as `structuredContent`.
+ * The issue payload as `structuredContent`. Fields are mapped explicitly, never spread from an
+ * api response, so a passthrough upstream schema cannot leak backend-only fields.
  *
- * Every field is mapped explicitly rather than spread from an api response, so a passthrough
- * upstream schema cannot leak backend-only fields into the public interface.
- *
- * `event.body` is the one open record: it is whatever Sentry's shared formatter emits
- * for `?llmFormat=json`, and its sections are decided there. Enumerating them here would make
- * this schema a second declaration of that contract, needing a bump every time a section is
- * added on the Sentry side.
+ * `event.body` is the one open record: Sentry's shared formatter decides its sections, so
+ * enumerating them here would be a second declaration of that contract.
  */
 export const getIssueDetailsOutputSchema = z.object({
   issue: z.object({
@@ -110,7 +106,7 @@ export const getIssueDetailsOutputSchema = z.object({
     .object({
       attached: z.string().nullish(),
       related: z.array(z.string()),
-      // the full count, since `related` is capped
+      // `related` is capped, so carry the total
       relatedCount: z.number(),
     })
     .nullish(),
@@ -140,13 +136,12 @@ export type GetIssueDetailsPayload = z.infer<
 >;
 
 /**
- * Parses the shared formatter's json body. Returns undefined when the caller's org is not on
- * the rollout yet, which is the signal to keep returning markdown: a structured result has to
- * carry the whole answer, and without the body it would not.
+ * The shared formatter's json body, or undefined when the org is not on the rollout yet, which
+ * is the signal to keep returning markdown.
  */
 function parseFormattedBody(event: Event): Record<string, unknown> | undefined {
-  // the same event-type gate the markdown path applies: a transaction still needs the local
-  // rendering, which carries the fetched performance trace that the shared body does not
+  // same gate the markdown path applies: a transaction needs the local rendering, which
+  // carries the performance trace the shared body does not
   if (!usesSharedFormatterBody(event)) {
     return undefined;
   }
@@ -193,8 +188,7 @@ function buildReplays(
   if (!attached && related.length === 0) {
     return null;
   }
-  // an issue can carry dozens of these; the markdown output shows a count plus the first few
-  // rather than every id, and the payload should not be the one place they all land
+  // markdown shows a count plus the first few, not every id
   return {
     attached,
     related: related.slice(0, MAX_RELATED_REPLAYS),
@@ -226,15 +220,14 @@ function buildIssueDetailsPayload({
   codeLocation?: CodeLocation;
 }): GetIssueDetailsPayload {
   const autofix = autofixState?.autofix;
-  // the run's own artifacts, not the whole state: an AutofixRunState carries every step and
-  // would dwarf the rest of the payload
+  // artifacts only: a whole AutofixRunState would dwarf the rest of the payload
   const summaries = autofix ? getAutofixArtifactSummaries(autofix) : undefined;
   const isPerf = isPerformanceIssueType(issue) && !!issue.metadata;
 
   return {
     issue: {
       shortId: issue.shortId,
-      // a performance issue's metadata carries the better title, as the markdown path prefers
+      // markdown prefers the metadata title for a performance issue
       title: (isPerf ? issue.metadata?.title : null) || issue.title,
       culprit: issue.culprit,
       firstSeen: issue.firstSeen,
@@ -256,8 +249,8 @@ function buildIssueDetailsPayload({
       platform: issue.platform,
       project: issue.project?.name,
       url: apiService.getIssueUrl(organizationSlug, issue.shortId),
-      // metadata.value is a query pattern only for a performance issue; on an error it is the
-      // exception message, so reading it unconditionally would misname the error text
+      // metadata.value is a query pattern for a performance issue, the exception message for
+      // an error, so reading it unconditionally misnames the error text
       location: isPerf ? issue.metadata?.location : null,
       queryPattern: isPerf ? issue.metadata?.value : null,
     },
@@ -283,8 +276,7 @@ function buildIssueDetailsPayload({
         }
       : null,
     replays: buildReplays(event, relatedReplayIds),
-    // mapped field by field, not handed through: several upstream schemas are passthrough, and
-    // structuredContent is a product contract rather than a view of the api response
+    // field by field, not handed through: several upstream schemas are passthrough
     externalIssues: externalIssues?.length
       ? externalIssues.map((issue) => ({
           id: String(issue.id),
@@ -354,10 +346,8 @@ export default defineTool({
     eventId: ParamEventId.optional(),
     issueUrl: ParamIssueUrl.optional(),
   },
-  // outputSchema is deliberately not declared yet. tools/list would export it immediately,
-  // while an org that is not on sentry's formatter rollout still gets a markdown result with
-  // no structuredContent -- advertising a schema that some success paths cannot satisfy. Wire
-  // it up once the rollout guarantees a json body on every event.
+  // no outputSchema yet: tools/list would export it immediately, while an org off the rollout
+  // still gets markdown with no structuredContent. Declare it once every event carries json.
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/packages/mcp-core/src/tools/catalog/get-issue-details.ts
+++ b/packages/mcp-core/src/tools/catalog/get-issue-details.ts
@@ -46,6 +46,8 @@ import { logError } from "../../telem/logging";
 import type { ServerContext } from "../../types";
 import { resolveCodeLocation } from "../support/code-location";
 
+// mirrors MAX_DISPLAY_REPLAYS in the markdown output
+const MAX_RELATED_REPLAYS = 5;
 const MAX_AI_CONVERSATION_MATCHES = 3;
 const AI_CONVERSATION_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const TRACE_ID_PATTERN = /^[0-9a-fA-F]{32}$/;
@@ -108,6 +110,8 @@ export const getIssueDetailsOutputSchema = z.object({
     .object({
       attached: z.string().nullish(),
       related: z.array(z.string()),
+      // the full count, since `related` is capped
+      relatedCount: z.number(),
     })
     .nullish(),
   externalIssues: z
@@ -189,7 +193,13 @@ function buildReplays(
   if (!attached && related.length === 0) {
     return null;
   }
-  return { attached, related };
+  // an issue can carry dozens of these; the markdown output shows a count plus the first few
+  // rather than every id, and the payload should not be the one place they all land
+  return {
+    attached,
+    related: related.slice(0, MAX_RELATED_REPLAYS),
+    relatedCount: related.length,
+  };
 }
 
 function buildIssueDetailsPayload({


### PR DESCRIPTION
A real issue returned 51 related replay ids. The markdown output shows a Related Replay Count plus the first MAX_DISPLAY_REPLAYS and an "and N more" line, so the payload was the one place every id landed. Caps at the same 5 and carries relatedCount so nothing is hidden by the cap.

Found by calling the tool against a live issue rather than a fixture, which is also why the count was missing: no test had more than a couple of replays.