### PR TITLE
fix(search-events): ground the agent in the org's real environments

### DIFF
--- a/packages/mcp-core/src/api-client/client.ts
+++ b/packages/mcp-core/src/api-client/client.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { DEFAULT_SEARCH_ISSUES_PERIOD } from "../constants";
 import { ConfigurationError } from "../errors";
+import { retryWithBackoff } from "../internal/fetch-utils";
 import { logIssue, logWarn } from "../telem/logging";
 import type { SentryProtocol } from "../types";
 import {
@@ -30,7 +31,6 @@ import {
   isSentryHost,
   type TraceMetricIdentifier,
 } from "../utils/url-utils";
-import { retryWithBackoff } from "../internal/fetch-utils";
 import { USER_AGENT } from "../version";
 import { apiPath } from "./api-path";
 import {
@@ -70,6 +70,7 @@ import {
   MonitorListSchema,
   MonitorSchema,
   MonitorStatsSchema,
+  OrganizationEnvironmentListSchema,
   OrganizationListSchema,
   OrganizationSchema,
   ProfileChunkResponseSchema,
@@ -130,6 +131,7 @@ import type {
   MonitorCheckInList,
   MonitorList,
   MonitorStats,
+  OrganizationEnvironmentList,
   OrganizationList,
   ProfileChunk,
   Project,
@@ -3414,6 +3416,37 @@ export class SentryApiService {
     );
     const body = await this.parseJsonResponse(response);
     return EventsValidationResponseSchema.parse(body);
+  }
+
+  /**
+   * List the organization's visible environments, optionally scoped to a
+   * project. The endpoint (`GET /organizations/{org}/environments/`) already
+   * filters to visible environments and excludes the empty-name "No Environment"
+   * pseudo-env; passing `project` narrows the list (verified against
+   * getsentry/sentry `OrganizationEnvironmentsEndpoint`).
+   */
+  async listEnvironments(
+    {
+      organizationSlug,
+      projectId,
+    }: {
+      organizationSlug: string;
+      projectId?: string;
+    },
+    opts?: RequestOptions,
+  ): Promise<OrganizationEnvironmentList> {
+    const queryParams = new URLSearchParams();
+    if (projectId) {
+      queryParams.set("project", projectId);
+    }
+    const suffix = queryParams.toString();
+    const body = await this.requestJSON(
+      apiPath`/organizations/${organizationSlug}/environments/` +
+        (suffix ? `?${suffix}` : ""),
+      undefined,
+      opts,
+    );
+    return OrganizationEnvironmentListSchema.parse(body);
   }
 
   private async fetchTraceItemAttributes(

--- a/packages/mcp-core/src/api-client/schema.ts
+++ b/packages/mcp-core/src/api-client/schema.ts
@@ -1349,6 +1349,17 @@ export const EventAttachmentSchema = z.object({
 
 export const EventAttachmentListSchema = z.array(EventAttachmentSchema);
 
+// GET /organizations/{org}/environments/ — visible environments (the endpoint
+// excludes the empty-name "No Environment" and hidden environments by default).
+export const OrganizationEnvironmentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const OrganizationEnvironmentListSchema = z.array(
+  OrganizationEnvironmentSchema,
+);
+
 /**
  * Schema for individual tag values within an issue's tag distribution.
  *

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -42,13 +42,13 @@ import type { z } from "zod";
 import type {
   AgenticOnboardingRunSchema,
   AgenticOnboardingStatusUpdateSchema,
-  AssignedToSchema,
-  AIConversationSummaryListSchema,
-  AIConversationSummarySchema,
   AIConversationDetailsResponseSchema,
   AIConversationSpanListSchema,
   AIConversationSpanSchema,
+  AIConversationSummaryListSchema,
+  AIConversationSummarySchema,
   AIConversationUserSchema,
+  AssignedToSchema,
   AutofixRunSchema,
   AutofixRunStateSchema,
   ClientKeyListSchema,
@@ -82,18 +82,16 @@ import type {
   IssueListSchema,
   IssueSchema,
   IssueTagValuesSchema,
+  MetricAlertRuleListSchema,
+  MetricAlertRuleSchema,
   MonitorCheckInListSchema,
   MonitorCheckInSchema,
   MonitorListSchema,
   MonitorSchema,
-  MonitorStatsSchema,
   MonitorStatSchema,
-  UptimeCheckListSchema,
-  UptimeCheckSchema,
-  UptimeMonitorListSchema,
-  UptimeMonitorSchema,
-  MetricAlertRuleListSchema,
-  MetricAlertRuleSchema,
+  MonitorStatsSchema,
+  OrganizationEnvironmentListSchema,
+  OrganizationEnvironmentSchema,
   OrganizationListSchema,
   OrganizationSchema,
   ProfileChunkResponseSchema,
@@ -123,8 +121,12 @@ import type {
   TransactionProfileSampleSchema,
   TransactionProfileSchema,
   UnknownEventSchema,
-  UserSchema,
+  UptimeCheckListSchema,
+  UptimeCheckSchema,
+  UptimeMonitorListSchema,
+  UptimeMonitorSchema,
   UserReportListSchema,
+  UserSchema,
 } from "./schema";
 
 export type AgenticOnboardingRun = z.infer<typeof AgenticOnboardingRunSchema>;
@@ -202,6 +204,12 @@ export type MonitorStats = z.infer<typeof MonitorStatsSchema>;
 export type UptimeMonitorList = z.infer<typeof UptimeMonitorListSchema>;
 export type UptimeCheckList = z.infer<typeof UptimeCheckListSchema>;
 export type EventAttachmentList = z.infer<typeof EventAttachmentListSchema>;
+export type OrganizationEnvironment = z.infer<
+  typeof OrganizationEnvironmentSchema
+>;
+export type OrganizationEnvironmentList = z.infer<
+  typeof OrganizationEnvironmentListSchema
+>;
 export type TagList = z.infer<typeof TagListSchema>;
 export type ClientKeyList = z.infer<typeof ClientKeyListSchema>;
 

--- a/packages/mcp-core/src/api-client/types.ts
+++ b/packages/mcp-core/src/api-client/types.ts
@@ -91,7 +91,6 @@ import type {
   MonitorStatSchema,
   MonitorStatsSchema,
   OrganizationEnvironmentListSchema,
-  OrganizationEnvironmentSchema,
   OrganizationListSchema,
   OrganizationSchema,
   ProfileChunkResponseSchema,
@@ -204,9 +203,6 @@ export type MonitorStats = z.infer<typeof MonitorStatsSchema>;
 export type UptimeMonitorList = z.infer<typeof UptimeMonitorListSchema>;
 export type UptimeCheckList = z.infer<typeof UptimeCheckListSchema>;
 export type EventAttachmentList = z.infer<typeof EventAttachmentListSchema>;
-export type OrganizationEnvironment = z.infer<
-  typeof OrganizationEnvironmentSchema
->;
 export type OrganizationEnvironmentList = z.infer<
   typeof OrganizationEnvironmentListSchema
 >;

--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.test.ts
@@ -15,7 +15,7 @@ import {
   LLMProviderError,
   UserInputError,
 } from "../../errors";
-import { logIssue } from "../../telem/logging";
+import { logIssue, logWarn } from "../../telem/logging";
 import { getAgentProvider } from "./provider-factory";
 
 vi.mock("../../telem/logging", () => ({
@@ -243,7 +243,8 @@ describe("callEmbeddedAgent", () => {
 
   it("throws LLMProviderError for provider budget/quota failures", async () => {
     const budgetError = new APICallError({
-      message: "Workspace monthly budget of $15000.00 exceeded. Contact your org admin.",
+      message:
+        "Workspace monthly budget of $15000.00 exceeded. Contact your org admin.",
       url: "https://openrouter.ai/api/v1/chat/completions",
       requestBodyValues: {},
       statusCode: 402,
@@ -370,13 +371,15 @@ describe("callEmbeddedAgent", () => {
     );
   });
 
-  it("converts NoOutputGeneratedError into AgentExecutionError after filing a Sentry issue", async () => {
+  it("treats NoOutputGeneratedError as a recoverable UserInputError without filing a Sentry issue", async () => {
     const noOutputError = new NoOutputGeneratedError({
       message: "No output generated.",
     });
 
     mockGenerateText.mockRejectedValue(noOutputError);
 
+    // Recoverable model limitation (usually repeated tool/validation failures),
+    // not a system fault — surface as user input and log a warning, not an issue.
     await expect(
       callEmbeddedAgent({
         system: "You are a test agent",
@@ -384,35 +387,16 @@ describe("callEmbeddedAgent", () => {
         tools: {},
         schema: testSchema,
       }),
-    ).rejects.toBeInstanceOf(AgentExecutionError);
+    ).rejects.toBeInstanceOf(UserInputError);
 
-    await expect(
-      callEmbeddedAgent({
-        system: "You are a test agent",
-        prompt: "Test prompt",
-        tools: {},
-        schema: testSchema,
-      }),
-    ).rejects.toMatchObject({
-      message: expect.stringContaining("No output generated."),
-      eventId: "mock-event-id",
-      cause: noOutputError,
-    });
-
-    expect(logIssue).toHaveBeenCalledWith(
-      noOutputError,
-      expect.objectContaining({
-        loggerScope: ["agents", "embedded"],
-        contexts: {
-          embeddedAgent: expect.objectContaining({
-            isNoOutputGenerated: true,
-          }),
-        },
-      }),
+    expect(logIssue).not.toHaveBeenCalled();
+    expect(logWarn).toHaveBeenCalledWith(
+      "Embedded agent produced no output",
+      expect.objectContaining({ loggerScope: ["agents", "embedded"] }),
     );
   });
 
-  it("treats missing experimental_output as NoOutputGeneratedError", async () => {
+  it("treats missing experimental_output as a recoverable UserInputError", async () => {
     mockGenerateText.mockResolvedValue({
       experimental_output: undefined,
     } as never);
@@ -424,17 +408,9 @@ describe("callEmbeddedAgent", () => {
         tools: {},
         schema: testSchema,
       }),
-    ).rejects.toBeInstanceOf(AgentExecutionError);
+    ).rejects.toBeInstanceOf(UserInputError);
 
-    expect(logIssue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "AI_NoOutputGeneratedError",
-        message: "No output generated.",
-      }),
-      expect.objectContaining({
-        loggerScope: ["agents", "embedded"],
-      }),
-    );
+    expect(logIssue).not.toHaveBeenCalled();
   });
 
   it("rethrows ConfigurationError from getProviderOptions without filing an issue", async () => {

--- a/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
+++ b/packages/mcp-core/src/internal/agents/callEmbeddedAgent.ts
@@ -1,22 +1,22 @@
 import {
-  generateText,
-  Output,
-  type Tool,
   APICallError,
+  generateText,
   NoObjectGeneratedError,
   NoOutputGeneratedError,
+  Output,
   RetryError,
   stepCountIs,
+  type Tool,
 } from "ai";
-import { getAgentProvider } from "./provider-factory";
+import type { z } from "zod";
 import {
   AgentExecutionError,
   ConfigurationError,
-  UserInputError,
   LLMProviderError,
+  UserInputError,
 } from "../../errors";
 import { logIssue, logWarn } from "../../telem/logging";
-import type { z } from "zod";
+import { getAgentProvider } from "./provider-factory";
 
 /**
  * Resolve the underlying provider failure from an AI SDK error.
@@ -210,6 +210,21 @@ export async function callEmbeddedAgent<
       );
     }
 
+    // NoOutputGeneratedError: the model exhausted its steps without emitting the
+    // structured output (typically after repeated tool/validation failures). This
+    // is a recoverable model limitation, not a system fault — surface it as user
+    // input like its NoObjectGeneratedError sibling and log a warning, instead of
+    // filing a Sentry issue for every occurrence.
+    if (NoOutputGeneratedError.isInstance(error)) {
+      logWarn("Embedded agent produced no output", {
+        loggerScope: ["agents", "embedded"],
+        extra: { errorMessage: error.message },
+      });
+      throw new UserInputError(
+        "The AI could not construct a valid query for this request. Please rephrase or narrow it — for example, specify the fields, a real environment name, or a time range.",
+      );
+    }
+
     // Handle LLM provider errors with user-friendly messages.
     // These are operational availability failures that should NOT create Sentry
     // issues per request (budget exhaustion, rate limits, provider outages).
@@ -242,9 +257,9 @@ export async function callEmbeddedAgent<
       throw error;
     }
 
-    // Unexpected agent failures (including NoOutputGeneratedError): file one
-    // Sentry issue, then throw a typed error so AI-powered tools can fall back
-    // or return a graceful response instead of hard-failing the MCP tool.
+    // Genuinely unexpected agent failures: file one Sentry issue, then throw a
+    // typed error so AI-powered tools can fall back or return a graceful response
+    // instead of hard-failing the MCP tool.
     throw toAgentExecutionError(error);
   }
 }

--- a/packages/mcp-core/src/tools/catalog/search-events-environment-note.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events-environment-note.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectRequestedEnvironments,
+  formatUnknownEnvironmentNote,
+} from "./search-events";
+
+describe("collectRequestedEnvironments", () => {
+  it("collects from the separate environment field (string and array)", () => {
+    expect(collectRequestedEnvironments("production", "")).toEqual([
+      "production",
+    ]);
+    expect(collectRequestedEnvironments(["prod", "staging"], "")).toEqual([
+      "prod",
+      "staging",
+    ]);
+    expect(collectRequestedEnvironments(null, "")).toEqual([]);
+  });
+
+  it("collects environment tokens from the query string (the route Sentry doesn't validate)", () => {
+    expect(collectRequestedEnvironments(null, "environment:qa")).toEqual([
+      "qa",
+    ]);
+    expect(
+      collectRequestedEnvironments(null, "level:error environment:staging"),
+    ).toEqual(["staging"]);
+    expect(
+      collectRequestedEnvironments(null, "environment:[prod,dev]"),
+    ).toEqual(["prod", "dev"]);
+    expect(collectRequestedEnvironments(null, 'environment:"qa eu"')).toEqual([
+      "qa eu",
+    ]);
+  });
+
+  it("merges the field and the query token", () => {
+    expect(
+      collectRequestedEnvironments("production", "environment:qa"),
+    ).toEqual(["production", "qa"]);
+  });
+});
+
+describe("formatUnknownEnvironmentNote", () => {
+  it("names the unknown env and lists the available ones", () => {
+    const note = formatUnknownEnvironmentNote(
+      ["qa"],
+      ["production", "staging", "development"],
+    );
+    expect(note).toContain("`qa`");
+    expect(note).toContain("not found");
+    expect(note).toContain("`production`");
+    expect(note).toContain("`staging`");
+    expect(note).toContain("Re-run");
+  });
+
+  it("caps the available list and reports the total", () => {
+    const many = Array.from({ length: 80 }, (_, i) => `env-${i}`);
+    const note = formatUnknownEnvironmentNote(["qa", "qa"], many);
+    expect(note).toContain("(80 total)");
+    expect(note).not.toContain("`env-79`");
+    // Deduped unknowns.
+    expect(note.match(/`qa`/g)?.length).toBe(1);
+  });
+});

--- a/packages/mcp-core/src/tools/catalog/search-events-environment-note.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events-environment-note.test.ts
@@ -36,6 +36,24 @@ describe("collectRequestedEnvironments", () => {
       collectRequestedEnvironments("production", "environment:qa"),
     ).toEqual(["production", "qa"]);
   });
+
+  it("ignores dotted keys and quoted text that aren't real environment filters", () => {
+    // `deployment.environment` is a different (OTel) field, not the env filter.
+    expect(
+      collectRequestedEnvironments(null, "deployment.environment:prod"),
+    ).toEqual([]);
+    // `environment:` inside a quoted value (e.g. a message) is not a filter.
+    expect(
+      collectRequestedEnvironments(null, 'message:"environment:foo"'),
+    ).toEqual([]);
+    // A real environment filter alongside those is still collected.
+    expect(
+      collectRequestedEnvironments(
+        null,
+        'deployment.environment:prod environment:qa message:"environment:bar"',
+      ),
+    ).toEqual(["qa"]);
+  });
 });
 
 describe("formatUnknownEnvironmentNote", () => {

--- a/packages/mcp-core/src/tools/catalog/search-events-environment-note.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events-environment-note.test.ts
@@ -26,6 +26,11 @@ describe("collectRequestedEnvironments", () => {
     expect(
       collectRequestedEnvironments(null, "environment:[prod,dev]"),
     ).toEqual(["prod", "dev"]);
+    // IN-list with spaces after commas (official syntax) — tokenizer splits it,
+    // so it must be rejoined rather than parsed as garbage.
+    expect(
+      collectRequestedEnvironments(null, "environment:[prod, dev] level:error"),
+    ).toEqual(["prod", "dev"]);
     expect(collectRequestedEnvironments(null, 'environment:"qa eu"')).toEqual([
       "qa eu",
     ]);

--- a/packages/mcp-core/src/tools/catalog/search-events.test.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.test.ts
@@ -307,6 +307,53 @@ describe("search_events", () => {
     );
   });
 
+  it("flags an unknown environment even on the structured (non-agent) path", async () => {
+    const query = 'transaction:"checkout" environment:nonexistent-xyz';
+    mswServer.use(
+      http.get(
+        "https://sentry.io/api/0/organizations/test-org/environments/",
+        () =>
+          HttpResponse.json([
+            { id: "1", name: "production" },
+            { id: "2", name: "development" },
+          ]),
+      ),
+      http.get("https://sentry.io/api/0/organizations/test-org/events/", () =>
+        HttpResponse.json({ data: [] }),
+      ),
+    );
+
+    const result = await searchEvents.handler(
+      {
+        organizationSlug: "test-org",
+        regionUrl: null,
+        projectSlug: null,
+        query,
+        dataset: "spans",
+        fields: ["id", "timestamp"],
+        sort: "-timestamp",
+        period: "24h",
+        limit: 10,
+        includeExplanation: false,
+      },
+      {
+        constraints: {
+          organizationSlug: null,
+          regionUrl: null,
+          projectSlug: null,
+        },
+        accessToken: "test-token",
+        userId: "1",
+      },
+    );
+
+    // No agent runs, but the env typo in the query is still caught + surfaced.
+    expect(mockGenerateText).not.toHaveBeenCalled();
+    expect(result).toContain("not found in this organization");
+    expect(result).toContain("nonexistent-xyz");
+    expect(result).toContain("`production`");
+  });
+
   it("should link directly to AI conversation details for a single conversation id filter", async () => {
     const query = 'gen_ai.conversation.id:"14365297"';
 

--- a/packages/mcp-core/src/tools/catalog/search-events.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.ts
@@ -191,14 +191,24 @@ export function collectRequestedEnvironments(
   // Tokenize (quote/escape-aware) and only take tokens that ARE an `environment:`
   // filter, so dotted keys like `deployment.environment:` and `environment:`
   // inside quoted text (e.g. a message value) aren't mistaken for a filter.
-  for (const token of tokenizeSearchQuery(query)) {
-    const match = /^environment:(.*)$/is.exec(token);
+  const tokens = tokenizeSearchQuery(query);
+  for (let i = 0; i < tokens.length; i++) {
+    const match = /^environment:(.*)$/is.exec(tokens[i]);
     if (!match) {
       continue;
     }
-    const raw = match[1];
+    let value = match[1];
+    // An IN-list (`environment:[a, b]`) can be split across tokens on its
+    // internal spaces; rejoin following tokens until the list is closed.
+    while (
+      value.startsWith("[") &&
+      !value.includes("]") &&
+      i + 1 < tokens.length
+    ) {
+      value += ` ${tokens[++i]}`;
+    }
     const inner =
-      raw.startsWith("[") && raw.endsWith("]") ? raw.slice(1, -1) : raw;
+      value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
     for (const part of inner.split(",")) {
       const cleaned = part.trim().replace(/^["']|["']$/g, "");
       if (cleaned) {

--- a/packages/mcp-core/src/tools/catalog/search-events.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.ts
@@ -188,12 +188,19 @@ export function collectRequestedEnvironments(
   } else if (Array.isArray(environment)) {
     values.push(...environment);
   }
-  const tokenPattern = /\benvironment:(\[[^\]]*\]|"[^"]*"|\S+)/gi;
-  for (const match of query.matchAll(tokenPattern)) {
+  // Tokenize (quote/escape-aware) and only take tokens that ARE an `environment:`
+  // filter, so dotted keys like `deployment.environment:` and `environment:`
+  // inside quoted text (e.g. a message value) aren't mistaken for a filter.
+  for (const token of tokenizeSearchQuery(query)) {
+    const match = /^environment:(.*)$/is.exec(token);
+    if (!match) {
+      continue;
+    }
     const raw = match[1];
-    const inner = raw.startsWith("[") ? raw.slice(1, -1) : raw;
+    const inner =
+      raw.startsWith("[") && raw.endsWith("]") ? raw.slice(1, -1) : raw;
     for (const part of inner.split(",")) {
-      const cleaned = part.trim().replace(/^"|"$/g, "");
+      const cleaned = part.trim().replace(/^["']|["']$/g, "");
       if (cleaned) {
         values.push(cleaned);
       }
@@ -512,10 +519,14 @@ export default defineTool({
 
     // Fetch the org's real environments once: used to ground the agent prompt
     // (below) and to flag any requested environment that doesn't exist. Skipped
-    // when the agent won't run and no environment was requested.
+    // only when nothing references an environment — including a structured query
+    // that skips the agent but puts `environment:` in the query string.
     const willRunAgent = hasAgentProvider() && !canRunWithoutAgent;
+    const inputReferencesEnvironment =
+      params.environment != null ||
+      collectRequestedEnvironments(null, params.query ?? "").length > 0;
     const environmentNames =
-      willRunAgent || params.environment != null
+      willRunAgent || inputReferencesEnvironment
         ? await fetchEnvironmentNames({
             apiService,
             organizationSlug,

--- a/packages/mcp-core/src/tools/catalog/search-events.ts
+++ b/packages/mcp-core/src/tools/catalog/search-events.ts
@@ -20,6 +20,7 @@ import {
 } from "../../utils/events-datasets";
 import { extractConversationIdFromSearchQuery } from "../../utils/url-utils";
 import {
+  fetchEnvironmentNames,
   searchEventsAgent,
   type searchEventsAgentOutputSchema,
 } from "../support/search-events/agent";
@@ -169,6 +170,53 @@ function appendSearchFilter(query: string, filter?: string): string {
     return trimmedQuery;
   }
   return [trimmedQuery, filter].filter(Boolean).join(" ");
+}
+
+/**
+ * Collect the environment names a search actually filters on — from both the
+ * separate `environment` field and any `environment:` token in the query string.
+ * Sentry only validates the former against real environments, so a bad value in
+ * the query (e.g. a typo) otherwise slips through and silently returns nothing.
+ */
+export function collectRequestedEnvironments(
+  environment: string | string[] | null | undefined,
+  query: string,
+): string[] {
+  const values: string[] = [];
+  if (typeof environment === "string") {
+    values.push(environment);
+  } else if (Array.isArray(environment)) {
+    values.push(...environment);
+  }
+  const tokenPattern = /\benvironment:(\[[^\]]*\]|"[^"]*"|\S+)/gi;
+  for (const match of query.matchAll(tokenPattern)) {
+    const raw = match[1];
+    const inner = raw.startsWith("[") ? raw.slice(1, -1) : raw;
+    for (const part of inner.split(",")) {
+      const cleaned = part.trim().replace(/^"|"$/g, "");
+      if (cleaned) {
+        values.push(cleaned);
+      }
+    }
+  }
+  return values;
+}
+
+/**
+ * Note listing the org's real environments when a search references one that
+ * doesn't exist, so the caller can retry with a valid name. We don't guess a
+ * match — the calling agent maps from the list.
+ */
+export function formatUnknownEnvironmentNote(
+  unknown: string[],
+  available: string[],
+): string {
+  const uniqueUnknown = [...new Set(unknown)].map((name) => `\`${name}\``);
+  const shown = available.slice(0, 50).map((name) => `\`${name}\``);
+  const more =
+    available.length > shown.length ? ` (${available.length} total)` : "";
+  const label = uniqueUnknown.length === 1 ? "environment" : "environments";
+  return `> ⚠️ Requested ${label} not found in this organization: ${uniqueUnknown.join(", ")}. Available environments: ${shown.join(", ")}${more}. Re-run filtering by one of these, or omit the environment to search all.`;
 }
 
 function applyEnvironmentToEventsQuery(
@@ -462,7 +510,23 @@ export default defineTool({
     const canRunWithoutAgent =
       shouldTrustStructuredTraceSearch && hasExplicitFields && hasExplicitSort;
 
-    if (hasAgentProvider() && !canRunWithoutAgent) {
+    // Fetch the org's real environments once: used to ground the agent prompt
+    // (below) and to flag any requested environment that doesn't exist. Skipped
+    // when the agent won't run and no environment was requested.
+    const willRunAgent = hasAgentProvider() && !canRunWithoutAgent;
+    const environmentNames =
+      willRunAgent || params.environment != null
+        ? await fetchEnvironmentNames({
+            apiService,
+            organizationSlug,
+            projectId,
+          })
+        : [];
+    const knownEnvironments = new Set(
+      environmentNames.map((name) => name.toLowerCase()),
+    );
+
+    if (willRunAgent) {
       const parsed = await withProviderFallback<SearchEventsAgentResult>({
         operation: "search_events.rewrite",
         fallback: () => ({
@@ -491,6 +555,7 @@ export default defineTool({
               organizationSlug,
               apiService,
               projectId,
+              environmentNames,
             })
           ).result,
       });
@@ -555,6 +620,22 @@ export default defineTool({
           : (params.fields ?? defaultFieldsForDataset(dataset));
     }
 
+    // Flag any requested environment that doesn't exist (checking both the
+    // separate field and `environment:` tokens in the query) so the caller can
+    // retry with a valid name instead of silently getting zero results.
+    const unknownEnvironments =
+      knownEnvironments.size > 0
+        ? collectRequestedEnvironments(environment, sentryQuery).filter(
+            (name) => !knownEnvironments.has(name.toLowerCase()),
+          )
+        : [];
+    const environmentNote =
+      unknownEnvironments.length > 0
+        ? formatUnknownEnvironmentNote(unknownEnvironments, environmentNames)
+        : "";
+    const withEnvironmentNote = (text: string): string =>
+      environmentNote ? `${environmentNote}\n\n${text}` : text;
+
     if (dataset === "replays") {
       const replaySort = sortParam || DEFAULT_REPLAY_SORT;
       if (!isValidReplaySort(replaySort)) {
@@ -599,7 +680,7 @@ export default defineTool({
         replays.length,
       );
 
-      return formatReplayResults({
+      const replayOutput = formatReplayResults({
         replays,
         inputQuery: params.query || sentryQuery || "recent replays",
         includeExplanation: params.includeExplanation,
@@ -622,6 +703,7 @@ export default defineTool({
         availableToolNames: context.availableToolNames,
         directToolNames: context.directToolNames,
       });
+      return withEnvironmentNote(replayOutput);
     }
 
     // Sentry rejects the request if the sort column isn't in the selected
@@ -766,15 +848,15 @@ export default defineTool({
 
     switch (dataset) {
       case "errors":
-        return formatErrorResults(formatParams);
+        return withEnvironmentNote(formatErrorResults(formatParams));
       case "logs":
-        return formatLogResults(formatParams);
+        return withEnvironmentNote(formatLogResults(formatParams));
       case "spans":
-        return formatSpanResults(formatParams);
+        return withEnvironmentNote(formatSpanResults(formatParams));
       case "profiles":
-        return formatProfileResults(formatParams);
+        return withEnvironmentNote(formatProfileResults(formatParams));
       default:
-        return formatTraceMetricsResults(formatParams);
+        return withEnvironmentNote(formatTraceMetricsResults(formatParams));
     }
   },
 });

--- a/packages/mcp-core/src/tools/support/search-events/agent.ts
+++ b/packages/mcp-core/src/tools/support/search-events/agent.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import type { SentryApiService } from "../../../api-client";
-import { callEmbeddedAgent } from "../../../internal/agents/callEmbeddedAgent";
+import {
+  callEmbeddedAgent,
+  type ToolCall,
+} from "../../../internal/agents/callEmbeddedAgent";
 import { createDatasetFieldsTool } from "../../../internal/agents/tools/dataset-fields";
 import { createOtelLookupTool } from "../../../internal/agents/tools/otel-semantics";
 import { createWhoamiTool } from "../../../internal/agents/tools/whoami";
@@ -100,11 +103,10 @@ const MAX_INLINE_ENVIRONMENTS = 100;
 /**
  * Append the organization's real environment names to the system prompt.
  *
- * Without this the model invents `environment` values (`":null"`, `".*"`,
- * `["production","staging","development"]`, `" "` …) that Sentry's validation
- * rejects, burning the step budget and producing no output — the single biggest
- * source of search_events failures. Grounding it in the real names lets it pick
- * a valid one or omit the field.
+ * Without this the model invents `environment` values (e.g. `":null"`, `".*"`)
+ * that Sentry rejects, burning the step budget and producing no output — the top
+ * source of search_events failures. Grounding it lets the model pick a real one
+ * or omit the field.
  */
 export function buildSystemPromptWithEnvironments(
   base: string,
@@ -152,7 +154,7 @@ export async function searchEventsAgent(
   options: SearchEventsAgentOptions,
 ): Promise<{
   result: z.output<typeof searchEventsAgentOutputSchema>;
-  toolCalls: any[];
+  toolCalls: ToolCall[];
 }> {
   // Provider check happens in callEmbeddedAgent via getAgentProvider()
   // Create tools pre-bound with the provided API service and organization

--- a/packages/mcp-core/src/tools/support/search-events/agent.ts
+++ b/packages/mcp-core/src/tools/support/search-events/agent.ts
@@ -84,6 +84,12 @@ export interface SearchEventsAgentOptions {
   organizationSlug: string;
   apiService: SentryApiService;
   projectId?: string;
+  /**
+   * The org's real environment names, used to ground the prompt. When omitted
+   * the agent fetches them itself; the search_events tool passes a pre-fetched
+   * list so the same call is reused for post-agent validation.
+   */
+  environmentNames?: string[];
 }
 
 // Above this many environments we stop inlining the full list into the prompt
@@ -118,11 +124,13 @@ export function buildSystemPromptWithEnvironments(
 
 /**
  * Best-effort fetch of the org's environment names (scoped to the project when
- * known). Failures are non-fatal — the agent still runs, just without grounding.
+ * known). Failures are non-fatal — callers still run, just without grounding.
  */
-async function fetchEnvironmentNames(
-  options: SearchEventsAgentOptions,
-): Promise<string[]> {
+export async function fetchEnvironmentNames(options: {
+  apiService: SentryApiService;
+  organizationSlug: string;
+  projectId?: string;
+}): Promise<string[]> {
   try {
     const environments = await options.apiService.listEnvironments({
       organizationSlug: options.organizationSlug,
@@ -172,8 +180,10 @@ export async function searchEventsAgent(
   const whoamiTool = createWhoamiTool({ apiService: options.apiService });
 
   // Ground the agent in the org's real environments so it stops inventing
-  // invalid `environment` values (the top cause of no-output failures).
-  const environmentNames = await fetchEnvironmentNames(options);
+  // invalid `environment` values (the top cause of no-output failures). The
+  // tool passes a pre-fetched list; fall back to fetching for standalone callers.
+  const environmentNames =
+    options.environmentNames ?? (await fetchEnvironmentNames(options));
 
   // Use callEmbeddedAgent to translate the query with tool call capture
   return await callEmbeddedAgent<

--- a/packages/mcp-core/src/tools/support/search-events/agent.ts
+++ b/packages/mcp-core/src/tools/support/search-events/agent.ts
@@ -27,11 +27,11 @@ export const searchEventsAgentOutputSchema = z
       .describe("Array of field names to return in results."),
     sort: z.string().describe("Sort parameter for results."),
     environment: z
-      .union([z.string(), z.array(z.string()).min(1)])
+      .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
       .nullable()
       .default(null)
       .describe(
-        "Separate environment filter for datasets like replays that do not support environment in the query string. Use a string for one environment or an array when multiple environments are requested.",
+        "Separate environment filter for datasets like replays that do not support environment in the query string. Set only to a real environment the user named (see the 'Available environments' list); omit otherwise. Never use wildcards, placeholders, or example values.",
       ),
     timeRange: z
       .union([
@@ -86,6 +86,56 @@ export interface SearchEventsAgentOptions {
   projectId?: string;
 }
 
+// Above this many environments we stop inlining the full list into the prompt
+// (token cost) and rely on the guidance text alone; validation still checks the
+// value against the real list.
+const MAX_INLINE_ENVIRONMENTS = 100;
+
+/**
+ * Append the organization's real environment names to the system prompt.
+ *
+ * Without this the model invents `environment` values (`":null"`, `".*"`,
+ * `["production","staging","development"]`, `" "` …) that Sentry's validation
+ * rejects, burning the step budget and producing no output — the single biggest
+ * source of search_events failures. Grounding it in the real names lets it pick
+ * a valid one or omit the field.
+ */
+export function buildSystemPromptWithEnvironments(
+  base: string,
+  environmentNames: string[],
+): string {
+  if (environmentNames.length === 0) {
+    return base;
+  }
+  const rule =
+    'When the user names an environment, set the `environment` field to a matching value from this list EXACTLY; otherwise OMIT the field. Never use wildcards, placeholders, "null", "*", empty strings, or example values.';
+  if (environmentNames.length <= MAX_INLINE_ENVIRONMENTS) {
+    const list = environmentNames.map((name) => `"${name}"`).join(", ");
+    return `${base}\n\n## Available environments\nThe only valid \`environment\` values for this organization are: ${list}.\n${rule}`;
+  }
+  return `${base}\n\n## Environments\nThis organization has ${environmentNames.length} environments. ${rule}`;
+}
+
+/**
+ * Best-effort fetch of the org's environment names (scoped to the project when
+ * known). Failures are non-fatal — the agent still runs, just without grounding.
+ */
+async function fetchEnvironmentNames(
+  options: SearchEventsAgentOptions,
+): Promise<string[]> {
+  try {
+    const environments = await options.apiService.listEnvironments({
+      organizationSlug: options.organizationSlug,
+      projectId: options.projectId,
+    });
+    return environments
+      .map((environment) => environment.name)
+      .filter((name) => name.length > 0);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Search events agent - single entry point for translating natural language queries to Sentry search syntax
  * This returns both the translated query result AND the tool calls made by the agent
@@ -121,12 +171,16 @@ export async function searchEventsAgent(
   });
   const whoamiTool = createWhoamiTool({ apiService: options.apiService });
 
+  // Ground the agent in the org's real environments so it stops inventing
+  // invalid `environment` values (the top cause of no-output failures).
+  const environmentNames = await fetchEnvironmentNames(options);
+
   // Use callEmbeddedAgent to translate the query with tool call capture
   return await callEmbeddedAgent<
     z.output<typeof searchEventsAgentOutputSchema>,
     typeof searchEventsAgentOutputSchema
   >({
-    system: systemPrompt,
+    system: buildSystemPromptWithEnvironments(systemPrompt, environmentNames),
     prompt: options.query,
     tools: {
       datasetAttributes: datasetAttributesTool,

--- a/packages/mcp-core/src/tools/support/search-events/config.ts
+++ b/packages/mcp-core/src/tools/support/search-events/config.ts
@@ -256,7 +256,7 @@ COMMON ERRORS TO AVOID:
 export const BASE_COMMON_FIELDS = {
   project: "Project slug",
   timestamp: "When the event occurred",
-  environment: "Environment (production, staging, development)",
+  environment: "Deployment environment name (omit unless the user names one)",
   release: "Release version",
   platform: "Platform (javascript, python, etc.)",
   "user.id": "User ID",

--- a/packages/mcp-core/src/tools/support/search-events/environments.test.ts
+++ b/packages/mcp-core/src/tools/support/search-events/environments.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { SentryApiService } from "../../../api-client";
+import { buildSystemPromptWithEnvironments } from "./agent";
+
+describe("buildSystemPromptWithEnvironments", () => {
+  it("returns the base prompt unchanged when there are no environments", () => {
+    expect(buildSystemPromptWithEnvironments("BASE", [])).toBe("BASE");
+  });
+
+  it("inlines a small list of real environment names with a guardrail", () => {
+    const out = buildSystemPromptWithEnvironments("BASE", [
+      "production",
+      "dev",
+    ]);
+    expect(out).toContain("BASE");
+    expect(out).toContain("Available environments");
+    expect(out).toContain('"production"');
+    expect(out).toContain('"dev"');
+    // Guardrail against the hallucinated placeholders that caused the failures.
+    expect(out).toContain("OMIT the field");
+    expect(out).toContain("Never use wildcards");
+  });
+
+  it("does not dump the full list for very large orgs", () => {
+    const many = Array.from({ length: 250 }, (_, i) => `env-${i}`);
+    const out = buildSystemPromptWithEnvironments("BASE", many);
+    expect(out).toContain("250 environments");
+    expect(out).not.toContain('"env-0"');
+  });
+});
+
+describe("SentryApiService.listEnvironments", () => {
+  const apiService = new SentryApiService({ accessToken: "test-token" });
+
+  it("returns the organization's environments", async () => {
+    const envs = await apiService.listEnvironments({
+      organizationSlug: "sentry-mcp-evals",
+    });
+    expect(envs.map((e) => e.name)).toEqual(["production", "development"]);
+  });
+});

--- a/packages/mcp-server-mocks/src/index.ts
+++ b/packages/mcp-server-mocks/src/index.ts
@@ -990,6 +990,15 @@ export const restHandlers = buildHandlers([
 
   {
     method: "get",
+    path: "/api/0/organizations/sentry-mcp-evals/environments/",
+    fetch: () =>
+      HttpResponse.json([
+        { id: "1", name: "production" },
+        { id: "2", name: "development" },
+      ]),
+  },
+  {
+    method: "get",
     path: "/api/0/organizations/sentry-mcp-evals/releases/",
     fetch: () => HttpResponse.json([releaseFixture]),
   },


### PR DESCRIPTION
## Summary

Fixes the top issue in the `mcp-server` Sentry project — `AI_NoOutputGeneratedError` in the `search_events` embedded agent (MCP-SERVER-F1Z: **57,959 users**, \~514k events).

**Root cause:** when a user didn't name an environment, the agent invented `environment` values (`:null`, `.*`, `["production","staging","development"]`, `" "`, `["*"]`, `/dev/null` …). Sentry's `/events/validate/` rejected every one ("Unknown environments selected") — \~100% of validation failures, \~67% of `validateSearch` calls. When the agent couldn't recover within its 5-step budget it produced no structured output → `AI_NoOutputGeneratedError`. Two of our own inputs drove it: the prompt listed `(production, staging, development)` as if they were values, and the output schema accepted any string.

## Changes

* `SentryApiService.listEnvironments` — `GET /organizations/{org}/environments/` (project-scoped), Zod schema validated against `getsentry/sentry` (visible-only `{id,name}`).
* **Ground the agent:** fetch the org's real environments and inject them into the system prompt so the model uses a valid name or omits the field (list capped for large orgs).
* **Stop seeding hallucinations:** drop the example env names from the field description; require a non-empty string in the output schema.
* **Graceful tail:** treat `NoOutputGeneratedError` as a recoverable `UserInputError` (log a warning, not a Sentry issue) so the residual tail stops flooding Sentry.

## Verification (end-to-end, prod model `openai/gpt-5.6-luna`)

Reproduced real F1Z user flows through the MCP stdio server + the agent directly:

<!-- linear:table-colwidths:266,266,266 -->
| Query | Before (hallucinated) | After |
| -- | -- | -- |
| "errors in the **production** environment" | junk | `environment: production` ✅ |
| "show me errors in **prod**" | junk | `environment: production` (mapped) ✅ |
| "issue **APP-PRODUCTION-684**" | `["production","staging","development"]` | `environment: null` ✅ |
| "all errors last hour" (no env) | `:null` / `__none__` | `environment: null` (omitted) ✅ |

Every case: validation passes on the first try, valid output produced, **zero** `AI_NoOutputGeneratedError`. `listEnvironments` verified against production (e.g. the `sentry` org → 21 real environments).

Refs MCP-SERVER-F1Z.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)